### PR TITLE
fix(tests): parametrize expected peer name from cwd basename

### DIFF
--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -522,12 +522,13 @@ class TestMcpRegistration:
 
         assert mock_request.await_count == 3
         assert mock_request.await_args_list[0].args == ("GET", "/peers/by-pane/%251")
+        cwd = mcp_server.Path.cwd()
         assert mock_request.await_args_list[2].args == (
             "POST",
             "/peers",
             {
-                "name": "repowire",
-                "path": str(mcp_server.Path.cwd()),
+                "name": cwd.name or "root",
+                "path": str(cwd),
                 "circle": "0",
                 "backend": "codex",
                 "pane_id": "%1",


### PR DESCRIPTION
Closes repowire-e3a.

## Summary
- `tests/test_spawn.py::TestMcpRegistration::test_tmux_lazy_registration_uses_pane_and_circle` hardcoded `"repowire"` as the expected peer name in the registration POST body.
- The actual code (`repowire/mcp/server.py:178`) derives the name from `Path.cwd().name or "root"`, so the test only passed when pytest ran from a worktree literally named `repowire`. Any sibling worktree (e.g. `repowire-ask-ack`, `repowire.fix-spawn-test-basename`) made the test fail.
- Fix: derive the expected name the same way the production code does — `cwd.name or "root"` — so the assertion holds regardless of worktree path.

## Test plan
- [x] `pytest tests/test_spawn.py` from worktree named `repowire.fix-spawn-test-basename`: 36/36 passing (was 35/36 before)
- [x] `pytest` (full): 368 passing
- [x] `ruff check tests/test_spawn.py` clean

## Notes
Found yesterday during jph (silence tmux curl, PR #97) when running full pytest from a sibling worktree. Filed as e3a, fixed here.