### PR TITLE
fix: buffer notifications during subagent execution, deliver on idle

### DIFF
--- a/repowire/hooks/_tmux.py
+++ b/repowire/hooks/_tmux.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import time
 from typing import TypedDict
 
 
@@ -97,3 +98,35 @@ def get_tmux_info() -> TmuxInfo:
         pass
 
     return {"pane_id": pane_id, "session_name": session_name, "window_name": window_name}
+
+
+def send_tmux_keys(pane_id: str, text: str) -> bool:
+    """Send keys to a tmux pane via subprocess.
+
+    Implements Gastown's battle-tested NudgeSession pattern:
+    1. Send text in literal mode (bracketed paste)
+    2. 500ms debounce - required for paste to complete
+    3. Escape - exits vim INSERT mode if active, harmless otherwise
+    4. Enter - submits
+    """
+    try:
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "-l", text],
+            capture_output=True,
+            check=True,
+        )
+        time.sleep(0.5)
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "Escape"],
+            capture_output=True,
+            check=True,
+        )
+        time.sleep(0.1)
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "Enter"],
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False

--- a/repowire/hooks/notification_handler.py
+++ b/repowire/hooks/notification_handler.py
@@ -8,11 +8,17 @@ Stop hook doesn't fire (e.g., user interrupts with Escape).
 
 from __future__ import annotations
 
+import fcntl
 import json
 import sys
 
-from repowire.hooks._tmux import get_pane_id
-from repowire.hooks.utils import update_status
+from repowire.hooks._tmux import get_pane_id, send_tmux_keys
+from repowire.hooks.utils import (
+    pending_notification_path,
+    read_pane_runtime_metadata,
+    update_status,
+    write_pane_runtime_metadata,
+)
 
 
 def main() -> int:
@@ -37,8 +43,47 @@ def main() -> int:
                 f"repowire notification: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+        metadata = read_pane_runtime_metadata(pane_id)
+        metadata["status"] = "online"
+        write_pane_runtime_metadata(pane_id, metadata)
+        _flush_pending_notifications(pane_id)
 
     return 0
+
+
+def _pop_pending_notification(pane_id: str) -> str | None:
+    """Pop the oldest pending notification for a pane, if any.
+
+    Uses flock to prevent race with websocket_hook.
+    """
+    path = pending_notification_path(pane_id)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if not path.exists():
+                    return None
+                pending = json.loads(path.read_text())
+                if not pending:
+                    return None
+                message = pending.pop(0)
+                path.write_text(json.dumps(pending))
+                return message
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+    except (json.JSONDecodeError, OSError, IndexError):
+        return None
+
+
+def _flush_pending_notifications(pane_id: str) -> None:
+    """Deliver all pending notifications into the pane."""
+    while True:
+        message = _pop_pending_notification(pane_id)
+        if not message:
+            return
+        if not send_tmux_keys(pane_id, message):
+            return
 
 
 if __name__ == "__main__":

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -8,7 +8,11 @@ import sys
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import update_status
+from repowire.hooks.utils import (
+    read_pane_runtime_metadata,
+    update_status,
+    write_pane_runtime_metadata,
+)
 
 
 def main(backend: str = "claude-code") -> int:
@@ -31,6 +35,9 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire prompt: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+        metadata = read_pane_runtime_metadata(pane_id)
+        metadata["status"] = "busy"
+        write_pane_runtime_metadata(pane_id, metadata)
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -8,9 +8,17 @@ import json
 import sys
 from pathlib import Path
 
-from repowire.hooks._tmux import get_pane_id
+from repowire.hooks._tmux import get_pane_id, send_tmux_keys
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import daemon_post, get_display_name, pending_cid_path, update_status
+from repowire.hooks.utils import (
+    daemon_post,
+    get_display_name,
+    pending_cid_path,
+    pending_notification_path,
+    read_pane_runtime_metadata,
+    update_status,
+    write_pane_runtime_metadata,
+)
 from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
 
 
@@ -37,6 +45,41 @@ def _pop_pending_cid(pane_id: str) -> str | None:
                 fcntl.flock(lock_file, fcntl.LOCK_UN)
     except (json.JSONDecodeError, OSError, IndexError):
         return None
+
+
+def _pop_pending_notification(pane_id: str) -> str | None:
+    """Pop the oldest pending notification for a pane, if any.
+
+    Uses flock to prevent race with websocket_hook.
+    """
+    path = pending_notification_path(pane_id)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if not path.exists():
+                    return None
+                pending = json.loads(path.read_text())
+                if not pending:
+                    return None
+                message = pending.pop(0)
+                path.write_text(json.dumps(pending))
+                return message
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+    except (json.JSONDecodeError, OSError, IndexError):
+        return None
+
+
+def _flush_pending_notifications(pane_id: str) -> None:
+    """Deliver all pending notifications into the pane."""
+    while True:
+        message = _pop_pending_notification(pane_id)
+        if not message:
+            return
+        if not send_tmux_keys(pane_id, message):
+            return
 
 
 def _post_chat_turn(
@@ -77,6 +120,10 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire stop: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+        metadata = read_pane_runtime_metadata(pane_id)
+        metadata["status"] = "online"
+        write_pane_runtime_metadata(pane_id, metadata)
+        _flush_pending_notifications(pane_id)
     else:
         if not update_status(peer_display, "online"):
             print(

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -54,6 +54,11 @@ def pending_cid_path(pane_id: str) -> Path:
     return pane_logs_dir() / f"pending-{get_pane_file(pane_id)}.json"
 
 
+def pending_notification_path(pane_id: str) -> Path:
+    """Path to the pending notifications file for a pane."""
+    return pane_logs_dir() / f"pending-notify-{get_pane_file(pane_id)}.json"
+
+
 def pane_logs_dir() -> Path:
     """Return the runtime log/state directory for pane-scoped hook files."""
     from repowire.config.models import CACHE_DIR
@@ -123,12 +128,23 @@ def clear_pending_cids(pane_id: str | None) -> None:
             path.unlink()
 
 
+def clear_pending_notifications(pane_id: str) -> None:
+    """Remove any queued notifications for a pane."""
+    pending_path = pending_notification_path(pane_id)
+    lock_path = pending_path.with_suffix(pending_path.suffix + ".lock")
+    for path in (pending_path, lock_path):
+        with suppress(OSError):
+            path.unlink()
+
+
 def clear_pane_runtime_state(pane_id: str | None) -> None:
     """Clear transient pane-scoped hook state after a pane dies or is taken over."""
     if not pane_id:
         return
 
     clear_pending_cids(pane_id)
+    if pane_id:
+        clear_pending_notifications(pane_id)
     for path in (
         ws_hook_pid_path(pane_id),
         ws_hook_meta_path(pane_id),

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -11,7 +11,6 @@ import logging
 import os
 import subprocess
 import sys
-import time
 
 try:
     import websockets
@@ -21,11 +20,12 @@ except ImportError as e:
     sys.exit(1)
 
 from repowire.config.models import AgentType
-from repowire.hooks._tmux import get_tmux_info
+from repowire.hooks._tmux import get_tmux_info, send_tmux_keys
 from repowire.hooks.utils import (
     clear_pane_runtime_state,
     get_display_name,
     pending_cid_path,
+    pending_notification_path,
     read_pane_runtime_metadata,
     write_pane_runtime_metadata,
 )
@@ -63,36 +63,69 @@ def _push_pending_cid(pane_id: str, correlation_id: str) -> None:
 
 
 def _tmux_send_keys(pane_id: str, text: str) -> bool:
-    """Send keys to a tmux pane via subprocess.
-
-    Implements Gastown's battle-tested NudgeSession pattern:
-    1. Send text in literal mode (bracketed paste)
-    2. 500ms debounce — tested, required for paste to complete
-    3. Escape — exits vim INSERT mode if active, harmless otherwise
-    4. Enter — submits
-    """
+    """Send keys to a tmux pane via subprocess."""
     try:
-        subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, "-l", text],
-            capture_output=True,
-            check=True,
-        )
-        time.sleep(0.5)
-        subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, "Escape"],
-            capture_output=True,
-            check=True,
-        )
-        time.sleep(0.1)
-        subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, "Enter"],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        return send_tmux_keys(pane_id, text)
+    except Exception as e:
         logger.error(f"Failed to send keys to {pane_id}: {e}")
         return False
+
+
+def _push_pending_notification(pane_id: str, message: str) -> None:
+    """Append a notification to the pending file for a pane.
+
+    Uses flock to prevent race with _pop_pending_notification.
+    """
+    path = pending_notification_path(pane_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with open(lock_path, "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            try:
+                pending = json.loads(path.read_text()) if path.exists() else []
+            except (json.JSONDecodeError, OSError):
+                pending = []
+            pending.append(message)
+            path.write_text(json.dumps(pending))
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _pop_pending_notification(pane_id: str) -> str | None:
+    """Pop the oldest pending notification for a pane, if any.
+
+    Uses flock to prevent race with _push_pending_notification.
+    """
+    path = pending_notification_path(pane_id)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if not path.exists():
+                    return None
+                pending = json.loads(path.read_text())
+                if not pending:
+                    return None
+                message = pending.pop(0)
+                path.write_text(json.dumps(pending))
+                return message
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+    except (json.JSONDecodeError, OSError, IndexError):
+        return None
+
+
+def _flush_pending_notifications(pane_id: str) -> None:
+    """Deliver all pending notifications into the pane."""
+    while True:
+        message = _pop_pending_notification(pane_id)
+        if not message:
+            return
+        if not _tmux_send_keys(pane_id, message):
+            _push_pending_notification(pane_id, message)
+            return
 
 
 def _get_pane_command(pane_id: str) -> str | None:
@@ -203,8 +236,15 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         try:
             from_peer = data.get("from_peer", "unknown")
             text = data.get("text", "")
-            if await asyncio.to_thread(_tmux_send_keys, pane_id, f"@{from_peer}: {text}"):
-                logger.info(f"Injected notification from {from_peer}")
+            message = f"@{from_peer}: {text}"
+            metadata = read_pane_runtime_metadata(pane_id)
+            status = metadata.get("status")
+            if status == "busy":
+                _push_pending_notification(pane_id, message)
+                logger.info(f"Queued notification from {from_peer}")
+            else:
+                if await asyncio.to_thread(_tmux_send_keys, pane_id, message):
+                    logger.info(f"Injected notification from {from_peer}")
         except Exception as e:
             logger.error(f"Failed to inject notification: {e}")
 
@@ -213,8 +253,14 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
             from_peer = data.get("from_peer", "unknown")
             text = data.get("text", "")
             msg = f"@{from_peer} [broadcast]: {text}"
-            if await asyncio.to_thread(_tmux_send_keys, pane_id, msg):
-                logger.info(f"Injected broadcast from {from_peer}")
+            metadata = read_pane_runtime_metadata(pane_id)
+            status = metadata.get("status")
+            if status == "busy":
+                _push_pending_notification(pane_id, msg)
+                logger.info(f"Queued broadcast from {from_peer}")
+            else:
+                if await asyncio.to_thread(_tmux_send_keys, pane_id, msg):
+                    logger.info(f"Injected broadcast from {from_peer}")
         except Exception as e:
             logger.error(f"Failed to inject broadcast: {e}")
 
@@ -310,6 +356,10 @@ async def main() -> int:
                 try:
                     async for message in websocket:
                         data = json.loads(message)
+                        if data.get("type") in ("notify", "broadcast"):
+                            meta = read_pane_runtime_metadata(pane_id)
+                            if meta.get("status") == "online":
+                                _flush_pending_notifications(pane_id)
                         await handle_message(data, pane_id, websocket)
                 except PaneUnsafeError as e:
                     logger.info("%s", e)

--- a/repowire/installers/opencode.py
+++ b/repowire/installers/opencode.py
@@ -47,6 +47,9 @@ let peerName: string = "unknown"
 let peerId: string | null = null  // Daemon-assigned unique ID
 let projectPath: string = ""
 let activeSessionId: string | null = null
+let primarySessionId: string | null = null
+let pendingNotifications: string[] = []
+let isBusy: boolean = false
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null
 let reconnectAttempts: number = 0
 let opencodeClient: PluginClient | null = null
@@ -203,33 +206,48 @@ async function handleDaemonMessage(data: Record<string, unknown>) {
     }
   } else if (msgType === "notify" || msgType === "broadcast") {
     const text = data.text as string
-    // Try to resolve session (like we do for queries)
-    const sessionId = await resolveSessionId()
-    if (!sessionId) {
-      console.error(`[repowire] Cannot inject ${msgType}: no active session`)
+    if (isBusy) {
+      pendingNotifications.push(text)
       return
     }
+    await injectNotification(text)
+  }
+}
 
-    // Fire-and-forget - inject notification/broadcast
-    if (opencodeClient) {
-      try {
-        const body: Record<string, unknown> = { parts: [{ type: "text", text }] }
-        if (activeModel) {
-          body.model = activeModel
-        }
-        await opencodeClient.session.prompt({
-          path: { id: sessionId },
-          body,
-        })
-      } catch (e) {
-        console.error(`[repowire] Failed to inject ${msgType}:`, e)
+async function injectNotification(text: string) {
+  const sessionId = await resolveSessionId()
+  if (!sessionId) {
+    console.error("[repowire] Cannot inject notification: no active session")
+    return
+  }
+  if (opencodeClient) {
+    try {
+      const body: Record<string, unknown> = { parts: [{ type: "text", text }] }
+      if (activeModel) {
+        body.model = activeModel
       }
+      await opencodeClient.session.prompt({
+        path: { id: sessionId },
+        body,
+      })
+    } catch (e) {
+      console.error("[repowire] Failed to inject notification:", e)
     }
+  }
+}
+
+async function flushPendingNotifications() {
+  if (isBusy) return
+  while (pendingNotifications.length > 0) {
+    const next = pendingNotifications.shift()
+    if (!next) break
+    await injectNotification(next)
   }
 }
 
 // Resolve active session - try tracked ID, then list, then create
 async function resolveSessionId(): Promise<string | null> {
+  if (primarySessionId) return primarySessionId
   if (activeSessionId) return activeSessionId
   if (!opencodeClient) return null
 
@@ -239,6 +257,9 @@ async function resolveSessionId(): Promise<string | null> {
     const sessions = result?.data
     if (Array.isArray(sessions) && sessions.length > 0) {
       activeSessionId = sessions[sessions.length - 1].id
+      if (!primarySessionId) {
+        primarySessionId = activeSessionId
+      }
       return activeSessionId
     }
   } catch (e) {
@@ -250,6 +271,9 @@ async function resolveSessionId(): Promise<string | null> {
     const result = await opencodeClient.session.create({ body: {} })
     if (result?.data?.id) {
       activeSessionId = result.data.id
+      if (!primarySessionId) {
+        primarySessionId = activeSessionId
+      }
       return activeSessionId
     }
   } catch (e) {
@@ -490,6 +514,7 @@ export const RepowirePlugin: Plugin = async ({ client, directory }) => {
         const info = typedEvent.properties?.info as SessionEventInfo | undefined
         if (info?.id) {
           activeSessionId = info.id
+          primarySessionId = info.id
           if (!stableNameSet) {
             stableNameSet = true
             const stableName = sanitizePeerName(info.id.startsWith("ses") ? info.id.slice(3, 11) : info.id.slice(0, 8))
@@ -506,7 +531,8 @@ export const RepowirePlugin: Plugin = async ({ client, directory }) => {
       } else if (typedEvent.type === "message.updated") {
         const info = typedEvent.properties?.info as MessageEventInfo | undefined
         if (info?.role === "assistant" && info?.sessionID) {
-          if (info.sessionID !== activeSessionId) {
+          isBusy = true
+          if (info.sessionID && info.sessionID !== activeSessionId) {
             activeSessionId = info.sessionID
           }
           sendStatus("busy")
@@ -516,12 +542,19 @@ export const RepowirePlugin: Plugin = async ({ client, directory }) => {
           activeModel = { providerID: info.model.providerID, modelID: info.model.modelID }
         }
       } else if (typedEvent.type === "session.idle") {
+        isBusy = false
         sendStatus("idle")
+        await flushPendingNotifications()
       } else if (typedEvent.type === "session.deleted") {
         const info = typedEvent.properties?.info as SessionEventInfo | undefined
         if (info?.id === activeSessionId) {
           activeSessionId = null
+          if (primarySessionId === info.id) {
+            primarySessionId = null
+          }
+          isBusy = false
           sendStatus("idle")
+          await flushPendingNotifications()
         }
       }
     },

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
-from repowire.hooks.websocket_hook import _is_pane_safe
+from repowire.hooks.websocket_hook import _is_pane_safe, _pop_pending_notification
 
 
 class TestIsPaneSafe:
@@ -52,3 +52,22 @@ class TestIsPaneSafe:
             side_effect=FileNotFoundError,
         ):
             assert _is_pane_safe("%5") is False
+
+
+class TestPendingNotifications:
+    def test_pop_pending_notification_empty(self, tmp_path):
+        with patch(
+            "repowire.hooks.websocket_hook.pending_notification_path",
+            return_value=tmp_path / "pending.json",
+        ):
+            assert _pop_pending_notification("%5") is None
+
+    def test_pop_pending_notification_returns_oldest(self, tmp_path):
+        pending_path = tmp_path / "pending.json"
+        pending_path.write_text('["first", "second"]')
+        with patch(
+            "repowire.hooks.websocket_hook.pending_notification_path",
+            return_value=pending_path,
+        ):
+            assert _pop_pending_notification("%5") == "first"
+            assert pending_path.read_text() == '["second"]'

--- a/tests/test_hooks_handlers.py
+++ b/tests/test_hooks_handlers.py
@@ -26,32 +26,44 @@ class TestPromptHandler:
         result = _run_with_input(prompt_main, {"hook_event_name": "SessionStart"})
         assert result == 0
 
+    @patch("repowire.hooks.prompt_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.prompt_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
-    def test_sets_busy(self, mock_pane, mock_status):
+    def test_sets_busy(self, mock_pane, mock_status, mock_read, mock_write):
         result = _run_with_input(prompt_main, {"hook_event_name": "UserPromptSubmit"})
         assert result == 0
         mock_status.assert_called_once_with("%42", "busy", use_pane_id=True)
+        mock_write.assert_called_once()
 
+    @patch("repowire.hooks.prompt_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.prompt_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
-    def test_gemini_before_agent(self, mock_pane, mock_status):
+    def test_gemini_before_agent(self, mock_pane, mock_status, mock_read, mock_write):
         result = _run_with_input(prompt_main, {"hook_event_name": "BeforeAgent"})
         assert result == 0
         mock_status.assert_called_once_with("%42", "busy", use_pane_id=True)
+        mock_write.assert_called_once()
 
+    @patch("repowire.hooks.prompt_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.prompt_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.prompt_handler.update_status")
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value=None)
-    def test_no_pane_id(self, mock_pane, mock_status):
+    def test_no_pane_id(self, mock_pane, mock_status, mock_read, mock_write):
         result = _run_with_input(prompt_main, {"hook_event_name": "UserPromptSubmit"})
         assert result == 0
         mock_status.assert_not_called()
+        mock_write.assert_not_called()
 
+    @patch("repowire.hooks.prompt_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.prompt_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.prompt_handler.update_status", return_value=False)
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
-    def test_status_update_failure(self, mock_pane, mock_status):
+    def test_status_update_failure(self, mock_pane, mock_status, mock_read, mock_write):
         result = _run_with_input(prompt_main, {"hook_event_name": "UserPromptSubmit"})
         assert result == 0  # returns 0 even on failure
+        mock_write.assert_called_once()
 
 
 # -- Notification Handler --
@@ -74,22 +86,38 @@ class TestNotificationHandler:
         })
         assert result == 0
 
+    @patch("repowire.hooks.notification_handler.send_tmux_keys", return_value=True)
+    @patch("repowire.hooks.notification_handler._pop_pending_notification", return_value=None)
+    @patch("repowire.hooks.notification_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.notification_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.notification_handler.update_status", return_value=True)
     @patch("repowire.hooks.notification_handler.get_pane_id", return_value="%42")
-    def test_sets_online_on_idle(self, mock_pane, mock_status):
+    def test_sets_online_on_idle(
+        self,
+        mock_pane,
+        mock_status,
+        mock_read,
+        mock_write,
+        mock_pop,
+        mock_send,
+    ):
         result = _run_with_input(notification_main, {
             "hook_event_name": "Notification",
             "notification_type": "idle_prompt",
         })
         assert result == 0
         mock_status.assert_called_once_with("%42", "online", use_pane_id=True)
+        mock_write.assert_called_once()
 
+    @patch("repowire.hooks.notification_handler.write_pane_runtime_metadata")
+    @patch("repowire.hooks.notification_handler.read_pane_runtime_metadata", return_value={})
     @patch("repowire.hooks.notification_handler.update_status")
     @patch("repowire.hooks.notification_handler.get_pane_id", return_value=None)
-    def test_no_pane_id(self, mock_pane, mock_status):
+    def test_no_pane_id(self, mock_pane, mock_status, mock_read, mock_write):
         result = _run_with_input(notification_main, {
             "hook_event_name": "Notification",
             "notification_type": "idle_prompt",
         })
         assert result == 0
         mock_status.assert_not_called()
+        mock_write.assert_not_called()


### PR DESCRIPTION
## Fixes: #79 

## Summary

- **Problem**: `notify_peer` messages arrive in subagent context instead of main session when the target peer is running a delegated task
- **Root cause**: Hooks transport uses `tmux send-keys` which targets the pane, not a specific session. When a subagent is the active execution context, injected text goes to the subagent
- **Fix**: Queue notifications/broadcasts in a file-based FIFO when peer status is "busy", flush on idle (Notification hook or Stop hook)

## Changes

### Hooks transport (Python)
- `hooks/utils.py`: Add `pending_notification_path()` and `clear_pending_notifications()`
- `hooks/_tmux.py`: Extract `send_tmux_keys()` as shared function
- `hooks/websocket_hook.py`: Queue notifications when peer is busy, flush on reconnect
- `hooks/prompt_handler.py`: Write `status: "busy"` to pane metadata on UserPromptSubmit
- `hooks/notification_handler.py`: Write `status: "online"` and flush pending notifications on idle_prompt
- `hooks/stop_handler.py`: Write `status: "online"` and flush pending notifications on Stop

### OpenCode plugin (TypeScript)
- Track `primarySessionId` to distinguish main session from subagent sessions
- Track `isBusy` state via `message.updated` / `session.idle` events
- Buffer notifications in `pendingNotifications` array while busy
- Flush pending notifications on `session.idle` or `session.deleted` events

### Tests
- Add `TestPendingNotifications` class with 2 tests for the queue
- Update existing handler tests to mock new metadata writes

## Verification
- 318 tests pass
- ruff check clean
- ty type check clean