### PR TITLE
feat: server-issued tokens for relay auth

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -893,12 +893,11 @@ def relay_start(host: str, port: int) -> None:
 
 @relay.command(name="generate-key")
 @click.option("--user-id", default="default", help="User ID for the key")
-@click.option("--name", default="default", help="Key name/description")
-def relay_generate_key(user_id: str, name: str) -> None:
+def relay_generate_key(user_id: str) -> None:
     """Generate an API key for relay authentication."""
-    from repowire.relay.auth import generate_api_key
+    from repowire.relay.auth import register_token
 
-    api_key = generate_api_key(user_id, name)
+    api_key = register_token(user_id)
     console.print("[green]Generated API key:[/]")
     console.print(f"  {api_key.key}")
     console.print("")

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -44,16 +44,19 @@ class RelayConfig(BaseModel):
         return f"{base}/d/{self.api_key}/dashboard"
 
     def ensure_api_key(self) -> str:
-        """Generate and set API key if missing. Returns the key."""
+        """Register with relay and set API key if missing. Returns the key."""
         if self.api_key:
             return self.api_key
         import getpass
 
-        from repowire.relay.auth import generate_api_key
+        import httpx
 
-        key = generate_api_key(getpass.getuser())
-        self.api_key = key.key
-        return key.key
+        relay_http = self.url.replace("wss://", "https://")
+        user_id = getpass.getuser()
+        resp = httpx.post(f"{relay_http}/api/v1/register", json={"user_id": user_id})
+        resp.raise_for_status()
+        self.api_key = resp.json()["api_key"]
+        return self.api_key
 
 
 class PeerConfig(BaseModel):

--- a/repowire/relay/auth.py
+++ b/repowire/relay/auth.py
@@ -1,78 +1,45 @@
-"""Stateless HMAC-based API key authentication for the relay server."""
+"""Token-based authentication for the relay server.
+
+Tokens are server-issued random strings. The relay maintains an in-memory
+registry of valid tokens. Clients obtain tokens via POST /api/v1/register.
+"""
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
-import os
+import secrets
 
 from pydantic import BaseModel, Field
 
 log = logging.getLogger(__name__)
 
 API_KEY_PREFIX = "rw_"
-_DEV_SECRET = "repowire-dev-secret-do-not-use-in-production"
+TOKEN_BYTES = 24  # 32 chars base64url
 
 
 class APIKey(BaseModel):
-    """An API key for relay authentication."""
+    """A relay API key (token)."""
 
     key: str = Field(..., description="The full API key string")
     user_id: str = Field(..., description="User identifier")
-    name: str = Field(default="default", description="Key name/label")
 
 
-_cached_secret: str | None = None
-_cached_env_value: str | None = None
+# Server-side token registry: key -> APIKey
+_token_registry: dict[str, APIKey] = {}
 
 
-def _get_secret() -> str:
-    """Return the HMAC signing secret from env, falling back to dev secret. Cached."""
-    global _cached_secret, _cached_env_value
-    env_value = os.environ.get("REPOWIRE_RELAY_SECRET")
-    if _cached_secret is not None and env_value == _cached_env_value:
-        return _cached_secret
-    _cached_env_value = env_value
-    if not env_value:
-        log.warning("REPOWIRE_RELAY_SECRET not set — using insecure dev secret")
-        _cached_secret = _DEV_SECRET
-    else:
-        _cached_secret = env_value
-    return _cached_secret
-
-
-def _compute_signature(secret: str, user_id: str) -> str:
-    """HMAC-SHA256(secret, user_id), truncated to 16 hex chars."""
-    sig = hmac.new(secret.encode(), user_id.encode(), hashlib.sha256).hexdigest()
-    return sig[:16]
-
-
-def generate_api_key(user_id: str, name: str = "default") -> APIKey:
-    """Generate an API key: rw_{user_id}_{signature}."""
-    secret = _get_secret()
-    sig = _compute_signature(secret, user_id)
-    key = f"{API_KEY_PREFIX}{user_id}_{sig}"
-    return APIKey(key=key, user_id=user_id, name=name)
+def register_token(user_id: str) -> APIKey:
+    """Issue a new token for a user. If user already has one, return it."""
+    for api_key in _token_registry.values():
+        if api_key.user_id == user_id:
+            return api_key
+    token = f"{API_KEY_PREFIX}{secrets.token_urlsafe(TOKEN_BYTES)}"
+    api_key = APIKey(key=token, user_id=user_id)
+    _token_registry[token] = api_key
+    log.info("Registered token for user %s", user_id)
+    return api_key
 
 
 def validate_api_key(key: str) -> APIKey | None:
-    """Parse and validate an API key by recomputing the HMAC signature."""
-    if not key.startswith(API_KEY_PREFIX):
-        return None
-
-    body = key[len(API_KEY_PREFIX) :]
-    parts = body.rsplit("_", 1)
-    if len(parts) != 2:
-        return None
-
-    user_id, sig = parts
-    if not user_id or not sig:
-        return None
-
-    secret = _get_secret()
-    expected = _compute_signature(secret, user_id)
-    if not hmac.compare_digest(sig, expected):
-        return None
-
-    return APIKey(key=key, user_id=user_id)
+    """Validate a token against the registry."""
+    return _token_registry.get(key)

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -18,8 +18,9 @@ from uuid import uuid4
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, Response
+from pydantic import BaseModel
 
-from repowire.relay.auth import APIKey, validate_api_key
+from repowire.relay.auth import APIKey, register_token, validate_api_key
 
 log = logging.getLogger(__name__)
 
@@ -253,6 +254,16 @@ def create_app() -> FastAPI:
     @app.get("/health")
     async def health() -> dict[str, Any]:
         return {"status": "ok", "connected_daemons": len(_connections)}
+
+    # -- Registration --
+
+    class RegisterRequest(BaseModel):
+        user_id: str
+
+    @app.post("/api/v1/register")
+    async def register(req: RegisterRequest) -> dict[str, str]:
+        api_key = register_token(req.user_id)
+        return {"api_key": api_key.key, "user_id": api_key.user_id}
 
     # -- Connected daemons (authenticated) --
 

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,73 +1,46 @@
-from unittest.mock import patch
-
-from repowire.relay.auth import APIKey, generate_api_key, validate_api_key
+from repowire.relay.auth import APIKey, _token_registry, register_token, validate_api_key
 
 
 class TestRelayAuth:
-    def test_generate_api_key(self):
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "test-secret"}):
-            api_key = generate_api_key("user1", "test-key")
+    def setup_method(self):
+        _token_registry.clear()
 
-            assert api_key.key.startswith("rw_")
-            assert api_key.user_id == "user1"
-            assert api_key.name == "test-key"
-            assert "user1" in api_key.key
+    def test_register_token(self):
+        api_key = register_token("user1")
+        assert api_key.key.startswith("rw_")
+        assert api_key.user_id == "user1"
 
-    def test_validate_api_key(self):
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "test-secret"}):
-            generated = generate_api_key("user1", "test")
-            validated = validate_api_key(generated.key)
+    def test_register_returns_same_for_same_user(self):
+        k1 = register_token("user1")
+        k2 = register_token("user1")
+        assert k1.key == k2.key
 
-            assert validated is not None
-            assert validated.user_id == "user1"
-            assert validated.key == generated.key
+    def test_register_different_users_get_different_keys(self):
+        k1 = register_token("user1")
+        k2 = register_token("user2")
+        assert k1.key != k2.key
 
-    def test_validate_invalid_signature(self):
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "test-secret"}):
-            result = validate_api_key("rw_user1_0000000000000000")
-            assert result is None
+    def test_validate_registered_key(self):
+        registered = register_token("user1")
+        validated = validate_api_key(registered.key)
+        assert validated is not None
+        assert validated.user_id == "user1"
+        assert validated.key == registered.key
+
+    def test_validate_unknown_key(self):
+        result = validate_api_key("rw_doesnotexist")
+        assert result is None
 
     def test_validate_wrong_prefix(self):
-        result = validate_api_key("bad_user1_abc")
+        result = validate_api_key("bad_prefix_key")
         assert result is None
-
-    def test_validate_malformed_key(self):
-        result = validate_api_key("rw_nosignaturepart")
-        assert result is None
-
-    def test_different_secret_rejects(self):
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "secret-a"}):
-            generated = generate_api_key("user1")
-
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "secret-b"}):
-            result = validate_api_key(generated.key)
-            assert result is None
-
-    def test_dev_secret_fallback(self):
-        with patch.dict("os.environ", {}, clear=True):
-            api_key = generate_api_key("devuser")
-            validated = validate_api_key(api_key.key)
-
-            assert validated is not None
-            assert validated.user_id == "devuser"
 
     def test_api_key_model(self):
-        key = APIKey(key="rw_user1_abcdef0123456789", user_id="user1", name="test")
-        assert key.key == "rw_user1_abcdef0123456789"
-        assert key.name == "test"
+        key = APIKey(key="rw_test123", user_id="user1")
+        assert key.key == "rw_test123"
+        assert key.user_id == "user1"
 
-    def test_user_id_with_underscores(self):
-        """user_id containing underscores should work since we rsplit on last _."""
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "test-secret"}):
-            generated = generate_api_key("org_team_user")
-            validated = validate_api_key(generated.key)
-
-            assert validated is not None
-            assert validated.user_id == "org_team_user"
-
-    def test_deterministic(self):
-        """Same secret + user_id always produces the same key."""
-        with patch.dict("os.environ", {"REPOWIRE_RELAY_SECRET": "test-secret"}):
-            k1 = generate_api_key("user1")
-            k2 = generate_api_key("user1")
-            assert k1.key == k2.key
+    def test_token_length(self):
+        api_key = register_token("user1")
+        # rw_ prefix + 32 chars of base64url
+        assert len(api_key.key) > 20


### PR DESCRIPTION
## Summary

Replace HMAC-based auth with server-issued random tokens. Fixes the broken flow where local setup generates keys with a dev secret that doesn't match the production relay.

**Before:** Client generates HMAC key locally → needs same secret as server → broken for hosted relay
**After:** Client calls `POST /api/v1/register` on relay → server issues random token → works for everyone

- `POST /api/v1/register` — server generates `rw_` + 32 chars of `secrets.token_urlsafe`
- Same user_id always returns same token (idempotent)
- `repowire setup --relay` and `repowire serve --relay` call the register endpoint
- No shared secret needed between client and server
- Removed `REPOWIRE_RELAY_SECRET` env var, HMAC logic, dev secret fallback

## Test plan

- [x] 101 tests pass
- [ ] Deploy relay with register endpoint
- [ ] `repowire setup --relay` gets a valid token from relay.repowire.io
- [ ] Token works for WebSocket connect and HTTP tunnel