### PR TITLE
feat(spawn): backend-aware post-spawn lifecycle middleware (supersedes v0.10.5/v0.10.6 codex work)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.10.6"
+version = "0.11.0"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -11,6 +12,7 @@ from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_config, get_peer_registry
 from repowire.daemon.peer_registry import PeerRegistry
+from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.spawn import AGENT_COMMANDS, SpawnConfig, SpawnResult, kill_peer, spawn_peer
 
 _COMMAND_TO_BACKEND: dict[str, AgentType] = {
@@ -55,6 +57,14 @@ class SpawnRequest(BaseModel):
     path: str = Field(..., description="Absolute path to the project directory")
     command: str = Field(..., description="Command to run — must be in allowed_commands")
     circle: str = Field(default="default", description="Circle to spawn into")
+    message: str | None = Field(
+        default=None,
+        description=(
+            "Optional warmup message to send to the spawned agent. Used by "
+            "backends whose hook lifecycle requires a first prompt (codex). "
+            "Other backends ignore it. Default: a short branded warmup."
+        ),
+    )
 
 
 class SpawnResponse(BaseModel):
@@ -138,17 +148,35 @@ async def spawn(
     """
     _validate_spawn_request(request.path, request.command)
 
+    resolved_path = str(Path(request.path).expanduser().resolve())
+    backend = _backend_from_command(request.command)
+
     try:
         result: SpawnResult = spawn_peer(
             SpawnConfig(
-                path=str(Path(request.path).expanduser().resolve()),
+                path=resolved_path,
                 circle=request.circle,
-                backend=_backend_from_command(request.command),
+                backend=backend,
                 command=request.command,
+                message=request.message,
             )
         )
     except (ValueError, RuntimeError) as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    # Schedule post-spawn warmup in the background -- the codex case sleeps
+    # ~10s and would otherwise stall the /spawn response. claude/opencode/gemini
+    # warmups are no-ops and return immediately.
+    if result.pane_id:
+        asyncio.ensure_future(
+            post_spawn_warmup(
+                backend,
+                result.pane_id,
+                path=resolved_path,
+                circle=request.circle,
+                message=result.message,
+            )
+        )
 
     return SpawnResponse(display_name=result.display_name, tmux_session=result.tmux_session)
 

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -19,6 +19,10 @@ _COMMAND_TO_BACKEND: dict[str, AgentType] = {
     cmd: backend for backend, cmd in AGENT_COMMANDS.items()
 }
 
+# Strong references to background warmup tasks. asyncio holds only weak refs to
+# tasks, so without this set a long-sleeping warmup can be GC'd mid-flight.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
 
 def _backend_from_command(command: str) -> AgentType:
     """Derive AgentType from the first token of the command string."""
@@ -166,9 +170,10 @@ async def spawn(
 
     # Schedule post-spawn warmup in the background -- the codex case sleeps
     # ~10s and would otherwise stall the /spawn response. claude/opencode/gemini
-    # warmups are no-ops and return immediately.
+    # warmups are no-ops and return immediately. Hold a strong ref to the task
+    # in a module-level set so asyncio doesn't GC it mid-sleep.
     if result.pane_id:
-        asyncio.ensure_future(
+        task = asyncio.create_task(
             post_spawn_warmup(
                 backend,
                 result.pane_id,
@@ -177,6 +182,8 @@ async def spawn(
                 message=result.message,
             )
         )
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
 
     return SpawnResponse(display_name=result.display_name, tmux_session=result.tmux_session)
 

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -222,10 +222,9 @@ def main(backend: str = "claude-code") -> int:
         # Register peer via HTTP -- daemon assigns peer_id and display_name.
         # Codex strips tmux env from hook subprocesses, so fall back to the
         # spawn hint before defaulting.
-        hint = consume_hint(cwd, backend)
         circle = (
             tmux_info["session_name"]
-            or (hint.circle if hint else None)
+            or consume_hint(cwd, backend)
             or "default"
         )
         metadata = {"project": folder_name}

--- a/repowire/installers/post_spawn.py
+++ b/repowire/installers/post_spawn.py
@@ -1,0 +1,124 @@
+"""Per-backend post-spawn lifecycle middleware.
+
+Each backend gets a chance to nudge its freshly spawned tmux pane through its
+own startup quirks (codex's lazy SessionStart, future runtimes' init dialogs,
+etc.) so the rest of the system can rely on the normal hook lifecycle.
+
+Backends that fire SessionStart at process boot (claude-code, opencode) are
+no-ops. Codex requires a tmux send-keys nudge because its SessionStart hook
+fires on first user prompt, not at boot — without this nudge the peer would
+sit invisible-from-outside until a human types something.
+
+Default the message to a short branded warmup; callers (the MCP spawn_peer
+tool) can override with a per-spawn intent string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+
+from repowire.config.models import AgentType
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WARMUP_TEMPLATE = (
+    "Hi from repowire. You have been spawned in {path} under circle "
+    "{circle}. Standing by for instructions."
+)
+
+
+async def post_spawn_warmup(
+    backend: AgentType,
+    pane_id: str,
+    *,
+    path: str,
+    circle: str,
+    message: str | None = None,
+) -> None:
+    """Run the post-spawn lifecycle nudge for a backend.
+
+    Args:
+        backend: Which agent runtime is hosting the spawned pane.
+        pane_id: tmux pane id (e.g. "%42") to drive.
+        path: Project path the agent is starting in. Used in the default message.
+        circle: Circle the peer was spawned into. Used in the default message.
+        message: Optional override for the default warmup text.
+
+    Best-effort. Logs and swallows any failure -- a stalled warmup must not
+    block the spawn flow or any other peer's work.
+    """
+    try:
+        if backend == AgentType.CODEX:
+            text = message or DEFAULT_WARMUP_TEMPLATE.format(path=path, circle=circle)
+            await _codex_warmup(pane_id, text)
+        else:
+            # claude-code, opencode, gemini: SessionStart (or equivalent) fires
+            # at boot, so no nudge needed. If a future backend needs one, add a
+            # branch here.
+            return
+    except Exception as e:
+        logger.warning("post_spawn_warmup failed for %s pane %s: %s", backend, pane_id, e)
+
+
+async def _codex_warmup(pane_id: str, message: str) -> None:
+    """Drive codex's startup lifecycle by sending a warmup prompt.
+
+    Codex's SessionStart hook fires lazily on first user prompt submission,
+    not at process boot. Without a nudge, peers spawned via /spawn would not
+    register their websocket transport with the daemon until a human typed
+    something. Sending a synthetic first prompt fires the hook within seconds.
+
+    Sequence (rule-based, validated by probe at 20/20 success across detached
+    and attached panes on codex 0.130.0):
+      1. Sleep 8s   -- codex boot + first-run update budget
+      2. C-m x 4    -- dismiss any startup dialog (trust prompt, update prompt)
+                       300ms apart; empty submits are no-ops in codex's TUI
+      3. Sleep 1s   -- let the TUI settle into idle state
+      4. send-keys message + C-m   -- the actual warmup, fires SessionStart
+
+    Total runtime: ~10-13s. Runs as a background task so the /spawn POST
+    response is not blocked.
+    """
+    if not pane_id:
+        return
+    if not shutil.which("tmux"):
+        logger.warning("codex warmup: tmux binary not found, skipping")
+        return
+
+    await asyncio.sleep(8)
+
+    for _ in range(4):
+        await _tmux_send(pane_id, "C-m")
+        await asyncio.sleep(0.3)
+
+    await asyncio.sleep(1)
+
+    await _tmux_send(pane_id, message, literal=True)
+    await asyncio.sleep(0.2)
+    await _tmux_send(pane_id, "C-m")
+
+
+async def _tmux_send(pane_id: str, text: str, *, literal: bool = False) -> None:
+    """Send a key/literal to a tmux pane via the tmux binary.
+
+    Args:
+        pane_id: Target tmux pane (e.g. "%42").
+        text: Literal text to type (with `literal=True`) or a tmux key name
+              like "C-m" or "Enter".
+        literal: When True, pass `-l` so the bytes are not parsed as key names.
+    """
+    args = ["tmux", "send-keys", "-t", pane_id]
+    if literal:
+        args.append("-l")
+    args.append(text)
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, err = await proc.communicate()
+    if proc.returncode != 0:
+        msg = err.decode("utf-8", "replace").strip()
+        logger.warning("tmux send-keys failed (rc=%d): %s", proc.returncode, msg)

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 from pathlib import Path
 from urllib.parse import quote
 from uuid import uuid4
@@ -14,14 +13,7 @@ from mcp.server.fastmcp import FastMCP
 
 from repowire.config.models import DEFAULT_DAEMON_URL
 from repowire.hooks._tmux import get_pane_id, get_tmux_info
-from repowire.hooks.utils import (
-    get_display_name,
-    pane_logs_dir,
-    read_pane_runtime_metadata,
-    write_pane_runtime_metadata,
-    ws_hook_lock_path,
-    ws_hook_pid_path,
-)
+from repowire.hooks.utils import get_display_name, read_pane_runtime_metadata
 from repowire.protocol.errors import DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError
 from repowire.spawn_hints import consume_hint
 
@@ -184,13 +176,8 @@ async def _ensure_registered(*, strict: bool = False) -> None:
 
     # Tmux env is stripped by codex's MCP sandbox, so session_name is None
     # there. Fall back to the spawn hint dropped by the daemon's /spawn route
-    # before defaulting to "default". The hint may also carry the tmux pane_id
-    # captured at spawn time -- the only anchor a codex MCP subprocess has to
-    # the pane that owns it, since codex strips TMUX/TMUX_PANE here.
-    hint = consume_hint(str(cwd), backend)
-    circle = tmux_info["session_name"] or (hint.circle if hint else None) or "default"
-    hint_pane_id = hint.pane_id if hint else None
-    effective_pane_id = pane_id or hint_pane_id
+    # before defaulting to "default".
+    circle = tmux_info["session_name"] or consume_hint(str(cwd), backend) or "default"
 
     try:
         body: dict = {
@@ -199,147 +186,16 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             "circle": circle,
             "backend": backend,
         }
-        if effective_pane_id:
-            body["pane_id"] = effective_pane_id
+        if pane_id:
+            body["pane_id"] = pane_id
         result = await daemon_request("POST", "/peers", body)
         # Cache the daemon-assigned name
         assigned = result.get("display_name")
-        peer_id = result.get("peer_id")
         if assigned:
             _cached_peer_name = assigned
         _registered = True
     except Exception:
-        return  # Best-effort -- daemon may be down
-
-    # Codex MCP subprocesses don't fire SessionStart at startup, so without
-    # this we'd register a peer that has no inbound websocket transport.
-    # Spawn the ws-hook ourselves when the spawn hint anchored us to a pane.
-    if backend == "codex" and hint_pane_id and assigned:
-        _spawn_ws_hook_for_pane(
-            pane_id=hint_pane_id,
-            display_name=assigned,
-            peer_id=peer_id,
-            backend=backend,
-            cwd=str(cwd),
-        )
-
-
-def _spawn_ws_hook_for_pane(
-    *,
-    pane_id: str,
-    display_name: str,
-    peer_id: str | None,
-    backend: str,
-    cwd: str,
-) -> None:
-    """Spawn the websocket_hook subprocess for a codex pane.
-
-    Mirrors the SessionStart-driven path in session_handler.py but anchors on
-    the pane_id recovered from the spawn hint, since codex strips tmux env
-    from the MCP subprocess. Idempotent via flock: a later SessionStart that
-    fires when the user finally prompts will see the lock held and either
-    treat us as the same live session or take over cleanly.
-    """
-    import fcntl
-    import subprocess
-
-    from repowire.hooks import session_handler  # local import to avoid cycle
-
-    log_dir = pane_logs_dir()
-    pane_file = pane_id.replace("%", "") or "unknown"
-    lock_path = ws_hook_lock_path(pane_id)
-    pid_path = ws_hook_pid_path(pane_id)
-
-    try:
-        lock_fd = open(lock_path, "w")
-    except OSError as e:
-        logger.warning("ws-hook spawn: cannot open lock for %s: %s", pane_id, e)
-        return
-
-    try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        # Another process owns this pane already (a real SessionStart, or an
-        # earlier MCP eager spawn). Trust it and bail.
-        lock_fd.close()
-        return
-
-    write_pane_runtime_metadata(
-        pane_id,
-        {
-            "backend": backend,
-            "cwd": cwd,
-            "display_name": display_name,
-            "hook_session_id": "",  # filled by SessionStart if it fires later
-            "peer_id": peer_id,
-        },
-    )
-
-    hook_script = Path(session_handler.__file__).parent / "websocket_hook.py"
-    if not hook_script.exists():
-        lock_fd.close()
-        return
-
-    log_file = open(log_dir / f"ws-hook-{pane_file}.log", "w")
-    try:
-        env = os.environ.copy()
-        env["REPOWIRE_DISPLAY_NAME"] = display_name
-        if peer_id:
-            env["REPOWIRE_PEER_ID"] = peer_id
-        env["REPOWIRE_BACKEND"] = backend
-        # Codex strips TMUX/TMUX_PANE from the MCP subprocess. Reinject them
-        # so the ws-hook can reach tmux for inbound message injection.
-        env["TMUX_PANE"] = pane_id
-        env.setdefault("TMUX", _discover_tmux_env(pane_id) or "")
-        try:
-            proc = subprocess.Popen(
-                [sys.executable, str(hook_script)],
-                stdout=log_file,
-                stderr=log_file,
-                start_new_session=True,
-                cwd=cwd,
-                env=env,
-                pass_fds=(lock_fd.fileno(),),
-            )
-            pid_path.write_text(str(proc.pid))
-        except OSError as e:
-            logger.warning("ws-hook spawn failed for %s: %s", pane_id, e)
-    finally:
-        log_file.close()
-        lock_fd.close()  # child inherits flock; parent releases fd
-
-
-def _discover_tmux_env(pane_id: str) -> str | None:
-    """Find the TMUX env value (socket,pid,session) for a pane.
-
-    Used when spawning the ws-hook from the codex MCP subprocess, which has
-    TMUX stripped. Without TMUX set, the hook's `tmux` shell-outs would
-    target the wrong server. Returns None if we can't discover it (no tmux
-    binary, no matching pane); the caller falls back to an empty string.
-    """
-    import shutil
-    import subprocess
-
-    if not shutil.which("tmux"):
-        return None
-    try:
-        result = subprocess.run(
-            ["tmux", "display-message", "-t", pane_id, "-p",
-             "#{socket_path},#{pid},#{session_id}"],
-            capture_output=True, text=True, timeout=3,
-        )
-    except (subprocess.SubprocessError, FileNotFoundError, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    raw = result.stdout.strip()
-    if not raw or "," not in raw:
-        return None
-    socket_path, pid, session_id = raw.split(",", 2)
-    # tmux's TMUX env format is "socket_path,pid,session_index". session_id is
-    # like "$3" -- strip the leading "$" to get the index.
-    sid = session_id.lstrip("$")
-    return f"{socket_path},{pid},{sid}"
+        pass  # Best-effort -- daemon may be down
 
 
 def create_mcp_server() -> FastMCP:
@@ -602,12 +458,4 @@ def create_mcp_server() -> FastMCP:
 async def run_mcp_server() -> None:
     """Run the MCP server."""
     mcp = create_mcp_server()
-    # Eager-register at startup so peers whose SessionStart hook fires lazily
-    # (codex: only on first user prompt) appear in the daemon registry as soon
-    # as their MCP subprocess is alive. Idempotent for runtimes whose hook
-    # already ran -- _ensure_registered short-circuits on a fast GET.
-    try:
-        await _ensure_registered()
-    except Exception as e:
-        logger.debug("Eager MCP registration failed (non-fatal): %s", e)
     await mcp.run_stdio_async()

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -392,7 +392,12 @@ def create_mcp_server() -> FastMCP:
         return f"description updated: {description}"
 
     @mcp.tool()
-    async def spawn_peer(path: str, command: str, circle: str = "default") -> str:
+    async def spawn_peer(
+        path: str,
+        command: str,
+        circle: str = "default",
+        message: str | None = None,
+    ) -> str:
         """[Repowire mesh] Spawn a new coding session in a different project directory.
 
         The command must exactly match an entry in daemon.spawn.allowed_commands
@@ -406,6 +411,11 @@ def create_mcp_server() -> FastMCP:
         The circle maps to the tmux session name and cannot be reassigned after
         spawn.
 
+        Pass `message` to seed the spawned agent with first-turn context (task
+        brief, who spawned them, what to work on). Required for codex peers to
+        register with the mesh promptly; treated as a friendly opening prompt
+        by other backends. If omitted, codex gets a short default warmup.
+
         Do NOT use SendMessage to reach spawned peers. SendMessage is a Claude
         Code harness tool for same-session teammates only. Use ask_peer() or
         notify_peer() instead.
@@ -414,15 +424,16 @@ def create_mcp_server() -> FastMCP:
             path: Absolute path to the project directory
             command: Command to run (e.g. "claude", "claude --dangerously-skip-permissions")
             circle: Circle to spawn into (default: "default") -- maps to tmux session name
+            message: Optional first-turn prompt for the spawned agent. Codex
+                     requires it (or a default) to fire its SessionStart hook.
 
         Returns:
             Spawn confirmation with display_name and tmux_session
         """
-        result = await daemon_request(
-            "POST",
-            "/spawn",
-            {"path": path, "command": command, "circle": circle},
-        )
+        body: dict = {"path": path, "command": command, "circle": circle}
+        if message is not None:
+            body["message"] = message
+        result = await daemon_request("POST", "/spawn", body)
         name = result["display_name"]
         tmux = result["tmux_session"]
         return (

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -84,10 +84,8 @@ def spawn_peer(config: SpawnConfig) -> SpawnResult:
         raise ValueError(f"Unknown agent type: {config.backend}")
 
     # Drop a hint so runtimes that strip tmux env (codex) can still discover
-    # the requested circle and tmux pane when their MCP/hook subprocess
-    # registers. pane_id is the anchor that lets the codex MCP eager-register
-    # spawn its websocket_hook before SessionStart fires.
-    write_hint(config.path, config.backend.value, config.circle, pane_id=pane.id)
+    # the requested circle when their MCP/hook subprocess registers.
+    write_hint(config.path, config.backend.value, config.circle)
 
     pane.send_keys(cmd, enter=True)
 

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -29,6 +29,7 @@ class SpawnConfig:
     circle: str
     backend: AgentType
     command: str = ""  # Full command to run (e.g., "claude --model opus")
+    message: str | None = None  # Optional warmup intent passed to post_spawn_warmup
 
     @property
     def display_name(self) -> str:
@@ -42,6 +43,8 @@ class SpawnResult:
 
     display_name: str
     tmux_session: str  # e.g., "circle:name"
+    pane_id: str  # tmux pane id (e.g. "%42") for post-spawn warmup
+    message: str | None = None  # Echo of the warmup intent (None = use default)
 
 
 def spawn_peer(config: SpawnConfig) -> SpawnResult:
@@ -94,6 +97,8 @@ def spawn_peer(config: SpawnConfig) -> SpawnResult:
     return SpawnResult(
         display_name=window_name,
         tmux_session=tmux_session,
+        pane_id=pane.id or "",
+        message=config.message,
     )
 
 

--- a/repowire/spawn_hints.py
+++ b/repowire/spawn_hints.py
@@ -21,20 +21,11 @@ import json
 import logging
 import time
 from contextlib import suppress
-from dataclasses import dataclass
 from pathlib import Path
 
 from repowire.config.models import CACHE_DIR
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Hint:
-    """Spawn intent recovered for a (path, backend) pair."""
-
-    circle: str
-    pane_id: str | None = None
 
 # Hints older than this are ignored and treated as garbage. Spawn → MCP boot
 # → eager register usually completes within a few seconds; 5 minutes is
@@ -57,21 +48,16 @@ def _hint_path(path: str, backend: str) -> Path:
     return _hints_dir() / f"{_hint_key(path, backend)}.json"
 
 
-def write_hint(
-    path: str, backend: str, circle: str, pane_id: str | None = None,
-) -> None:
+def write_hint(path: str, backend: str, circle: str) -> None:
     """Record spawn intent so a peer registering from this path+backend can
-    discover its requested circle and (when the runtime strips tmux env)
-    its tmux pane.
+    discover its requested circle.
     """
-    payload: dict = {
+    payload = {
         "path": str(Path(path).resolve()),
         "backend": backend,
         "circle": circle,
         "ts": time.time(),
     }
-    if pane_id:
-        payload["pane_id"] = pane_id
     target = _hint_path(path, backend)
     try:
         target.write_text(json.dumps(payload))
@@ -79,12 +65,11 @@ def write_hint(
         logger.warning("spawn_hints: failed to write %s: %s", target, e)
 
 
-def consume_hint(path: str, backend: str) -> Hint | None:
+def consume_hint(path: str, backend: str) -> str | None:
     """Read and delete the spawn hint for (path, backend).
 
-    Returns the recovered Hint (circle + optional pane_id), or None if no
-    fresh hint exists. Stale hints (older than HINT_TTL_SECONDS) are deleted
-    and treated as missing.
+    Returns the requested circle, or None if no fresh hint exists. Stale
+    hints (older than HINT_TTL_SECONDS) are deleted and treated as missing.
     """
     target = _hint_path(path, backend)
     try:
@@ -112,5 +97,4 @@ def consume_hint(path: str, backend: str) -> Hint | None:
 
     if age > HINT_TTL_SECONDS:
         return None
-    pane_id = data.get("pane_id") if isinstance(data.get("pane_id"), str) else None
-    return Hint(circle=circle, pane_id=pane_id)
+    return circle

--- a/tests/test_post_spawn.py
+++ b/tests/test_post_spawn.py
@@ -1,0 +1,147 @@
+"""Tests for installers/post_spawn lifecycle middleware."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.config.models import AgentType
+from repowire.installers.post_spawn import (
+    DEFAULT_WARMUP_TEMPLATE,
+    _codex_warmup,
+    post_spawn_warmup,
+)
+
+
+class TestPostSpawnWarmup:
+    """post_spawn_warmup dispatches to the right backend handler."""
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_codex_calls_codex_warmup(self, mock_codex: AsyncMock) -> None:
+        await post_spawn_warmup(
+            AgentType.CODEX, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+        mock_codex.assert_awaited_once()
+        await_args = mock_codex.await_args
+        assert await_args is not None
+        pane_arg, text_arg = await_args.args
+        assert pane_arg == "%42"
+        assert "/tmp/proj" in text_arg
+        assert "5" in text_arg
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_custom_message_overrides_default(self, mock_codex: AsyncMock) -> None:
+        await post_spawn_warmup(
+            AgentType.CODEX, "%42",
+            path="/tmp/proj", circle="5",
+            message="Custom task brief",
+        )
+        mock_codex.assert_awaited_once_with("%42", "Custom task brief")
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_claude_code_is_noop(self, mock_codex: AsyncMock) -> None:
+        await post_spawn_warmup(
+            AgentType.CLAUDE_CODE, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+        mock_codex.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_opencode_is_noop(self, mock_codex: AsyncMock) -> None:
+        await post_spawn_warmup(
+            AgentType.OPENCODE, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+        mock_codex.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_gemini_is_noop(self, mock_codex: AsyncMock) -> None:
+        await post_spawn_warmup(
+            AgentType.GEMINI, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+        mock_codex.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_warmup_swallows_exceptions(self, mock_codex: AsyncMock) -> None:
+        """A stalled or buggy warmup must not bubble up to /spawn."""
+        mock_codex.side_effect = RuntimeError("tmux exploded")
+        # Must not raise.
+        await post_spawn_warmup(
+            AgentType.CODEX, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+
+
+class TestCodexWarmup:
+    """_codex_warmup drives the tmux send-keys sequence."""
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.shutil.which", return_value="/usr/bin/tmux")
+    async def test_codex_warmup_sequence(
+        self,
+        _mock_which,
+        mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _codex_warmup("%42", "Hello task")
+
+        # 4 C-m for dialog dismissal + 1 message + 1 C-m submit = 6 sends
+        assert mock_send.await_count == 6
+        calls = mock_send.await_args_list
+        # First 4 are C-m (dialog dismissals)
+        for i in range(4):
+            assert calls[i].args == ("%42", "C-m")
+        # Then the literal message
+        assert calls[4].args == ("%42", "Hello task")
+        assert calls[4].kwargs == {"literal": True}
+        # Then the final submit C-m
+        assert calls[5].args == ("%42", "C-m")
+
+        # Sleeps: 8s boot + 4×0.3s between C-m + 1s settle + 0.2s pre-submit
+        sleep_args = [c.args[0] for c in mock_sleep.await_args_list]
+        assert sleep_args[0] == 8  # boot
+        assert sleep_args[1:5] == [0.3, 0.3, 0.3, 0.3]
+        assert sleep_args[5] == 1  # settle
+        assert sleep_args[6] == 0.2  # pre-submit
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.shutil.which", return_value=None)
+    async def test_codex_warmup_skips_when_tmux_missing(
+        self,
+        _mock_which,
+        _mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _codex_warmup("%42", "Hello task")
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    async def test_codex_warmup_skips_when_pane_id_empty(
+        self,
+        _mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _codex_warmup("", "Hello task")
+        mock_send.assert_not_awaited()
+
+
+def test_default_warmup_template_renders() -> None:
+    """The default template must accept path and circle placeholders."""
+    rendered = DEFAULT_WARMUP_TEMPLATE.format(path="/tmp/proj", circle="5")
+    assert "/tmp/proj" in rendered
+    assert "5" in rendered

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -673,45 +673,12 @@ class TestSpawnRouteBackendFromCommand:
         assert _backend_from_command("") is AgentType.CLAUDE_CODE
 
 
-class TestEagerMcpRegistration:
-    """run_mcp_server eagerly registers the peer before entering the stdio loop.
-
-    This warms up runtimes (codex) whose SessionStart hook fires lazily on
-    first user prompt, so the peer appears in the daemon registry as soon as
-    its MCP subprocess is alive.
-    """
+class TestRunMcpServer:
+    """Sanity check that run_mcp_server enters the stdio loop."""
 
     @pytest.mark.asyncio
-    async def test_run_mcp_server_calls_ensure_registered_before_stdio(self) -> None:
+    async def test_run_mcp_server_runs_stdio(self) -> None:
         import repowire.mcp.server as mcp_server
-
-        order: list[str] = []
-
-        async def fake_ensure() -> None:
-            order.append("ensure")
-
-        mock_mcp = MagicMock()
-
-        async def fake_stdio() -> None:
-            order.append("stdio")
-
-        mock_mcp.run_stdio_async = fake_stdio
-
-        with (
-            patch.object(mcp_server, "_ensure_registered", fake_ensure),
-            patch.object(mcp_server, "create_mcp_server", return_value=mock_mcp),
-        ):
-            await mcp_server.run_mcp_server()
-
-        assert order == ["ensure", "stdio"]
-
-    @pytest.mark.asyncio
-    async def test_run_mcp_server_proceeds_when_eager_registration_fails(self) -> None:
-        """Daemon downtime at MCP startup must not block the stdio loop."""
-        import repowire.mcp.server as mcp_server
-
-        async def failing_ensure() -> None:
-            raise RuntimeError("daemon down")
 
         stdio_called = False
         mock_mcp = MagicMock()
@@ -722,142 +689,7 @@ class TestEagerMcpRegistration:
 
         mock_mcp.run_stdio_async = fake_stdio
 
-        with (
-            patch.object(mcp_server, "_ensure_registered", failing_ensure),
-            patch.object(mcp_server, "create_mcp_server", return_value=mock_mcp),
-        ):
+        with patch.object(mcp_server, "create_mcp_server", return_value=mock_mcp):
             await mcp_server.run_mcp_server()
 
         assert stdio_called is True
-
-
-class TestCodexEagerWsHookSpawn:
-    """Codex MCP eager registration must spawn ws-hook when the spawn hint
-    anchors it to a tmux pane. Without this, codex peers register but have
-    no inbound transport — notify_peer would 500 with "No connection for
-    session X".
-    """
-
-    @pytest.mark.asyncio
-    @patch("repowire.mcp.server._spawn_ws_hook_for_pane")
-    @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
-    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
-    @patch(
-        "repowire.mcp.server.get_tmux_info",
-        return_value={"pane_id": None, "session_name": None, "window_name": None},
-    )
-    @patch("repowire.mcp.server.consume_hint")
-    async def test_codex_eager_register_spawns_ws_hook_when_hint_has_pane(
-        self,
-        mock_consume: MagicMock,
-        _mock_tmux,
-        mock_request: AsyncMock,
-        mock_my_name: AsyncMock,
-        mock_spawn_hook: MagicMock,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        import repowire.mcp.server as mcp_server
-        from repowire.spawn_hints import Hint
-
-        mcp_server._registered = False
-        mcp_server._cached_peer_name = None
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(mcp_server, "_detect_backend", lambda: "codex")
-        mock_my_name.return_value = "proj-codex"
-
-        mock_consume.return_value = Hint(circle="5", pane_id="%42")
-        mock_request.side_effect = [
-            Exception("not found"),  # GET /peers/{name} (no pane branch)
-            {"peers": []},  # GET /peers?path&backend fallback miss
-            {"display_name": "proj-codex", "peer_id": "repow-5-abc12345"},  # POST /peers
-        ]
-
-        await mcp_server._ensure_registered()
-
-        mock_spawn_hook.assert_called_once()
-        kwargs = mock_spawn_hook.call_args.kwargs
-        assert kwargs["pane_id"] == "%42"
-        assert kwargs["display_name"] == "proj-codex"
-        assert kwargs["peer_id"] == "repow-5-abc12345"
-        assert kwargs["backend"] == "codex"
-
-    @pytest.mark.asyncio
-    @patch("repowire.mcp.server._spawn_ws_hook_for_pane")
-    @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
-    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
-    @patch(
-        "repowire.mcp.server.get_tmux_info",
-        return_value={"pane_id": None, "session_name": None, "window_name": None},
-    )
-    @patch("repowire.mcp.server.consume_hint")
-    async def test_codex_eager_register_skips_ws_hook_without_pane(
-        self,
-        mock_consume: MagicMock,
-        _mock_tmux,
-        mock_request: AsyncMock,
-        mock_my_name: AsyncMock,
-        mock_spawn_hook: MagicMock,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """No pane anchor (externally-attached codex, not /spawn) => no ws-hook."""
-        import repowire.mcp.server as mcp_server
-        from repowire.spawn_hints import Hint
-
-        mcp_server._registered = False
-        mcp_server._cached_peer_name = None
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(mcp_server, "_detect_backend", lambda: "codex")
-        mock_my_name.return_value = "proj-codex"
-
-        mock_consume.return_value = Hint(circle="5", pane_id=None)
-        mock_request.side_effect = [
-            Exception("not found"),
-            {"peers": []},
-            {"display_name": "proj-codex", "peer_id": "repow-5-abc12345"},
-        ]
-
-        await mcp_server._ensure_registered()
-
-        mock_spawn_hook.assert_not_called()
-
-    @pytest.mark.asyncio
-    @patch("repowire.mcp.server._spawn_ws_hook_for_pane")
-    @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
-    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
-    @patch(
-        "repowire.mcp.server.get_tmux_info",
-        return_value={"pane_id": None, "session_name": None, "window_name": None},
-    )
-    @patch("repowire.mcp.server.consume_hint")
-    async def test_non_codex_backend_does_not_spawn_ws_hook(
-        self,
-        mock_consume: MagicMock,
-        _mock_tmux,
-        mock_request: AsyncMock,
-        mock_my_name: AsyncMock,
-        mock_spawn_hook: MagicMock,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Claude/Gemini already get ws-hook via SessionStart; MCP must not double-spawn."""
-        import repowire.mcp.server as mcp_server
-        from repowire.spawn_hints import Hint
-
-        mcp_server._registered = False
-        mcp_server._cached_peer_name = None
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(mcp_server, "_detect_backend", lambda: "claude-code")
-        mock_my_name.return_value = "proj-claude-code"
-
-        mock_consume.return_value = Hint(circle="5", pane_id="%42")
-        mock_request.side_effect = [
-            Exception("not found"),
-            {"peers": []},
-            {"display_name": "proj-claude-code", "peer_id": "repow-5-abc12345"},
-        ]
-
-        await mcp_server._ensure_registered()
-
-        mock_spawn_hook.assert_not_called()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -62,9 +62,12 @@ class TestSpawnResult:
         result = SpawnResult(
             display_name="myapp",
             tmux_session="default:myapp",
+            pane_id="%42",
         )
         assert result.display_name == "myapp"
         assert result.tmux_session == "default:myapp"
+        assert result.pane_id == "%42"
+        assert result.message is None
 
 
 class TestUniqueWindowName:

--- a/tests/test_spawn_hints.py
+++ b/tests/test_spawn_hints.py
@@ -20,18 +20,7 @@ def tmp_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def test_write_then_consume_returns_circle(tmp_cache: Path) -> None:
     write_hint("/tmp/proj", "codex", "5")
-    hint = consume_hint("/tmp/proj", "codex")
-    assert hint is not None
-    assert hint.circle == "5"
-    assert hint.pane_id is None
-
-
-def test_write_with_pane_id_round_trips(tmp_cache: Path) -> None:
-    write_hint("/tmp/proj", "codex", "5", pane_id="%42")
-    hint = consume_hint("/tmp/proj", "codex")
-    assert hint is not None
-    assert hint.circle == "5"
-    assert hint.pane_id == "%42"
+    assert consume_hint("/tmp/proj", "codex") == "5"
 
 
 def test_consume_deletes_hint(tmp_cache: Path) -> None:
@@ -47,10 +36,8 @@ def test_consume_missing_returns_none(tmp_cache: Path) -> None:
 def test_hints_keyed_by_path_and_backend(tmp_cache: Path) -> None:
     write_hint("/tmp/proj", "codex", "5")
     write_hint("/tmp/proj", "claude-code", "7")
-    h_codex = consume_hint("/tmp/proj", "codex")
-    h_claude = consume_hint("/tmp/proj", "claude-code")
-    assert h_codex is not None and h_codex.circle == "5"
-    assert h_claude is not None and h_claude.circle == "7"
+    assert consume_hint("/tmp/proj", "codex") == "5"
+    assert consume_hint("/tmp/proj", "claude-code") == "7"
 
 
 def test_stale_hint_returns_none_and_is_deleted(
@@ -81,5 +68,4 @@ def test_path_resolved_so_equivalent_paths_match(tmp_cache: Path, tmp_path: Path
     real.mkdir()
     write_hint(str(real), "codex", "5")
     # Same path with a redundant segment that resolve() will normalize.
-    hint = consume_hint(str(real / "." ), "codex")
-    assert hint is not None and hint.circle == "5"
+    assert consume_hint(str(real / "." ), "codex") == "5"

--- a/uv.lock
+++ b/uv.lock
@@ -953,7 +953,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.10.6"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Replaces today's v0.10.5 + v0.10.6 MCP-sandbox workarounds with a clean per-backend `post_spawn_warmup` lifecycle middleware. Codex's SessionStart hook fires lazily on first user prompt, so the daemon's `/spawn` now sends a synthetic first prompt via `tmux send-keys` after spawning the pane — putting peer registration back on the normal hook lifecycle path.

History is preserved: no `git revert`. Today's commits stay in the log; a fresh undo commit reverses their net effect, and a feature commit adds the new shape.

## Commits

- **abad364** — undo MCP eager-register + codex ws-hook self-spawn (today's v0.10.5/v0.10.6 work)
- **c1dce2e** — feat(spawn): backend-aware post-spawn lifecycle middleware

## What changes

### Removed (today's MCP-sandbox workarounds, no longer needed)
- Eager `_ensure_registered()` call at MCP server startup (8a7ee26)
- `_spawn_ws_hook_for_pane` + `_discover_tmux_env` in `mcp/server.py` (fbe2549)
- `pane_id` field in spawn hints (fbe2549)
- 5 tests covering the above

### Retained
- `spawn_hints.py` for circle propagation only (b7cc301, reverted to string-return shape). Codex MCP sandbox strips TMUX env so the hint is still the only way to recover the requested circle.
- Lazy `_ensure_registered()` on first MCP tool call. Backend-agnostic fallback for runtimes that don't fire SessionStart (gemini one-shot mode, etc.).

### Added
- `repowire/installers/post_spawn.py` — per-backend `post_spawn_warmup(backend, pane_id, *, path, circle, message)` dispatcher
- Codex implementation: 8s boot sleep → `C-m × 4` (dismiss startup dialogs) → 1s settle → `send-keys message` → `C-m` (fires SessionStart)
- claude-code / opencode / gemini: no-op (their hooks fire at boot)
- `SpawnConfig.message`, `SpawnResult.pane_id`, `SpawnResult.message`
- `SpawnRequest.message` HTTP field
- `mcp.spawn_peer(message=None)` optional kwarg — lets orchestrators seed spawn-time intent ("Hi codex, you've been spawned to investigate X")
- 10 new tests for `post_spawn_warmup` and `_codex_warmup`

### Daemon `/spawn` runs the warmup as an `asyncio.ensure_future` background task so the HTTP response is not blocked by the 10+ second codex sleep.

## Probe data

Codex 0.130.0, single host. 20 trials of the rule-based shape:
- **20/20 success** across 10 detached + 10 attached tmux modes
- SessionStart fires 0.64–4.08s after submit (median 1.30s, mean 1.38s)
- No detached-vs-attached skew

## Smoke (on this machine, just now)

1. `uv tool install --force --reinstall .` → v0.11.0 installed
2. `launchctl kickstart -k gui/501/io.repowire.daemon` → daemon back up in 4s, peers reconnected
3. `POST /spawn {path: clusterkit, command: codex, circle: 5, message: "..."}` → returns 200 immediately with `{display_name: clusterkit, tmux_session: 5:clusterkit}`
4. ~13s later: `clusterkit-codex` appears in `list_peers` (circle=5, online, status=online), `ws-hook-279.log` shows "Connected with session_id: repow-5-856a70ac"
5. `mcp__repowire__notify_peer(clusterkit-codex, ...)` → 200 OK, notification injected into pane (visible in ws-hook log: `Injected notification from repowire.investigate-codex-ws-claude-code`)

End-to-end works.

## Test plan

- [x] All 390 unit tests pass (was 380 + 10 new for post_spawn)
- [x] `ruff check repowire/` clean
- [x] `ty check repowire/` clean
- [x] Smoke: fresh codex peer spawned via `/spawn` registers in correct circle and receives notifications
- [x] Smoke: warmup runs as background task; `/spawn` HTTP response is not blocked

## Bumps version

0.10.6 → **0.11.0** (architectural shape change; new MCP tool arg)

## Known follow-ups (deferred)

- Externally-attached codex peers (user runs `codex` manually in a pane, no `/spawn` involved) still rely on the user's first prompt to fire SessionStart. That's the correct behavior — the user's own prompt IS the warmup.
- Codex hooks deprecation warning (`codex_hooks` → `hooks`): tracked elsewhere, not in scope here.