### PR TITLE
test: add unit tests for protocol/peers.py

### DIFF
--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -85,6 +85,8 @@ class TestToDict:
         assert d["name"] == "dev"  # backward compat alias
         assert d["path"] == "/app"
         assert d["machine"] == "laptop"
+        assert d["tmux_session"] is None
+        assert d["backend"] == AgentType.CLAUDE_CODE
         assert d["description"] == "doing stuff"
         assert d["circle"] == "global"
         assert d["status"] == "offline"
@@ -120,13 +122,12 @@ class TestLegacyFields:
         peer = Peer(name="legacy-peer", path="/app", machine="host")
         assert peer.peer_id == "legacy-legacy-peer"
 
-    def test_peer_id_generated_from_tmux_session_when_no_name(self):
+    def test_peer_id_generated_from_tmux_session_priority(self):
         peer = Peer(
             display_name="x", path="/app", machine="host", tmux_session="dev:main"
         )
-        # peer_id should be provided or auto-generated from tmux_session
-        # In this case display_name is provided so peer_id generated from it
-        assert "x" in peer.peer_id or "dev:main" in peer.peer_id
+        # tmux_session has priority over display_name for legacy peer_id generation
+        assert peer.peer_id == "legacy-dev:main"
 
 
 class TestIsLocal:

--- a/tests/test_peers.py
+++ b/tests/test_peers.py
@@ -1,0 +1,139 @@
+"""Tests for repowire/protocol/peers.py — Peer model helpers."""
+
+from datetime import datetime
+
+from repowire.config.models import AgentType
+from repowire.protocol.peers import Peer, PeerRole, PeerStatus
+
+
+def _make_peer(**kwargs) -> Peer:
+    defaults = dict(peer_id="repow-dev-a1b2c3d4", display_name="dev", path="/app", machine="laptop")
+    defaults.update(kwargs)
+    return Peer(**defaults)
+
+
+class TestBackendHelpers:
+    def test_is_claude_code(self):
+        peer = _make_peer(backend=AgentType.CLAUDE_CODE)
+        assert peer.is_claude_code()
+        assert not peer.is_opencode()
+        assert not peer.is_codex()
+        assert not peer.is_gemini()
+
+    def test_is_opencode(self):
+        peer = _make_peer(backend=AgentType.OPENCODE)
+        assert peer.is_opencode()
+        assert not peer.is_claude_code()
+
+    def test_is_codex(self):
+        peer = _make_peer(backend=AgentType.CODEX)
+        assert peer.is_codex()
+        assert not peer.is_claude_code()
+
+    def test_is_gemini(self):
+        peer = _make_peer(backend=AgentType.GEMINI)
+        assert peer.is_gemini()
+        assert not peer.is_claude_code()
+
+    def test_default_backend_is_claude_code(self):
+        peer = _make_peer()
+        assert peer.is_claude_code()
+
+
+class TestPeerStatus:
+    def test_default_status_is_offline(self):
+        peer = _make_peer()
+        assert peer.status == PeerStatus.OFFLINE
+
+    def test_explicit_status(self):
+        peer = _make_peer(status=PeerStatus.ONLINE)
+        assert peer.status == PeerStatus.ONLINE
+
+    def test_busy_status(self):
+        peer = _make_peer(status=PeerStatus.BUSY)
+        assert peer.status == PeerStatus.BUSY
+
+
+class TestPeerRole:
+    def test_default_role_is_agent(self):
+        peer = _make_peer()
+        assert peer.role == PeerRole.AGENT
+
+    def test_agent_does_not_bypass_circles(self):
+        peer = _make_peer(role=PeerRole.AGENT)
+        assert not peer.bypasses_circles
+
+    def test_service_bypasses_circles(self):
+        peer = _make_peer(role=PeerRole.SERVICE)
+        assert peer.bypasses_circles
+
+    def test_orchestrator_bypasses_circles(self):
+        peer = _make_peer(role=PeerRole.ORCHESTRATOR)
+        assert peer.bypasses_circles
+
+    def test_human_bypasses_circles(self):
+        peer = _make_peer(role=PeerRole.HUMAN)
+        assert peer.bypasses_circles
+
+
+class TestToDict:
+    def test_includes_all_fields(self):
+        peer = _make_peer(description="doing stuff")
+        d = peer.to_dict()
+        assert d["peer_id"] == "repow-dev-a1b2c3d4"
+        assert d["display_name"] == "dev"
+        assert d["name"] == "dev"  # backward compat alias
+        assert d["path"] == "/app"
+        assert d["machine"] == "laptop"
+        assert d["description"] == "doing stuff"
+        assert d["circle"] == "global"
+        assert d["status"] == "offline"
+        assert d["role"] == "agent"
+        assert d["last_seen"] is None
+        assert d["metadata"] == {}
+
+    def test_status_serialized_as_string(self):
+        peer = _make_peer(status=PeerStatus.ONLINE)
+        assert peer.to_dict()["status"] == "online"
+
+    def test_role_serialized_as_string(self):
+        peer = _make_peer(role=PeerRole.ORCHESTRATOR)
+        assert peer.to_dict()["role"] == "orchestrator"
+
+    def test_last_seen_serialized_as_isoformat(self):
+        ts = datetime(2025, 1, 15, 12, 0, 0)
+        peer = _make_peer(last_seen=ts)
+        assert peer.to_dict()["last_seen"] == ts.isoformat()
+
+    def test_metadata_included(self):
+        peer = _make_peer(metadata={"env": "prod", "version": "1.2"})
+        assert peer.to_dict()["metadata"] == {"env": "prod", "version": "1.2"}
+
+
+class TestLegacyFields:
+    def test_name_maps_to_display_name(self):
+        peer = Peer(name="legacy-peer", path="/app", machine="host")
+        assert peer.display_name == "legacy-peer"
+        assert peer.name == "legacy-peer"
+
+    def test_peer_id_generated_from_name_when_missing(self):
+        peer = Peer(name="legacy-peer", path="/app", machine="host")
+        assert peer.peer_id == "legacy-legacy-peer"
+
+    def test_peer_id_generated_from_tmux_session_when_no_name(self):
+        peer = Peer(
+            display_name="x", path="/app", machine="host", tmux_session="dev:main"
+        )
+        # peer_id should be provided or auto-generated from tmux_session
+        # In this case display_name is provided so peer_id generated from it
+        assert "x" in peer.peer_id or "dev:main" in peer.peer_id
+
+
+class TestIsLocal:
+    def test_local_when_tmux_session_set(self):
+        peer = _make_peer(tmux_session="dev:claude")
+        assert peer.is_local()
+
+    def test_not_local_when_no_tmux_session(self):
+        peer = _make_peer()
+        assert not peer.is_local()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -6,49 +6,6 @@ from repowire.protocol.messages import (
     QueryMessage,
     ResponseMessage,
 )
-from repowire.protocol.peers import Peer, PeerStatus
-
-
-class TestPeer:
-    def test_create_peer(self):
-        peer = Peer(
-            name="backend",
-            path="/app/backend",
-            machine="laptop",
-            tmux_session="claude-backend",
-        )
-
-        assert peer.name == "backend"
-        assert peer.path == "/app/backend"
-        assert peer.machine == "laptop"
-        assert peer.tmux_session == "claude-backend"
-        assert peer.status == PeerStatus.OFFLINE
-        assert peer.is_local() is True
-
-    def test_peer_to_dict(self):
-        peer = Peer(
-            name="frontend",
-            path="/app/frontend",
-            machine="desktop",
-            status=PeerStatus.ONLINE,
-        )
-
-        data = peer.to_dict()
-
-        assert data["name"] == "frontend"
-        assert data["status"] == "online"
-        assert data["tmux_session"] is None
-
-    def test_peer_from_constructor_with_legacy_fields(self):
-        peer = Peer(
-            name="api",
-            path="/app/api",
-            machine="server",
-            status=PeerStatus.BUSY,
-        )
-
-        assert peer.name == "api"
-        assert peer.status == PeerStatus.BUSY
 
 
 class TestMessages:


### PR DESCRIPTION
Closes #44

## What

Adds `tests/test_peers.py` with 23 unit tests covering the `Peer` model helpers in `repowire/protocol/peers.py`.

## Coverage

- `is_claude_code()`, `is_opencode()`, `is_codex()`, `is_gemini()` — correct backend detection, mutually exclusive
- `PeerStatus` defaults and explicit values
- `PeerRole` + `bypasses_circles` — agent does not bypass, service/orchestrator/human do
- `to_dict()` — all fields present, enums serialized as strings, `last_seen` as ISO format
- Legacy field handling (`name` → `display_name`, auto-generated `peer_id`)
- `is_local()` based on `tmux_session` presence

All 23 tests pass.