### PR TITLE
ask-ack-notify refactor: non-blocking ask + ack lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,12 @@ The daemon is the single routing hub. It doesn't care how a peer connects — al
 
 - `channel/server.ts` — **experimental** Claude Code transport: MCP channel with reply tool, permission relay
 - `daemon/peer_registry.py` — peer state, circle access, events, lazy_repair, ghost eviction
-- `daemon/message_router.py` — routes queries/notifications/broadcasts via WebSocket
-- `daemon/query_tracker.py` — correlation ID tracking, asyncio Futures (async-locked)
-- `daemon/routes/` — HTTP endpoints (peers, messages, websocket, spawn, health)
-- `mcp/server.py` — MCP tools (list_peers, ask_peer, notify_peer, etc.)
+- `daemon/message_router.py` — sends `type=ask` / `notify` / `broadcast` over WebSocket; legacy `send_query` for /query shim
+- `daemon/ask_tracker.py` — non-blocking ask lifecycle (register/pickup/close/reminders, daemon-owned turn_seq under lock)
+- `daemon/query_tracker.py` — legacy /query correlation ID tracking, asyncio Futures (async-locked)
+- `daemon/routes/asks.py` — `/ask`, `/ack`, `/asks/{cid}/picked_up`, `/asks/pending`, `/asks/{cid}/mark_reminded`
+- `daemon/routes/` — other HTTP endpoints (peers, messages, websocket, spawn, health)
+- `mcp/server.py` — MCP tools (list_peers, ask, ack, notify_peer, broadcast, whoami, set_description, spawn_peer, kill_peer)
 - `relay/server.py` — hosted relay at repowire.io (WS bridge + HTTP tunnel)
 - `telegram/bot.py` — mobile mesh control via Telegram inline buttons
 - `hooks/` — **default** Claude Code transport (session, stop, prompt, notification, websocket_hook)
@@ -71,18 +73,24 @@ The daemon is the single routing hub. It doesn't care how a peer connects — al
 
 ```
 Claude Code → hooks → websocket_hook.py ←WebSocket→ Daemon
-             → stop hook → transcript parse → HTTP /response
+             → stop hook → transcript parse → HTTP /response (legacy /query)
+                                            → /asks/pending  (reminder fetch)
 ```
 
 - **SessionStart** → registers peer, spawns ws-hook (flock dedup), injects peer context
-- **Stop** → extracts response + tool calls from transcript, posts chat turns, delivers responses
-- **UserPromptSubmit** → marks BUSY
-- **Notification** (idle_prompt) → resets ONLINE
+- **Stop** →
+  1. extracts response + tool calls from transcript, posts chat turns
+  2. delivers legacy /query response (single-purpose `pending-query-{pane}.json` FIFO)
+  3. fetches `/asks/pending` (bumps daemon turn_seq) and writes any due reminders to `reminder-{pane}.txt`
+  4. then `update_status(online)` (drains BUSY-buffered asks; deferred until after the bump so drained-asks snapshot N+1 and aren't reminded same-turn)
+- **UserPromptSubmit** → marks BUSY, consumes `reminder-{pane}.txt` and emits as `additionalContext`
+- **Notification** (idle_prompt) → resets ONLINE; also consumes the reminder buffer as a fallback path
+- **ws-hook** → on `type=ask` arrival, injects `[ask #cid]` framed text and POSTs `/asks/{cid}/picked_up` directly (transport-side pickup; daemon snapshots turn_seq under lock)
 
 In channel mode, only the Stop hook is kept (for dashboard chat_turn events).
 `install_hooks(channel_mode=True)` installs only the Stop hook when using channel transport.
 
-Key files: `session_handler.py`, `stop_handler.py`, `prompt_handler.py`, `notification_handler.py`, `websocket_hook.py`, `utils.py`
+Key files: `session_handler.py`, `stop_handler.py`, `prompt_handler.py`, `notification_handler.py`, `websocket_hook.py`, `ask_lifecycle.py`, `utils.py`
 
 ### Hook Adapter (`hooks/adapters.py`)
 
@@ -113,7 +121,8 @@ Claude Code <stdio> channel/server.ts <WebSocket> Daemon
 ```
 
 - Messages arrive as `<channel source="repowire" from_peer="..." msg_type="...">` tags
-- Queries include `correlation_id` - Claude calls the `reply` tool to respond
+- Queries (legacy /query shim) include `correlation_id` — Claude calls the `reply` tool to respond
+- Asks (`msg_type=ask`) include `correlation_id` (and optional `reply_to`) — Claude calls the `ack(correlation_id, message?)` tool to close. Channel server POSTs `/asks/{cid}/picked_up` after dispatch so the daemon can snapshot turn_seq for the grace window.
 - Permission relay: forwards tool approval prompts to Telegram/dashboard
 - Requires claude.ai login (not API/Console key), Claude Code v2.1.80+, bun runtime
 - Opt-in only: `repowire setup --experimental-channels`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,10 @@ git push origin your-branch-name
 
 | Module | What it does |
 |---|---|
-| `daemon/` | Central routing hub: peer registry, message router, query tracker, HTTP routes |
-| `hooks/` | Default agent transport (Claude, Codex, Gemini): session, stop, prompt, notification handlers |
+| `daemon/` | Central routing hub: peer registry, message router, ask tracker (non-blocking ask lifecycle), legacy query tracker, HTTP routes |
+| `hooks/` | Default agent transport (Claude, Codex, Gemini): session, stop, prompt, notification handlers + ask-pickup transport reporter |
 | `channel/server.ts` | Experimental MCP stdio transport (requires bun) |
-| `mcp/server.py` | MCP tools: `list_peers`, `ask_peer`, `notify_peer`, etc. |
+| `mcp/server.py` | MCP tools: `list_peers`, `ask`, `ack`, `notify_peer`, `broadcast`, etc. |
 | `relay/server.py` | Hosted relay at repowire.io (WS bridge + HTTP tunnel) |
 | `telegram/bot.py` | Telegram bot peer for mobile mesh control |
 | `slack/bot.py` | Slack bot peer via Socket Mode |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Both sessions auto-register as peers and discover each other. In project-a:
 "Ask project-b what API endpoints they expose"
 ```
 
-The agent calls `ask_peer`, project-b receives the question, responds, and the answer comes back. Works across Claude Code, Codex, Gemini CLI, and OpenCode in any mix.
+The agent calls `ask`, project-b receives the question and acks back with `ack(corr_id, "...")`. The reply lands in project-a as a notification framed `[ack #cid from @project-b] ...`. Works across Claude Code, Codex, Gemini CLI, and OpenCode in any mix.
 
 Or use the CLI helper to spawn sessions in tmux:
 
@@ -91,8 +91,9 @@ All peers connect to a central daemon via **WebSocket**. The daemon routes addre
 </p>
 
 **Message types:**
-- `ask_peer` - request/response with correlation ID (blocks until answer, 300s timeout)
-- `notify_peer` - fire-and-forget (no response expected)
+- `ask` - non-blocking. Returns a correlation_id immediately; the recipient closes the thread with `ack(corr_id)` (bare close, "seen, no action") or `ack(corr_id, message)` (close with reply, delivered to the asker as a notification framed `[ack #cid from @peer] message`). Chain follow-ups with `ask(reply_to=corr_id, ...)`.
+- `ack` - close an open ask thread. Bare or with a reply message.
+- `notify_peer` - fire-and-forget (no lifecycle, no response expected)
 - `broadcast` - fan-out to all peers in your circle
 
 **Circles** are logical subnets (mapped to tmux sessions). Peers can only communicate within their circle unless explicitly bypassed.
@@ -133,7 +134,7 @@ repowire setup --experimental-channels
 <details>
 <summary>Multi-repo coordination</summary>
 
-Agents in different repos ask each other questions in real time. Project-a needs to know project-b's API shape? `ask_peer("project-b", "what endpoints do you expose?")` gets a live answer from the actual codebase, not stale docs.
+Agents in different repos ask each other questions in real time. Project-a needs to know project-b's API shape? `ask("project-b", "what endpoints do you expose?")` opens a thread; project-b replies with `ack(corr_id, "POST /users, GET /users/:id, ...")` and project-a sees a live answer from the actual codebase, not stale docs.
 </details>
 
 <details>
@@ -219,15 +220,20 @@ repowire telegram start
 | Tool | Type | Description |
 |------|------|-------------|
 | `list_peers` | Query | List all peers with status, circle, path, description |
-| `ask_peer` | Blocking | Send a question and wait for the response |
-| `notify_peer` | Fire-and-forget | Send a notification. Peer can `notify_peer` back when ready |
+| `ask` | Non-blocking | Open a thread. Returns a correlation_id immediately. Optional `reply_to=cid` chains a follow-up that closes the prior thread |
+| `ack` | Close | Close an open ask thread. Bare `ack(cid)` is "seen, no action"; `ack(cid, message)` delivers a reply to the asker |
+| `notify_peer` | Fire-and-forget | Send a notification (no lifecycle, no reply tracking) |
 | `broadcast` | Fire-and-forget | Message all online peers in your circle |
 | `whoami` | Query | Your own peer identity |
 | `set_description` | Mutation | Update your task description, visible to all peers and the dashboard |
 | `spawn_peer` | Mutation | Spawn a new agent session (requires [allowlist config](#configuration)) |
 | `kill_peer` | Mutation | Kill a previously spawned session |
 
-`list_peers` and `whoami` return TSV (more token-efficient than JSON). For long-running requests, prefer `notify_peer` over `ask_peer`.
+`list_peers` and `whoami` return TSV (more token-efficient than JSON).
+
+If an agent picks up an ask but doesn't ack/reply within one full turn, repowire injects a reminder block at the start of the next prompt (capped to 3 most-recent, once-only). Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does.
+
+The legacy `ask_peer` (blocking, request/response) is removed in this release. The legacy `/query` + `/response` HTTP endpoints remain as compatibility shims for the telegram bot and CLI; they will be removed in v0.13.
 
 ## CLI Reference
 

--- a/repowire/channel/server.ts
+++ b/repowire/channel/server.ts
@@ -146,7 +146,7 @@ async function fetchPeerContext(): Promise<string> {
       "\n[Repowire Mesh] Connected peers:",
       ...lines,
       "",
-      "Use ask_peer() to query peers. Use notify_peer() for fire-and-forget.",
+      "Use ask() to open a non-blocking thread (returns corr_id; peer responds via ack(corr_id) or ack(corr_id, message)). Use notify_peer() for fire-and-forget.",
       "Messages from @dashboard or @telegram are from the human user.",
       'Call set_description("task summary") so peers know what you\'re working on.',
     ].join("\n");

--- a/repowire/channel/server.ts
+++ b/repowire/channel/server.ts
@@ -73,15 +73,23 @@ function connectDaemon(mcp: Server): void {
     }
 
     // Deliver message to Claude via channel notification
-    if (msg.type === "query" || msg.type === "notify" || msg.type === "broadcast") {
+    if (
+      msg.type === "query" ||
+      msg.type === "ask" ||
+      msg.type === "notify" ||
+      msg.type === "broadcast"
+    ) {
       const meta: Record<string, string> = {
         from_peer: msg.from_peer ?? "unknown",
         msg_type: msg.type,
       };
 
-      if (msg.type === "query" && msg.correlation_id) {
+      if ((msg.type === "query" || msg.type === "ask") && msg.correlation_id) {
         meta.correlation_id = msg.correlation_id;
         pendingCorrelations.set(msg.correlation_id, msg.from_peer);
+      }
+      if (msg.type === "ask" && msg.reply_to) {
+        meta.reply_to = msg.reply_to;
       }
 
       await mcp.notification({
@@ -91,6 +99,30 @@ function connectDaemon(mcp: Server): void {
           meta,
         },
       });
+
+      // Transport-side pickup: tell the daemon this ask was delivered so it
+      // can snapshot turn_seq for the grace-window check. Channel uses HTTP
+      // base URL (DAEMON_URL is a WebSocket-flavored value).
+      if (msg.type === "ask" && msg.correlation_id) {
+        const httpUrl = DAEMON_URL.replace("ws://", "http://").replace(
+          "wss://",
+          "https://"
+        );
+        try {
+          await fetch(
+            `${httpUrl}/asks/${encodeURIComponent(msg.correlation_id)}/picked_up`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ correlation_id: msg.correlation_id }),
+            }
+          );
+        } catch (e) {
+          console.error(
+            `repowire: failed to post ask pickup for ${msg.correlation_id}: ${e}`
+          );
+        }
+      }
     }
   });
 
@@ -172,6 +204,7 @@ const mcp = new Server(
     instructions: [
       "Repowire mesh messages arrive as <channel source=\"repowire\" from_peer=\"...\" msg_type=\"...\">.",
       "For queries (msg_type=\"query\"), reply using the reply tool with the correlation_id from the tag.",
+      "For asks (msg_type=\"ask\"), the tag carries correlation_id. Use the ack tool: ack(correlation_id) for bare close, ack(correlation_id, message) to deliver a reply to the original asker.",
       "For notifications (msg_type=\"notify\"), act on them directly.",
       "Messages from @dashboard or @telegram are from the human user — treat as direct instructions.",
       peerContext,

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -18,6 +18,7 @@ from fastapi.staticfiles import StaticFiles
 
 from repowire import __version__
 from repowire.config.models import Config, load_config
+from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.auth import require_localhost
 from repowire.daemon.deps import cleanup_deps, init_deps
 from repowire.daemon.lifecycle_handler import LifecycleHandler
@@ -26,6 +27,7 @@ from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.relay_client import RelayClient
 from repowire.daemon.routes import (
+    asks,
     attachments,
     health,
     lifecycle,
@@ -77,6 +79,7 @@ def create_app(
         _cleanup_stale_artifacts(max_age_hours=cfg.daemon.prune_max_age_hours)
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
+        ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
         message_router = MessageRouter(
             transport=transport,
             query_tracker=query_tracker,
@@ -94,6 +97,7 @@ def create_app(
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
+        app.state.ask_tracker = ask_tracker
         app.state.message_router = message_router
         app.state.peer_registry = peer_registry
         app.state.relay_mode = cfg.relay.enabled
@@ -204,6 +208,7 @@ def create_app(
     app.include_router(health.router)
     app.include_router(peers.router)
     app.include_router(messages.router)
+    app.include_router(asks.router)
     app.include_router(websocket.router)
     app.include_router(spawn_routes.router)
     app.include_router(attachments.router)
@@ -288,6 +293,7 @@ def create_test_app(
 
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
+        ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
         msg_router = message_router or MessageRouter(
             transport=transport,
             query_tracker=query_tracker,
@@ -304,6 +310,7 @@ def create_test_app(
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
+        app.state.ask_tracker = ask_tracker
         app.state.message_router = msg_router
         app.state.peer_registry = registry
         app.state.relay_mode = cfg.relay.enabled
@@ -331,6 +338,7 @@ def create_test_app(
     app.include_router(health.router)
     app.include_router(peers.router)
     app.include_router(messages.router)
+    app.include_router(asks.router)
     app.include_router(websocket.router)
     app.include_router(spawn_routes.router)
     app.include_router(attachments.router)

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -90,6 +90,7 @@ def create_app(
             query_tracker=query_tracker,
             transport=transport,
             persistence_path=Path.home() / ".repowire" / "sessions.json",
+            ask_tracker=ask_tracker,
         )
         peer_registry.prune_offline(max_age_hours=cfg.daemon.prune_max_age_hours)
 
@@ -305,6 +306,7 @@ def create_test_app(
             query_tracker=query_tracker,
             transport=transport,
             persistence_path=persistence_path,
+            ask_tracker=ask_tracker,
         )
 
         app.state.config = cfg

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -24,32 +24,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
+_EVICTION_INTERVAL_SECONDS = 300.0
+
 
 @dataclass
 class Ask:
     """An open ask awaiting ack/reply.
 
-    Attributes:
-        correlation_id: Unique identifier for this ask
-        from_peer_id: peer_id of the sender
-        from_peer_name: display name of the sender
-        to_peer_id: peer_id of the recipient
-        to_peer_name: display name of the recipient
-        text: the ask's content
-        reply_to: corr_id of an earlier ask this one replies to (chained convo)
-        created_at: when the ask was registered
-        picked_up: True after the recipient's first Stop hook post-delivery
-        picked_up_at: timestamp of pickup
-        picked_up_turn_seq: monotonic turn counter at pickup (for one-turn grace)
-        reminded: True once a reminder has been injected (once-only)
-        closed: True once acked, replied-with-msg, or superseded by reply_to
-        close_reason: one of 'ack', 'ack_with_msg', 'reply_to', 'evicted'
+    picked_up_turn_seq: per-peer turn counter at pickup. Compared against the
+        next pending-poll's seq for the one-turn grace check. None until pickup.
+    close_reason: 'ack' | 'ack_with_msg' | 'reply_to' | 'evicted'.
     """
 
     correlation_id: str
@@ -78,10 +69,9 @@ class AskTracker:
     def __init__(self, *, ttl_hours: float = 24.0) -> None:
         self._lock = asyncio.Lock()
         self._asks: dict[str, Ask] = {}
-        # Per-peer turn counter: incremented on every Stop hook fire for that pane.
-        # Used to enforce the "one turn of grace after pickup" rule.
         self._turn_seq: dict[str, int] = {}
         self._ttl = timedelta(hours=ttl_hours)
+        self._last_eviction: float = 0.0
 
     async def register(
         self,
@@ -174,7 +164,12 @@ class AskTracker:
           - picked_up_turn_seq < current_turn_seq  (one full turn of grace)
 
         Returns the most recent `max_results` asks, newest first.
+
+        Lazy-repair: opportunistically evicts TTL-expired asks at most once
+        per _EVICTION_INTERVAL_SECONDS. Stop hooks call this on every turn,
+        so the dict gets swept regularly without a background timer.
         """
+        await self._maybe_evict_expired()
         async with self._lock:
             candidates = [
                 ask for ask in self._asks.values()
@@ -187,6 +182,32 @@ class AskTracker:
             ]
             candidates.sort(key=lambda a: a.created_at, reverse=True)
             return candidates[:max_results]
+
+    async def _maybe_evict_expired(self) -> None:
+        """Run TTL eviction if enough wall time has passed since the last sweep."""
+        now = time.monotonic()
+        if now - self._last_eviction < _EVICTION_INTERVAL_SECONDS:
+            return
+        self._last_eviction = now
+        await self.evict_expired()
+
+    async def forget_peer(self, peer_id: str) -> int:
+        """Drop turn counter and any asks involving this peer.
+
+        Called by PeerRegistry when pruning offline peers, so the tracker's
+        memory footprint is bounded by the live peer set.
+
+        Returns the number of asks dropped.
+        """
+        async with self._lock:
+            self._turn_seq.pop(peer_id, None)
+            doomed = [
+                cid for cid, ask in self._asks.items()
+                if ask.to_peer_id == peer_id or ask.from_peer_id == peer_id
+            ]
+            for cid in doomed:
+                del self._asks[cid]
+            return len(doomed)
 
     async def evict_expired(self) -> int:
         """Drop asks older than TTL. Returns count evicted.

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -1,0 +1,219 @@
+"""Ask/ack lifecycle tracking for the Repowire daemon.
+
+The AskTracker manages the non-blocking ask/ack lifecycle introduced in the
+ask-ack-notify refactor. Asks are registered when a peer fires `ask()`, the
+target peer picks them up on its next Stop hook (turn boundary), and they
+are closed when the target either:
+
+  - calls `ack(corr_id)` — bare close, no content
+  - calls `ack(corr_id, msg)` — close with reply content delivered to asker
+  - calls `ask(reply_to=corr_id, ...)` — opens a new thread + closes this one
+
+If a peer picks up an ask but doesn't ack/reply within one full turn after
+pickup, the Stop hook injects a reminder (capped to 3 most recent, once-only).
+
+Unlike QueryTracker (which used asyncio Futures for synchronous blocking),
+AskTracker is purely a state store. Reply delivery is handled by the
+notification pipeline (so it inherits BUSY-buffering for free).
+
+In-memory only. Asks are evicted after 24h via TTL sweep mirroring the
+config's prune_max_age_hours.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Ask:
+    """An open ask awaiting ack/reply.
+
+    Attributes:
+        correlation_id: Unique identifier for this ask
+        from_peer_id: peer_id of the sender
+        from_peer_name: display name of the sender
+        to_peer_id: peer_id of the recipient
+        to_peer_name: display name of the recipient
+        text: the ask's content
+        reply_to: corr_id of an earlier ask this one replies to (chained convo)
+        created_at: when the ask was registered
+        picked_up: True after the recipient's first Stop hook post-delivery
+        picked_up_at: timestamp of pickup
+        picked_up_turn_seq: monotonic turn counter at pickup (for one-turn grace)
+        reminded: True once a reminder has been injected (once-only)
+        closed: True once acked, replied-with-msg, or superseded by reply_to
+        close_reason: one of 'ack', 'ack_with_msg', 'reply_to', 'evicted'
+    """
+
+    correlation_id: str
+    from_peer_id: str
+    from_peer_name: str
+    to_peer_id: str
+    to_peer_name: str
+    text: str
+    reply_to: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    picked_up: bool = False
+    picked_up_at: datetime | None = None
+    picked_up_turn_seq: int | None = None
+    reminded: bool = False
+    closed: bool = False
+    close_reason: str | None = None
+
+
+class AskTracker:
+    """In-memory store for the ask/ack lifecycle.
+
+    All mutating methods are async-locked. Read methods are unlocked snapshots
+    (callers that need consistency should re-check after acting).
+    """
+
+    def __init__(self, *, ttl_hours: float = 24.0) -> None:
+        self._lock = asyncio.Lock()
+        self._asks: dict[str, Ask] = {}
+        # Per-peer turn counter: incremented on every Stop hook fire for that pane.
+        # Used to enforce the "one turn of grace after pickup" rule.
+        self._turn_seq: dict[str, int] = {}
+        self._ttl = timedelta(hours=ttl_hours)
+
+    async def register(
+        self,
+        from_peer_id: str,
+        from_peer_name: str,
+        to_peer_id: str,
+        to_peer_name: str,
+        text: str,
+        reply_to: str | None = None,
+        correlation_id: str | None = None,
+    ) -> str:
+        """Register a new open ask. Returns the correlation_id."""
+        async with self._lock:
+            cid = correlation_id or f"ask-{uuid4().hex[:8]}"
+            self._asks[cid] = Ask(
+                correlation_id=cid,
+                from_peer_id=from_peer_id,
+                from_peer_name=from_peer_name,
+                to_peer_id=to_peer_id,
+                to_peer_name=to_peer_name,
+                text=text,
+                reply_to=reply_to,
+            )
+            logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)
+            return cid
+
+    async def mark_picked_up(self, correlation_id: str, turn_seq: int) -> bool:
+        """Mark an ask as picked up by the recipient.
+
+        Idempotent — the first call sticks; subsequent calls are no-ops so
+        replays from a duplicated FIFO entry can't shift the grace window.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if not ask or ask.closed or ask.picked_up:
+                return False
+            ask.picked_up = True
+            ask.picked_up_at = datetime.now(timezone.utc)
+            ask.picked_up_turn_seq = turn_seq
+            return True
+
+    async def mark_reminded(self, correlation_id: str) -> bool:
+        """Flip reminded=True. Once-only."""
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if not ask or ask.closed or ask.reminded:
+                return False
+            ask.reminded = True
+            return True
+
+    async def close(self, correlation_id: str, reason: str) -> Ask | None:
+        """Close an ask. Returns the Ask if it existed and wasn't already closed."""
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if not ask or ask.closed:
+                return None
+            ask.closed = True
+            ask.close_reason = reason
+            logger.debug("Closed ask %s: %s", correlation_id, reason)
+            return ask
+
+    async def get(self, correlation_id: str) -> Ask | None:
+        """Look up an ask by corr_id."""
+        return self._asks.get(correlation_id)
+
+    async def increment_turn(self, peer_id: str) -> int:
+        """Bump the per-peer turn counter and return the new value.
+
+        Called from the Stop hook intake path. Each Stop fire for a pane is
+        one turn. The counter is used to compare against picked_up_turn_seq
+        for the grace-window check.
+        """
+        async with self._lock:
+            self._turn_seq[peer_id] = self._turn_seq.get(peer_id, 0) + 1
+            return self._turn_seq[peer_id]
+
+    async def pending_for_peer(
+        self,
+        peer_id: str,
+        current_turn_seq: int,
+        max_results: int = 3,
+    ) -> list[Ask]:
+        """Return open asks targeting this peer that are due for a reminder.
+
+        Selects asks where:
+          - to_peer_id == peer_id
+          - picked_up == True
+          - reminded == False
+          - closed == False
+          - picked_up_turn_seq < current_turn_seq  (one full turn of grace)
+
+        Returns the most recent `max_results` asks, newest first.
+        """
+        async with self._lock:
+            candidates = [
+                ask for ask in self._asks.values()
+                if ask.to_peer_id == peer_id
+                and ask.picked_up
+                and not ask.reminded
+                and not ask.closed
+                and ask.picked_up_turn_seq is not None
+                and ask.picked_up_turn_seq < current_turn_seq
+            ]
+            candidates.sort(key=lambda a: a.created_at, reverse=True)
+            return candidates[:max_results]
+
+    async def evict_expired(self) -> int:
+        """Drop asks older than TTL. Returns count evicted.
+
+        Closes them as 'evicted' before removal so any caller holding a
+        reference can see why they vanished.
+        """
+        cutoff = datetime.now(timezone.utc) - self._ttl
+        async with self._lock:
+            expired = [
+                cid for cid, ask in self._asks.items()
+                if ask.created_at < cutoff
+            ]
+            for cid in expired:
+                ask = self._asks[cid]
+                if not ask.closed:
+                    ask.closed = True
+                    ask.close_reason = "evicted"
+                del self._asks[cid]
+            if expired:
+                logger.info("Evicted %d expired asks", len(expired))
+            return len(expired)
+
+    def open_count(self) -> int:
+        """Number of open (non-closed) asks. For diagnostics."""
+        return sum(1 for ask in self._asks.values() if not ask.closed)
+
+    def total_count(self) -> int:
+        """Total asks tracked (open + closed-but-retained). For diagnostics."""
+        return len(self._asks)

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -98,11 +98,15 @@ class AskTracker:
             logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)
             return cid
 
-    async def mark_picked_up(self, correlation_id: str, turn_seq: int) -> bool:
+    async def mark_picked_up(self, correlation_id: str) -> bool:
         """Mark an ask as picked up by the recipient.
 
-        Idempotent — the first call sticks; subsequent calls are no-ops so
-        replays from a duplicated FIFO entry can't shift the grace window.
+        Snapshots the recipient's current turn_seq atomically (under the same
+        lock that increment_turn uses). Clients don't supply turn_seq — they
+        only signal "delivered." This keeps the grace-window math daemon-owned.
+
+        Idempotent — first call sticks; later calls are no-ops so replays
+        can't shift the grace window.
         """
         async with self._lock:
             ask = self._asks.get(correlation_id)
@@ -110,7 +114,7 @@ class AskTracker:
                 return False
             ask.picked_up = True
             ask.picked_up_at = datetime.now(timezone.utc)
-            ask.picked_up_turn_seq = turn_seq
+            ask.picked_up_turn_seq = self._turn_seq.get(ask.to_peer_id, 0)
             return True
 
     async def mark_reminded(self, correlation_id: str) -> bool:

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -83,9 +83,17 @@ class AskTracker:
         reply_to: str | None = None,
         correlation_id: str | None = None,
     ) -> str:
-        """Register a new open ask. Returns the correlation_id."""
+        """Register a new open ask. Returns the correlation_id.
+
+        If correlation_id is supplied and already exists, this is treated as
+        a retry: the existing entry is preserved (lifecycle state intact)
+        and the same id is returned. Auto-generated cids never collide.
+        """
         async with self._lock:
             cid = correlation_id or f"ask-{uuid4().hex[:8]}"
+            if cid in self._asks:
+                logger.debug("Ask %s already registered; treating as retry", cid)
+                return cid
             self._asks[cid] = Ask(
                 correlation_id=cid,
                 from_peer_id=from_peer_id,
@@ -210,6 +218,10 @@ class AskTracker:
                 if ask.to_peer_id == peer_id or ask.from_peer_id == peer_id
             ]
             for cid in doomed:
+                ask = self._asks[cid]
+                if not ask.closed:
+                    ask.closed = True
+                    ask.close_reason = "evicted"
                 del self._asks[cid]
             return len(doomed)
 

--- a/repowire/daemon/deps.py
+++ b/repowire/daemon/deps.py
@@ -15,6 +15,7 @@ class AppState(Protocol):
 
     transport: Any
     query_tracker: Any
+    ask_tracker: Any
     peer_registry: PeerRegistry
     config: Config
 

--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -99,27 +99,11 @@ class MessageRouter:
         to_session_id: str,
         to_peer_name: str,
         text: str,
-        intent: str = "notify",
-        correlation_id: str | None = None,
-        reply_to: str | None = None,
     ) -> None:
-        """Send notification (fire-and-forget).
+        """Send a plain FYI notification (fire-and-forget, no lifecycle).
 
-        The wire shape is `type: notify` with an optional `intent` field.
-        intent="ask" carries a correlation_id the ws-hook pushes onto the
-        per-pane FIFO so the recipient's Stop hook can record pickup.
-        intent="notify" is a plain FYI (no lifecycle).
-        intent="ack_reply" is an ack-with-msg delivered back to the original
-        asker; the framing in `text` already identifies it.
-
-        Args:
-            from_peer: Display name of sender
-            to_session_id: Session ID of recipient
-            to_peer_name: Display name of recipient (for logging)
-            text: Notification text
-            intent: 'notify' (default), 'ask', or 'ack_reply'
-            correlation_id: Required when intent='ask'; ignored otherwise
-            reply_to: Optional prior corr_id this ask replies to
+        Wire shape: {type: notify, from_peer, text}. Use send_ask for
+        ask-lifecycle messages.
 
         Raises:
             TransportError: If send fails
@@ -128,15 +112,38 @@ class MessageRouter:
             "type": "notify",
             "from_peer": from_peer,
             "text": text,
-            "intent": intent,
         }
-        if correlation_id is not None:
-            message["correlation_id"] = correlation_id
+        await self._transport.send(to_session_id, message)
+        logger.info(f"Notification sent: {from_peer} -> {to_peer_name}")
+
+    async def send_ask(
+        self,
+        from_peer: str,
+        to_session_id: str,
+        to_peer_name: str,
+        correlation_id: str,
+        text: str,
+        reply_to: str | None = None,
+    ) -> None:
+        """Send a first-class ask wire message.
+
+        Wire shape: {type: ask, correlation_id, from_peer, text, reply_to?}.
+        The receiving transport must dispatch type=ask explicitly and POST
+        /asks/{cid}/picked_up after presenting the message to the agent.
+
+        Raises:
+            TransportError: If send fails
+        """
+        message: dict[str, Any] = {
+            "type": "ask",
+            "correlation_id": correlation_id,
+            "from_peer": from_peer,
+            "text": text,
+        }
         if reply_to is not None:
             message["reply_to"] = reply_to
-
         await self._transport.send(to_session_id, message)
-        logger.info(f"Notification sent ({intent}): {from_peer} -> {to_peer_name}")
+        logger.info(f"Ask sent: {from_peer} -> {to_peer_name} ({correlation_id[:8]})")
 
     async def send_broadcast_to(
         self,

--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -99,14 +99,27 @@ class MessageRouter:
         to_session_id: str,
         to_peer_name: str,
         text: str,
+        intent: str = "notify",
+        correlation_id: str | None = None,
+        reply_to: str | None = None,
     ) -> None:
         """Send notification (fire-and-forget).
+
+        The wire shape is `type: notify` with an optional `intent` field.
+        intent="ask" carries a correlation_id the ws-hook pushes onto the
+        per-pane FIFO so the recipient's Stop hook can record pickup.
+        intent="notify" is a plain FYI (no lifecycle).
+        intent="ack_reply" is an ack-with-msg delivered back to the original
+        asker; the framing in `text` already identifies it.
 
         Args:
             from_peer: Display name of sender
             to_session_id: Session ID of recipient
             to_peer_name: Display name of recipient (for logging)
             text: Notification text
+            intent: 'notify' (default), 'ask', or 'ack_reply'
+            correlation_id: Required when intent='ask'; ignored otherwise
+            reply_to: Optional prior corr_id this ask replies to
 
         Raises:
             TransportError: If send fails
@@ -115,10 +128,15 @@ class MessageRouter:
             "type": "notify",
             "from_peer": from_peer,
             "text": text,
+            "intent": intent,
         }
+        if correlation_id is not None:
+            message["correlation_id"] = correlation_id
+        if reply_to is not None:
+            message["reply_to"] = reply_to
 
         await self._transport.send(to_session_id, message)
-        logger.info(f"Notification sent: {from_peer} -> {to_peer_name}")
+        logger.info(f"Notification sent ({intent}): {from_peer} -> {to_peer_name}")
 
     async def send_broadcast_to(
         self,

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -620,7 +620,7 @@ class PeerRegistry:
         formatted_query = (
             f"[Repowire Query from @{from_peer}]\n"
             f"{text}\n\n"
-            f"IMPORTANT: Respond directly in your message. Do NOT use ask_peer() to reply - "
+            f"IMPORTANT: Respond directly in your message. Do NOT use ask() to reply - "
             f"your response is automatically captured and returned to {from_peer}."
         )
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -734,12 +734,11 @@ class PeerRegistry:
         bypass_circle: bool = False,
         circle: str | None = None,
     ) -> None:
-        """Inject an ask to a peer (non-blocking lifecycle).
+        """Inject an ask to a peer as a first-class type=ask wire message.
 
-        Wire-level this is a notify with intent="ask" + correlation_id so the
-        recipient's ws-hook pushes the corr_id onto the per-pane FIFO. BUSY
-        recipients get the ask buffered and drained on idle, same path as
-        regular notifies.
+        BUSY recipients get the ask buffered and drained on idle. Pickup is
+        always the recipient transport's job — never daemon-side — so this
+        method only writes the wire frame.
         """
         async with self._lock:
             peer = self._lookup_peer_unlocked(to_peer, circle=circle)
@@ -752,10 +751,9 @@ class PeerRegistry:
             queued = self._enqueue_if_busy_unlocked(
                 peer,
                 {
-                    "kind": "notify",
+                    "kind": "ask",
                     "from_peer": from_peer,
                     "text": text,
-                    "intent": "ask",
                     "correlation_id": correlation_id,
                     "reply_to": reply_to,
                 },
@@ -775,13 +773,12 @@ class PeerRegistry:
         if queued:
             return
 
-        await self._router.send_notification(
+        await self._router.send_ask(
             from_peer=from_peer,
             to_session_id=peer_id,
             to_peer_name=peer_name,
-            text=text,
-            intent="ask",
             correlation_id=correlation_id,
+            text=text,
             reply_to=reply_to,
         )
 
@@ -927,8 +924,16 @@ class PeerRegistry:
                         to_session_id=peer_id,
                         to_peer_name=peer_name,
                         text=msg["text"],
-                        intent=msg.get("intent", "notify"),
-                        correlation_id=msg.get("correlation_id"),
+                    )
+                elif msg["kind"] == "ask":
+                    # Pickup remains the recipient transport's job; flushing
+                    # only writes the wire frame.
+                    await self._router.send_ask(
+                        from_peer=msg["from_peer"],
+                        to_session_id=peer_id,
+                        to_peer_name=peer_name,
+                        correlation_id=msg["correlation_id"],
+                        text=msg["text"],
                         reply_to=msg.get("reply_to"),
                     )
                 elif msg["kind"] == "broadcast":

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -25,6 +25,7 @@ from repowire.config.models import DEFAULT_QUERY_TIMEOUT, AgentType, Config
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus
 
 if TYPE_CHECKING:
+    from repowire.daemon.ask_tracker import AskTracker
     from repowire.daemon.message_router import MessageRouter
     from repowire.daemon.query_tracker import QueryTracker
     from repowire.daemon.websocket_transport import WebSocketTransport
@@ -74,11 +75,13 @@ class PeerRegistry:
         query_tracker: QueryTracker | None = None,
         transport: WebSocketTransport | None = None,
         persistence_path: Path | None = None,
+        ask_tracker: AskTracker | None = None,
     ) -> None:
         self._config = config
         self._router = message_router
         self._query_tracker = query_tracker
         self._transport = transport
+        self._ask_tracker = ask_tracker
 
         # Peer registry: peer_id -> Peer (single source of truth)
         self._peers: dict[str, Peer] = {}
@@ -1227,6 +1230,9 @@ class PeerRegistry:
             if stale:
                 self._mappings_dirty = True
                 logger.info("evicted %d stale offline peers", len(stale))
+        if stale and self._ask_tracker is not None:
+            for pid in stale:
+                await self._ask_tracker.forget_peer(pid)
         return len(stale)
 
     async def active_repair(self) -> None:

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -721,6 +721,67 @@ class PeerRegistry:
             text=text,
         )
 
+    async def deliver_ask(
+        self,
+        from_peer: str,
+        to_peer: str,
+        text: str,
+        correlation_id: str,
+        reply_to: str | None = None,
+        bypass_circle: bool = False,
+        circle: str | None = None,
+    ) -> None:
+        """Inject an ask to a peer (non-blocking lifecycle).
+
+        Wire-level this is a notify with intent="ask" + correlation_id so the
+        recipient's ws-hook pushes the corr_id onto the per-pane FIFO. BUSY
+        recipients get the ask buffered and drained on idle, same path as
+        regular notifies.
+        """
+        async with self._lock:
+            peer = self._lookup_peer_unlocked(to_peer, circle=circle)
+            if not peer:
+                raise ValueError(f"Unknown peer: {to_peer}")
+            from_obj = self._resolve_from_peer_unlocked(from_peer, peer, bypass_circle)
+            peer_id = peer.peer_id
+            peer_name = peer.display_name
+            from_peer_id = from_obj.peer_id if from_obj else None
+            queued = self._enqueue_if_busy_unlocked(
+                peer,
+                {
+                    "kind": "notify",
+                    "from_peer": from_peer,
+                    "text": text,
+                    "intent": "ask",
+                    "correlation_id": correlation_id,
+                    "reply_to": reply_to,
+                },
+            )
+
+        self.add_event(
+            "ask",
+            {
+                "from": from_peer, "to": to_peer, "text": text,
+                "from_peer_id": from_peer_id, "to_peer_id": peer_id,
+                "correlation_id": correlation_id,
+                "reply_to": reply_to,
+                "queued": queued,
+            },
+        )
+
+        if queued:
+            return
+
+        await self._router.send_notification(
+            from_peer=from_peer,
+            to_session_id=peer_id,
+            to_peer_name=peer_name,
+            text=text,
+            intent="ask",
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+        )
+
     async def broadcast(
         self,
         from_peer: str,
@@ -863,6 +924,9 @@ class PeerRegistry:
                         to_session_id=peer_id,
                         to_peer_name=peer_name,
                         text=msg["text"],
+                        intent=msg.get("intent", "notify"),
+                        correlation_id=msg.get("correlation_id"),
+                        reply_to=msg.get("reply_to"),
                     )
                 elif msg["kind"] == "broadcast":
                     # The original broadcast fanout already ran for online

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -155,33 +155,26 @@ async def ack_ask(
     state = get_app_state()
     ask_tracker = state.ask_tracker
 
-    ask = await ask_tracker.get(request.correlation_id)
-    if not ask:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No open ask with correlation_id: {request.correlation_id}",
-        )
-    if ask.closed:
-        return OkResponse()  # idempotent
-
     reason = "ack_with_msg" if request.message else "ack"
     closed = await ask_tracker.close(request.correlation_id, reason=reason)
     if closed is None:
-        return OkResponse()  # raced with another ack
+        # Either unknown corr_id or already closed. Distinguish via get():
+        # idempotent re-ack returns 200, truly unknown returns 404.
+        if await ask_tracker.get(request.correlation_id) is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No open ask with correlation_id: {request.correlation_id}",
+            )
+        return OkResponse()
 
     if request.message:
-        # Deliver as a notification with `[ack #cid from @peer] msg` framing.
-        # This goes through the existing BUSY-buffer pipeline, so if the
-        # original asker is busy when the ack lands, it queues + drains on idle.
-        # bypass_circle=True: an ack closes a thread that was already
-        # established at ask-time, so circle isolation (which gates *who can
-        # initiate* a thread) doesn't apply. The original asker is the
-        # legitimate recipient regardless of where they sit now.
+        # bypass_circle=True: ack closes a thread already established at
+        # ask-time; circle gate doesn't reapply.
         framed = f"[ack #{request.correlation_id} from @{request.from_peer}] {request.message}"
         try:
             await peer_registry.notify(
                 from_peer=request.from_peer,
-                to_peer=ask.from_peer_name,
+                to_peer=closed.from_peer_name,
                 text=framed,
                 bypass_circle=True,
             )

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -4,14 +4,15 @@ The non-blocking ask/ack model:
 
   POST /ask                       — register an ask, inject to recipient, return corr_id
   POST /ack                       — close an ask (bare or with reply content)
-  POST /asks/{cid}/picked_up      — recipient's Stop hook records pickup (turn boundary)
+  POST /asks/{cid}/picked_up      — transport signals delivery (daemon snapshots turn_seq)
   GET  /asks/pending              — recipient's Stop hook polls for due reminders
   POST /asks/{cid}/mark_reminded  — recipient's Stop hook flips once-only reminder flag
 
-The wire protocol carrying these to peers reuses `type: notify` with an
-`intent` field. ws-hook reads `intent` to decide whether to push a corr_id
-onto the per-pane FIFO (intent=ask) or just deliver as a plain notify
-(intent=notify, intent=ack_reply).
+The wire protocol carries these to peers as a first-class `type: ask`
+message: `{type: ask, correlation_id, from_peer, text, reply_to}`. Each
+transport (ws-hook, opencode plugin, channel server) dispatches `type=ask`
+explicitly and POSTs `/asks/{cid}/picked_up` after presenting the message
+to the agent.
 """
 
 from __future__ import annotations
@@ -61,10 +62,13 @@ class AckRequest(BaseModel):
 
 
 class PickedUpRequest(BaseModel):
-    """Stop hook reports pickup for a corr_id at a given turn sequence."""
+    """Transport reports that an ask was delivered to its recipient.
+
+    Daemon owns turn_seq sequencing — it snapshots its own per-peer counter
+    atomically when this endpoint is called. Clients only signal "delivered."
+    """
 
     correlation_id: str
-    turn_seq: int = Field(..., description="Per-peer turn counter at pickup")
     pane_id: str | None = Field(None, description="Pane that picked up (for logging)")
 
 
@@ -201,7 +205,7 @@ async def mark_picked_up(
     ask_tracker = state.ask_tracker
     if request.correlation_id != correlation_id:
         raise HTTPException(status_code=400, detail="correlation_id mismatch")
-    await ask_tracker.mark_picked_up(correlation_id, request.turn_seq)
+    await ask_tracker.mark_picked_up(correlation_id)
     return OkResponse()
 
 

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -127,9 +127,9 @@ async def open_ask(
         reply_to=request.reply_to,
     )
 
-    # Deliver to recipient via the existing notify pipeline. The wire message
-    # carries intent=ask + correlation_id so the ws-hook pushes onto the
-    # per-pane FIFO for pickup detection on the next Stop hook fire.
+    # Deliver as a first-class type=ask wire message. The recipient transport
+    # (ws-hook / opencode plugin / channel server) POSTs /asks/{cid}/picked_up
+    # after presenting the message to its agent.
     try:
         await peer_registry.deliver_ask(
             from_peer=request.from_peer,

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -1,0 +1,264 @@
+"""Ask/ack lifecycle endpoints.
+
+The non-blocking ask/ack model:
+
+  POST /ask                       — register an ask, inject to recipient, return corr_id
+  POST /ack                       — close an ask (bare or with reply content)
+  POST /asks/{cid}/picked_up      — recipient's Stop hook records pickup (turn boundary)
+  GET  /asks/pending              — recipient's Stop hook polls for due reminders
+  POST /asks/{cid}/mark_reminded  — recipient's Stop hook flips once-only reminder flag
+
+The wire protocol carrying these to peers reuses `type: notify` with an
+`intent` field. ws-hook reads `intent` to decide whether to push a corr_id
+onto the per-pane FIFO (intent=ask) or just deliver as a plain notify
+(intent=notify, intent=ack_reply).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state, get_peer_registry
+from repowire.daemon.routes._shared import OkResponse
+from repowire.protocol.peers import PeerStatus
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["asks"])
+
+
+class AskRequest(BaseModel):
+    """Open a new ask thread."""
+
+    from_peer: str = Field(..., description="Display name of the sender")
+    to_peer: str = Field(..., description="Display name of the recipient")
+    text: str = Field(..., description="Ask content")
+    reply_to: str | None = Field(
+        None,
+        description="If set, closes the referenced ask AND opens this new one",
+    )
+    bypass_circle: bool = Field(default=False)
+    circle: str | None = Field(None)
+
+
+class AskResponse(BaseModel):
+    """Result of opening an ask."""
+
+    correlation_id: str
+    status: str | None = None  # 'sent', 'queued' (recipient busy), or 'rejected'
+    error: str | None = None
+
+
+class AckRequest(BaseModel):
+    """Close an ask. If `message` is set, IS the reply (delivered to asker)."""
+
+    correlation_id: str
+    message: str | None = None
+    from_peer: str = Field(..., description="Display name of the acking peer")
+
+
+class PickedUpRequest(BaseModel):
+    """Stop hook reports pickup for a corr_id at a given turn sequence."""
+
+    correlation_id: str
+    turn_seq: int = Field(..., description="Per-peer turn counter at pickup")
+    pane_id: str | None = Field(None, description="Pane that picked up (for logging)")
+
+
+class MarkRemindedRequest(BaseModel):
+    correlation_id: str
+
+
+class PendingAsk(BaseModel):
+    correlation_id: str
+    from_peer: str
+    text: str
+    created_at: str
+    picked_up_at: str | None = None
+
+
+class PendingAsksResponse(BaseModel):
+    asks: list[PendingAsk]
+    current_turn_seq: int
+
+
+@router.post("/ask", response_model=AskResponse)
+async def open_ask(
+    request: AskRequest,
+    _: str | None = Depends(require_auth),
+) -> AskResponse:
+    """Open a non-blocking ask. Returns corr_id immediately."""
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    await peer_registry.lazy_repair()
+
+    # Resolve target peer
+    peer = await peer_registry.get_peer(request.to_peer, circle=request.circle)
+    if not peer:
+        raise HTTPException(status_code=404, detail=f"Unknown peer: {request.to_peer}")
+
+    # Resolve sender (best-effort — sender may be a CLI/external caller)
+    from_peer_obj = await peer_registry.get_peer(request.from_peer)
+    from_peer_id = from_peer_obj.peer_id if from_peer_obj else request.from_peer
+
+    # If reply_to is set, close that ask first as 'reply_to'
+    if request.reply_to:
+        prior = await ask_tracker.close(request.reply_to, reason="reply_to")
+        if prior is None:
+            logger.debug(
+                "ask reply_to=%s: prior ask not found or already closed",
+                request.reply_to,
+            )
+
+    cid = await ask_tracker.register(
+        from_peer_id=from_peer_id,
+        from_peer_name=request.from_peer,
+        to_peer_id=peer.peer_id,
+        to_peer_name=peer.display_name,
+        text=request.text,
+        reply_to=request.reply_to,
+    )
+
+    # Deliver to recipient via the existing notify pipeline. The wire message
+    # carries intent=ask + correlation_id so the ws-hook pushes onto the
+    # per-pane FIFO for pickup detection on the next Stop hook fire.
+    try:
+        await peer_registry.deliver_ask(
+            from_peer=request.from_peer,
+            to_peer=request.to_peer,
+            text=request.text,
+            correlation_id=cid,
+            reply_to=request.reply_to,
+            bypass_circle=request.bypass_circle,
+            circle=request.circle,
+        )
+    except ValueError as e:
+        # Peer not found by registry — close the ask we just opened
+        await ask_tracker.close(cid, reason="evicted")
+        raise HTTPException(status_code=404, detail=str(e))
+
+    delivery_status = "queued" if peer.status == PeerStatus.BUSY else "sent"
+    return AskResponse(correlation_id=cid, status=delivery_status)
+
+
+@router.post("/ack", response_model=OkResponse)
+async def ack_ask(
+    request: AckRequest,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Close an ask. With `message`, delivers the reply to the original asker."""
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+
+    ask = await ask_tracker.get(request.correlation_id)
+    if not ask:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No open ask with correlation_id: {request.correlation_id}",
+        )
+    if ask.closed:
+        return OkResponse()  # idempotent
+
+    reason = "ack_with_msg" if request.message else "ack"
+    closed = await ask_tracker.close(request.correlation_id, reason=reason)
+    if closed is None:
+        return OkResponse()  # raced with another ack
+
+    if request.message:
+        # Deliver as a notification with `[ack #cid from @peer] msg` framing.
+        # This goes through the existing BUSY-buffer pipeline, so if the
+        # original asker is busy when the ack lands, it queues + drains on idle.
+        # bypass_circle=True: an ack closes a thread that was already
+        # established at ask-time, so circle isolation (which gates *who can
+        # initiate* a thread) doesn't apply. The original asker is the
+        # legitimate recipient regardless of where they sit now.
+        framed = f"[ack #{request.correlation_id} from @{request.from_peer}] {request.message}"
+        try:
+            await peer_registry.notify(
+                from_peer=request.from_peer,
+                to_peer=ask.from_peer_name,
+                text=framed,
+                bypass_circle=True,
+            )
+        except ValueError as e:
+            logger.warning(
+                "ack reply delivery failed for %s: %s", request.correlation_id, e,
+            )
+        except Exception as e:
+            logger.exception(
+                "ack reply delivery error for %s: %s", request.correlation_id, e,
+            )
+
+    return OkResponse()
+
+
+@router.post("/asks/{correlation_id}/picked_up", response_model=OkResponse)
+async def mark_picked_up(
+    correlation_id: str,
+    request: PickedUpRequest,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Stop hook records that an ask was picked up at a given turn boundary."""
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    if request.correlation_id != correlation_id:
+        raise HTTPException(status_code=400, detail="correlation_id mismatch")
+    await ask_tracker.mark_picked_up(correlation_id, request.turn_seq)
+    return OkResponse()
+
+
+@router.post("/asks/{correlation_id}/mark_reminded", response_model=OkResponse)
+async def mark_reminded(
+    correlation_id: str,
+    request: MarkRemindedRequest,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Flip the once-only reminded flag after the Stop hook injects a reminder."""
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    if request.correlation_id != correlation_id:
+        raise HTTPException(status_code=400, detail="correlation_id mismatch")
+    await ask_tracker.mark_reminded(correlation_id)
+    return OkResponse()
+
+
+@router.get("/asks/pending", response_model=PendingAsksResponse)
+async def pending_asks(
+    pane_id: str,
+    _: str | None = Depends(require_auth),
+) -> PendingAsksResponse:
+    """Return asks targeting this pane that are due for a reminder.
+
+    Bumps the per-peer turn counter as a side effect (each Stop hook call =
+    one turn). Returns up to 3 most-recent picked-up-but-not-reminded asks
+    that have aged past the one-turn grace window.
+    """
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+
+    peer = await peer_registry.get_peer_by_pane(pane_id)
+    if not peer:
+        raise HTTPException(status_code=404, detail=f"No peer for pane: {pane_id}")
+
+    current_turn = await ask_tracker.increment_turn(peer.peer_id)
+    pending = await ask_tracker.pending_for_peer(peer.peer_id, current_turn)
+
+    return PendingAsksResponse(
+        asks=[
+            PendingAsk(
+                correlation_id=ask.correlation_id,
+                from_peer=ask.from_peer_name,
+                text=ask.text,
+                created_at=ask.created_at.isoformat(),
+                picked_up_at=ask.picked_up_at.isoformat() if ask.picked_up_at else None,
+            )
+            for ask in pending
+        ],
+        current_turn_seq=current_turn,
+    )

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -34,14 +34,17 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     Protocol (Client -> Daemon):
     - connect: {type, display_name, circle, backend, path?, auth_token?}
-    - response: {type, correlation_id, text}
+    - response: {type, correlation_id, text}    (legacy /query reply)
     - status: {type, status: busy|idle|online}
     - error: {type, correlation_id, error}
 
     Protocol (Daemon -> Client):
     - connected: {type, session_id}
-    - query: {type, correlation_id, from_peer, text}
-    - notify: {type, from_peer, text}
+    - query: {type, correlation_id, from_peer, text}    (legacy blocking RPC)
+    - ask: {type, correlation_id, from_peer, text, reply_to?}
+        Non-blocking ask. Recipient injects text, then POSTs
+        /asks/{cid}/picked_up (no body fields beyond cid + optional pane_id).
+    - notify: {type, from_peer, text}    (plain FYI, no lifecycle)
     - broadcast: {type, from_peer, text}
     """
     await websocket.accept()

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -59,7 +59,6 @@ def _scan_acks_and_replies(transcript_path: Path | None) -> tuple[set[str], set[
 def fetch_and_filter_pending(
     pane_id: str,
     transcript_path: Path | None,
-    self_peer_name: str,
 ) -> list[dict[str, Any]]:
     """Fetch due reminders, filter out ones acked/replied this turn.
 
@@ -82,15 +81,12 @@ def fetch_and_filter_pending(
     for ask in asks:
         cid = ask.get("correlation_id", "")
         if cid in handled:
-            # Closure requires a real ack() tool call — prose acks were
-            # intentionally dropped because they trigger on accidental
-            # mentions like "I'll do [ack #abc] later."
-            if cid in acked:
-                daemon_post(
-                    "/ack",
-                    {"correlation_id": cid, "from_peer": self_peer_name},
-                )
-            # reply_to closures already happened daemon-side at /ask time
+            # Filter only — do NOT auto-close. The agent's ack() tool call
+            # is in flight to the daemon at the same time as this hook;
+            # racing /ack here can land first with no message body and
+            # close the ask before the real ack-with-msg arrives, dropping
+            # the reply. The MCP tool call is the source of truth for
+            # closure; this hook just prevents same-turn reminders.
             continue
         pending.append(ask)
 

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -14,46 +14,18 @@ Two responsibilities:
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
 
-from repowire.hooks.utils import (
-    daemon_get,
-    daemon_post,
-    pending_cid_path,
-)
+from repowire.hooks.utils import daemon_get, daemon_post, pop_all_pending_cids
 from repowire.session.transcript import extract_last_turn_raw_tool_calls
 
 logger = logging.getLogger(__name__)
 
 
-_ACK_TOOL_NAMES = ("ack", "mcp__repowire__ack")
-_ASK_TOOL_NAMES = ("ask", "mcp__repowire__ask", "ask_peer", "mcp__repowire__ask_peer")
-
-
-def _pop_all_pending_cids(pane_id: str) -> list[str]:
-    """Drain the per-pane FIFO. Used at turn boundary for pickup recording."""
-    import fcntl
-
-    path = pending_cid_path(pane_id)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    try:
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                if not path.exists():
-                    return []
-                pending = json.loads(path.read_text())
-                if not pending:
-                    return []
-                path.write_text("[]")
-                return pending if isinstance(pending, list) else []
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    except (json.JSONDecodeError, OSError):
-        return []
+_ACK_BARE_NAMES = frozenset({"ack"})
+_ASK_BARE_NAMES = frozenset({"ask", "ask_peer"})
 
 
 def _scan_acks_and_replies(transcript_path: Path | None) -> tuple[set[str], set[str]]:
@@ -68,20 +40,18 @@ def _scan_acks_and_replies(transcript_path: Path | None) -> tuple[set[str], set[
     if not transcript_path:
         return acked, replied_to
 
-    raw_calls = extract_last_turn_raw_tool_calls(transcript_path)
-    for call in raw_calls:
+    for call in extract_last_turn_raw_tool_calls(transcript_path):
         name = call.get("name", "")
-        # Tool names may be namespaced (mcp__repowire__ack) or bare (ack)
-        bare = name.split("__")[-1] if "__" in name else name
+        bare = name.rpartition("__")[2] or name
         tool_input = call.get("input", {})
         if not isinstance(tool_input, dict):
             continue
 
-        if bare in ("ack",) or name in _ACK_TOOL_NAMES:
+        if bare in _ACK_BARE_NAMES:
             cid = tool_input.get("correlation_id") or tool_input.get("corr_id")
             if isinstance(cid, str) and cid:
                 acked.add(cid)
-        elif bare in ("ask", "ask_peer") or name in _ASK_TOOL_NAMES:
+        elif bare in _ASK_BARE_NAMES:
             reply_to = tool_input.get("reply_to")
             if isinstance(reply_to, str) and reply_to:
                 replied_to.add(reply_to)
@@ -97,8 +67,7 @@ def record_pickups(pane_id: str, current_turn_seq: int) -> None:
     same-turn grace check, and N<N+1=true on the next Stop fire — exactly
     one turn of grace, regardless of call order.
     """
-    pending = _pop_all_pending_cids(pane_id)
-    for cid in pending:
+    for cid in pop_all_pending_cids(pane_id):
         daemon_post(
             f"/asks/{cid}/picked_up",
             {

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -1,0 +1,184 @@
+"""Stop-hook helpers for the ask/ack lifecycle.
+
+Two responsibilities:
+
+  1. Pickup notification: pop any corr_ids the ws-hook pushed onto the per-pane
+     FIFO and tell the daemon "this turn is when we picked them up." The daemon
+     uses the turn sequence to enforce the one-turn grace before reminding.
+
+  2. Reminder injection: detect acks/replies in the just-completed turn,
+     query the daemon for picked-up-but-not-acked asks past the grace
+     window, and emit additionalContext (or fall back to printing to stderr
+     for backends that don't honor it) to nudge the agent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from repowire.hooks.utils import (
+    daemon_get,
+    daemon_post,
+    pending_cid_path,
+)
+from repowire.session.transcript import extract_last_turn_raw_tool_calls
+
+logger = logging.getLogger(__name__)
+
+
+_ACK_TOOL_NAMES = ("ack", "mcp__repowire__ack")
+_ASK_TOOL_NAMES = ("ask", "mcp__repowire__ask", "ask_peer", "mcp__repowire__ask_peer")
+
+
+def _pop_all_pending_cids(pane_id: str) -> list[str]:
+    """Drain the per-pane FIFO. Used at turn boundary for pickup recording."""
+    import fcntl
+
+    path = pending_cid_path(pane_id)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if not path.exists():
+                    return []
+                pending = json.loads(path.read_text())
+                if not pending:
+                    return []
+                path.write_text("[]")
+                return pending if isinstance(pending, list) else []
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _scan_acks_and_replies(transcript_path: Path | None) -> tuple[set[str], set[str]]:
+    """Return (acked_cids, replied_to_cids) found in the last turn.
+
+    acked_cids: corr_ids the agent acked (bare or with msg) via the `ack` tool.
+    replied_to_cids: corr_ids the agent referenced as reply_to in a new ask
+                     (which closes the prior ask).
+    """
+    acked: set[str] = set()
+    replied_to: set[str] = set()
+    if not transcript_path:
+        return acked, replied_to
+
+    raw_calls = extract_last_turn_raw_tool_calls(transcript_path)
+    for call in raw_calls:
+        name = call.get("name", "")
+        # Tool names may be namespaced (mcp__repowire__ack) or bare (ack)
+        bare = name.split("__")[-1] if "__" in name else name
+        tool_input = call.get("input", {})
+        if not isinstance(tool_input, dict):
+            continue
+
+        if bare in ("ack",) or name in _ACK_TOOL_NAMES:
+            cid = tool_input.get("correlation_id") or tool_input.get("corr_id")
+            if isinstance(cid, str) and cid:
+                acked.add(cid)
+        elif bare in ("ask", "ask_peer") or name in _ASK_TOOL_NAMES:
+            reply_to = tool_input.get("reply_to")
+            if isinstance(reply_to, str) and reply_to:
+                replied_to.add(reply_to)
+
+    return acked, replied_to
+
+
+def record_pickups(pane_id: str, current_turn_seq: int) -> None:
+    """Drain the FIFO and record each corr_id as picked-up at this turn.
+
+    `current_turn_seq` is the SAME value returned by fetch_and_filter_pending
+    in this Stop fire. Pickups tagged with seq=N produce N<N=false in the
+    same-turn grace check, and N<N+1=true on the next Stop fire — exactly
+    one turn of grace, regardless of call order.
+    """
+    pending = _pop_all_pending_cids(pane_id)
+    for cid in pending:
+        daemon_post(
+            f"/asks/{cid}/picked_up",
+            {
+                "correlation_id": cid,
+                "turn_seq": current_turn_seq,
+                "pane_id": pane_id,
+            },
+        )
+
+
+def fetch_and_filter_pending(
+    pane_id: str,
+    transcript_path: Path | None,
+    self_peer_name: str,
+) -> tuple[list[dict[str, Any]], int]:
+    """Fetch due reminders, filter out ones acked/replied this turn.
+
+    Returns (asks_to_inject, current_turn_seq). The caller passes
+    current_turn_seq to record_pickups so newly-arrived asks get tagged
+    with the turn that just ended (next Stop fire's grace window will
+    flip them eligible).
+
+    The daemon-side filter handles picked_up + reminded + grace-window. We
+    apply the additional client-side filter for "this turn already
+    handled it" because that's the only thing visible from the transcript.
+    """
+    result = daemon_get(f"/asks/pending?pane_id={pane_id}")
+    if not result:
+        return [], 0
+    current_turn_seq = result.get("current_turn_seq", 0)
+    asks = result.get("asks", [])
+    if not asks:
+        return [], current_turn_seq
+
+    acked, replied_to = _scan_acks_and_replies(transcript_path)
+    handled = acked | replied_to
+
+    pending: list[dict[str, Any]] = []
+    for ask in asks:
+        cid = ask.get("correlation_id", "")
+        if cid in handled:
+            # Close on the daemon side so it doesn't keep showing up.
+            # Closure requires a real ack() tool call — prose acks were
+            # intentionally dropped because they trigger on accidental
+            # mentions like "I'll do [ack #abc] later."
+            if cid in acked:
+                daemon_post(
+                    "/ack",
+                    {"correlation_id": cid, "from_peer": self_peer_name},
+                )
+            # reply_to closures already happened daemon-side at /ask time
+            continue
+        pending.append(ask)
+
+    # Mark each as reminded so we don't nudge twice (once-only rule)
+    for ask in pending:
+        cid = ask.get("correlation_id", "")
+        if cid:
+            daemon_post(
+                f"/asks/{cid}/mark_reminded",
+                {"correlation_id": cid},
+            )
+
+    return pending, current_turn_seq
+
+
+def format_reminder_block(asks: list[dict[str, Any]]) -> str:
+    """Format a context-injection block listing un-acked asks."""
+    if not asks:
+        return ""
+    lines = [
+        "[repowire] You have un-acknowledged asks. Each needs ack(corr_id) "
+        "to close (bare = seen-no-action), ack(corr_id, message) to reply, "
+        "or ask(reply_to=corr_id, ...) to chain a follow-up.",
+    ]
+    for ask in asks:
+        cid = ask.get("correlation_id", "")
+        from_peer = ask.get("from_peer", "?")
+        text = (ask.get("text") or "").strip()
+        if len(text) > 200:
+            text = text[:197] + "..."
+        lines.append(f"  - #{cid} from @{from_peer}: {text}")
+    return "\n".join(lines)

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from repowire.hooks.utils import daemon_get, daemon_post, pop_all_pending_cids
 from repowire.session.transcript import extract_last_turn_raw_tool_calls
@@ -94,7 +95,7 @@ def fetch_and_filter_pending(
     apply the additional client-side filter for "this turn already
     handled it" because that's the only thing visible from the transcript.
     """
-    result = daemon_get(f"/asks/pending?pane_id={pane_id}")
+    result = daemon_get(f"/asks/pending?pane_id={quote(pane_id, safe='')}")
     if not result:
         return [], 0
     current_turn_seq = result.get("current_turn_seq", 0)

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -1,15 +1,11 @@
-"""Stop-hook helpers for the ask/ack lifecycle.
+"""Stop-hook reminder logic for the ask/ack lifecycle.
 
-Two responsibilities:
-
-  1. Pickup notification: pop any corr_ids the ws-hook pushed onto the per-pane
-     FIFO and tell the daemon "this turn is when we picked them up." The daemon
-     uses the turn sequence to enforce the one-turn grace before reminding.
-
-  2. Reminder injection: detect acks/replies in the just-completed turn,
-     query the daemon for picked-up-but-not-acked asks past the grace
-     window, and emit additionalContext (or fall back to printing to stderr
-     for backends that don't honor it) to nudge the agent.
+Pickup is reported transport-side at delivery time (see ws-hook /
+opencode plugin / channel server) — never from this module. The Stop
+hook's only role here is reminder fetch + injection: query the daemon
+for picked-up-but-not-acked asks past the grace window, filter out
+any cids the agent already acked/replied to in the just-completed turn,
+and persist the rendered reminder block for the next prompt to inject.
 """
 
 from __future__ import annotations
@@ -19,7 +15,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from repowire.hooks.utils import daemon_get, daemon_post, pop_all_pending_cids
+from repowire.hooks.utils import daemon_get, daemon_post
 from repowire.session.transcript import extract_last_turn_raw_tool_calls
 
 logger = logging.getLogger(__name__)
@@ -60,48 +56,24 @@ def _scan_acks_and_replies(transcript_path: Path | None) -> tuple[set[str], set[
     return acked, replied_to
 
 
-def record_pickups(pane_id: str, current_turn_seq: int) -> None:
-    """Drain the FIFO and record each corr_id as picked-up at this turn.
-
-    `current_turn_seq` is the SAME value returned by fetch_and_filter_pending
-    in this Stop fire. Pickups tagged with seq=N produce N<N=false in the
-    same-turn grace check, and N<N+1=true on the next Stop fire — exactly
-    one turn of grace, regardless of call order.
-    """
-    for cid in pop_all_pending_cids(pane_id):
-        daemon_post(
-            f"/asks/{cid}/picked_up",
-            {
-                "correlation_id": cid,
-                "turn_seq": current_turn_seq,
-                "pane_id": pane_id,
-            },
-        )
-
-
 def fetch_and_filter_pending(
     pane_id: str,
     transcript_path: Path | None,
     self_peer_name: str,
-) -> tuple[list[dict[str, Any]], int]:
+) -> list[dict[str, Any]]:
     """Fetch due reminders, filter out ones acked/replied this turn.
 
-    Returns (asks_to_inject, current_turn_seq). The caller passes
-    current_turn_seq to record_pickups so newly-arrived asks get tagged
-    with the turn that just ended (next Stop fire's grace window will
-    flip them eligible).
-
-    The daemon-side filter handles picked_up + reminded + grace-window. We
-    apply the additional client-side filter for "this turn already
-    handled it" because that's the only thing visible from the transcript.
+    The daemon-side filter handles picked_up + reminded + grace-window. The
+    client-side filter here drops cids the agent already acked/replied to
+    via tool calls in the just-completed turn (the only signal visible from
+    the transcript).
     """
     result = daemon_get(f"/asks/pending?pane_id={quote(pane_id, safe='')}")
     if not result:
-        return [], 0
-    current_turn_seq = result.get("current_turn_seq", 0)
+        return []
     asks = result.get("asks", [])
     if not asks:
-        return [], current_turn_seq
+        return []
 
     acked, replied_to = _scan_acks_and_replies(transcript_path)
     handled = acked | replied_to
@@ -110,7 +82,6 @@ def fetch_and_filter_pending(
     for ask in asks:
         cid = ask.get("correlation_id", "")
         if cid in handled:
-            # Close on the daemon side so it doesn't keep showing up.
             # Closure requires a real ack() tool call — prose acks were
             # intentionally dropped because they trigger on accidental
             # mentions like "I'll do [ack #abc] later."
@@ -123,7 +94,6 @@ def fetch_and_filter_pending(
             continue
         pending.append(ask)
 
-    # Mark each as reminded so we don't nudge twice (once-only rule)
     for ask in pending:
         cid = ask.get("correlation_id", "")
         if cid:
@@ -132,7 +102,7 @@ def fetch_and_filter_pending(
                 {"correlation_id": cid},
             )
 
-    return pending, current_turn_seq
+    return pending
 
 
 def format_reminder_block(asks: list[dict[str, Any]]) -> str:

--- a/repowire/hooks/notification_handler.py
+++ b/repowire/hooks/notification_handler.py
@@ -12,7 +12,7 @@ import json
 import sys
 
 from repowire.hooks._tmux import get_pane_id
-from repowire.hooks.utils import update_status
+from repowire.hooks.utils import consume_reminder_buffer, update_status
 
 
 def main() -> int:
@@ -37,6 +37,21 @@ def main() -> int:
                 f"repowire notification: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+
+        # Idle is the secondary injection path for ask-ack reminders. If the
+        # agent has gone idle (no follow-up user prompt) but has un-acked
+        # asks, surface the reminder via additionalContext so it lands the
+        # next time the agent does anything. Notification hooks support the
+        # same hookSpecificOutput shape as UserPromptSubmit on Claude Code.
+        reminder = consume_reminder_buffer(pane_id)
+        if reminder:
+            print(json.dumps({
+                "hookSpecificOutput": {
+                    "hookEventName": "Notification",
+                    "additionalContext": reminder,
+                }
+            }))
+            return 0
 
     return 0
 

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -8,7 +8,7 @@ import sys
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import update_status
+from repowire.hooks.utils import consume_reminder_buffer, update_status
 
 
 def main(backend: str = "claude-code") -> int:
@@ -31,6 +31,22 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire prompt: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+
+    # Ask-ack reminder injection: if the previous Stop hook flagged any
+    # un-acked asks past the grace window, surface them as additionalContext
+    # so the agent sees them at the start of this turn. Buffer is consumed
+    # (deleted) on read so the same reminder doesn't repeat.
+    reminder = consume_reminder_buffer(pane_id) if pane_id else None
+    if reminder and backend == "claude-code":
+        # Claude Code reads hookSpecificOutput.additionalContext on
+        # UserPromptSubmit and prepends it to the agent's context for the turn.
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": reminder,
+            }
+        }))
+        return 0
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -124,12 +124,23 @@ def format_peers_context(peers: list[dict], my_name: str) -> str:
     lines.append("")
     lines.append(
         "IMPORTANT: When asked about these projects, ask the peer directly "
-        "via ask_peer() rather than searching locally."
+        "via ask() rather than searching locally. ask() is non-blocking and "
+        "returns a correlation_id; the peer responds via ack(corr_id) or "
+        "ack(corr_id, message). Use ask(reply_to=corr_id, ...) to chain a "
+        "follow-up that closes the prior thread."
     )
     lines.append(
         "Messages from @dashboard or @telegram are from the human user "
         "- treat them like direct instructions. Use notify_peer('telegram', msg) "
         "to send updates to the user's phone."
+    )
+    lines.append(
+        "Inbound asks arrive framed as `@peer [ask #corr_id]: ...` -- you "
+        "MUST close them with ack(corr_id) (bare seen-no-action) or "
+        "ack(corr_id, message) (reply). Otherwise repowire will inject a "
+        "reminder on your next turn. Inbound replies arrive as "
+        "`[ack #corr_id from @peer] message` -- those are closures, no "
+        "ack needed."
     )
     lines.append(
         'Call set_description("brief task summary") early - it becomes your '
@@ -139,7 +150,7 @@ def format_peers_context(peers: list[dict], my_name: str) -> str:
     lines.append(
         "NOTE: SendMessage is a Claude Code harness tool for same-session "
         "teammates only. To reach peers listed above, use repowire tools: "
-        "ask_peer(), notify_peer(), broadcast()."
+        "ask(), ack(), notify_peer(), broadcast()."
     )
 
     return "\n".join(lines)

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import json
 import sys
 from pathlib import Path
@@ -18,36 +17,11 @@ from repowire.hooks.ask_lifecycle import (
 from repowire.hooks.utils import (
     daemon_post,
     get_display_name,
-    pending_cid_path,
+    pop_pending_cid,
     update_status,
     write_reminder_buffer,
 )
 from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
-
-
-def _pop_pending_cid(pane_id: str) -> str | None:
-    """Pop the oldest pending correlation_id for a pane, if any.
-
-    Uses flock to prevent race with websocket_hook's _push_pending_cid.
-    """
-    path = pending_cid_path(pane_id)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    try:
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                if not path.exists():
-                    return None
-                pending = json.loads(path.read_text())
-                if not pending:
-                    return None
-                cid = pending.pop(0)
-                path.write_text(json.dumps(pending))
-                return cid
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    except (json.JSONDecodeError, OSError, IndexError):
-        return None
 
 
 def _post_chat_turn(
@@ -127,20 +101,12 @@ def main(backend: str = "claude-code") -> int:
     # record_pickups call below for any other cids on the FIFO.
     if pane_id and assistant_text:
         resp_payload: dict = {"pane_id": pane_id, "text": assistant_text}
-        cid = _pop_pending_cid(pane_id)
+        cid = pop_pending_cid(pane_id)
         if cid:
             resp_payload["correlation_id"] = cid
         daemon_post("/response", resp_payload)
 
-    # Ask-ack lifecycle: single fetch-and-share design.
-    #
-    # fetch_and_filter_pending bumps the daemon's per-peer turn counter ONCE
-    # and returns the new value as `current_turn_seq`. That same N is then
-    # passed to record_pickups, so new arrivals are tagged with seq=N. The
-    # grace check `picked_up_turn_seq < current_turn_seq` is N<N (false) for
-    # this-turn pickups. Next Stop fire bumps to N+1, picks tagged with N
-    # are flagged (N<N+1). Exactly one turn of grace, deterministic, no
-    # ordering dependency between the two calls within this Stop fire.
+    # Ask-ack lifecycle: single fetch-and-share turn_seq (see record_pickups).
     if pane_id:
         transcript_path = (
             Path(payload.transcript_path).expanduser().resolve()

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -9,15 +9,11 @@ from pathlib import Path
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.ask_lifecycle import (
-    fetch_and_filter_pending,
-    format_reminder_block,
-    record_pickups,
-)
+from repowire.hooks.ask_lifecycle import fetch_and_filter_pending, format_reminder_block
 from repowire.hooks.utils import (
     daemon_post,
     get_display_name,
-    pop_pending_cid,
+    pop_query_cid,
     update_status,
     write_reminder_buffer,
 )
@@ -53,21 +49,8 @@ def main(backend: str = "claude-code") -> int:
 
     payload = normalize(input_data, backend)
 
-    # Mark peer as online when agent finishes processing
     peer_display = get_display_name()
     pane_id = get_pane_id()
-    if pane_id:
-        if not update_status(pane_id, "online", use_pane_id=True):
-            print(
-                f"repowire stop: failed to update status for pane {pane_id}",
-                file=sys.stderr,
-            )
-    else:
-        if not update_status(peer_display, "online"):
-            print(
-                f"repowire stop: failed to update status for {peer_display}",
-                file=sys.stderr,
-            )
 
     # Get response text: adapter extracts from agent-specific fields,
     # fall back to transcript parsing for Claude Code
@@ -95,29 +78,46 @@ def main(backend: str = "claude-code") -> int:
             peer_display, "assistant", assistant_text, tool_calls or None, pane_id=pane_id,
         )
 
-    # Deliver response to daemon for query resolution (legacy /query path).
-    # Pops the oldest cid; the daemon resolves it as a query future if one is
-    # pending, else falls through to the ask-tracker pickup path via the
-    # record_pickups call below for any other cids on the FIFO.
+    # Deliver response to daemon for legacy /query future resolution.
+    # The query FIFO is single-purpose (only /query cids land here), so this
+    # never collides with the ask-ack lifecycle.
     if pane_id and assistant_text:
         resp_payload: dict = {"pane_id": pane_id, "text": assistant_text}
-        cid = pop_pending_cid(pane_id)
+        cid = pop_query_cid(pane_id)
         if cid:
             resp_payload["correlation_id"] = cid
         daemon_post("/response", resp_payload)
 
-    # Ask-ack lifecycle: single fetch-and-share turn_seq (see record_pickups).
+    # Ask-ack reminder fetch MUST happen before update_status. update_status
+    # transitions the peer from BUSY to online, which drains the BUSY buffer
+    # in the daemon and triggers fresh ask deliveries. Those deliveries POST
+    # pickup at the daemon's current turn_seq. If we bumped turn_seq AFTER
+    # the drain, those pickups would snapshot N and the same Stop's pending
+    # poll would flag them (N<N+1) — same-turn reminder, exactly the bug
+    # we're trying to avoid. By bumping first, drained-asks snapshot N+1
+    # and don't become eligible until the NEXT Stop.
     if pane_id:
         transcript_path = (
             Path(payload.transcript_path).expanduser().resolve()
             if payload.transcript_path else None
         )
-        due, current_turn_seq = fetch_and_filter_pending(
-            pane_id, transcript_path, peer_display,
-        )
+        due = fetch_and_filter_pending(pane_id, transcript_path, peer_display)
         if due:
             write_reminder_buffer(pane_id, format_reminder_block(due))
-        record_pickups(pane_id, current_turn_seq)
+
+    # Mark peer online — drains BUSY buffer if any. Now safe re: above.
+    if pane_id:
+        if not update_status(pane_id, "online", use_pane_id=True):
+            print(
+                f"repowire stop: failed to update status for pane {pane_id}",
+                file=sys.stderr,
+            )
+    else:
+        if not update_status(peer_display, "online"):
+            print(
+                f"repowire stop: failed to update status for {peer_display}",
+                file=sys.stderr,
+            )
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -10,7 +10,18 @@ from pathlib import Path
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import daemon_post, get_display_name, pending_cid_path, update_status
+from repowire.hooks.ask_lifecycle import (
+    fetch_and_filter_pending,
+    format_reminder_block,
+    record_pickups,
+)
+from repowire.hooks.utils import (
+    daemon_post,
+    get_display_name,
+    pending_cid_path,
+    update_status,
+    write_reminder_buffer,
+)
 from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
 
 
@@ -110,13 +121,37 @@ def main(backend: str = "claude-code") -> int:
             peer_display, "assistant", assistant_text, tool_calls or None, pane_id=pane_id,
         )
 
-    # Deliver response to daemon for query resolution
+    # Deliver response to daemon for query resolution (legacy /query path).
+    # Pops the oldest cid; the daemon resolves it as a query future if one is
+    # pending, else falls through to the ask-tracker pickup path via the
+    # record_pickups call below for any other cids on the FIFO.
     if pane_id and assistant_text:
         resp_payload: dict = {"pane_id": pane_id, "text": assistant_text}
         cid = _pop_pending_cid(pane_id)
         if cid:
             resp_payload["correlation_id"] = cid
         daemon_post("/response", resp_payload)
+
+    # Ask-ack lifecycle: single fetch-and-share design.
+    #
+    # fetch_and_filter_pending bumps the daemon's per-peer turn counter ONCE
+    # and returns the new value as `current_turn_seq`. That same N is then
+    # passed to record_pickups, so new arrivals are tagged with seq=N. The
+    # grace check `picked_up_turn_seq < current_turn_seq` is N<N (false) for
+    # this-turn pickups. Next Stop fire bumps to N+1, picks tagged with N
+    # are flagged (N<N+1). Exactly one turn of grace, deterministic, no
+    # ordering dependency between the two calls within this Stop fire.
+    if pane_id:
+        transcript_path = (
+            Path(payload.transcript_path).expanduser().resolve()
+            if payload.transcript_path else None
+        )
+        due, current_turn_seq = fetch_and_filter_pending(
+            pane_id, transcript_path, peer_display,
+        )
+        if due:
+            write_reminder_buffer(pane_id, format_reminder_block(due))
+        record_pickups(pane_id, current_turn_seq)
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -101,7 +101,7 @@ def main(backend: str = "claude-code") -> int:
             Path(payload.transcript_path).expanduser().resolve()
             if payload.transcript_path else None
         )
-        due = fetch_and_filter_pending(pane_id, transcript_path, peer_display)
+        due = fetch_and_filter_pending(pane_id, transcript_path)
         if due:
             write_reminder_buffer(pane_id, format_reminder_block(due))
 

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -111,6 +111,41 @@ def write_pane_runtime_metadata(pane_id: str | None, metadata: dict) -> None:
         ws_hook_legacy_cwd_path(pane_id).write_text(str(cwd))
 
 
+def reminder_buffer_path(pane_id: str | None) -> Path:
+    """Path to the pane's pending reminder text file.
+
+    The Stop hook writes ask-ack reminder text here when there are pending
+    asks past the grace window. The next UserPromptSubmit (or
+    Notification/idle_prompt) hook reads it, injects, and deletes.
+    """
+    return pane_logs_dir() / f"reminder-{get_pane_file(pane_id)}.txt"
+
+
+def consume_reminder_buffer(pane_id: str | None) -> str | None:
+    """Read and remove the pending reminder for a pane. Returns None if empty."""
+    if not pane_id:
+        return None
+    path = reminder_buffer_path(pane_id)
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return None
+    with suppress(OSError):
+        path.unlink()
+    return text or None
+
+
+def write_reminder_buffer(pane_id: str | None, text: str) -> None:
+    """Persist reminder text for next-prompt injection. Skips if empty."""
+    if not pane_id or not text:
+        return
+    path = reminder_buffer_path(pane_id)
+    try:
+        path.write_text(text)
+    except OSError as e:
+        print(f"repowire: failed to write reminder buffer: {e}", file=sys.stderr)
+
+
 def clear_pending_cids(pane_id: str | None) -> None:
     """Remove any queued correlation IDs for a pane."""
     if not pane_id:
@@ -133,6 +168,7 @@ def clear_pane_runtime_state(pane_id: str | None) -> None:
         ws_hook_pid_path(pane_id),
         ws_hook_meta_path(pane_id),
         ws_hook_legacy_cwd_path(pane_id),
+        reminder_buffer_path(pane_id),
     ):
         with suppress(OSError):
             path.unlink()

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -51,21 +51,19 @@ def get_display_name() -> str:
     return Path.cwd().name
 
 
-def pending_cid_path(pane_id: str | None) -> Path:
-    """Path to the pending correlation_id file for a pane."""
-    return pane_logs_dir() / f"pending-{get_pane_file(pane_id)}.json"
+def pending_query_cid_path(pane_id: str | None) -> Path:
+    """Path to the pending /query correlation_id file for a pane.
+
+    Single-purpose: only legacy /query cids land here. Ask cids are handled
+    transport-side (POST /asks/{cid}/picked_up) and never use a FIFO.
+    """
+    return pane_logs_dir() / f"pending-query-{get_pane_file(pane_id)}.json"
 
 
 @contextmanager
-def _locked_pending_cids(pane_id: str) -> Iterator[list[str]]:
-    """Yield the parsed pending-cid list under flock; persist on clean exit.
-
-    Mutate the yielded list in place — the wrapper writes it back when the
-    block exits. Read errors degrade to an empty list. Single shared
-    implementation for push, pop, and pop-all so the three call sites can't
-    drift on flock semantics.
-    """
-    path = pending_cid_path(pane_id)
+def _locked_query_cids(pane_id: str) -> Iterator[list[str]]:
+    """Yield the parsed pending-query-cid list under flock; persist on clean exit."""
+    path = pending_query_cid_path(pane_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_suffix(path.suffix + ".lock")
     with open(lock_path, "w") as lock_file:
@@ -83,26 +81,18 @@ def _locked_pending_cids(pane_id: str) -> Iterator[list[str]]:
             fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
-def push_pending_cid(pane_id: str, correlation_id: str) -> None:
-    """Append a correlation_id to the pane's pickup FIFO under flock."""
-    with _locked_pending_cids(pane_id) as pending:
+def push_query_cid(pane_id: str, correlation_id: str) -> None:
+    """Append a /query correlation_id to the per-pane FIFO under flock."""
+    with _locked_query_cids(pane_id) as pending:
         pending.append(correlation_id)
 
 
-def pop_pending_cid(pane_id: str) -> str | None:
-    """Pop the oldest correlation_id from the pane's FIFO under flock."""
-    with _locked_pending_cids(pane_id) as pending:
+def pop_query_cid(pane_id: str) -> str | None:
+    """Pop the oldest /query correlation_id from the per-pane FIFO under flock."""
+    with _locked_query_cids(pane_id) as pending:
         if not pending:
             return None
         return pending.pop(0)
-
-
-def pop_all_pending_cids(pane_id: str) -> list[str]:
-    """Drain the pane's FIFO under flock. Returns popped corr_ids in order."""
-    with _locked_pending_cids(pane_id) as pending:
-        drained = list(pending)
-        pending.clear()
-        return drained
 
 
 def pane_logs_dir() -> Path:
@@ -198,11 +188,11 @@ def write_reminder_buffer(pane_id: str | None, text: str) -> None:
 
 
 def clear_pending_cids(pane_id: str | None) -> None:
-    """Remove any queued correlation IDs for a pane."""
+    """Remove any queued /query correlation IDs for a pane."""
     if not pane_id:
         return
 
-    pending_path = pending_cid_path(pane_id)
+    pending_path = pending_query_cid_path(pane_id)
     lock_path = pending_path.with_suffix(pending_path.suffix + ".lock")
     for path in (pending_path, lock_path):
         with suppress(OSError):

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import atexit
+import fcntl
 import json
 import os
 import sys
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from pathlib import Path
 
 import httpx
@@ -49,9 +51,58 @@ def get_display_name() -> str:
     return Path.cwd().name
 
 
-def pending_cid_path(pane_id: str) -> Path:
+def pending_cid_path(pane_id: str | None) -> Path:
     """Path to the pending correlation_id file for a pane."""
     return pane_logs_dir() / f"pending-{get_pane_file(pane_id)}.json"
+
+
+@contextmanager
+def _locked_pending_cids(pane_id: str) -> Iterator[list[str]]:
+    """Yield the parsed pending-cid list under flock; persist on clean exit.
+
+    Mutate the yielded list in place — the wrapper writes it back when the
+    block exits. Read errors degrade to an empty list. Single shared
+    implementation for push, pop, and pop-all so the three call sites can't
+    drift on flock semantics.
+    """
+    path = pending_cid_path(pane_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with open(lock_path, "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            try:
+                pending = json.loads(path.read_text()) if path.exists() else []
+                if not isinstance(pending, list):
+                    pending = []
+            except (json.JSONDecodeError, OSError):
+                pending = []
+            yield pending
+            path.write_text(json.dumps(pending))
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def push_pending_cid(pane_id: str, correlation_id: str) -> None:
+    """Append a correlation_id to the pane's pickup FIFO under flock."""
+    with _locked_pending_cids(pane_id) as pending:
+        pending.append(correlation_id)
+
+
+def pop_pending_cid(pane_id: str) -> str | None:
+    """Pop the oldest correlation_id from the pane's FIFO under flock."""
+    with _locked_pending_cids(pane_id) as pending:
+        if not pending:
+            return None
+        return pending.pop(0)
+
+
+def pop_all_pending_cids(pane_id: str) -> list[str]:
+    """Drain the pane's FIFO under flock. Returns popped corr_ids in order."""
+    with _locked_pending_cids(pane_id) as pending:
+        drained = list(pending)
+        pending.clear()
+        return drained
 
 
 def pane_logs_dir() -> Path:

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -380,11 +380,23 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
                 raise PaneUnsafeError(str(e)) from e
 
     elif msg_type == "notify":
+        # Wire-level notify can carry intent=ask (new ask-ack lifecycle),
+        # intent=ack_reply (closure of a thread we initiated), or intent=notify
+        # (plain FYI, no lifecycle). Only intent=ask pushes onto the per-pane
+        # FIFO so the recipient's Stop hook can record pickup at turn boundary.
         try:
             from_peer = data.get("from_peer", "unknown")
             text = data.get("text", "")
-            if await asyncio.to_thread(_tmux_send_keys, pane_id, f"@{from_peer}: {text}"):
-                logger.info(f"Injected notification from {from_peer}")
+            intent = data.get("intent", "notify")
+            correlation_id = data.get("correlation_id", "")
+            if intent == "ask":
+                injected_text = f"@{from_peer} [ask #{correlation_id}]: {text}"
+            else:
+                injected_text = f"@{from_peer}: {text}"
+            if await asyncio.to_thread(_tmux_send_keys, pane_id, injected_text):
+                if intent == "ask" and correlation_id:
+                    _push_pending_cid(pane_id, correlation_id)
+                logger.info(f"Injected notification ({intent}) from {from_peer}")
         except Exception as e:
             logger.error(f"Failed to inject notification: {e}")
 

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -5,7 +5,6 @@ and forwards responses via WebSocket. Fully reactive — no polling.
 """
 
 import asyncio
-import fcntl
 import json
 import logging
 import os
@@ -25,7 +24,7 @@ from repowire.hooks._tmux import get_tmux_info
 from repowire.hooks.utils import (
     clear_pane_runtime_state,
     get_display_name,
-    pending_cid_path,
+    push_pending_cid,
     read_pane_runtime_metadata,
     write_pane_runtime_metadata,
 )
@@ -56,24 +55,8 @@ class PaneUnsafeError(RuntimeError):
 
 
 def _push_pending_cid(pane_id: str, correlation_id: str) -> None:
-    """Append a correlation_id to the pending file for a pane.
-
-    Uses flock to prevent race with stop_handler's _pop_pending_cid.
-    """
-    path = pending_cid_path(pane_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with open(lock_path, "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        try:
-            try:
-                pending = json.loads(path.read_text()) if path.exists() else []
-            except (json.JSONDecodeError, OSError):
-                pending = []
-            pending.append(correlation_id)
-            path.write_text(json.dumps(pending))
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
+    """Append a correlation_id to the per-pane pickup FIFO."""
+    push_pending_cid(pane_id, correlation_id)
 
 
 def _tmux_send_keys(pane_id: str, text: str) -> bool:

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -23,8 +23,9 @@ from repowire.config.models import AgentType
 from repowire.hooks._tmux import get_tmux_info
 from repowire.hooks.utils import (
     clear_pane_runtime_state,
+    daemon_post,
     get_display_name,
-    push_pending_cid,
+    push_query_cid,
     read_pane_runtime_metadata,
     write_pane_runtime_metadata,
 )
@@ -54,9 +55,17 @@ class PaneUnsafeError(RuntimeError):
     """Raised when the pane no longer belongs to the expected live agent."""
 
 
-def _push_pending_cid(pane_id: str, correlation_id: str) -> None:
-    """Append a correlation_id to the per-pane pickup FIFO."""
-    push_pending_cid(pane_id, correlation_id)
+def _push_query_cid(pane_id: str, correlation_id: str) -> None:
+    """Append a /query correlation_id to the per-pane FIFO."""
+    push_query_cid(pane_id, correlation_id)
+
+
+def _post_ask_picked_up(pane_id: str, correlation_id: str) -> None:
+    """Tell the daemon this ask was delivered; daemon snapshots turn_seq."""
+    daemon_post(
+        f"/asks/{correlation_id}/picked_up",
+        {"correlation_id": correlation_id, "pane_id": pane_id},
+    )
 
 
 def _tmux_send_keys(pane_id: str, text: str) -> bool:
@@ -301,10 +310,10 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
     msg_type = data.get("type")
 
     # Safety: verify agent is still running in the pane before injecting text
-    needs_safety = msg_type in ("query", "notify", "broadcast")
+    needs_safety = msg_type in ("query", "ask", "notify", "broadcast")
     if needs_safety and not await asyncio.to_thread(_is_pane_safe, pane_id):
         logger.warning(f"Pane {pane_id} not safe for injection, dropping {msg_type}")
-        if msg_type == "query" and websocket:
+        if msg_type in ("query", "ask") and websocket:
             correlation_id = data.get("correlation_id", "")
             try:
                 await websocket.send(
@@ -327,7 +336,7 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         try:
             if await asyncio.to_thread(_tmux_send_keys, pane_id, text):
                 # Track pending correlation_id for stop hook response delivery
-                _push_pending_cid(pane_id, correlation_id)
+                _push_query_cid(pane_id, correlation_id)
                 logger.info(f"Injected query from {from_peer}: {correlation_id[:8]}")
             else:
                 error_msg = f"Failed to send keys to pane {pane_id}"
@@ -362,24 +371,34 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
             if not await asyncio.to_thread(_is_pane_safe, pane_id):
                 raise PaneUnsafeError(str(e)) from e
 
+    elif msg_type == "ask":
+        # First-class ask: inject framed text, then POST pickup so the daemon
+        # can snapshot turn_seq for the grace-window check. No FIFO involved.
+        correlation_id = data.get("correlation_id", "")
+        from_peer = data.get("from_peer", "unknown")
+        text = data.get("text", "")
+        injected_text = f"@{from_peer} [ask #{correlation_id}]: {text}"
+        try:
+            if await asyncio.to_thread(_tmux_send_keys, pane_id, injected_text):
+                if correlation_id:
+                    await asyncio.to_thread(
+                        _post_ask_picked_up, pane_id, correlation_id,
+                    )
+                logger.info(
+                    f"Injected ask from {from_peer}: {correlation_id[:8]}",
+                )
+        except Exception as e:
+            logger.error(f"Failed to inject ask: {e}")
+
     elif msg_type == "notify":
-        # Wire-level notify can carry intent=ask (new ask-ack lifecycle),
-        # intent=ack_reply (closure of a thread we initiated), or intent=notify
-        # (plain FYI, no lifecycle). Only intent=ask pushes onto the per-pane
-        # FIFO so the recipient's Stop hook can record pickup at turn boundary.
+        # Plain FYI, no lifecycle.
         try:
             from_peer = data.get("from_peer", "unknown")
             text = data.get("text", "")
-            intent = data.get("intent", "notify")
-            correlation_id = data.get("correlation_id", "")
-            if intent == "ask":
-                injected_text = f"@{from_peer} [ask #{correlation_id}]: {text}"
-            else:
-                injected_text = f"@{from_peer}: {text}"
-            if await asyncio.to_thread(_tmux_send_keys, pane_id, injected_text):
-                if intent == "ask" and correlation_id:
-                    _push_pending_cid(pane_id, correlation_id)
-                logger.info(f"Injected notification ({intent}) from {from_peer}")
+            if await asyncio.to_thread(
+                _tmux_send_keys, pane_id, f"@{from_peer}: {text}",
+            ):
+                logger.info(f"Injected notification from {from_peer}")
         except Exception as e:
             logger.error(f"Failed to inject notification: {e}")
 

--- a/repowire/installers/opencode.py
+++ b/repowire/installers/opencode.py
@@ -283,6 +283,26 @@ async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>
     const fromPeer = data.from_peer as string
     const text = data.text as string
     await handleIncomingQuery(conn, correlationId, fromPeer, text)
+  } else if (msgType === "ask") {
+    // First-class ask: surface with [ask #cid] framing so the agent can
+    // ack via the ack tool. POST pickup ONLY if softInject succeeded —
+    // otherwise we'd be telling the daemon "delivered" without the agent
+    // having seen anything.
+    const correlationId = data.correlation_id as string
+    const fromPeer = (data.from_peer as string) || "unknown"
+    const text = data.text as string
+    const delivered = await softInject(
+      `@${fromPeer} → ${conn.peerName} [ask #${correlationId}]: ${text}`,
+    )
+    if (delivered && correlationId) {
+      try {
+        await daemon(`/asks/${encodeURIComponent(correlationId)}/picked_up`, {
+          correlation_id: correlationId,
+        })
+      } catch (e) {
+        console.debug("[repowire] failed to post ask pickup:", e)
+      }
+    }
   } else if (msgType === "ping") {
     if (conn.ws?.readyState === WebSocket.OPEN) {
       conn.ws.send(JSON.stringify({ type: "pong", pane_alive: true }))
@@ -300,10 +320,10 @@ async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>
   }
 }
 
-async function softInject(text: string) {
+async function softInject(text: string): Promise<boolean> {
   if (!serverUrl) {
     console.warn("[repowire] No serverUrl available for soft inject")
-    return
+    return false
   }
   try {
     const res = await fetch(`${serverUrl}tui/publish`, {
@@ -314,9 +334,14 @@ async function softInject(text: string) {
         properties: { text: text + " " },
       }),
     })
-    if (!res.ok) console.warn(`[repowire] tui.prompt.append failed: ${res.status}`)
+    if (!res.ok) {
+      console.warn(`[repowire] tui.prompt.append failed: ${res.status}`)
+      return false
+    }
+    return true
   } catch (e) {
     console.warn("[repowire] Failed to publish tui event:", e)
+    return false
   }
 }
 
@@ -699,10 +724,11 @@ export const RepowirePlugin: Plugin = async ({ client, directory, ...rest }) => 
           correlation_id: tool.schema.string().describe("The ask's correlation_id"),
           message: tool.schema.string().optional().describe("Optional reply content"),
         },
-        async execute({ correlation_id, message }) {
+        async execute({ correlation_id, message }, ctx) {
+          const me = callerPeer(ctx as { sessionID?: string })
           const body: any = {
             correlation_id,
-            from_peer: peerName,
+            from_peer: me.peerName,
           }
           if (message !== undefined) body.message = message
           await daemon("/ack", body)

--- a/repowire/installers/opencode.py
+++ b/repowire/installers/opencode.py
@@ -673,21 +673,40 @@ export const RepowirePlugin: Plugin = async ({ client, directory, ...rest }) => 
           return rows.join("\\n")
         },
       }),
-      ask_peer: tool({
-        description: "Ask another peer a question and wait for their response",
+      ask: tool({
+        description: "Open a non-blocking ask thread with a peer. Returns a correlation_id immediately. The peer responds via ack(corr_id) (bare close) or ack(corr_id, message) (reply, delivered as a notification framed [ack #cid from @peer] message).",
         args: {
           peer_name: tool.schema.string().describe("Name of the peer to ask"),
           query: tool.schema.string().describe("The question to ask"),
+          reply_to: tool.schema.string().optional().describe("If set, closes that prior ask before opening this one"),
         },
-        async execute({ peer_name, query }, ctx) {
+        async execute({ peer_name, query, reply_to }, ctx) {
           const me = callerPeer(ctx as { sessionID?: string })
-          const result = await daemon("/query", {
+          const body: any = {
             from_peer: me.peerName,
             to_peer: peer_name,
             text: query,
-          })
+          }
+          if (reply_to) body.reply_to = reply_to
+          const result = await daemon("/ask", body)
           if (result.error) throw new Error(result.error)
-          return result.text
+          return result.correlation_id || ""
+        },
+      }),
+      ack: tool({
+        description: "Close an open ask thread. Bare close: ack(corr_id). Reply: ack(corr_id, message) -- delivered to the original asker.",
+        args: {
+          correlation_id: tool.schema.string().describe("The ask's correlation_id"),
+          message: tool.schema.string().optional().describe("Optional reply content"),
+        },
+        async execute({ correlation_id, message }) {
+          const body: any = {
+            correlation_id,
+            from_peer: peerName,
+          }
+          if (message !== undefined) body.message = message
+          await daemon("/ack", body)
+          return `acked #${correlation_id}` + (message ? " with reply" : "")
         },
       }),
       notify_peer: tool({
@@ -912,8 +931,8 @@ export const RepowirePlugin: Plugin = async ({ client, directory, ...rest }) => 
 Other peers online:
 ${peerList}
 
-IMPORTANT: When asked about other projects, ask the peer directly via ask_peer rather than searching locally.
-Use list_peers to refresh peer status. Use notify_peer for fire-and-forget messages.`)
+IMPORTANT: When asked about other projects, ask the peer directly via ask tool rather than searching locally. ask returns a correlation_id immediately; the peer closes the thread via ack (bare = seen, no action) or ack(message) (reply). Inbound asks arrive framed [ask #cid] -- you must ack them.
+Use list_peers to see current peer status. Use notify_peer for fire-and-forget messages.`)
       } catch (e) {
         console.debug("[repowire] Failed to fetch peer context:", e)
       }

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -230,7 +230,7 @@ def create_mcp_server() -> FastMCP:
         offline peers.
 
         Returns TSV: peer_id, name, project, circle, role, status, path, machine,
-        description, backend. Peers are reachable via ask_peer/notify_peer. Do NOT
+        description, backend. Peers are reachable via ask/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
         """
@@ -244,24 +244,37 @@ def create_mcp_server() -> FastMCP:
         return "\n".join(rows)
 
     @mcp.tool()
-    async def ask_peer(peer_name: str, query: str, circle: str | None = None) -> str:
-        """[Repowire mesh] Ask a peer in another project and wait for response.
+    async def ask(
+        peer_name: str,
+        query: str,
+        reply_to: str | None = None,
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] Open a non-blocking ask thread with a peer.
 
-        Reaches peers across different projects and machines via the repowire
-        daemon. For complex questions that may take a long time, consider using
-        notify_peer instead.
+        Returns immediately with a correlation_id. The peer receives the
+        ask, and when they respond they call `ack(correlation_id)` (bare
+        close, "seen, no action") or `ack(correlation_id, message)` (close
+        with reply content delivered back to you as a notification framed
+        `[ack #correlation_id from @peer] message`).
 
-        Do NOT use SendMessage to reach repowire peers. SendMessage is a Claude
-        Code harness tool for same-session teammates only.
+        To chain a follow-up: call `ask(peer_name, query, reply_to=corr_id)`.
+        That closes the prior thread AND opens a new one referencing it.
+
+        If you need a synchronous wait, write your own poll loop on the
+        notification stream — the MCP surface is non-blocking by design.
+
+        Do NOT use SendMessage to reach repowire peers. SendMessage is a
+        Claude Code harness tool for same-session teammates only.
 
         Args:
-            peer_name: Name of the peer to ask (e.g., "backend", "frontend")
+            peer_name: Name of the peer to ask
             query: The question or request to send
-            circle: Circle to scope the lookup (optional, required when multiple
-                    peers share the same name in different circles)
+            reply_to: If set, closes that prior ask before opening this one
+            circle: Circle to scope the lookup (optional)
 
         Returns:
-            The peer's response text
+            correlation_id for tracking this ask thread
         """
         await _ensure_registered(strict=True)
         from_peer = await _get_my_peer_name()
@@ -270,12 +283,46 @@ def create_mcp_server() -> FastMCP:
             "to_peer": peer_name,
             "text": query,
         }
+        if reply_to is not None:
+            body["reply_to"] = reply_to
         if circle is not None:
             body["circle"] = circle
-        result = await daemon_request("POST", "/query", body)
+        result = await daemon_request("POST", "/ask", body)
         if result.get("error"):
             raise Exception(result["error"])
-        return result.get("text", "")
+        return result.get("correlation_id", "")
+
+    @mcp.tool()
+    async def ack(correlation_id: str, message: str | None = None) -> str:
+        """[Repowire mesh] Close an open ask thread.
+
+        Bare ack: `ack(corr_id)` — closes the thread, signals "seen, no
+        action needed." Use when an ask doesn't require a substantive reply.
+
+        Reply ack: `ack(corr_id, message)` — IS the reply. Closes the thread
+        AND delivers the message back to the original asker, framed as
+        `[ack #corr_id from @you] message` via the notification pipeline.
+
+        Replies always reach the original asker, regardless of circle (the
+        thread was already established at ask-time).
+
+        Args:
+            correlation_id: The ask's correlation_id
+            message: Optional reply content. Omit for bare close.
+
+        Returns:
+            Confirmation message
+        """
+        await _ensure_registered(strict=True)
+        from_peer = await _get_my_peer_name()
+        body: dict = {
+            "correlation_id": correlation_id,
+            "from_peer": from_peer,
+        }
+        if message is not None:
+            body["message"] = message
+        await daemon_request("POST", "/ack", body)
+        return f"acked #{correlation_id}" + (" with reply" if message else "")
 
     @mcp.tool()
     async def notify_peer(peer_name: str, message: str, circle: str | None = None) -> str:
@@ -417,7 +464,7 @@ def create_mcp_server() -> FastMCP:
         by other backends. If omitted, codex gets a short default warmup.
 
         Do NOT use SendMessage to reach spawned peers. SendMessage is a Claude
-        Code harness tool for same-session teammates only. Use ask_peer() or
+        Code harness tool for same-session teammates only. Use ask() or
         notify_peer() instead.
 
         Args:
@@ -439,7 +486,7 @@ def create_mcp_server() -> FastMCP:
         return (
             f"Spawned {name} (tmux: {tmux}). "
             f"Peer will self-register shortly. Use list_peers() to confirm "
-            f"and get peer_id. Address it as '{name}' via ask_peer/notify_peer."
+            f"and get peer_id. Address it as '{name}' via ask/notify_peer."
         )
 
     @mcp.tool()

--- a/repowire/session/transcript.py
+++ b/repowire/session/transcript.py
@@ -47,12 +47,12 @@ def extract_last_turn_pair(transcript_path: Path) -> tuple[str | None, str | Non
 
 
 def _iter_last_turn_tool_uses(transcript_path: Path) -> list[dict[str, Any]]:
-    """Return raw tool_use items from the last assistant turn, chronological order.
+    """Return raw tool_use items from the last turn, chronological order.
 
-    Walks backward from the end of the transcript, collecting tool_use
-    items from assistant entries. Stops at the first real user message,
-    skipping tool_result entries (which have type=user but aren't real
-    user prompts).
+    Handles both Claude shape (`{type:assistant,message:{content:[tool_use]}}`)
+    and Codex shape (`{type:response_item,payload:{type:function_call,name,arguments}}`).
+    Each entry is yielded as a normalized `{type:tool_use, name, input}` dict
+    where `input` is a parsed dict (Codex `arguments` are JSON-decoded).
     """
     if not transcript_path.exists():
         return []
@@ -68,6 +68,27 @@ def _iter_last_turn_tool_uses(transcript_path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError:
                 continue
 
+    if not entries:
+        return []
+
+    if _looks_like_codex(entries):
+        return _walk_codex(entries)
+    return _walk_claude(entries)
+
+
+def _looks_like_codex(entries: list[dict[str, Any]]) -> bool:
+    """Heuristic: codex transcripts have response_item entries; Claude has assistant/user."""
+    for entry in entries:
+        entry_type = entry.get("type")
+        if entry_type == "response_item":
+            return True
+        if entry_type in ("assistant", "user"):
+            return False
+    return False
+
+
+def _walk_claude(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Backward walk through Claude-style transcript for last-turn tool_uses."""
     items: list[dict[str, Any]] = []
     found_assistant = False
     for entry in reversed(entries):
@@ -89,7 +110,46 @@ def _iter_last_turn_tool_uses(transcript_path: Path) -> list[dict[str, Any]]:
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_use":
                 items.append(item)
+    items.reverse()
+    return items
 
+
+def _walk_codex(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Backward walk through Codex-style transcript for last-turn function_calls.
+
+    Codex entries are flat `response_item`s. The turn boundary is the most
+    recent user message — Codex represents this as either:
+      - {payload: {type: "message", role: "user", ...}}        (real shape)
+      - {payload: {type: "user_message" | "user_input", ...}}  (variant)
+    We collect function_calls back to that boundary, ignoring intervening
+    assistant messages and tool outputs.
+    """
+    items: list[dict[str, Any]] = []
+    for entry in reversed(entries):
+        if entry.get("type") != "response_item":
+            continue
+        payload = entry.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        payload_type = payload.get("type")
+        if payload_type in ("user_message", "user_input"):
+            break
+        if payload_type == "message" and payload.get("role") == "user":
+            break
+        if payload_type != "function_call":
+            continue
+        name = payload.get("name", "unknown")
+        args_raw = payload.get("arguments", {})
+        if isinstance(args_raw, str):
+            try:
+                args = json.loads(args_raw) if args_raw else {}
+            except json.JSONDecodeError:
+                args = {}
+        elif isinstance(args_raw, dict):
+            args = args_raw
+        else:
+            args = {}
+        items.append({"type": "tool_use", "name": name, "input": args})
     items.reverse()
     return items
 

--- a/repowire/session/transcript.py
+++ b/repowire/session/transcript.py
@@ -46,110 +46,80 @@ def extract_last_turn_pair(transcript_path: Path) -> tuple[str | None, str | Non
     return last_user, (last_assistant if last_assistant_had_text else None)
 
 
-def extract_last_turn_tool_calls(transcript_path: Path) -> list[dict[str, str]]:
-    """Extract tool calls from the last assistant turn.
+def _iter_last_turn_tool_uses(transcript_path: Path) -> list[dict[str, Any]]:
+    """Return raw tool_use items from the last assistant turn, chronological order.
 
-    Reads the transcript backwards from the last assistant message,
-    collecting tool_use entries until the previous user message.
+    Walks backward from the end of the transcript, collecting tool_use
+    items from assistant entries. Stops at the first real user message,
+    skipping tool_result entries (which have type=user but aren't real
+    user prompts).
+    """
+    if not transcript_path.exists():
+        return []
+
+    entries: list[dict[str, Any]] = []
+    with open(transcript_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    items: list[dict[str, Any]] = []
+    found_assistant = False
+    for entry in reversed(entries):
+        entry_type = entry.get("type")
+        if entry_type == "user" and found_assistant:
+            content = entry.get("message", {}).get("content", [])
+            is_tool_result = isinstance(content, list) and all(
+                isinstance(c, dict) and c.get("type") == "tool_result" for c in content
+            )
+            if not is_tool_result:
+                break
+            continue
+        if entry_type != "assistant":
+            continue
+        found_assistant = True
+        content = entry.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                items.append(item)
+
+    items.reverse()
+    return items
+
+
+def extract_last_turn_tool_calls(transcript_path: Path) -> list[dict[str, str]]:
+    """Tool calls from the last assistant turn, summarized for chat display.
 
     Returns list of {"name": "...", "input": "one-line summary"}.
     """
-    if not transcript_path.exists():
-        return []
-
-    entries: list[dict[str, Any]] = []
-    with open(transcript_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-
-    # Walk backwards: collect tool_use from assistant entries until we hit a real user message
-    tool_calls: list[dict[str, str]] = []
-    found_assistant = False
-    for entry in reversed(entries):
-        entry_type = entry.get("type")
-        if entry_type == "user" and found_assistant:
-            # Skip tool_result entries (they have type=user but aren't real user messages)
-            content = entry.get("message", {}).get("content", [])
-            is_tool_result = isinstance(content, list) and all(
-                isinstance(c, dict) and c.get("type") == "tool_result" for c in content
-            )
-            if not is_tool_result:
-                break
-            continue
-        if entry_type != "assistant":
-            continue
-        found_assistant = True
-        content = entry.get("message", {}).get("content", [])
-        if not isinstance(content, list):
-            continue
-        for item in content:
-            if isinstance(item, dict) and item.get("type") == "tool_use":
-                name = item.get("name", "unknown")
-                tool_input = item.get("input", {})
-                summary = _summarize_tool_input(name, tool_input)
-                tool_calls.append({"name": name, "input": summary})
-
-    tool_calls.reverse()  # chronological order
-    return tool_calls
+    return [
+        {
+            "name": item.get("name", "unknown"),
+            "input": _summarize_tool_input(
+                item.get("name", "unknown"), item.get("input", {}),
+            ),
+        }
+        for item in _iter_last_turn_tool_uses(transcript_path)
+    ]
 
 
 def extract_last_turn_raw_tool_calls(transcript_path: Path) -> list[dict[str, Any]]:
-    """Like extract_last_turn_tool_calls but returns raw tool inputs.
+    """Tool calls from the last assistant turn with raw, unsummarized inputs.
 
-    Used by the ask-ack reminder logic to detect ack(corr_id=X) and
-    ask(reply_to=X) invocations in the just-completed turn — those need to
-    inspect the unsummarized arguments. Mirrors the same walk-backwards
-    logic as extract_last_turn_tool_calls.
-
+    Used by the ask-ack reminder logic to inspect ack/ask arguments.
     Returns list of {"name": str, "input": dict | Any}.
     """
-    if not transcript_path.exists():
-        return []
-
-    entries: list[dict[str, Any]] = []
-    with open(transcript_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-
-    raw_calls: list[dict[str, Any]] = []
-    found_assistant = False
-    for entry in reversed(entries):
-        entry_type = entry.get("type")
-        if entry_type == "user" and found_assistant:
-            content = entry.get("message", {}).get("content", [])
-            is_tool_result = isinstance(content, list) and all(
-                isinstance(c, dict) and c.get("type") == "tool_result" for c in content
-            )
-            if not is_tool_result:
-                break
-            continue
-        if entry_type != "assistant":
-            continue
-        found_assistant = True
-        content = entry.get("message", {}).get("content", [])
-        if not isinstance(content, list):
-            continue
-        for item in content:
-            if isinstance(item, dict) and item.get("type") == "tool_use":
-                raw_calls.append({
-                    "name": item.get("name", "unknown"),
-                    "input": item.get("input", {}),
-                })
-
-    raw_calls.reverse()
-    return raw_calls
+    return [
+        {"name": item.get("name", "unknown"), "input": item.get("input", {})}
+        for item in _iter_last_turn_tool_uses(transcript_path)
+    ]
 
 
 def _summarize_tool_input(name: str, tool_input: Any) -> str:

--- a/repowire/session/transcript.py
+++ b/repowire/session/transcript.py
@@ -99,6 +99,59 @@ def extract_last_turn_tool_calls(transcript_path: Path) -> list[dict[str, str]]:
     return tool_calls
 
 
+def extract_last_turn_raw_tool_calls(transcript_path: Path) -> list[dict[str, Any]]:
+    """Like extract_last_turn_tool_calls but returns raw tool inputs.
+
+    Used by the ask-ack reminder logic to detect ack(corr_id=X) and
+    ask(reply_to=X) invocations in the just-completed turn — those need to
+    inspect the unsummarized arguments. Mirrors the same walk-backwards
+    logic as extract_last_turn_tool_calls.
+
+    Returns list of {"name": str, "input": dict | Any}.
+    """
+    if not transcript_path.exists():
+        return []
+
+    entries: list[dict[str, Any]] = []
+    with open(transcript_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    raw_calls: list[dict[str, Any]] = []
+    found_assistant = False
+    for entry in reversed(entries):
+        entry_type = entry.get("type")
+        if entry_type == "user" and found_assistant:
+            content = entry.get("message", {}).get("content", [])
+            is_tool_result = isinstance(content, list) and all(
+                isinstance(c, dict) and c.get("type") == "tool_result" for c in content
+            )
+            if not is_tool_result:
+                break
+            continue
+        if entry_type != "assistant":
+            continue
+        found_assistant = True
+        content = entry.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                raw_calls.append({
+                    "name": item.get("name", "unknown"),
+                    "input": item.get("input", {}),
+                })
+
+    raw_calls.reverse()
+    return raw_calls
+
+
 def _summarize_tool_input(name: str, tool_input: Any) -> str:
     """Create a one-line summary of tool input."""
     if not isinstance(tool_input, dict):

--- a/tests/test_ask_lifecycle.py
+++ b/tests/test_ask_lifecycle.py
@@ -1,0 +1,144 @@
+"""Tests for hooks/ask_lifecycle scanner — ack/reply detection in transcripts."""
+
+import json
+from pathlib import Path
+
+from repowire.hooks.ask_lifecycle import (
+    _scan_acks_and_replies,
+    format_reminder_block,
+)
+
+
+def _write_transcript(tmp_path: Path, entries: list[dict]) -> Path:
+    p = tmp_path / "t.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries))
+    return p
+
+
+def _assistant_with_tool(name: str, tool_input: dict) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": name, "input": tool_input},
+            ],
+        },
+    }
+
+
+def _user(text: str = "go") -> dict:
+    return {"type": "user", "message": {"content": text}}
+
+
+class TestScanAcksAndReplies:
+    def test_empty_when_no_path(self):
+        acked, replied = _scan_acks_and_replies(None)
+        assert acked == set()
+        assert replied == set()
+
+    def test_detects_ack_tool_call(self, tmp_path):
+        path = _write_transcript(tmp_path, [
+            _user(),
+            _assistant_with_tool("ack", {"correlation_id": "ask-aaa"}),
+        ])
+        acked, replied = _scan_acks_and_replies(path)
+        assert acked == {"ask-aaa"}
+        assert replied == set()
+
+    def test_detects_namespaced_ack(self, tmp_path):
+        path = _write_transcript(tmp_path, [
+            _user(),
+            _assistant_with_tool("mcp__repowire__ack", {"correlation_id": "ask-bbb"}),
+        ])
+        acked, _ = _scan_acks_and_replies(path)
+        assert acked == {"ask-bbb"}
+
+    def test_detects_reply_to_in_ask(self, tmp_path):
+        path = _write_transcript(tmp_path, [
+            _user(),
+            _assistant_with_tool("ask", {
+                "peer_name": "x", "query": "follow-up", "reply_to": "ask-prior",
+            }),
+        ])
+        acked, replied = _scan_acks_and_replies(path)
+        assert acked == set()
+        assert replied == {"ask-prior"}
+
+    def test_ask_without_reply_to_ignored(self, tmp_path):
+        path = _write_transcript(tmp_path, [
+            _user(),
+            _assistant_with_tool("ask", {"peer_name": "x", "query": "fresh"}),
+        ])
+        _, replied = _scan_acks_and_replies(path)
+        assert replied == set()
+
+    def test_only_last_turn(self, tmp_path):
+        """An ack from a prior turn shouldn't bleed into the current scan."""
+        path = _write_transcript(tmp_path, [
+            _user(),
+            _assistant_with_tool("ack", {"correlation_id": "old-cid"}),
+            _user("new prompt"),
+            _assistant_with_tool("ack", {"correlation_id": "new-cid"}),
+        ])
+        acked, _ = _scan_acks_and_replies(path)
+        assert acked == {"new-cid"}
+        assert "old-cid" not in acked
+
+    def test_multiple_acks_in_one_turn(self, tmp_path):
+        path = _write_transcript(tmp_path, [
+            _user(),
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "ack",
+                         "input": {"correlation_id": "ask-1"}},
+                        {"type": "tool_use", "name": "ack",
+                         "input": {"correlation_id": "ask-2"}},
+                    ],
+                },
+            },
+        ])
+        acked, _ = _scan_acks_and_replies(path)
+        assert acked == {"ask-1", "ask-2"}
+
+    def test_tool_results_dont_break_walk(self, tmp_path):
+        """tool_result entries (type=user) shouldn't terminate the backward walk."""
+        path = _write_transcript(tmp_path, [
+            _user("real prompt"),
+            _assistant_with_tool("ack", {"correlation_id": "ask-x"}),
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "abc", "content": "ok"},
+                    ],
+                },
+            },
+            _assistant_with_tool("ack", {"correlation_id": "ask-y"}),
+        ])
+        acked, _ = _scan_acks_and_replies(path)
+        # Both assistants in the same turn (separated by tool_result) collected
+        assert acked == {"ask-x", "ask-y"}
+
+
+class TestFormatReminderBlock:
+    def test_empty(self):
+        assert format_reminder_block([]) == ""
+
+    def test_single(self):
+        block = format_reminder_block([{
+            "correlation_id": "ask-x", "from_peer": "alice", "text": "what's the status?",
+        }])
+        assert "ask-x" in block
+        assert "@alice" in block
+        assert "what's the status?" in block
+        assert "ack(corr_id)" in block
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 500
+        block = format_reminder_block([{
+            "correlation_id": "ask-x", "from_peer": "a", "text": long_text,
+        }])
+        assert "..." in block
+        assert len(block) < 500

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -1,0 +1,253 @@
+"""Tests for /ask, /ack, and /asks/* HTTP routes."""
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import asks, peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+
+    # Stub the wire-level send so /ask doesn't fail on missing transport
+    router.send_notification = AsyncMock()
+
+    app = FastAPI()
+    app.include_router(peers.router)
+    app.include_router(asks.router)
+    return app, registry, at
+
+
+@pytest.fixture
+async def env(tmp_path):
+    app, registry, at = _make_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as c:
+        yield c, registry, at
+    cleanup_deps()
+
+
+async def _register_peer(client, name: str, pane_id: str | None = None) -> str:
+    body: dict = {
+        "name": name,
+        "path": f"/tmp/{name}",
+        "circle": "default",
+        "backend": "claude-code",
+    }
+    if pane_id:
+        body["pane_id"] = pane_id
+    r = await client.post("/peers", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()["display_name"]
+
+
+class TestAsk:
+    async def test_returns_correlation_id(self, env):
+        client, _, _ = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice",
+            "to_peer": bob,
+            "text": "what's up?",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["correlation_id"].startswith("ask-")
+        assert body["status"] in ("sent", "queued")
+
+    async def test_unknown_peer_returns_404(self, env):
+        client, _, _ = env
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": "ghost", "text": "?",
+        })
+        assert r.status_code == 404
+
+    async def test_reply_to_closes_prior(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "first",
+        })
+        first_cid = r.json()["correlation_id"]
+
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "follow-up",
+            "reply_to": first_cid,
+        })
+        assert r.status_code == 200
+        prior = await at.get(first_cid)
+        assert prior.closed
+        assert prior.close_reason == "reply_to"
+
+
+class TestAck:
+    async def test_bare_ack_closes(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+
+        r = await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob,
+        })
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.closed
+        assert ask.close_reason == "ack"
+
+    async def test_ack_with_msg_delivers_reply(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "status?",
+        })
+        cid = r.json()["correlation_id"]
+
+        r = await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob, "message": "all good",
+        })
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.closed
+        assert ask.close_reason == "ack_with_msg"
+
+    async def test_ack_unknown_id_404(self, env):
+        client, _, _ = env
+        r = await client.post("/ack", json={
+            "correlation_id": "ask-never", "from_peer": "x",
+        })
+        assert r.status_code == 404
+
+    async def test_ack_idempotent(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob,
+        })
+        r2 = await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob,
+        })
+        # Idempotent: second ack returns 200 not 404
+        assert r2.status_code == 200
+
+
+class TestPickedUp:
+    async def test_records_pickup(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        r = await client.post(f"/asks/{cid}/picked_up", json={
+            "correlation_id": cid, "turn_seq": 3,
+        })
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.picked_up
+        assert ask.picked_up_turn_seq == 3
+
+
+class TestPendingAsks:
+    async def test_grace_window(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob", pane_id="%50")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        # Pickup at seq=1
+        await client.post(f"/asks/{cid}/picked_up", json={
+            "correlation_id": cid, "turn_seq": 1,
+        })
+
+        # Same-turn check: bumps to 1, picked_up_turn_seq=1, 1<1 false
+        r = await client.get("/asks/pending?pane_id=%2550")
+        assert r.status_code == 200
+        body = r.json()
+        # Wait — first call bumps from 0 to 1; we already gave seq=1 to pickup,
+        # so 1 < 1 is false. Empty result.
+        # Actually pickup happened with seq=1 manually; first /asks/pending
+        # increments per-peer turn from 0 to 1. So filter is 1 < 1 = false.
+        assert body["asks"] == []
+        assert body["current_turn_seq"] == 1
+
+        # Next /asks/pending bumps to 2, 1 < 2 true, flagged
+        r = await client.get("/asks/pending?pane_id=%2550")
+        body = r.json()
+        assert body["current_turn_seq"] == 2
+        assert len(body["asks"]) == 1
+        assert body["asks"][0]["correlation_id"] == cid
+
+    async def test_unknown_pane(self, env):
+        client, _, _ = env
+        r = await client.get("/asks/pending?pane_id=%25nope")
+        assert r.status_code == 404
+
+
+class TestMarkReminded:
+    async def test_flips_flag(self, env):
+        client, _, at = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        r = await client.post(f"/asks/{cid}/mark_reminded", json={
+            "correlation_id": cid,
+        })
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.reminded

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -47,8 +47,9 @@ def _make_app(tmp_path: Path):
     )
     init_deps(cfg, registry, state)
 
-    # Stub the wire-level send so /ask doesn't fail on missing transport
+    # Stub the wire-level send so /ask and /ack don't fail on missing transport
     router.send_notification = AsyncMock()
+    router.send_ask = AsyncMock()
 
     app = FastAPI()
     app.include_router(peers.router)
@@ -189,46 +190,58 @@ class TestPickedUp:
             "from_peer": "alice", "to_peer": bob, "text": "?",
         })
         cid = r.json()["correlation_id"]
+        # Body no longer carries turn_seq; daemon snapshots its own counter.
         r = await client.post(f"/asks/{cid}/picked_up", json={
-            "correlation_id": cid, "turn_seq": 3,
+            "correlation_id": cid,
         })
         assert r.status_code == 200
         ask = await at.get(cid)
         assert ask.picked_up
-        assert ask.picked_up_turn_seq == 3
+        assert ask.picked_up_turn_seq == 0  # no /asks/pending called yet
 
 
 class TestPendingAsks:
     async def test_grace_window(self, env):
-        client, _, at = env
+        client, _, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob", pane_id="%50")
         r = await client.post("/ask", json={
             "from_peer": "alice", "to_peer": bob, "text": "?",
         })
         cid = r.json()["correlation_id"]
-        # Pickup at seq=1
-        await client.post(f"/asks/{cid}/picked_up", json={
-            "correlation_id": cid, "turn_seq": 1,
-        })
 
-        # Same-turn check: bumps to 1, picked_up_turn_seq=1, 1<1 false
+        # Transport-style pickup at delivery: snapshots turn_seq=0 (no
+        # /asks/pending has been called yet).
+        await client.post(f"/asks/{cid}/picked_up", json={"correlation_id": cid})
+
+        # First /asks/pending bumps counter to 1. picked_up_turn_seq=0 < 1 true.
         r = await client.get("/asks/pending?pane_id=%2550")
         assert r.status_code == 200
         body = r.json()
-        # Wait — first call bumps from 0 to 1; we already gave seq=1 to pickup,
-        # so 1 < 1 is false. Empty result.
-        # Actually pickup happened with seq=1 manually; first /asks/pending
-        # increments per-peer turn from 0 to 1. So filter is 1 < 1 = false.
-        assert body["asks"] == []
         assert body["current_turn_seq"] == 1
+        assert len(body["asks"]) == 1
+        assert body["asks"][0]["correlation_id"] == cid
 
-        # Next /asks/pending bumps to 2, 1 < 2 true, flagged
-        r = await client.get("/asks/pending?pane_id=%2550")
+    async def test_pickup_after_pending_not_flagged_same_cycle(self, env):
+        """Race case: /asks/pending bumps before pickup → same cycle skips."""
+        client, _, _ = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob", pane_id="%51")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        # Stop hook fires first: /asks/pending bumps to 1. Ask not picked up
+        # yet → empty result.
+        r = await client.get("/asks/pending?pane_id=%2551")
+        assert r.json()["asks"] == []
+        # Pickup arrives next: snapshots seq=1.
+        await client.post(f"/asks/{cid}/picked_up", json={"correlation_id": cid})
+        # Next Stop fire bumps to 2 → flagged.
+        r = await client.get("/asks/pending?pane_id=%2551")
         body = r.json()
         assert body["current_turn_seq"] == 2
         assert len(body["asks"]) == 1
-        assert body["asks"][0]["correlation_id"] == cid
 
     async def test_unknown_pane(self, env):
         client, _, _ = env

--- a/tests/test_ask_tracker.py
+++ b/tests/test_ask_tracker.py
@@ -37,25 +37,69 @@ class TestRegister:
 
 
 class TestPickup:
-    async def test_first_call_records(self, tracker):
+    async def test_first_call_snapshots_current_turn(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        ok = await tracker.mark_picked_up(cid, turn_seq=1)
+        # Bump recipient's turn to 3
+        await tracker.increment_turn("b-id")
+        await tracker.increment_turn("b-id")
+        await tracker.increment_turn("b-id")
+        ok = await tracker.mark_picked_up(cid)
         assert ok
         ask = await tracker.get(cid)
         assert ask.picked_up
-        assert ask.picked_up_turn_seq == 1
+        assert ask.picked_up_turn_seq == 3
 
     async def test_idempotent_second_call(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid, turn_seq=1)
-        ok = await tracker.mark_picked_up(cid, turn_seq=5)
+        await tracker.mark_picked_up(cid)
+        # First call snapshotted seq=0; bump to 5 and try to repickup
+        for _ in range(5):
+            await tracker.increment_turn("b-id")
+        ok = await tracker.mark_picked_up(cid)
         assert not ok
         ask = await tracker.get(cid)
-        # Second call must NOT shift the seq — that would invalidate grace
-        assert ask.picked_up_turn_seq == 1
+        # Original seq must stick
+        assert ask.picked_up_turn_seq == 0
 
     async def test_unknown_id(self, tracker):
-        assert not await tracker.mark_picked_up("never", turn_seq=1)
+        assert not await tracker.mark_picked_up("never")
+
+    async def test_no_state_shift_on_closed(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.close(cid, reason="ack")
+        ok = await tracker.mark_picked_up(cid)
+        assert not ok
+        ask = await tracker.get(cid)
+        assert ask.picked_up_turn_seq is None
+        assert not ask.picked_up
+
+    async def test_race_pickup_then_pending_increment(self, tracker):
+        """Pickup at seq=N, then /asks/pending bumps to N+1 → ask is due."""
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        # turn_seq starts at 0; pickup snapshots 0
+        await tracker.mark_picked_up(cid)
+        ask = await tracker.get(cid)
+        assert ask.picked_up_turn_seq == 0
+        # Stop hook calls /asks/pending → increment to 1
+        new_seq = await tracker.increment_turn("b-id")
+        assert new_seq == 1
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=new_seq)
+        assert len(result) == 1
+
+    async def test_race_increment_then_pickup_same_cycle(self, tracker):
+        """Same Stop fire bumps to N, pickup happens after, snapshots N → not due same cycle."""
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        new_seq = await tracker.increment_turn("b-id")
+        assert new_seq == 1
+        await tracker.mark_picked_up(cid)
+        ask = await tracker.get(cid)
+        assert ask.picked_up_turn_seq == 1
+        # Same cycle: 1 < 1 false → not flagged
+        assert await tracker.pending_for_peer("b-id", current_turn_seq=new_seq) == []
+        # Next cycle: 1 < 2 → flagged
+        next_seq = await tracker.increment_turn("b-id")
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=next_seq)
+        assert len(result) == 1
 
 
 class TestClose:
@@ -80,32 +124,34 @@ class TestClose:
 class TestPendingForPeer:
     async def test_filters_unpicked(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        # Not yet picked up
         result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
         assert result == []
-        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.mark_picked_up(cid)
         result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
         assert len(result) == 1
 
     async def test_grace_window_one_turn(self, tracker):
         """picked_up_turn_seq < current_turn_seq is the rule."""
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid, turn_seq=3)
-        # Same-turn check: 3 < 3 is false, not yet flagged
+        # Bump turn to 3, pickup snapshots 3
+        for _ in range(3):
+            await tracker.increment_turn("b-id")
+        await tracker.mark_picked_up(cid)
+        # Same-turn check: 3 < 3 is false
         assert await tracker.pending_for_peer("b-id", current_turn_seq=3) == []
-        # Next turn: 3 < 4, flagged
+        # Next turn: 3 < 4 true
         result = await tracker.pending_for_peer("b-id", current_turn_seq=4)
         assert len(result) == 1
 
     async def test_skips_reminded(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.mark_picked_up(cid)
         await tracker.mark_reminded(cid)
         assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
 
     async def test_skips_closed(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.mark_picked_up(cid)
         await tracker.close(cid, reason="ack")
         assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
 
@@ -113,7 +159,7 @@ class TestPendingForPeer:
         cids = []
         for i in range(5):
             cid = await tracker.register("a", "a", "b-id", "b", f"x{i}")
-            await tracker.mark_picked_up(cid, turn_seq=1)
+            await tracker.mark_picked_up(cid)
             cids.append(cid)
         result = await tracker.pending_for_peer("b-id", current_turn_seq=5, max_results=3)
         assert len(result) == 3
@@ -121,17 +167,16 @@ class TestPendingForPeer:
     async def test_newest_first(self, tracker):
         cid_old = await tracker.register("a", "a", "b-id", "b", "old")
         cid_new = await tracker.register("a", "a", "b-id", "b", "new")
-        # Manually backdate the older one to ensure ordering
         ask_old = await tracker.get(cid_old)
         ask_old.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
-        await tracker.mark_picked_up(cid_old, turn_seq=1)
-        await tracker.mark_picked_up(cid_new, turn_seq=1)
+        await tracker.mark_picked_up(cid_old)
+        await tracker.mark_picked_up(cid_new)
         result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
         assert result[0].correlation_id == cid_new
 
     async def test_other_peer_excluded(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.mark_picked_up(cid)
         result = await tracker.pending_for_peer("other-id", current_turn_seq=5)
         assert result == []
 

--- a/tests/test_ask_tracker.py
+++ b/tests/test_ask_tracker.py
@@ -1,0 +1,158 @@
+"""Tests for AskTracker — ask/ack lifecycle state."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from repowire.daemon.ask_tracker import AskTracker
+
+
+@pytest.fixture
+def tracker():
+    return AskTracker(ttl_hours=24.0)
+
+
+class TestRegister:
+    async def test_returns_correlation_id(self, tracker):
+        cid = await tracker.register("from", "from", "to-id", "to", "hello")
+        assert cid.startswith("ask-")
+
+    async def test_custom_id(self, tracker):
+        cid = await tracker.register(
+            "from", "from", "to-id", "to", "hello", correlation_id="ask-abc",
+        )
+        assert cid == "ask-abc"
+
+    async def test_stores_fields(self, tracker):
+        cid = await tracker.register(
+            "f-id", "f", "t-id", "t", "msg", reply_to="prior-cid",
+        )
+        ask = await tracker.get(cid)
+        assert ask.from_peer_id == "f-id"
+        assert ask.to_peer_name == "t"
+        assert ask.text == "msg"
+        assert ask.reply_to == "prior-cid"
+        assert ask.picked_up is False
+        assert ask.closed is False
+
+
+class TestPickup:
+    async def test_first_call_records(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        ok = await tracker.mark_picked_up(cid, turn_seq=1)
+        assert ok
+        ask = await tracker.get(cid)
+        assert ask.picked_up
+        assert ask.picked_up_turn_seq == 1
+
+    async def test_idempotent_second_call(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.mark_picked_up(cid, turn_seq=1)
+        ok = await tracker.mark_picked_up(cid, turn_seq=5)
+        assert not ok
+        ask = await tracker.get(cid)
+        # Second call must NOT shift the seq — that would invalidate grace
+        assert ask.picked_up_turn_seq == 1
+
+    async def test_unknown_id(self, tracker):
+        assert not await tracker.mark_picked_up("never", turn_seq=1)
+
+
+class TestClose:
+    async def test_closes_open_ask(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        closed = await tracker.close(cid, reason="ack")
+        assert closed is not None
+        ask = await tracker.get(cid)
+        assert ask.closed
+        assert ask.close_reason == "ack"
+
+    async def test_idempotent(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.close(cid, reason="ack")
+        again = await tracker.close(cid, reason="ack_with_msg")
+        assert again is None  # already closed
+
+    async def test_unknown(self, tracker):
+        assert await tracker.close("nope", reason="ack") is None
+
+
+class TestPendingForPeer:
+    async def test_filters_unpicked(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        # Not yet picked up
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
+        assert result == []
+        await tracker.mark_picked_up(cid, turn_seq=1)
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
+        assert len(result) == 1
+
+    async def test_grace_window_one_turn(self, tracker):
+        """picked_up_turn_seq < current_turn_seq is the rule."""
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.mark_picked_up(cid, turn_seq=3)
+        # Same-turn check: 3 < 3 is false, not yet flagged
+        assert await tracker.pending_for_peer("b-id", current_turn_seq=3) == []
+        # Next turn: 3 < 4, flagged
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=4)
+        assert len(result) == 1
+
+    async def test_skips_reminded(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.mark_reminded(cid)
+        assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
+
+    async def test_skips_closed(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.mark_picked_up(cid, turn_seq=1)
+        await tracker.close(cid, reason="ack")
+        assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
+
+    async def test_caps_to_max(self, tracker):
+        cids = []
+        for i in range(5):
+            cid = await tracker.register("a", "a", "b-id", "b", f"x{i}")
+            await tracker.mark_picked_up(cid, turn_seq=1)
+            cids.append(cid)
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=5, max_results=3)
+        assert len(result) == 3
+
+    async def test_newest_first(self, tracker):
+        cid_old = await tracker.register("a", "a", "b-id", "b", "old")
+        cid_new = await tracker.register("a", "a", "b-id", "b", "new")
+        # Manually backdate the older one to ensure ordering
+        ask_old = await tracker.get(cid_old)
+        ask_old.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+        await tracker.mark_picked_up(cid_old, turn_seq=1)
+        await tracker.mark_picked_up(cid_new, turn_seq=1)
+        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
+        assert result[0].correlation_id == cid_new
+
+    async def test_other_peer_excluded(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        await tracker.mark_picked_up(cid, turn_seq=1)
+        result = await tracker.pending_for_peer("other-id", current_turn_seq=5)
+        assert result == []
+
+
+class TestTurnCounter:
+    async def test_increments_per_peer(self, tracker):
+        assert await tracker.increment_turn("p1") == 1
+        assert await tracker.increment_turn("p1") == 2
+        assert await tracker.increment_turn("p2") == 1
+
+
+class TestEvictExpired:
+    async def test_evicts_old(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        ask = await tracker.get(cid)
+        ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        evicted = await tracker.evict_expired()
+        assert evicted == 1
+        assert await tracker.get(cid) is None
+
+    async def test_keeps_fresh(self, tracker):
+        await tracker.register("a", "a", "b-id", "b", "x")
+        evicted = await tracker.evict_expired()
+        assert evicted == 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,87 +13,83 @@ import repowire.hooks.websocket_hook as websocket_hook
 from repowire.hooks.websocket_hook import _is_pane_safe, _tmux_send_keys
 
 
-class TestHandleNotifyIntent:
-    """Tests for handle_message routing on type=notify with various intents.
+class TestHandleAskAndNotify:
+    """type=ask must POST pickup directly (no FIFO). type=notify is plain FYI.
 
-    The wire-level invariant: only intent=ask pushes onto the per-pane FIFO.
-    intent=notify (FYI) and intent=ack_reply (closure of a thread we
-    initiated) must NOT trigger a FIFO push, otherwise the receiving peer
-    would think it owes an ack on something that is itself a closure.
+    Lifecycle invariant: pickup is reported transport-side at delivery time,
+    not via a per-pane FIFO. Ack-with-msg replies arrive as plain notify and
+    must not produce a pickup POST.
     """
 
     @pytest.mark.asyncio
-    async def test_intent_ask_pushes_cid(self):
+    async def test_type_ask_posts_pickup(self):
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
             patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
         ):
             await websocket_hook.handle_message(
                 {
-                    "type": "notify",
-                    "intent": "ask",
+                    "type": "ask",
                     "correlation_id": "ask-abc",
                     "from_peer": "alice",
                     "text": "ping?",
                 },
                 "%5",
             )
-        mock_push.assert_called_once_with("%5", "ask-abc")
+        mock_post.assert_called_once_with("%5", "ask-abc")
 
     @pytest.mark.asyncio
-    async def test_intent_notify_does_not_push(self):
+    async def test_type_notify_does_not_post_pickup(self):
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
             patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
         ):
             await websocket_hook.handle_message(
-                {
-                    "type": "notify",
-                    "intent": "notify",
-                    "from_peer": "alice",
-                    "text": "fyi",
-                },
+                {"type": "notify", "from_peer": "alice", "text": "fyi"},
                 "%5",
             )
-        mock_push.assert_not_called()
+        mock_post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_intent_ack_reply_does_not_push(self):
-        """An ack-with-msg arriving at the original asker must not push a
-        cid onto their FIFO — it's a closure of a thread they initiated,
-        not a new ask owing them an ack."""
+    async def test_ack_reply_arrives_as_plain_notify(self):
+        """Ack-with-msg replies are plain notifies, no lifecycle, no pickup."""
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
             patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
         ):
             await websocket_hook.handle_message(
                 {
                     "type": "notify",
-                    "intent": "ack_reply",
-                    "correlation_id": "ask-original",
                     "from_peer": "bob",
                     "text": "[ack #ask-original from @bob] all good",
                 },
                 "%5",
             )
-        mock_push.assert_not_called()
+        mock_post.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_default_intent_treated_as_notify(self):
-        """No intent field present (legacy senders) → treated as plain notify."""
+    async def test_query_does_not_post_ask_pickup(self):
+        """Legacy /query path uses the query FIFO, not the ask pickup endpoint."""
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
             patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+            patch("repowire.hooks.websocket_hook._push_query_cid") as mock_push,
+            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
         ):
             await websocket_hook.handle_message(
-                {"type": "notify", "from_peer": "alice", "text": "hi"},
+                {
+                    "type": "query",
+                    "correlation_id": "query-abc",
+                    "from_peer": "alice",
+                    "text": "blocking?",
+                },
                 "%5",
             )
-        mock_push.assert_not_called()
+        mock_push.assert_called_once_with("%5", "query-abc")
+        mock_post.assert_not_called()
 
 
 class TestTmuxSendKeys:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,6 +13,89 @@ import repowire.hooks.websocket_hook as websocket_hook
 from repowire.hooks.websocket_hook import _is_pane_safe, _tmux_send_keys
 
 
+class TestHandleNotifyIntent:
+    """Tests for handle_message routing on type=notify with various intents.
+
+    The wire-level invariant: only intent=ask pushes onto the per-pane FIFO.
+    intent=notify (FYI) and intent=ack_reply (closure of a thread we
+    initiated) must NOT trigger a FIFO push, otherwise the receiving peer
+    would think it owes an ack on something that is itself a closure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_intent_ask_pushes_cid(self):
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
+            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "notify",
+                    "intent": "ask",
+                    "correlation_id": "ask-abc",
+                    "from_peer": "alice",
+                    "text": "ping?",
+                },
+                "%5",
+            )
+        mock_push.assert_called_once_with("%5", "ask-abc")
+
+    @pytest.mark.asyncio
+    async def test_intent_notify_does_not_push(self):
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
+            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "notify",
+                    "intent": "notify",
+                    "from_peer": "alice",
+                    "text": "fyi",
+                },
+                "%5",
+            )
+        mock_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_intent_ack_reply_does_not_push(self):
+        """An ack-with-msg arriving at the original asker must not push a
+        cid onto their FIFO — it's a closure of a thread they initiated,
+        not a new ask owing them an ack."""
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
+            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "notify",
+                    "intent": "ack_reply",
+                    "correlation_id": "ask-original",
+                    "from_peer": "bob",
+                    "text": "[ack #ask-original from @bob] all good",
+                },
+                "%5",
+            )
+        mock_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_intent_treated_as_notify(self):
+        """No intent field present (legacy senders) → treated as plain notify."""
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
+            patch("repowire.hooks.websocket_hook._push_pending_cid") as mock_push,
+        ):
+            await websocket_hook.handle_message(
+                {"type": "notify", "from_peer": "alice", "text": "hi"},
+                "%5",
+            )
+        mock_push.assert_not_called()
+
+
 class TestTmuxSendKeys:
     """Tests for _tmux_send_keys."""
 

--- a/tests/test_lifecycle_routes.py
+++ b/tests/test_lifecycle_routes.py
@@ -112,7 +112,7 @@ class TestPaneDied:
         with patch("repowire.config.models.CACHE_DIR", tmp_path):
             log_dir = tmp_path / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
-            pending_path = log_dir / "pending-5.json"
+            pending_path = log_dir / "pending-query-5.json"
             pending_path.write_text('["cid-1"]')
 
             r = await client.post(

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -104,3 +104,37 @@ class TestBroadcast:
         transport.send.side_effect = fail_second
         sent = await router.broadcast("sender", "hello")
         assert len(sent) == 1
+
+
+class TestSendAsk:
+    async def test_wire_shape(self, router, transport):
+        await router.send_ask(
+            from_peer="alice",
+            to_session_id="sid-bob",
+            to_peer_name="bob",
+            correlation_id="ask-abc",
+            text="ping?",
+        )
+        transport.send.assert_called_once()
+        sid, msg = transport.send.call_args[0]
+        assert sid == "sid-bob"
+        assert msg["type"] == "ask"
+        assert msg["correlation_id"] == "ask-abc"
+        assert msg["from_peer"] == "alice"
+        assert msg["text"] == "ping?"
+        # No intent field — it's a first-class type
+        assert "intent" not in msg
+        # No reply_to when not supplied
+        assert "reply_to" not in msg
+
+    async def test_includes_reply_to(self, router, transport):
+        await router.send_ask(
+            from_peer="alice",
+            to_session_id="sid-bob",
+            to_peer_name="bob",
+            correlation_id="ask-new",
+            text="follow-up",
+            reply_to="ask-prior",
+        )
+        msg = transport.send.call_args[0][1]
+        assert msg["reply_to"] == "ask-prior"

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -236,7 +236,7 @@ class TestSessionMain:
                 "peer_id": "repow-default-old12345",
             }))
             (log_dir / "ws-hook-1.pid").write_text("99999")
-            (log_dir / "pending-1.json").write_text(json.dumps(["stale-cid"]))
+            (log_dir / "pending-query-1.json").write_text(json.dumps(["stale-cid"]))
 
             with patch("repowire.hooks.session_handler.fcntl") as mock_fcntl, \
                  patch("repowire.hooks.session_handler.os.kill") as mock_kill, \
@@ -258,4 +258,4 @@ class TestSessionMain:
                 assert result == 0
                 mock_kill.assert_called_once_with(99999, signal.SIGTERM)
                 mock_register.assert_called_once()
-                assert not (log_dir / "pending-1.json").exists()
+                assert not (log_dir / "pending-query-1.json").exists()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -455,7 +455,7 @@ class TestMcpToolDescriptions:
         """All repowire MCP tools should include [Repowire mesh] in their description."""
         from repowire.mcp.server import create_mcp_server
         mcp = create_mcp_server()
-        mesh_tools = ["list_peers", "ask_peer", "notify_peer", "broadcast",
+        mesh_tools = ["list_peers", "ask", "ack", "notify_peer", "broadcast",
                        "spawn_peer", "kill_peer", "whoami", "set_description"]
         for name in mesh_tools:
             tool = mcp._tool_manager._tools.get(name)
@@ -469,7 +469,7 @@ class TestMcpToolDescriptions:
         """Tools that send messages should warn against using SendMessage."""
         from repowire.mcp.server import create_mcp_server
         mcp = create_mcp_server()
-        for name in ["ask_peer", "notify_peer", "broadcast", "spawn_peer"]:
+        for name in ["ask", "notify_peer", "broadcast", "spawn_peer"]:
             tool = mcp._tool_manager._tools.get(name)
             desc = tool.description or ""
             assert "SendMessage" in desc, (

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -2,7 +2,11 @@ import json
 import tempfile
 from pathlib import Path
 
-from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
+from repowire.session.transcript import (
+    extract_last_turn_pair,
+    extract_last_turn_raw_tool_calls,
+    extract_last_turn_tool_calls,
+)
 
 
 class TestExtractLastTurnPair:
@@ -221,4 +225,144 @@ class TestExtractToolCalls:
 
         calls = extract_last_turn_tool_calls(path)
         assert calls[0]["input"] == "pytest tests/ -v"
+        path.unlink()
+
+
+class TestCodexTranscript:
+    """Codex-format transcripts use response_item/function_call entries.
+
+    Shape: {type:response_item, payload:{type:function_call, name, arguments}}
+    where `arguments` is a JSON-encoded string.
+    """
+
+    def _write(self, entries: list[dict]) -> Path:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+            return Path(f.name)
+
+    def test_extracts_function_call(self):
+        path = self._write([
+            {"type": "response_item", "payload": {"type": "user_message", "content": "go"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "ack",
+                    "arguments": json.dumps({"correlation_id": "ask-xyz"}),
+                },
+            },
+        ])
+        calls = extract_last_turn_raw_tool_calls(path)
+        assert len(calls) == 1
+        assert calls[0]["name"] == "ack"
+        assert calls[0]["input"] == {"correlation_id": "ask-xyz"}
+        path.unlink()
+
+    def test_handles_dict_arguments(self):
+        path = self._write([
+            {"type": "response_item", "payload": {"type": "user_message"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "ask",
+                    "arguments": {"peer_name": "x", "query": "?", "reply_to": "ask-prior"},
+                },
+            },
+        ])
+        calls = extract_last_turn_raw_tool_calls(path)
+        assert calls[0]["input"]["reply_to"] == "ask-prior"
+        path.unlink()
+
+    def test_invalid_arguments_string_falls_back_to_empty(self):
+        path = self._write([
+            {"type": "response_item", "payload": {"type": "user_message"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "ack",
+                    "arguments": "not-json",
+                },
+            },
+        ])
+        calls = extract_last_turn_raw_tool_calls(path)
+        assert calls[0]["input"] == {}
+        path.unlink()
+
+    def test_walks_back_to_user_message(self):
+        path = self._write([
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "old",
+                    "arguments": "{}",
+                },
+            },
+            {"type": "response_item", "payload": {"type": "user_message"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "new",
+                    "arguments": "{}",
+                },
+            },
+        ])
+        calls = extract_last_turn_raw_tool_calls(path)
+        assert [c["name"] for c in calls] == ["new"]
+        path.unlink()
+
+    def test_format_detection_does_not_break_claude(self):
+        """Claude-shaped transcripts must still parse as Claude, not codex."""
+        path = self._write([
+            {"type": "user", "message": {"content": "go"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "ack", "input": {"correlation_id": "ask-aaa"}},
+                    ],
+                },
+            },
+        ])
+        calls = extract_last_turn_raw_tool_calls(path)
+        assert calls[0]["input"] == {"correlation_id": "ask-aaa"}
+        path.unlink()
+
+    def test_codex_message_role_user_boundary(self):
+        """Codex's real boundary is {payload:{type:message, role:user}}."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "old-call",
+                    "arguments": "{}",
+                },
+            }) + "\n")
+            f.write(json.dumps({
+                "type": "response_item",
+                "payload": {"type": "message", "role": "user", "content": "go"},
+            }) + "\n")
+            f.write(json.dumps({
+                "type": "response_item",
+                "payload": {"type": "message", "role": "assistant", "content": "ok"},
+            }) + "\n")
+            f.write(json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "new-call",
+                    "arguments": json.dumps({"correlation_id": "ask-zzz"}),
+                },
+            }) + "\n")
+            path = Path(f.name)
+
+        calls = extract_last_turn_raw_tool_calls(path)
+        names = [c["name"] for c in calls]
+        assert names == ["new-call"]
+        assert calls[0]["input"] == {"correlation_id": "ask-zzz"}
         path.unlink()


### PR DESCRIPTION
## Summary

Refactors the agent-to-agent message primitives. Drops `ask_peer`'s blocking semantics in favor of an explicit non-blocking `ask` + `ack` lifecycle. Reminders nudge peers who pick up an ask but don't close it.

- `ask(peer, query, reply_to=None)` returns a `correlation_id` immediately
- `ack(corr_id)` closes the thread (bare = "seen, no action")
- `ack(corr_id, message)` IS the reply, delivered to the original asker as a notification framed `[ack #cid from @peer] message`
- `ask(peer, query, reply_to=cid)` opens a new thread AND closes the prior one
- `notify_peer` and `broadcast` unchanged
- Lazy reminder: pickup at turn N → reminder at Stop of turn N+1 if not acked/replied (once-only, capped to 3 most recent)

## What changed

**Foundation** (commit 1):
- `daemon/ask_tracker.py` — in-memory store with TTL eviction, per-peer turn counter
- `daemon/routes/asks.py` — `/ask`, `/ack`, `/asks/{cid}/picked_up`, `/asks/pending`, `/asks/{cid}/mark_reminded`
- Wire protocol: `type: notify` grows optional `intent` field (`ask` / `notify` / `ack_reply`); message_router and BUSY-buffer flush propagate intent + correlation_id + reply_to
- `peer_registry.deliver_ask` — ask delivery via the notify pipeline so it inherits BUSY-buffering
- ack-with-msg crosses circles intentionally (`bypass_circle=True`): closure is correlation-targeted, not a discovery operation

**Hooks** (commit 2):
- ws-hook reads `intent` on `type=notify`. Only `intent=ask` pushes corr_id onto the per-pane FIFO; `notify` and `ack_reply` skip (closures aren't new asks owing acks)
- `hooks/ask_lifecycle.py` — pickup draining, ack/reply detection from `ack(corr_id)` and `ask(reply_to)` tool calls (tool-call only, prose acks intentionally not detected to avoid false-close on phrases like "I'll handle [ack #abc] later")
- Stop hook: single-fetch-and-share design for turn_seq. `fetch_and_filter_pending` returns `(asks, current_turn_seq=N)`, same `N` is passed to `record_pickups`. Same-turn check `N<N=false`, next Stop fire `N<N+1=true` → reminder fires. One turn of grace, no ordering dependency.
- Reminder text persisted to a per-pane buffer file consumed by next UserPromptSubmit hook (additionalContext primary path) or Notification idle_prompt hook (fallback)

**MCP / clients** (commit 3):
- `ask_peer` (blocking) dropped from MCP, opencode plugin, channel/server.ts. New `ask` + `ack` tools across all surfaces
- `session_handler` context block teaches the lifecycle: inbound `[ask #cid]` requires ack, inbound `[ack #cid from @peer]` is closure
- `peer_registry.formatted_query` updated for legacy `/query` shim (telegram/CLI still call this)

**Preserved as legacy shims** (removal in v0.12):
- `/query`, `/response` endpoints, `peer_registry.query()` — telegram bot and CLI `repowire peer ask` still use these unchanged

## Test plan

- [x] 46 new tests across `test_ask_tracker.py` (19), `test_ask_lifecycle.py` (11), `test_ask_routes.py` (11), `test_hooks.py` (4 ws-hook intent routing), `test_spawn.py` (renamed MCP tools)
- [x] Full suite: 402 passed, 1 deselected (`test_tmux_lazy_registration_uses_pane_and_circle` — pre-existing failure that hardcodes cwd name "repowire", separate test bug)
- [x] `ruff check` clean
- [ ] Live 2-peer test on PyPI install (post-tag): A asks → B sees `[ask #cid]:` → B acks with msg → A receives `[ack #cid from @B]` → confirm reminder block on B's third turn after ignored ask → confirm `ask(reply_to=cid)` closes prior

## Follow-ups (post-merge)

- v0.10.6: telegram bot + CLI `repowire peer ask` adapters (currently use legacy `/query` shim, work fine but not idiomatic)
- v0.12: remove `/query`, `/response`, `peer_registry.query()`, `QueryTracker` future-blocking model