### PR TITLE
fix(hooks): use pooled httpx client to prevent loopback port exhaustion

### DIFF
--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import sys
-import urllib.error
-import urllib.request
 from contextlib import suppress
 from pathlib import Path
+
+import httpx
 
 from repowire.config.models import DEFAULT_DAEMON_URL
 
 DAEMON_URL = os.environ.get("REPOWIRE_DAEMON_URL", DEFAULT_DAEMON_URL)
+
+# Module-level pooled HTTP client so sequential daemon calls within one hook
+# process reuse the same TCP connection via keep-alive. Previously each
+# urllib.request.urlopen() call opened a fresh socket, leaving TIME_WAIT
+# accumulation heavy enough under multi-session Claude Code workloads to
+# exhaust the macOS ephemeral port pool (EADDRNOTAVAIL on outbound IPv4).
+_client: httpx.Client | None = None
+
+
+def _get_client() -> httpx.Client:
+    global _client
+    if _client is None:
+        _client = httpx.Client(base_url=DAEMON_URL, timeout=2.0)
+        atexit.register(_client.close)
+    return _client
 
 
 def get_pane_file(pane_id: str | None) -> str:
@@ -125,29 +141,20 @@ def clear_pane_runtime_state(pane_id: str | None) -> None:
 def _log_daemon_error(method: str, path: str, exc: Exception) -> None:
     """Log daemon request failure, including HTTP response body when available."""
     msg = f"repowire: daemon {method} {path} failed: {exc}"
-    if isinstance(exc, urllib.error.HTTPError):
-        try:
-            body = exc.read().decode(errors="ignore")
-            if body:
-                msg += f" - Body: {body}"
-        except Exception:
-            pass
+    if isinstance(exc, httpx.HTTPStatusError):
+        body = exc.response.text
+        if body:
+            msg += f" - Body: {body}"
     print(msg, file=sys.stderr)
 
 
 def daemon_post(path: str, payload: dict, *, timeout: float = 2.0) -> dict | None:
     """POST JSON to daemon. Returns parsed response or None on failure."""
     try:
-        data = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
-            f"{DAEMON_URL}{path}",
-            data=data,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        resp = _get_client().post(path, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.HTTPError, json.JSONDecodeError) as e:
         _log_daemon_error("POST", path, e)
         return None
 
@@ -155,10 +162,10 @@ def daemon_post(path: str, payload: dict, *, timeout: float = 2.0) -> dict | Non
 def daemon_get(path: str, *, timeout: float = 2.0) -> dict | None:
     """GET from daemon. Returns parsed response or None on failure."""
     try:
-        req = urllib.request.Request(f"{DAEMON_URL}{path}", method="GET")
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        resp = _get_client().get(path, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except (httpx.HTTPError, json.JSONDecodeError) as e:
         _log_daemon_error("GET", path, e)
         return None
 


### PR DESCRIPTION
## Summary

Replace stdlib `urllib.request` calls in `repowire/hooks/utils.py` with a module-level pooled `httpx.Client`. Prevents loopback TIME_WAIT accumulation from exhausting the macOS ephemeral port range under heavy Claude Code hook workloads.

## Symptom

On systems running multiple concurrent Claude Code sessions with frequent tool use, TCP sockets in TIME_WAIT state on 127.0.0.1 accumulate fast enough to exhaust the macOS ephemeral port range (49152–65535, ~16k ports). Once exhausted:

- Outbound IPv4 connections from every process on the machine fail with `EADDRNOTAVAIL` (`Can't assign requested address`)
- Browsers show `ERR_ADDRESS_INVALID` on IPv4-only destinations (IPv6 sites still work because they use a separate source-port accounting path)
- Recovery requires either the kernel's lazy TIME_WAIT expiry (which I observed wedging under heavy load) or a reboot

I hit this while running 3 concurrent Claude Code sessions for ~30 minutes. `netstat` showed 19,410 TIME_WAITs, with 6,557 targeting a single peer port and 14,498 total against 127.0.0.1.

## Root cause

`daemon_post` and `daemon_get` in `repowire/hooks/utils.py` each call `urllib.request.urlopen`, which opens a fresh TCP connection per request with no keep-alive. Hook invocations commonly produce 2–3 sequential POSTs per Claude turn, and each POST produces one short-lived loopback socket that lingers in TIME_WAIT for 2×MSL (~30s on macOS).

Representative daemon.log excerpt from the repro:

```
POST /session/update HTTP/1.1" 200 OK
POST /events/chat HTTP/1.1" 200 OK
POST /events/chat HTTP/1.1" 200 OK
```

At ~480 connections per second across concurrent sessions, the ephemeral pool exhausts in ~30 minutes.

Notably, `repowire/mcp/server.py` already uses `httpx.AsyncClient` correctly with connection reuse — this PR just brings `hooks/utils.py` in line with that pattern.

## Fix

Swap `daemon_post` and `daemon_get` to use a module-level `httpx.Client` so sequential calls within one hook process reuse a single TCP connection via HTTP keep-alive. `httpx` is already a runtime dependency (see `pyproject.toml`), so no new deps are introduced.

Design choices:

- **Lazy init** — client is created on first call so `REPOWIRE_DAEMON_URL` env override still applies
- **`atexit.register(client.close)`** — ensures graceful shutdown on process exit
- **Exception set** — `(urllib.error.URLError, OSError, json.JSONDecodeError)` → `(httpx.HTTPError, json.JSONDecodeError)`. `httpx.HTTPError` is the base of all httpx exceptions (`ConnectError`, `TimeoutException`, etc.), which previously surfaced as wrapped `URLError`/`OSError`
- **`_log_daemon_error`** — updated to read response body from `httpx.HTTPStatusError.response.text` instead of `urllib.error.HTTPError.read()`. Small ergonomic improvement since `response.text` is idempotent whereas the old `.read()` call was a one-shot stream

## Verification

- `pytest` — **all 291 tests pass**
- `ruff check repowire/` — clean
- `uv run ty check repowire/` — clean
- **Synthetic load test**: 100 sequential `daemon_get('/peers')` calls from one Python process. Prior code path would produce ~100 new TIME_WAITs on loopback; patched path produces **1** (the final client close at process exit via atexit)

## Risk / compatibility

- Function signatures unchanged (`daemon_post(path, payload, *, timeout) → dict | None` and `daemon_get(path, *, timeout) → dict | None`)
- Behavior on timeout / connection error preserved: stderr log + `None` return
- Behavior on 4xx/5xx: `raise_for_status()` now properly surfaces the response body in the stderr log (where the old code's `exc.read()` sometimes returned empty because of the one-shot stream)
- No change in daemon/server code — this is purely a client-side fix

Happy to iterate on any of this if you'd like the change split differently or the exception handling tightened.