### PR TITLE
daemon: buffer notify/broadcast for BUSY peers, drain on idle

### DIFF
--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -120,6 +120,23 @@ class MessageRouter:
         await self._transport.send(to_session_id, message)
         logger.info(f"Notification sent: {from_peer} -> {to_peer_name}")
 
+    async def send_broadcast_to(
+        self,
+        from_peer: str,
+        to_session_id: str,
+        to_peer_name: str,
+        text: str,
+    ) -> None:
+        """Deliver a single broadcast copy to one peer. Used to replay buffered
+        broadcasts to a peer that was BUSY when the original fanout ran."""
+        message: dict[str, Any] = {
+            "type": "broadcast",
+            "from_peer": from_peer,
+            "text": text,
+        }
+        await self._transport.send(to_session_id, message)
+        logger.info(f"Broadcast (deferred) sent: {from_peer} -> {to_peer_name}")
+
     async def broadcast(
         self,
         from_peer: str,

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -99,6 +99,15 @@ class PeerRegistry:
         self._last_repair: float = 0.0
         self._repair_lock = asyncio.Lock()
 
+        # Notifications/broadcasts buffered while a peer is BUSY. Issue #79:
+        # injecting during a busy turn drops the message into the active
+        # subagent's context instead of the human's main session. Drain on the
+        # BUSY -> ONLINE transition (see update_peer_status). In-memory only --
+        # buffered messages are best-effort and don't survive daemon restart.
+        # Cap per-peer to avoid unbounded growth if a peer never goes idle.
+        self._pending_messages: dict[str, list[dict[str, Any]]] = {}
+        self._pending_messages_max = 100
+
     # ------------------------------------------------------------------
     # Mapping persistence
     # ------------------------------------------------------------------
@@ -688,14 +697,22 @@ class PeerRegistry:
             peer_id = peer.peer_id
             peer_name = peer.display_name
             from_peer_id = from_obj.peer_id if from_obj else None
+            queued = self._enqueue_if_busy_unlocked(
+                peer,
+                {"kind": "notify", "from_peer": from_peer, "text": text},
+            )
 
         self.add_event(
             "notification",
             {
                 "from": from_peer, "to": to_peer, "text": text,
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
+                "queued": queued,
             },
         )
+
+        if queued:
+            return
 
         await self._router.send_notification(
             from_peer=from_peer,
@@ -720,6 +737,7 @@ class PeerRegistry:
         exclude_names.add(from_peer)
 
         exclude_session_ids: set[str] = set()
+        queued_peer_names: list[str] = []
         async with self._lock:
             from_peer_obj: Peer | None = None
             for name in exclude_names:
@@ -735,6 +753,18 @@ class PeerRegistry:
                 for sid, peer in self._peers.items():
                     if peer.circle != from_circle and not peer.bypasses_circles:
                         exclude_session_ids.add(sid)
+
+            # Queue for any BUSY recipient so the broadcast lands in their main
+            # session after they finish, not in whatever subagent is running.
+            for sid, peer in self._peers.items():
+                if sid in exclude_session_ids:
+                    continue
+                if self._enqueue_if_busy_unlocked(
+                    peer,
+                    {"kind": "broadcast", "from_peer": from_peer, "text": text},
+                ):
+                    exclude_session_ids.add(sid)
+                    queued_peer_names.append(peer.display_name)
 
             from_peer_id = from_peer_obj.peer_id if from_peer_obj else None
         self.add_event(
@@ -752,24 +782,104 @@ class PeerRegistry:
         )
 
         async with self._lock:
-            return [self._peers[sid].display_name for sid in sent_session_ids if sid in self._peers]
+            sent_names = [
+                self._peers[sid].display_name
+                for sid in sent_session_ids
+                if sid in self._peers
+            ]
+        # Recipients we deferred while busy still count as "will receive."
+        return sent_names + queued_peer_names
 
     # ------------------------------------------------------------------
     # Status / metadata mutations
     # ------------------------------------------------------------------
 
     async def update_peer_status(self, identifier: str, status: PeerStatus) -> None:
-        """Update peer status."""
+        """Update peer status, draining any buffered notifications on BUSY -> ONLINE."""
+        to_flush: list[dict[str, Any]] = []
+        flush_peer_id: str | None = None
+        flush_peer_name: str | None = None
         async with self._lock:
             peer = self._lookup_peer_unlocked(identifier)
-            if peer:
-                peer.status = status
-                peer.last_seen = datetime.now(timezone.utc)
-            else:
+            if not peer:
                 logger.warning(
                     "update_peer_status: peer not found: %s (status=%s not applied)",
                     identifier,
                     status.value,
+                )
+                return
+            previous = peer.status
+            peer.status = status
+            peer.last_seen = datetime.now(timezone.utc)
+            # Drain on any non-BUSY transition out of BUSY. OFFLINE drops the
+            # queue (the peer is gone); ONLINE replays it.
+            if previous == PeerStatus.BUSY and status != PeerStatus.BUSY:
+                queued = self._pending_messages.pop(peer.peer_id, [])
+                if status == PeerStatus.ONLINE and queued:
+                    to_flush = queued
+                    flush_peer_id = peer.peer_id
+                    flush_peer_name = peer.display_name
+
+        if to_flush and flush_peer_id and flush_peer_name:
+            await self._flush_pending(flush_peer_id, flush_peer_name, to_flush)
+
+    def _enqueue_if_busy_unlocked(self, peer: Peer, message: dict[str, Any]) -> bool:
+        """If peer is BUSY, append to its pending queue. Returns True if queued.
+
+        Caller must hold self._lock. The queue is per-peer FIFO; flush order is
+        preserved by appending here and popping the whole list at flush time.
+        """
+        if peer.status != PeerStatus.BUSY:
+            return False
+        queue = self._pending_messages.setdefault(peer.peer_id, [])
+        if len(queue) >= self._pending_messages_max:
+            # Drop oldest to bound memory under stuck-busy peers. Better than
+            # blocking the sender or unbounded growth.
+            dropped = queue.pop(0)
+            logger.warning(
+                "Pending queue for %s full (%d) -- dropping oldest %s from %s",
+                peer.display_name,
+                self._pending_messages_max,
+                dropped.get("kind"),
+                dropped.get("from_peer"),
+            )
+        queue.append(message)
+        return True
+
+    async def _flush_pending(
+        self,
+        peer_id: str,
+        peer_name: str,
+        messages: list[dict[str, Any]],
+    ) -> None:
+        """Send buffered notify/broadcast messages in order. Single task,
+        sequential await -- preserves FIFO ordering even if a send fails or
+        is slow."""
+        for msg in messages:
+            try:
+                if msg["kind"] == "notify":
+                    await self._router.send_notification(
+                        from_peer=msg["from_peer"],
+                        to_session_id=peer_id,
+                        to_peer_name=peer_name,
+                        text=msg["text"],
+                    )
+                elif msg["kind"] == "broadcast":
+                    # The original broadcast fanout already ran for online
+                    # recipients; this is just the deferred copy for one
+                    # previously-busy peer.
+                    await self._router.send_broadcast_to(
+                        from_peer=msg["from_peer"],
+                        to_session_id=peer_id,
+                        to_peer_name=peer_name,
+                        text=msg["text"],
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to flush buffered %s to %s: %s",
+                    msg.get("kind"),
+                    peer_name,
+                    e,
                 )
 
     async def update_description(

--- a/tests/test_notification_buffer.py
+++ b/tests/test_notification_buffer.py
@@ -1,0 +1,184 @@
+"""Tests for buffering notify/broadcast while a peer is BUSY.
+
+Issue #79: messages injected during a busy turn land in the active subagent's
+context instead of the human's main session. The fix buffers at the registry
+and drains on BUSY -> ONLINE.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repowire.config.models import Config
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+@pytest.fixture
+def router():
+    r = MagicMock(spec=MessageRouter)
+    r.send_query = AsyncMock(return_value="mock")
+    r.send_notification = AsyncMock()
+    r.send_broadcast_to = AsyncMock()
+    r.broadcast = AsyncMock(return_value=[])
+    return r
+
+
+@pytest.fixture
+def registry(router):
+    return PeerRegistry(config=Config(), message_router=router)
+
+
+def _add_peer(
+    registry: PeerRegistry,
+    name: str,
+    status: PeerStatus,
+    circle: str = "global",
+) -> Peer:
+    peer = Peer(name=name, path="/x", machine="local", circle=circle, status=status)
+    registry._peers[peer.peer_id] = peer
+    return peer
+
+
+class TestNotifyBuffersWhenBusy:
+    async def test_notify_to_busy_peer_is_queued(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.notify(
+            from_peer=sender.display_name,
+            to_peer=recipient.display_name,
+            text="hi",
+        )
+
+        router.send_notification.assert_not_awaited()
+        assert registry._pending_messages[recipient.peer_id] == [
+            {"kind": "notify", "from_peer": sender.display_name, "text": "hi"},
+        ]
+
+    async def test_notify_to_online_peer_is_sent_directly(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.ONLINE)
+
+        await registry.notify(
+            from_peer=sender.display_name,
+            to_peer=recipient.display_name,
+            text="hi",
+        )
+
+        router.send_notification.assert_awaited_once()
+        assert recipient.peer_id not in registry._pending_messages
+
+    async def test_busy_to_online_drains_in_order(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.notify(sender.display_name, recipient.display_name, "first")
+        await registry.notify(sender.display_name, recipient.display_name, "second")
+        await registry.notify(sender.display_name, recipient.display_name, "third")
+
+        router.send_notification.assert_not_awaited()
+
+        await registry.update_peer_status(recipient.peer_id, PeerStatus.ONLINE)
+
+        assert router.send_notification.await_count == 3
+        # Preserve FIFO order
+        texts = [c.kwargs["text"] for c in router.send_notification.await_args_list]
+        assert texts == ["first", "second", "third"]
+        # Queue cleared after drain
+        assert recipient.peer_id not in registry._pending_messages
+
+    async def test_busy_to_offline_drops_queue(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.notify(sender.display_name, recipient.display_name, "lost")
+        assert recipient.peer_id in registry._pending_messages
+
+        await registry.update_peer_status(recipient.peer_id, PeerStatus.OFFLINE)
+
+        router.send_notification.assert_not_awaited()
+        assert recipient.peer_id not in registry._pending_messages
+
+    async def test_status_unchanged_does_not_drain(self, registry, router):
+        # BUSY -> BUSY (no transition) should not trigger a flush.
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.notify(sender.display_name, recipient.display_name, "queued")
+
+        await registry.update_peer_status(recipient.peer_id, PeerStatus.BUSY)
+
+        router.send_notification.assert_not_awaited()
+        assert registry._pending_messages[recipient.peer_id]
+
+    async def test_queue_failure_does_not_block_subsequent_messages(self, registry, router):
+        # If a single flushed send raises, the rest of the queue must still go.
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.notify(sender.display_name, recipient.display_name, "first")
+        await registry.notify(sender.display_name, recipient.display_name, "second")
+
+        call_count = 0
+
+        async def maybe_fail(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transport flapped")
+
+        router.send_notification.side_effect = maybe_fail
+
+        await registry.update_peer_status(recipient.peer_id, PeerStatus.ONLINE)
+
+        # Both attempted, second still went through
+        assert router.send_notification.await_count == 2
+
+    async def test_queue_caps_at_max(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        registry._pending_messages_max = 3
+        for i in range(5):
+            await registry.notify(sender.display_name, recipient.display_name, f"msg-{i}")
+
+        queue = registry._pending_messages[recipient.peer_id]
+        assert len(queue) == 3
+        # Oldest dropped, newest preserved
+        assert [m["text"] for m in queue] == ["msg-2", "msg-3", "msg-4"]
+
+
+class TestBroadcastBuffersBusyRecipients:
+    async def test_busy_recipient_queued_not_sent(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        _add_peer(registry, "bob", PeerStatus.ONLINE)
+        busy = _add_peer(registry, "carol", PeerStatus.BUSY)
+
+        # Make sure the live MessageRouter.broadcast skips the busy peer.
+        # Our router mock returns []; we just check the exclude set passed.
+        await registry.broadcast(from_peer=sender.display_name, text="all hands")
+
+        # busy peer was queued
+        assert registry._pending_messages[busy.peer_id] == [
+            {"kind": "broadcast", "from_peer": sender.display_name, "text": "all hands"},
+        ]
+
+        # Excluded from the live fanout
+        exclude = router.broadcast.await_args.kwargs["exclude"]
+        assert busy.peer_id in exclude
+
+    async def test_drain_uses_send_broadcast_to(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        busy = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.broadcast(from_peer=sender.display_name, text="hi")
+        await registry.update_peer_status(busy.peer_id, PeerStatus.ONLINE)
+
+        router.send_broadcast_to.assert_awaited_once()
+        kwargs = router.send_broadcast_to.await_args.kwargs
+        assert kwargs["text"] == "hi"
+        assert kwargs["to_session_id"] == busy.peer_id


### PR DESCRIPTION
## Summary

Fixes #79. Closes the work originally tackled in #80 by @manascb1344 (closed because main shifted significantly and the bot review surfaced architectural concerns we wanted to address differently).

When peer A sends \`notify_peer\` to peer B and peer B is currently busy with a turn that delegated to a subagent, the notification arrives via tmux \`send-keys\` to the active pane — which is whatever subagent is running, not the human's main session. The fix buffers messages at the daemon registry while \`recipient.status == BUSY\` and drains on the \`BUSY -> ONLINE\` transition.

## Why daemon-side, not hook-side

The original contributor PR #80 added per-handler buffering across \`prompt_handler.py\`, \`notification_handler.py\`, \`stop_handler.py\`, and \`websocket_hook.py\` plus the OpenCode plugin. That meant duplicating the busy-tracking logic in every transport. The auto-review caught:

- Blocking I/O inside the asyncio loop in \`websocket_hook.py\`
- Notification ordering can flip on retry
- \`primarySessionId\` overwrite by subagent events in \`opencode.py\`
- Duplicated notify logic across handlers

Centralizing the buffer at the daemon registry resolves all four at once:

- **No new blocking I/O**: pure in-memory dict state under the existing \`asyncio.Lock\`. The flush awaits \`send_notification\` serially in a single task.
- **Ordering preserved**: single FIFO queue per peer, popped wholesale, iterated in order.
- **No primary-vs-subagent ambiguity**: the daemon's busy state is set by the existing \`UserPromptSubmit -> /session/update\` path; it doesn't care which session is currently active in the agent.
- **No duplicated logic**: handlers remain status-only. The registry owns delivery semantics. Applies to all transports (hooks, opencode, channel, slack, telegram) without per-transport changes.

## Behavior

- \`PeerRegistry.notify()\` checks status under the lock; if \`BUSY\`, appends \`{kind: notify, from_peer, text}\` to a per-peer pending list and returns.
- \`PeerRegistry.broadcast()\` skips \`BUSY\` recipients in the live fanout (adds them to \`exclude_session_ids\`) and queues their copy for later.
- \`PeerRegistry.update_peer_status()\` drains the queue on any non-BUSY transition: \`BUSY -> ONLINE\` replays in order; \`BUSY -> OFFLINE\` drops the queue (peer is gone).
- Per-peer cap of 100 messages — drops oldest if a peer never idles. Better than unbounded growth or blocking the sender.
- Failures during drain are logged per-message; subsequent messages still go.
- Added \`MessageRouter.send_broadcast_to()\` for replaying a single broadcast copy to one previously-busy peer (avoids the \`exclude\`-everyone-else dance).

## Wire format

Unchanged. The opencode plugin and ws-hook still receive the same \`{type: notify, from_peer, text}\` and \`{type: broadcast, ...}\` shapes — they just arrive after the recipient idles.

## Test plan

- [x] 9 new tests in \`tests/test_notification_buffer.py\` covering: queue-while-busy, direct-when-online, FIFO drain order, OFFLINE drops queue, BUSY->BUSY no-op, drain continues past send failure, queue cap evicts oldest, broadcast queues busy recipients, drain uses \`send_broadcast_to\`.
- [x] 340 tests pass total (was 331)
- [x] ruff + ty clean
- [ ] Live verify: have peer B run a long task, send peer B a notification, confirm it arrives after B's turn ends (not in subagent context).

## Customer-contract surface

Wire format unchanged. Delivery timing changes (delayed during busy windows) — but that's the bug fix. Patch-shape.

## Credit

Diagnosis and original implementation: @manascb1344 (#80).