### PR TITLE
feat: hide offline peers by default in peer list

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -909,13 +909,15 @@ def _get_daemon_url() -> str:
 
 
 @peer.command(name="list")
-def peer_list() -> None:
+@click.option("--show-offline", "-a", is_flag=True, help="Include offline peers")
+def peer_list(show_offline: bool) -> None:
     """List all registered peers and their status."""
     import httpx
 
     try:
+        params = None if show_offline else {"status": "online"}
         with httpx.Client(timeout=5.0) as client:
-            resp = client.get(f"{_get_daemon_url()}/peers")
+            resp = client.get(f"{_get_daemon_url()}/peers", params=params)
             resp.raise_for_status()
             peers = resp.json().get("peers", [])
     except httpx.ConnectError:

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -12,7 +12,7 @@ from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
-from repowire.protocol.peers import Peer, PeerRole
+from repowire.protocol.peers import Peer, PeerRole, PeerStatus
 
 router = APIRouter(tags=["peers"])
 
@@ -90,12 +90,19 @@ class UnregisterPeerRequest(BaseModel):
 
 @router.get("/peers", response_model=PeersResponse)
 async def list_peers(
+    status: str | None = Query(None, description="Filter by status (online, offline)"),
     _: str | None = Depends(require_auth),
 ) -> PeersResponse:
-    """Get list of all registered peers."""
+    """Get list of all registered peers, optionally filtered by status."""
     peer_registry = get_peer_registry()
     await peer_registry.lazy_repair()
     peers = await peer_registry.get_all_peers()
+
+    if status == "online":
+        peers = [p for p in peers if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)]
+    elif status == "offline":
+        peers = [p for p in peers if p.status == PeerStatus.OFFLINE]
+
     return PeersResponse(peers=[_peer_to_info(p) for p in peers])
 
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -90,7 +90,7 @@ class UnregisterPeerRequest(BaseModel):
 
 @router.get("/peers", response_model=PeersResponse)
 async def list_peers(
-    status: str | None = Query(None, description="Filter by status (online, offline)"),
+    status: str | None = Query(None, description="Filter by status", enum=["online", "offline"]),
     _: str | None = Depends(require_auth),
 ) -> PeersResponse:
     """Get list of all registered peers, optionally filtered by status."""

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -37,14 +37,16 @@ def _get_http_client() -> httpx.AsyncClient:
     return _http_client
 
 
-async def daemon_request(method: str, path: str, body: dict | None = None) -> dict:
+async def daemon_request(
+    method: str, path: str, body: dict | None = None, params: dict | None = None
+) -> dict:
     """Make an HTTP request to the daemon."""
     global _http_client
     try:
         client = _get_http_client()
         url = f"{DAEMON_URL}{path}"
         if method == "GET":
-            resp = await client.get(url)
+            resp = await client.get(url, params=params)
         else:
             resp = await client.post(url, json=body or {})
         resp.raise_for_status()
@@ -165,16 +167,20 @@ def create_mcp_server() -> FastMCP:
         )
 
     @mcp.tool()
-    async def list_peers() -> str:
+    async def list_peers(show_offline: bool = False) -> str:
         """[Repowire mesh] List all peers across projects and machines.
 
-        Returns TSV: peer_id, name, project, circle, status, path, machine, description.
+        By default shows only online/busy peers. Set show_offline=True to include
+        offline peers.
+
+        Returns TSV: peer_id, name, project, circle, status, path, machine, description, backend.
         These are cross-project peers reachable via ask_peer/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
         """
         await _ensure_registered()
-        result = await daemon_request("GET", "/peers")
+        params = None if show_offline else {"status": "online"}
+        result = await daemon_request("GET", "/peers", params=params)
         peers = result.get("peers", [])
         rows = [tsv_header]
         for p in peers:

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -173,8 +173,8 @@ def create_mcp_server() -> FastMCP:
         By default shows only online/busy peers. Set show_offline=True to include
         offline peers.
 
-        Returns TSV: peer_id, name, project, circle, status, path, machine, description, backend.
-        These are cross-project peers reachable via ask_peer/notify_peer. Do NOT
+        Returns TSV: peer_id, name, project, circle, role, status, path, machine,
+        description, backend. Peers are reachable via ask_peer/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
         """

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 """Tests for daemon HTTP routes (peers, messages, events)."""
 
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -33,6 +34,8 @@ def _make_test_app(tmp_path: Path):
     # Override events path to avoid loading real events
     registry._events_path = tmp_path / "events.json"
     registry._events.clear()
+    # Disable lazy_repair's demote logic (no WS in tests would mark all peers offline)
+    registry._last_repair = time.monotonic() + 3600
 
     app_state = SimpleNamespace(
         config=cfg,
@@ -172,6 +175,42 @@ class TestPeers:
         r = await client.get("/peers")
         names = [p["display_name"] for p in r.json()["peers"]]
         assert names.count(name) == 1
+
+    async def test_list_peers_status_filter(self, client):
+        r = await client.post("/peers", json={
+            "name": "onlinepeer",
+            "path": "/tmp/onlinepeer",
+            "circle": "default",
+            "backend": "claude-code",
+        })
+        online_name = r.json()["display_name"]
+
+        r = await client.post("/peers", json={
+            "name": "offlinepeer",
+            "path": "/tmp/offlinepeer",
+            "circle": "default",
+            "backend": "claude-code",
+        })
+        offline_name = r.json()["display_name"]
+
+        r = await client.post("/session/update", json={
+            "peer_name": offline_name,
+            "status": "offline",
+        })
+        assert r.status_code == 200
+
+        r = await client.get("/peers")
+        assert len(r.json()["peers"]) == 2
+
+        r = await client.get("/peers", params={"status": "online"})
+        peers = r.json()["peers"]
+        assert len(peers) == 1
+        assert peers[0]["display_name"] == online_name
+
+        r = await client.get("/peers", params={"status": "offline"})
+        peers = r.json()["peers"]
+        assert len(peers) == 1
+        assert peers[0]["display_name"] == offline_name
 
 
 # -- Events --


### PR DESCRIPTION
## Summary

Closes #65

- Add `status` query param to `/peers` endpoint (`online` or `offline`)
- Default `list_peers` MCP tool to show only online/busy peers (`show_offline=True` for all)
- Add `--show-offline / -a` flag to `repowire peer list` CLI

## Test plan

- [x] `pytest tests/test_routes.py::TestPeers` passes
- [x] `repowire peer list` shows only online peers
- [x] `repowire peer list --show-offline` shows all peers
- [x] MCP `list_peers()` returns online only, `list_peers(show_offline=True)` returns all