### PR TITLE
feat: add correlation IDs to notify_peer

### DIFF
--- a/.claude/skills/peer-communication-test/SKILL.md
+++ b/.claude/skills/peer-communication-test/SKILL.md
@@ -138,6 +138,25 @@ curl -s http://127.0.0.1:8377/events | jq '.[] | select(.type == "query" or .typ
 ### 5.3 Verify bidirectional communication (optional)
 Send a query from peer-b to peer-a to confirm two-way messaging.
 
+### 5.4 Send notification with correlation tracking
+Inject a notification from peer-a to peer-b:
+
+```bash
+tmux send-keys -t repowire-test:peer-a "Send a notification to peer '$PEER_B_NAME' saying 'Build completed successfully'. Use the notify_peer MCP tool and note the correlation ID returned." Enter
+```
+
+### 5.5 Verify correlation ID format
+Check events endpoint for notification with embedded correlation ID:
+
+```bash
+curl -s http://127.0.0.1:8377/events | jq '.[] | select(.type == "notification")'
+```
+
+Expected: Message text contains `[#notif-XXXXXXXX]` prefix.
+
+### 5.6 Verify peer-b received the notification
+The notification should appear in peer-b's session with the correlation ID embedded, allowing peer-b to reference it in any follow-up communication.
+
 ## Phase 6: Validation
 
 ### 6.1 Check success criteria
@@ -145,6 +164,8 @@ Send a query from peer-b to peer-a to confirm two-way messaging.
 - [ ] Query event logged with status "pending" then "success"
 - [ ] Response event logged with actual content
 - [ ] No timeout errors
+- [ ] Notification event logged with correlation ID in message
+- [ ] Correlation ID format matches `notif-XXXXXXXX`
 
 ### 6.2 Report results
 Display:

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from uuid import uuid4
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -85,19 +86,21 @@ def create_mcp_server() -> FastMCP:
             message: The notification message
 
         Returns:
-            Confirmation message
+            Correlation ID (format: notif-XXXXXXXX) that the receiving peer can
+            reference in follow-up communications.
         """
         my_name = _detect_my_peer_name()
+        correlation_id = f"notif-{uuid4().hex[:8]}"
         await daemon_request(
             "POST",
             "/notify",
             {
                 "from_peer": my_name,
                 "to_peer": peer_name,
-                "text": message,
+                "text": f"[#{correlation_id}] {message}",
             },
         )
-        return f"Notification sent to {peer_name}"
+        return correlation_id
 
     @mcp.tool()
     async def broadcast(message: str) -> str:


### PR DESCRIPTION
## Summary
- `notify_peer` now returns a correlation ID (format: `notif-XXXXXXXX`) instead of a confirmation string
- Correlation ID is embedded in the message as `[#notif-XXXXXXXX] {message}`
- Allows receiving peers to reference notifications in follow-up communications

## Test plan
- [ ] Run `/peer-communication-test` skill to validate notification correlation tracking
- [ ] Verify `notify_peer` returns correlation ID
- [ ] Verify receiving peer sees embedded `[#notif-...]` prefix in message