### PR TITLE
feat: add --relay flag to repowire setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ OpenCode has a plugin SDK. The repowire plugin (`~/.opencode/plugin/repowire.ts`
 ```bash
 # Main commands
 repowire setup                    # Install hooks, MCP server, daemon service
+repowire setup --relay            # Same + enable remote dashboard via repowire.io
 repowire setup --no-service       # Skip daemon service (run manually with 'serve')
 repowire status                   # Show what's installed and running
 repowire uninstall                # Remove all components
 
 # Daemon
 repowire serve                    # Run daemon in foreground
-repowire serve --relay            # Run with relay (remote dashboard + cross-machine mesh)
 repowire build-ui                 # Build web dashboard (development)
 
 # Peer management
@@ -233,21 +233,15 @@ The daemon also restricts CORS to localhost origins only.
 
 Access your dashboard from anywhere and connect agents across machines via [repowire.io](https://repowire.io).
 
-Enable relay in your config:
-
-```yaml
-# ~/.repowire/config.yaml
-relay:
-  enabled: true
+```bash
+repowire setup --relay
+# ✓ Configured agents: claude-code
+# ✓ Relay enabled
+#   Dashboard: https://relay.repowire.io/d/rw_prass_33e7233b0c4cf148/dashboard
+# ✓ Daemon service installed (launchd)
 ```
 
-Then restart the daemon (`repowire service restart`). On first start, an API key is auto-generated and saved. Your dashboard URL is printed in the logs:
-
-```
-Dashboard: https://repowire.io/d/rw_prass_33e7233b0c4cf148/dashboard
-```
-
-Open it from any browser — your local daemon is tunneled through the relay. No port forwarding, no VPN.
+Open the dashboard URL from any browser — your local daemon is tunneled through the relay. No port forwarding, no VPN.
 
 **How it works:** Your daemon opens an outbound WebSocket to `relay.repowire.io`. The relay bridges messages between daemons on different machines and proxies HTTP requests (dashboard, API) back through the tunnel.
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -73,8 +73,10 @@ def serve(host: str, port: int, relay: bool) -> None:
 
 @main.command()
 @click.option("--no-service", is_flag=True, help="Skip daemon service installation")
-def setup(no_service: bool) -> None:
+@click.option("--relay", is_flag=True, help="Enable hosted relay via repowire.io")
+def setup(no_service: bool, relay: bool) -> None:
     """One-time setup: install hooks/plugins, MCP server, and daemon service."""
+    import getpass
     import shutil
 
     _cleanup_legacy_artifacts()
@@ -97,6 +99,22 @@ def setup(no_service: bool) -> None:
         return
 
     console.print(f"[green]✓[/] Configured agents: {', '.join(agents_setup)}")
+
+    # Enable relay if requested
+    if relay:
+        from repowire.config.models import load_config
+        from repowire.relay.auth import generate_api_key
+
+        config = load_config()
+        config.relay.enabled = True
+        if not config.relay.api_key:
+            api_key = generate_api_key(getpass.getuser())
+            config.relay.api_key = api_key.key
+        config.save()
+        relay_url = config.relay.url.replace("wss://", "https://")
+        dashboard_url = f"{relay_url}/d/{config.relay.api_key}/dashboard"
+        console.print("[green]✓[/] Relay enabled")
+        console.print(f"  Dashboard: {dashboard_url}")
 
     # Install daemon as system service
     if not no_service:


### PR DESCRIPTION
## Summary

- `repowire setup --relay` enables relay, generates API key, prints dashboard URL
- README updated to use `setup --relay` as the primary relay setup flow
- Removed `serve --relay` from CLI reference (setup is the entry point)