### PR TITLE
fix: MCP identity mismatch and window rename propagation

### DIFF
--- a/repowire/daemon/lifecycle_handler.py
+++ b/repowire/daemon/lifecycle_handler.py
@@ -103,26 +103,17 @@ class LifecycleHandler:
     async def handle_window_renamed(
         self, session_name: str, new_name: str, pane_ids: list[str],
     ) -> int:
-        """Update display name for peers identified by their pane IDs.
+        """No-op. Window renames must not rewrite peer display_name.
 
-        Returns number of peers updated.
+        Why: Renaming would strip the backend suffix (e.g. -claude-code, -codex)
+        and create name collisions across backends sharing the same pane group.
+        Session registration is the sole source of peer naming.
         """
-        async def _rename(pane_id: str) -> bool:
-            peer = await self._registry.get_peer_by_pane(pane_id)
-            if peer and peer.display_name != new_name:
-                ok = await self._registry.update_peer_display_name(
-                    peer.peer_id, new_name,
-                )
-                if ok:
-                    logger.info(
-                        "window_renamed: %s → %s in circle %s",
-                        peer.display_name, new_name, session_name,
-                    )
-                return ok
-            return False
-
-        results = await asyncio.gather(*(_rename(pid) for pid in pane_ids))
-        return sum(results)
+        logger.debug(
+            "window_renamed ignored: session=%s new_name=%s panes=%d",
+            session_name, new_name, len(pane_ids),
+        )
+        return 0
 
     async def handle_client_detached(self, session_name: str) -> None:
         """Log client detach. No state change for now."""

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import socket
 from typing import Any
@@ -107,22 +108,19 @@ async def list_peers(
         peers = [p for p in peers if p.status == PeerStatus.OFFLINE]
     if path:
         # Normalize symlinks so registrations using different path forms still match.
-        # Cache realpath per unique stored path; only resolve when string equality fails.
-        target = os.path.realpath(path)
-        realpath_cache: dict[str, str] = {}
+        # realpath is blocking I/O; resolve every unique path once in a thread.
+        string_matches = [p for p in peers if p.path == path]
+        mismatched = [p for p in peers if p.path and p.path != path]
 
-        def _matches(p: Peer) -> bool:
-            if not p.path:
-                return False
-            if p.path == path:
-                return True
-            resolved = realpath_cache.get(p.path)
-            if resolved is None:
-                resolved = os.path.realpath(p.path)
-                realpath_cache[p.path] = resolved
-            return resolved == target
+        def _resolve_all(paths: list[str]) -> dict[str, str]:
+            unique = {p: os.path.realpath(p) for p in set(paths)}
+            return unique
 
-        peers = [p for p in peers if _matches(p)]
+        target, resolved_map = await asyncio.gather(
+            asyncio.to_thread(os.path.realpath, path),
+            asyncio.to_thread(_resolve_all, [p.path for p in mismatched]),
+        )
+        peers = string_matches + [p for p in mismatched if resolved_map.get(p.path) == target]
     if backend:
         peers = [p for p in peers if p.backend == backend]
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -90,11 +90,16 @@ class UnregisterPeerRequest(BaseModel):
 
 
 
+def _resolve_realpath_map(paths: list[str]) -> dict[str, str]:
+    """Resolve realpath for each unique path. Blocking I/O - run in thread."""
+    return {p: os.path.realpath(p) for p in set(paths)}
+
+
 @router.get("/peers", response_model=PeersResponse)
 async def list_peers(
     status: str | None = Query(None, description="Filter by status", enum=["online", "offline"]),
     path: str | None = Query(None, description="Filter by absolute path"),
-    backend: str | None = Query(None, description="Filter by backend"),
+    backend: AgentType | None = Query(None, description="Filter by backend"),
     _: str | None = Depends(require_auth),
 ) -> PeersResponse:
     """Get list of all registered peers, optionally filtered."""
@@ -111,14 +116,9 @@ async def list_peers(
         # realpath is blocking I/O; resolve every unique path once in a thread.
         string_matches = [p for p in peers if p.path == path]
         mismatched = [p for p in peers if p.path and p.path != path]
-
-        def _resolve_all(paths: list[str]) -> dict[str, str]:
-            unique = {p: os.path.realpath(p) for p in set(paths)}
-            return unique
-
         target, resolved_map = await asyncio.gather(
             asyncio.to_thread(os.path.realpath, path),
-            asyncio.to_thread(_resolve_all, [p.path for p in mismatched]),
+            asyncio.to_thread(_resolve_realpath_map, [p.path for p in mismatched]),
         )
         peers = string_matches + [p for p in mismatched if resolved_map.get(p.path) == target]
     if backend:

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -91,9 +91,11 @@ class UnregisterPeerRequest(BaseModel):
 @router.get("/peers", response_model=PeersResponse)
 async def list_peers(
     status: str | None = Query(None, description="Filter by status", enum=["online", "offline"]),
+    path: str | None = Query(None, description="Filter by absolute path"),
+    backend: str | None = Query(None, description="Filter by backend"),
     _: str | None = Depends(require_auth),
 ) -> PeersResponse:
-    """Get list of all registered peers, optionally filtered by status."""
+    """Get list of all registered peers, optionally filtered."""
     peer_registry = get_peer_registry()
     await peer_registry.lazy_repair()
     peers = await peer_registry.get_all_peers()
@@ -102,6 +104,10 @@ async def list_peers(
         peers = [p for p in peers if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)]
     elif status == "offline":
         peers = [p for p in peers if p.status == PeerStatus.OFFLINE]
+    if path:
+        peers = [p for p in peers if p.path == path]
+    if backend:
+        peers = [p for p in peers if p.backend == backend]
 
     return PeersResponse(peers=[_peer_to_info(p) for p in peers])
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -106,12 +106,23 @@ async def list_peers(
     elif status == "offline":
         peers = [p for p in peers if p.status == PeerStatus.OFFLINE]
     if path:
-        # Normalize symlinks so registrations using different path forms still match
+        # Normalize symlinks so registrations using different path forms still match.
+        # Cache realpath per unique stored path; only resolve when string equality fails.
         target = os.path.realpath(path)
-        peers = [
-            p for p in peers
-            if p.path and (p.path == path or os.path.realpath(p.path) == target)
-        ]
+        realpath_cache: dict[str, str] = {}
+
+        def _matches(p: Peer) -> bool:
+            if not p.path:
+                return False
+            if p.path == path:
+                return True
+            resolved = realpath_cache.get(p.path)
+            if resolved is None:
+                resolved = os.path.realpath(p.path)
+                realpath_cache[p.path] = resolved
+            return resolved == target
+
+        peers = [p for p in peers if _matches(p)]
     if backend:
         peers = [p for p in peers if p.backend == backend]
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import socket
 from typing import Any
 
@@ -105,7 +106,12 @@ async def list_peers(
     elif status == "offline":
         peers = [p for p in peers if p.status == PeerStatus.OFFLINE]
     if path:
-        peers = [p for p in peers if p.path == path]
+        # Normalize symlinks so registrations using different path forms still match
+        target = os.path.realpath(path)
+        peers = [
+            p for p in peers
+            if p.path and (p.path == path or os.path.realpath(p.path) == target)
+        ]
     if backend:
         peers = [p for p in peers if p.backend == backend]
 

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -127,11 +127,17 @@ async def _ensure_registered() -> None:
 
     backend = _detect_backend()
 
+    try:
+        cwd = Path.cwd()
+    except OSError as e:
+        logger.warning("Cannot resolve cwd for MCP registration: %s", e)
+        return
+
     # Last-resort identity resolution: find hook-registered peer by path+backend.
     # Avoids creating a duplicate when MCP subprocess lacks tmux env vars.
     try:
         result = await daemon_request("GET", "/peers", params={
-            "path": str(Path.cwd()),
+            "path": str(cwd),
             "backend": backend,
             "status": "online",
         })
@@ -151,8 +157,8 @@ async def _ensure_registered() -> None:
 
     try:
         body: dict = {
-            "name": Path.cwd().name,
-            "path": str(Path.cwd()),
+            "name": cwd.name,
+            "path": str(cwd),
             "circle": tmux_info["session_name"] or "default",
             "backend": backend,
         }

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -84,6 +84,15 @@ async def _get_my_peer_name() -> str:
     return _cached_peer_name
 
 
+def _detect_backend() -> str:
+    """Detect which agent runtime is hosting this MCP server."""
+    if os.environ.get("GEMINI_CLI"):
+        return "gemini"
+    if ".codex/" in os.environ.get("PATH", ""):
+        return "codex"
+    return os.environ.get("REPOWIRE_BACKEND", "claude-code")
+
+
 async def _ensure_registered() -> None:
     """Lazy-register this peer with the daemon on first MCP tool use.
 
@@ -116,13 +125,30 @@ async def _ensure_registered() -> None:
         except Exception:
             pass
 
-    # Detect backend from env set by each agent runtime
-    if os.environ.get("GEMINI_CLI"):
-        backend = "gemini"
-    elif ".codex/" in os.environ.get("PATH", ""):
-        backend = "codex"
-    else:
-        backend = os.environ.get("REPOWIRE_BACKEND", "claude-code")
+    backend = _detect_backend()
+
+    # Last-resort identity resolution: find hook-registered peer by path+backend.
+    # Avoids creating a duplicate when MCP subprocess lacks tmux env vars.
+    try:
+        result = await daemon_request("GET", "/peers", params={
+            "path": str(Path.cwd()),
+            "backend": backend,
+            "status": "online",
+        })
+        candidates = result.get("peers", [])
+        if candidates:
+            candidates.sort(
+                key=lambda p: (bool(p.get("tmux_session")), p.get("last_seen") or ""),
+                reverse=True,
+            )
+            assigned = candidates[0].get("display_name")
+            if assigned:
+                _cached_peer_name = assigned
+                _registered = True
+                return
+    except Exception:
+        pass
+
     try:
         body: dict = {
             "name": Path.cwd().name,

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -157,7 +157,7 @@ async def _ensure_registered() -> None:
 
     try:
         body: dict = {
-            "name": cwd.name,
+            "name": cwd.name or "root",
             "path": str(cwd),
             "circle": tmux_info["session_name"] or "default",
             "backend": backend,

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -146,8 +146,8 @@ async def _ensure_registered() -> None:
                 _cached_peer_name = assigned
                 _registered = True
                 return
-    except Exception:
-        pass
+    except (DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError) as e:
+        logger.debug("Path+backend peer lookup failed: %s", e)
 
     try:
         body: dict = {

--- a/tests/test_lifecycle_routes.py
+++ b/tests/test_lifecycle_routes.py
@@ -210,7 +210,8 @@ class TestSessionRenamed:
 
 
 class TestWindowRenamed:
-    async def test_updates_display_name(self, client_and_registry):
+    async def test_does_not_update_display_name(self, client_and_registry):
+        """Window renames must not rewrite peer display_name (would strip backend suffix)."""
         client, registry = client_and_registry
         peer = _make_peer(display_name="old-window", circle="alpha", pane_id="%5")
         await registry.register_peer(peer)
@@ -226,7 +227,7 @@ class TestWindowRenamed:
         assert r.status_code == 200
 
         result = await registry.get_peer(peer.peer_id)
-        assert result.display_name == "new-window"
+        assert result.display_name == "old-window"
 
 
 # -- client-detached --

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -212,6 +212,37 @@ class TestPeers:
         assert len(peers) == 1
         assert peers[0]["display_name"] == offline_name
 
+    async def test_list_peers_path_backend_filter(self, client):
+        await client.post("/peers", json={
+            "name": "alpha", "path": "/tmp/proj-x",
+            "circle": "default", "backend": "claude-code",
+        })
+        await client.post("/peers", json={
+            "name": "beta", "path": "/tmp/proj-x",
+            "circle": "default", "backend": "codex",
+        })
+        await client.post("/peers", json={
+            "name": "gamma", "path": "/tmp/proj-y",
+            "circle": "default", "backend": "claude-code",
+        })
+
+        r = await client.get("/peers", params={"path": "/tmp/proj-x"})
+        assert {p["backend"] for p in r.json()["peers"]} == {"claude-code", "codex"}
+        assert all(p["path"] == "/tmp/proj-x" for p in r.json()["peers"])
+
+        r = await client.get("/peers", params={"backend": "codex"})
+        peers = r.json()["peers"]
+        assert len(peers) == 1
+        assert peers[0]["backend"] == "codex"
+
+        r = await client.get(
+            "/peers", params={"path": "/tmp/proj-x", "backend": "claude-code"},
+        )
+        peers = r.json()["peers"]
+        assert len(peers) == 1
+        assert peers[0]["path"] == "/tmp/proj-x"
+        assert peers[0]["backend"] == "claude-code"
+
 
 # -- Events --
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -212,6 +212,22 @@ class TestPeers:
         assert len(peers) == 1
         assert peers[0]["display_name"] == offline_name
 
+    async def test_list_peers_path_filter_follows_symlinks(self, client, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        await client.post("/peers", json={
+            "name": "viasymlink", "path": str(link),
+            "circle": "default", "backend": "claude-code",
+        })
+
+        r = await client.get("/peers", params={"path": str(real)})
+        peers = r.json()["peers"]
+        assert len(peers) == 1
+        assert peers[0]["backend"] == "claude-code"
+
     async def test_list_peers_path_backend_filter(self, client):
         await client.post("/peers", json={
             "name": "alpha", "path": "/tmp/proj-x",

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -486,16 +486,17 @@ class TestMcpRegistration:
         mcp_server._registered = False
         mcp_server._cached_peer_name = None
         mock_request.side_effect = [
-            Exception("not found"),
-            {"display_name": "repowire-codex"},
+            Exception("not found"),  # /peers/by-pane lookup
+            {"peers": []},  # /peers?path&backend fallback
+            {"display_name": "repowire-codex"},  # POST /peers
         ]
 
         with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
             await mcp_server._ensure_registered()
 
-        assert mock_request.await_count == 2
+        assert mock_request.await_count == 3
         assert mock_request.await_args_list[0].args == ("GET", "/peers/by-pane/%251")
-        assert mock_request.await_args_list[1].args == (
+        assert mock_request.await_args_list[2].args == (
             "POST",
             "/peers",
             {
@@ -507,6 +508,43 @@ class TestMcpRegistration:
             },
         )
         assert mcp_server._cached_peer_name == "repowire-codex"
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.get_pane_id", return_value=None)
+    @patch(
+        "repowire.mcp.server.get_tmux_info",
+        return_value={"pane_id": None, "session_name": None, "window_name": None},
+    )
+    async def test_lazy_registration_adopts_existing_peer_by_path_backend(
+        self, _mock_tmux, _mock_pane, mock_request: AsyncMock,
+    ) -> None:
+        """When pane lookup fails, MCP should adopt hook-registered peer matching path+backend."""
+        import repowire.mcp.server as mcp_server
+
+        mcp_server._registered = False
+        mcp_server._cached_peer_name = None
+        mock_request.side_effect = [
+            Exception("name lookup fails"),  # GET /peers/<cwd-name>
+            {"peers": [{"display_name": "torale-seo", "tmux_session": "0:0"}]},
+        ]
+
+        with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
+            await mcp_server._ensure_registered()
+
+        assert mcp_server._cached_peer_name == "torale-seo"
+        assert mcp_server._registered is True
+        # Should NOT have made a POST to register a duplicate peer
+        post_calls = [c for c in mock_request.await_args_list if c.args[0] == "POST"]
+        assert len(post_calls) == 0
+        # Path+backend query should have been made
+        get_calls = [c for c in mock_request.await_args_list if c.args[0] == "GET"]
+        path_backend_call = next(
+            (c for c in get_calls if c.args[1] == "/peers" and "params" in c.kwargs),
+            None,
+        )
+        assert path_backend_call is not None
+        assert path_backend_call.kwargs["params"]["backend"] == "codex"
 
         mcp_server._registered = False
         mcp_server._cached_peer_name = None


### PR DESCRIPTION
## Summary

Fixes two peer identity bugs that caused messaging failures across agents in the same tmux session.

### Bug 1: MCP creates duplicate peer in `default` circle

MCP subprocess doesn't inherit `TMUX`/`TMUX_PANE` env vars from the agent CLI. Lazy registration then:
1. Fails pane lookup (no pane_id)
2. Fails name lookup (folder name ≠ hook-registered display_name)
3. Registers duplicate peer with `circle: "default"`

Meanwhile the hook registered correctly in circle `0`. MCP caches the wrong identity, so `ask_peer`/`notify_peer` fail the circle boundary check.

**Fix:** Before registering, MCP queries `GET /peers?path=...&backend=...` to find the hook-registered peer and adopts its identity. Requires new `path` and `backend` query params on the `/peers` endpoint.

### Bug 2: Window rename strips backend suffix

`handle_window_renamed` rewrote `peer.display_name = new_window_name`, stripping `-codex`/`-gemini`/`-claude-code` suffixes. Created three peers named `torale-seo` with different backends, making name-based routing ambiguous.

**Fix:** No-op `handle_window_renamed`. Session registration is the sole naming authority.

## Test plan

- [x] `pytest` - all 290 tests pass
- [x] `ruff check` and `ty check` pass
- [x] New unit test: MCP adopts existing peer by path+backend when pane lookup fails
- [x] Updated lifecycle test: window rename no longer updates display_name
- [x] Live test: `GET /peers?path=...&backend=...` returns filtered peers