### PR TITLE
refactor: simplify relay code

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -36,8 +36,6 @@ def main() -> None:
 @click.option("--relay", is_flag=True, help="Enable relay mode")
 def serve(host: str, port: int, relay: bool) -> None:
     """Start the repowire HTTP daemon."""
-    import getpass
-
     import uvicorn
 
     from repowire.config.models import load_config
@@ -47,22 +45,14 @@ def serve(host: str, port: int, relay: bool) -> None:
     if relay:
         config.relay.enabled = True
 
-    # Auto-generate relay key on first connect
-    if config.relay.enabled and not config.relay.api_key:
-        from repowire.relay.auth import generate_api_key
-
-        user_id = getpass.getuser()
-        api_key = generate_api_key(user_id)
-        config.relay.api_key = api_key.key
+    if config.relay.enabled:
+        config.relay.ensure_api_key()
         config.save()
-        console.print(f"[green]Generated relay key:[/] {api_key.key}")
 
     app = create_app(config=config)
     console.print(f"[cyan]Starting Repowire daemon on {host}:{port}...[/]")
-    if config.relay.enabled and config.relay.api_key:
-        relay_url = config.relay.url.replace("wss://", "https://").replace("/ws/relay", "")
-        dashboard_url = f"{relay_url}/d/{config.relay.api_key}/dashboard"
-        console.print(f"[green]Dashboard:[/] {dashboard_url}")
+    if config.relay.dashboard_url:
+        console.print(f"[green]Dashboard:[/] {config.relay.dashboard_url}")
     uvicorn.run(app, host=host, port=port, ws_ping_interval=None, ws_ping_timeout=None)
 
 
@@ -76,7 +66,6 @@ def serve(host: str, port: int, relay: bool) -> None:
 @click.option("--relay", is_flag=True, help="Enable hosted relay via repowire.io")
 def setup(no_service: bool, relay: bool) -> None:
     """One-time setup: install hooks/plugins, MCP server, and daemon service."""
-    import getpass
     import shutil
 
     _cleanup_legacy_artifacts()
@@ -103,18 +92,13 @@ def setup(no_service: bool, relay: bool) -> None:
     # Enable relay if requested
     if relay:
         from repowire.config.models import load_config
-        from repowire.relay.auth import generate_api_key
 
         config = load_config()
         config.relay.enabled = True
-        if not config.relay.api_key:
-            api_key = generate_api_key(getpass.getuser())
-            config.relay.api_key = api_key.key
+        config.relay.ensure_api_key()
         config.save()
-        relay_url = config.relay.url.replace("wss://", "https://")
-        dashboard_url = f"{relay_url}/d/{config.relay.api_key}/dashboard"
         console.print("[green]✓[/] Relay enabled")
-        console.print(f"  Dashboard: {dashboard_url}")
+        console.print(f"  Dashboard: {config.relay.dashboard_url}")
 
     # Install daemon as system service
     if not no_service:

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -35,6 +35,26 @@ class RelayConfig(BaseModel):
     url: str = Field(default="wss://relay.repowire.io", description="Relay server URL")
     api_key: str | None = Field(None, description="API key for authentication")
 
+    @property
+    def dashboard_url(self) -> str | None:
+        """Dashboard URL via the relay, or None if not configured."""
+        if not self.api_key:
+            return None
+        base = self.url.replace("wss://", "https://").replace("/ws/relay", "")
+        return f"{base}/d/{self.api_key}/dashboard"
+
+    def ensure_api_key(self) -> str:
+        """Generate and set API key if missing. Returns the key."""
+        if self.api_key:
+            return self.api_key
+        import getpass
+
+        from repowire.relay.auth import generate_api_key
+
+        key = generate_api_key(getpass.getuser())
+        self.api_key = key.key
+        return key.key
+
 
 class PeerConfig(BaseModel):
     """Configuration for a single peer.

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -32,27 +32,21 @@ logger = logging.getLogger(__name__)
 
 def create_app(
     config: Config | None = None,
-    relay_mode: bool = False,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
     Args:
         config: Optional configuration. Loaded from disk if not provided.
-        relay_mode: Enable relay mode for remote peer communication.
 
     Returns:
         Configured FastAPI application.
     """
-    _relay_mode = relay_mode
     _config = config
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         """Manage application startup and shutdown."""
         cfg = _config or load_config()
-
-        if _relay_mode:
-            cfg.relay.enabled = True
 
         # Build the component stack
         session_mapper = SessionMapper(persistence_path=Path.home() / ".repowire" / "sessions.json")
@@ -77,7 +71,7 @@ def create_app(
         app.state.query_tracker = query_tracker
         app.state.message_router = message_router
         app.state.peer_manager = peer_manager
-        app.state.relay_mode = _relay_mode or cfg.relay.enabled
+        app.state.relay_mode = cfg.relay.enabled
 
         await peer_manager.start()
         init_deps(cfg, peer_manager, app.state)
@@ -114,7 +108,7 @@ def create_app(
         "http://localhost:8377",
         "http://127.0.0.1:8377",
     ]
-    if _relay_mode or (_config and _config.relay.enabled):
+    if _config and _config.relay.enabled:
         cors_origins.extend(
             [
                 "https://repowire.io",

--- a/repowire/daemon/relay_client.py
+++ b/repowire/daemon/relay_client.py
@@ -39,6 +39,7 @@ class RelayClient:
         self._local_base_url = local_base_url
         self._ws: ClientConnection | None = None
         self._task: asyncio.Task[None] | None = None
+        self._http: httpx.AsyncClient | None = None
         self._stopping = False
 
     @property
@@ -52,12 +53,16 @@ class RelayClient:
             logger.info("Relay disabled or no API key — skipping relay client")
             return
         self._stopping = False
+        self._http = httpx.AsyncClient()
         self._task = asyncio.create_task(self._run_loop())
         logger.info("Relay client started (daemon_id=%s)", self._daemon_id)
 
     async def stop(self) -> None:
         """Gracefully disconnect."""
         self._stopping = True
+        if self._http:
+            await self._http.aclose()
+            self._http = None
         if self._ws:
             await self._ws.close()
             self._ws = None
@@ -171,8 +176,8 @@ class RelayClient:
         endpoint = endpoint_map[msg_type]
         payload = msg.get("payload", {})
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(f"{self._local_base_url}{endpoint}", json=payload)
+        assert self._http is not None
+        resp = await self._http.post(f"{self._local_base_url}{endpoint}", json=payload)
 
         response_body = (
             resp.json()
@@ -205,8 +210,8 @@ class RelayClient:
 
         content = base64.b64decode(body_b64) if body_b64 else None
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.request(method, url, headers=headers, content=content)
+        assert self._http is not None
+        resp = await self._http.request(method, url, headers=headers, content=content)
 
         resp_headers = dict(resp.headers)
         resp_body_b64 = base64.b64encode(resp.content).decode("ascii")

--- a/repowire/relay/auth.py
+++ b/repowire/relay/auth.py
@@ -23,13 +23,23 @@ class APIKey(BaseModel):
     name: str = Field(default="default", description="Key name/label")
 
 
+_cached_secret: str | None = None
+_cached_env_value: str | None = None
+
+
 def _get_secret() -> str:
-    """Return the HMAC signing secret from env, falling back to dev secret."""
-    secret = os.environ.get("REPOWIRE_RELAY_SECRET")
-    if not secret:
+    """Return the HMAC signing secret from env, falling back to dev secret. Cached."""
+    global _cached_secret, _cached_env_value
+    env_value = os.environ.get("REPOWIRE_RELAY_SECRET")
+    if _cached_secret is not None and env_value == _cached_env_value:
+        return _cached_secret
+    _cached_env_value = env_value
+    if not env_value:
         log.warning("REPOWIRE_RELAY_SECRET not set — using insecure dev secret")
-        return _DEV_SECRET
-    return secret
+        _cached_secret = _DEV_SECRET
+    else:
+        _cached_secret = env_value
+    return _cached_secret
 
 
 def _compute_signature(secret: str, user_id: str) -> str:

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -67,6 +67,14 @@ def _unregister(conn: DaemonConnection) -> None:
         keys.discard(key)
         if not keys:
             del _user_daemons[conn.user_id]
+    # Fail-fast any pending HTTP tunnel requests for this daemon
+    cancelled = 0
+    for req_id, future in list(_http_futures.items()):
+        if not future.done():
+            future.set_exception(ConnectionError("Daemon disconnected"))
+            cancelled += 1
+    if cancelled:
+        log.info("Cancelled %d pending tunnel requests for %s", cancelled, conn.daemon_id)
     log.info("Daemon disconnected: %s (user=%s)", conn.daemon_id, conn.user_id)
 
 
@@ -187,27 +195,16 @@ function go(e) {
 # ---------------------------------------------------------------------------
 
 
-async def _handle_relay_query(conn: DaemonConnection, msg: dict[str, Any]) -> None:
+async def _handle_targeted_forward(conn: DaemonConnection, msg: dict[str, Any]) -> None:
+    """Forward a message to a specific daemon by target_daemon_id."""
+    msg_type = msg.get("type", "?")
     target_id = msg.get("target_daemon_id")
     if not target_id:
-        log.warning("relay_query missing target_daemon_id from %s", conn.daemon_id)
+        log.warning("%s missing target_daemon_id from %s", msg_type, conn.daemon_id)
         return
     target = _get_daemon(conn.user_id, target_id)
     if not target:
-        log.warning("relay_query target %s not connected (user=%s)", target_id, conn.user_id)
-        return
-    msg["source_daemon_id"] = conn.daemon_id
-    await _forward_to_daemon(target, msg)
-
-
-async def _handle_relay_notify(conn: DaemonConnection, msg: dict[str, Any]) -> None:
-    target_id = msg.get("target_daemon_id")
-    if not target_id:
-        log.warning("relay_notify missing target_daemon_id from %s", conn.daemon_id)
-        return
-    target = _get_daemon(conn.user_id, target_id)
-    if not target:
-        log.warning("relay_notify target %s not connected (user=%s)", target_id, conn.user_id)
+        log.warning("%s target %s not connected (user=%s)", msg_type, target_id, conn.user_id)
         return
     msg["source_daemon_id"] = conn.daemon_id
     await _forward_to_daemon(target, msg)
@@ -220,19 +217,6 @@ async def _handle_relay_broadcast(conn: DaemonConnection, msg: dict[str, Any]) -
             await _forward_to_daemon(target, msg)
 
 
-async def _handle_relay_response(conn: DaemonConnection, msg: dict[str, Any]) -> None:
-    target_id = msg.get("target_daemon_id")
-    if not target_id:
-        log.warning("relay_response missing target_daemon_id from %s", conn.daemon_id)
-        return
-    target = _get_daemon(conn.user_id, target_id)
-    if not target:
-        log.warning("relay_response target %s not connected (user=%s)", target_id, conn.user_id)
-        return
-    msg["source_daemon_id"] = conn.daemon_id
-    await _forward_to_daemon(target, msg)
-
-
 async def _handle_http_response(msg: dict[str, Any]) -> None:
     request_id = msg.get("request_id")
     if not request_id:
@@ -243,10 +227,10 @@ async def _handle_http_response(msg: dict[str, Any]) -> None:
 
 
 _MSG_HANDLERS: dict[str, Any] = {
-    "relay_query": _handle_relay_query,
-    "relay_notify": _handle_relay_notify,
+    "relay_query": _handle_targeted_forward,
+    "relay_notify": _handle_targeted_forward,
     "relay_broadcast": _handle_relay_broadcast,
-    "relay_response": _handle_relay_response,
+    "relay_response": _handle_targeted_forward,
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Code review findings from /simplify on PRs #18, #20, #21. Net -3 lines.

- **Dedupe relay handlers**: `_handle_relay_query/notify/response` were identical — unified into `_handle_targeted_forward`
- **Reuse httpx client**: `relay_client.py` created a new `httpx.AsyncClient` per request — now a persistent instance attribute
- **Cache HMAC secret**: `_get_secret()` re-read env var on every auth call — now cached with invalidation on env change
- **Extract helpers**: dashboard URL construction and API key auto-generation duplicated in `serve` and `setup` — extracted to `RelayConfig.dashboard_url` property and `RelayConfig.ensure_api_key()` method
- **Remove `_relay_mode`**: redundant with `config.relay.enabled`, removed from `create_app`
- **Fail-fast orphaned tunnels**: `_unregister` now cancels pending `_http_futures` when a daemon disconnects instead of waiting 30s timeout