### PR TITLE
fix(kill_peer): use spawned-pane-id set as ownership marker (v0.11.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.11.1"
+version = "0.11.2"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/repowire/daemon/lifecycle_handler.py
+++ b/repowire/daemon/lifecycle_handler.py
@@ -36,8 +36,17 @@ class LifecycleHandler:
     async def handle_pane_died(self, pane_id: str) -> int:
         """Mark the peer in this pane OFFLINE and disconnect its transport.
 
+        Also clears the pane id from the spawn-ownership set so a future tmux
+        server restart can't reuse the id and accidentally match an externally
+        attached peer.
+
         Returns number of cancelled queries.
         """
+        # Imported here to avoid a routes → handler → routes import cycle.
+        from repowire.daemon.routes.spawn import forget_spawned_pane
+
+        forget_spawned_pane(pane_id)
+
         peer = await self._registry.get_peer_by_pane(pane_id)
         if not peer:
             logger.debug("pane_died: no peer for pane %s", pane_id)

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -18,7 +18,6 @@ from repowire.spawn import (
     SpawnConfig,
     SpawnResult,
     kill_pane,
-    kill_peer,
     spawn_peer,
 )
 
@@ -29,6 +28,13 @@ _COMMAND_TO_BACKEND: dict[str, AgentType] = {
 # Strong references to background warmup tasks. asyncio holds only weak refs to
 # tasks, so without this set a long-sleeping warmup can be GC'd mid-flight.
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+# Pane ids of peers spawned via /spawn. Used by /kill-peer to gate tmux pane
+# kills: only panes the daemon spawned should be killed. The OpenCode plugin
+# sends tmux_session from any user-attached pane, so tmux_session alone is not
+# a daemon-spawn signal. Lost on daemon restart — that case safe-fails to
+# "skip pane kill" (matches pre-v0.11.1 behavior).
+_SPAWNED_PANE_IDS: set[str] = set()
 
 
 def _backend_from_command(command: str) -> AgentType:
@@ -182,6 +188,12 @@ async def spawn(
     except (ValueError, RuntimeError) as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
 
+    # Record that we own this pane so /kill-peer can safely kill it later.
+    # Externally-attached agents (notably OpenCode) also report tmux_session,
+    # so tmux_session alone is NOT a daemon-spawn signal — pane_id ownership is.
+    if result.pane_id:
+        _SPAWNED_PANE_IDS.add(result.pane_id)
+
     # Schedule post-spawn warmup in the background -- the codex case sleeps
     # ~10s and would otherwise stall the /spawn response. claude/opencode/gemini
     # warmups are no-ops and return immediately. Hold a strong ref to the task
@@ -242,15 +254,14 @@ async def kill_registered_peer(
         )
 
     peer = resolved
-    # Only daemon-spawned peers populate tmux_session (SessionStart hook omits
-    # it). Use that as the gate so we never kill panes we don't own. Prefer
-    # pane_id for the actual kill — it's stable across window renames, while
-    # tmux_session is window-name based and silently fails after a rename.
+    # Only kill the pane if the daemon spawned it. We track spawned pane_ids
+    # in _SPAWNED_PANE_IDS at /spawn time. tmux_session is NOT a reliable
+    # ownership signal — the OpenCode plugin sends it from any user-attached
+    # pane (installers/opencode.py:213-216), and any HTTP /peers caller could
+    # too. Pane-id-set membership is the single source of truth.
     tmux_killed: bool | None = None
-    if peer.tmux_session:
-        if peer.pane_id:
-            tmux_killed = kill_pane(peer.pane_id)
-        else:
-            tmux_killed = kill_peer(peer.tmux_session)
+    if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
+        tmux_killed = kill_pane(peer.pane_id)
+        _SPAWNED_PANE_IDS.discard(peer.pane_id)
     await peer_registry.unregister_peer(peer.peer_id)
     return KillResponse(tmux_killed=tmux_killed)

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -32,9 +32,24 @@ _BACKGROUND_TASKS: set[asyncio.Task] = set()
 # Pane ids of peers spawned via /spawn. Used by /kill-peer to gate tmux pane
 # kills: only panes the daemon spawned should be killed. The OpenCode plugin
 # sends tmux_session from any user-attached pane, so tmux_session alone is not
-# a daemon-spawn signal. Lost on daemon restart — that case safe-fails to
-# "skip pane kill" (matches pre-v0.11.1 behavior).
+# a daemon-spawn signal.
+#
+# Lifecycle assumptions:
+# - Lost on daemon restart → /kill-peer safe-fails to tmux_killed=None
+# - Cleared on pane_died lifecycle event (see lifecycle_handler.handle_pane_died)
+#   to prevent stale entries from matching a reused pane id after a tmux server
+#   restart. Tmux pane ids are session-lifetime unique within a server, so this
+#   set is only safe for the current tmux server's lifetime.
 _SPAWNED_PANE_IDS: set[str] = set()
+
+
+def forget_spawned_pane(pane_id: str) -> None:
+    """Remove a pane id from the spawned set (called on pane_died lifecycle).
+
+    Idempotent. Used by daemon.lifecycle_handler to prevent stale entries
+    from matching reused pane ids after a tmux server restart.
+    """
+    _SPAWNED_PANE_IDS.discard(pane_id)
 
 
 def _backend_from_command(command: str) -> AgentType:
@@ -96,9 +111,14 @@ class KillResponse(BaseModel):
     """Result of a successful kill.
 
     `tmux_killed` reports whether the underlying tmux pane was terminated:
-    - True  → daemon-spawned peer, pane killed successfully
-    - False → daemon-spawned peer, but tmux kill failed (orphan pane likely)
-    - None  → externally-attached peer; daemon does not own its pane
+    - True  → pane kill attempted and succeeded
+    - False → pane kill attempted but failed (likely orphan pane already gone;
+              caller should verify with `tmux list-panes -a`)
+    - None  → pane kill skipped because daemon ownership was not proven.
+              Causes: peer was externally attached (no /spawn), peer had no
+              pane_id, or daemon restarted since /spawn (in-memory ownership
+              set was lost). Caller can verify with `tmux list-panes` and
+              follow up with manual `tmux kill-pane` if needed.
     """
 
     ok: bool = True

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -446,12 +446,20 @@ def create_mcp_server() -> FastMCP:
     async def kill_peer(peer_identifier: str, circle: str | None = None) -> str:
         """[Repowire mesh] Kill a registered local coding session.
 
+        The peer is always deregistered from the mesh. The tmux pane behind
+        it is only killed if the daemon spawned the peer via spawn_peer in
+        the current daemon lifetime. Externally attached peers, or peers
+        whose ownership was lost across a daemon restart, are deregistered
+        without touching tmux — verify and follow up with `tmux kill-pane`
+        if the pane survives.
+
         Args:
             peer_identifier: Peer ID or display name from list_peers.
             circle: Optional circle to disambiguate display names.
 
         Returns:
-            Confirmation message
+            Confirmation describing both the deregistration and the tmux
+            pane outcome.
         """
         payload: dict[str, str] = {
             "peer_identifier": peer_identifier,
@@ -459,9 +467,20 @@ def create_mcp_server() -> FastMCP:
         }
         if circle is not None:
             payload["circle"] = circle
-        await daemon_request("POST", "/kill-peer", payload)
+        result = await daemon_request("POST", "/kill-peer", payload)
         scoped = f" in circle {circle}" if circle else ""
-        return f"Killed peer {peer_identifier}{scoped}"
+        tmux_killed = (result or {}).get("tmux_killed")
+        if tmux_killed is True:
+            tmux_note = "tmux pane killed"
+        elif tmux_killed is False:
+            tmux_note = "tmux pane kill attempted but failed (verify with `tmux list-panes`)"
+        else:
+            tmux_note = (
+                "tmux pane kill skipped (daemon ownership not proven — "
+                "externally attached, or daemon restarted since spawn). "
+                "Verify with `tmux list-panes` and manually `tmux kill-pane` if needed."
+            )
+        return f"Killed peer {peer_identifier}{scoped}: {tmux_note}"
 
     return mcp
 

--- a/tests/test_lifecycle_routes.py
+++ b/tests/test_lifecycle_routes.py
@@ -131,6 +131,41 @@ class TestPaneDied:
         )
         assert r.status_code == 200
 
+    async def test_clears_spawned_pane_ownership(self, client_and_registry):
+        """pane_died must clear the pane id from _SPAWNED_PANE_IDS so a
+        future tmux server restart can't reuse it and accidentally match
+        an externally-attached peer."""
+        from repowire.daemon.routes import spawn as spawn_routes
+
+        client, _ = client_and_registry
+        spawn_routes._SPAWNED_PANE_IDS.add("%5")
+        try:
+            r = await client.post(
+                "/hooks/lifecycle/pane-died",
+                json={"pane_id": "%5"},
+            )
+            assert r.status_code == 200
+            assert "%5" not in spawn_routes._SPAWNED_PANE_IDS
+        finally:
+            spawn_routes._SPAWNED_PANE_IDS.discard("%5")
+
+    async def test_clears_spawned_pane_even_without_peer(self, client_and_registry):
+        """The cleanup happens even if no peer was registered for the pane —
+        e.g. spawned peer crashed before registering."""
+        from repowire.daemon.routes import spawn as spawn_routes
+
+        client, _ = client_and_registry
+        spawn_routes._SPAWNED_PANE_IDS.add("%88")
+        try:
+            r = await client.post(
+                "/hooks/lifecycle/pane-died",
+                json={"pane_id": "%88"},
+            )
+            assert r.status_code == 200
+            assert "%88" not in spawn_routes._SPAWNED_PANE_IDS
+        finally:
+            spawn_routes._SPAWNED_PANE_IDS.discard("%88")
+
 
 # -- session-closed --
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -264,27 +264,41 @@ class TestPeers:
 
 
 class TestKillPeer:
-    async def test_kill_peer_by_peer_id_resolves_tmux_session(self, client, monkeypatch):
+    """kill_peer route tests.
+
+    Ownership model: a peer's pane is killed iff its pane_id was recorded
+    in `_SPAWNED_PANE_IDS` at /spawn time. Neither tmux_session nor pane_id
+    presence alone implies daemon ownership — OpenCode (and any HTTP /peers
+    caller) can populate them for externally-attached panes.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_spawned_panes(self):
+        spawn_routes._SPAWNED_PANE_IDS.clear()
+        yield
+        spawn_routes._SPAWNED_PANE_IDS.clear()
+
+    async def test_kill_peer_by_peer_id_kills_spawned_pane(self, client, monkeypatch):
         registry = get_peer_registry()
         peer_id, _name = await registry.allocate_and_register(
             circle="5",
             backend=AgentType.CLAUDE_CODE,
             path="/tmp/torale",
             tmux_session="5:torale-window",
+            pane_id="%42",
         )
+        spawn_routes._SPAWNED_PANE_IDS.add("%42")
         killed: list[str] = []
-
-        def fake_kill(tmux_session: str) -> bool:
-            killed.append(tmux_session)
-            return True
-
-        monkeypatch.setattr(spawn_routes, "kill_peer", fake_kill)
+        monkeypatch.setattr(
+            spawn_routes, "kill_pane", lambda pid: killed.append(pid) or True,
+        )
 
         r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
 
         assert r.status_code == 200
-        assert r.json()["ok"] is True
-        assert killed == ["5:torale-window"]
+        assert r.json() == {"ok": True, "tmux_killed": True}
+        assert killed == ["%42"]
+        assert "%42" not in spawn_routes._SPAWNED_PANE_IDS  # cleared after kill
 
     async def test_kill_peer_by_name_and_circle(self, client, monkeypatch):
         registry = get_peer_registry()
@@ -293,14 +307,13 @@ class TestKillPeer:
             backend=AgentType.CLAUDE_CODE,
             path="/tmp/torale",
             tmux_session="5:torale-window",
+            pane_id="%42",
         )
+        spawn_routes._SPAWNED_PANE_IDS.add("%42")
         killed: list[str] = []
-
-        def fake_kill(tmux_session: str) -> bool:
-            killed.append(tmux_session)
-            return True
-
-        monkeypatch.setattr(spawn_routes, "kill_peer", fake_kill)
+        monkeypatch.setattr(
+            spawn_routes, "kill_pane", lambda pid: killed.append(pid) or True,
+        )
 
         r = await client.post(
             "/kill-peer",
@@ -308,7 +321,7 @@ class TestKillPeer:
         )
 
         assert r.status_code == 200
-        assert killed == ["5:torale-window"]
+        assert killed == ["%42"]
 
     async def test_kill_peer_ambiguous_display_name_returns_409(self, client, monkeypatch):
         registry = get_peer_registry()
@@ -317,18 +330,20 @@ class TestKillPeer:
             backend=AgentType.CLAUDE_CODE,
             path="/tmp/torale",
             tmux_session="5:torale-a",
+            pane_id="%1",
         )
         await registry.allocate_and_register(
             circle="6",
             backend=AgentType.CLAUDE_CODE,
             path="/tmp/torale",
             tmux_session="6:torale-b",
+            pane_id="%2",
         )
 
-        def fail_kill(tmux_session: str) -> bool:
-            raise AssertionError(f"should not kill ambiguous peer: {tmux_session}")
+        def fail_kill(*_args):
+            raise AssertionError("should not kill ambiguous peer")
 
-        monkeypatch.setattr(spawn_routes, "kill_peer", fail_kill)
+        monkeypatch.setattr(spawn_routes, "kill_pane", fail_kill)
 
         r = await client.post(
             "/kill-peer",
@@ -340,7 +355,7 @@ class TestKillPeer:
         assert "Ambiguous peer identifier" in detail["error"]
         assert {p["circle"] for p in detail["candidates"]} == {"5", "6"}
 
-    async def test_kill_peer_without_tmux_session_unregisters(self, client):
+    async def test_kill_peer_without_pane_id_unregisters(self, client):
         registry = get_peer_registry()
         peer_id, _name = await registry.allocate_and_register(
             circle="5",
@@ -351,85 +366,63 @@ class TestKillPeer:
         r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
 
         assert r.status_code == 200
+        assert r.json()["tmux_killed"] is None
         assert await registry.get_peer(peer_id) is None
 
-    async def test_kill_peer_with_dead_tmux_session_unregisters(self, client, monkeypatch):
+    async def test_kill_peer_opencode_attached_skips_tmux_kill(self, client, monkeypatch):
+        """OpenCode plugin sends BOTH tmux_session and pane_id from any user
+        tmux pane (installers/opencode.py:613-622, 213-216). Without a
+        spawned-pane record, /kill-peer must NOT touch the user's tmux.
+        """
         registry = get_peer_registry()
         peer_id, _name = await registry.allocate_and_register(
             circle="5",
-            backend=AgentType.CLAUDE_CODE,
+            backend=AgentType.OPENCODE,
             path="/tmp/torale",
-            tmux_session="5:torale-stale",
+            tmux_session="user-session:my-window",
+            pane_id="%77",
         )
-        monkeypatch.setattr(spawn_routes, "kill_peer", lambda _: False)
+        # _SPAWNED_PANE_IDS deliberately empty — peer was attached, not spawned
 
-        r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
+        def must_not_call(*_args):
+            raise AssertionError("must not touch tmux for externally-attached peer")
 
-        assert r.status_code == 200
-        assert await registry.get_peer(peer_id) is None
-
-    async def test_kill_peer_prefers_pane_id_when_available(self, client, monkeypatch):
-        """Spawned peers (tmux_session + pane_id both set) kill via pane_id."""
-        registry = get_peer_registry()
-        peer_id, _name = await registry.allocate_and_register(
-            circle="5",
-            backend=AgentType.CLAUDE_CODE,
-            path="/tmp/torale",
-            tmux_session="5:torale-window",
-            pane_id="%42",
-        )
-        pane_killed: list[str] = []
-        window_killed: list[str] = []
-
-        monkeypatch.setattr(
-            spawn_routes,
-            "kill_pane",
-            lambda pid: pane_killed.append(pid) or True,
-        )
-        monkeypatch.setattr(
-            spawn_routes,
-            "kill_peer",
-            lambda ts: window_killed.append(ts) or True,
-        )
+        monkeypatch.setattr(spawn_routes, "kill_pane", must_not_call)
 
         r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
 
         assert r.status_code == 200
         body = r.json()
-        assert body["ok"] is True
-        assert body["tmux_killed"] is True
-        assert pane_killed == ["%42"]
-        assert window_killed == []
+        assert body == {"ok": True, "tmux_killed": None}
+        assert await registry.get_peer(peer_id) is None
 
-    async def test_kill_peer_externally_attached_skips_tmux_kill(self, client, monkeypatch):
-        """Peer with pane_id but no tmux_session (SessionStart-registered)
-        is externally attached — daemon must not touch its tmux pane."""
+    async def test_kill_peer_claude_sessionstart_skips_tmux_kill(self, client, monkeypatch):
+        """Claude SessionStart hook sets pane_id but not tmux_session
+        (hooks/session_handler.py:42-51). Still must not be killed —
+        pane_id alone isn't ownership; only the spawned-set is.
+        """
         registry = get_peer_registry()
         peer_id, _name = await registry.allocate_and_register(
             circle="5",
             backend=AgentType.CLAUDE_CODE,
             path="/tmp/torale",
             pane_id="%99",
-            # NOTE: tmux_session intentionally omitted — mirrors SessionStart hook
         )
 
         def must_not_call(*_args):
             raise AssertionError("must not touch tmux for externally-attached peer")
 
         monkeypatch.setattr(spawn_routes, "kill_pane", must_not_call)
-        monkeypatch.setattr(spawn_routes, "kill_peer", must_not_call)
 
         r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
 
         assert r.status_code == 200
-        body = r.json()
-        assert body["ok"] is True
-        assert body["tmux_killed"] is None
+        assert r.json()["tmux_killed"] is None
         assert await registry.get_peer(peer_id) is None
 
     async def test_kill_peer_orphan_pane_surfaces_false(self, client, monkeypatch):
-        """If kill_pane fails (e.g. pane already gone), tmux_killed=False but
-        peer is still unregistered."""
+        """If kill_pane fails (pane already gone), tmux_killed=False but
+        peer is still unregistered and the spawn record is cleared."""
         registry = get_peer_registry()
         peer_id, _name = await registry.allocate_and_register(
             circle="5",
@@ -438,13 +431,40 @@ class TestKillPeer:
             tmux_session="5:torale-window",
             pane_id="%7",
         )
+        spawn_routes._SPAWNED_PANE_IDS.add("%7")
         monkeypatch.setattr(spawn_routes, "kill_pane", lambda _: False)
 
         r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
 
         assert r.status_code == 200
-        body = r.json()
-        assert body["tmux_killed"] is False
+        assert r.json()["tmux_killed"] is False
+        assert await registry.get_peer(peer_id) is None
+        assert "%7" not in spawn_routes._SPAWNED_PANE_IDS
+
+    async def test_kill_peer_post_restart_safefails(self, client, monkeypatch):
+        """After a daemon restart _SPAWNED_PANE_IDS is empty. kill_peer must
+        safe-fail (skip pane kill, return tmux_killed=None, still unregister)
+        rather than guess and risk killing a user's pane."""
+        registry = get_peer_registry()
+        peer_id, _name = await registry.allocate_and_register(
+            circle="5",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/torale",
+            tmux_session="5:torale-window",
+            pane_id="%55",
+        )
+        # _SPAWNED_PANE_IDS empty (simulates post-restart state)
+
+        monkeypatch.setattr(
+            spawn_routes,
+            "kill_pane",
+            lambda _: (_ for _ in ()).throw(AssertionError("must not call")),
+        )
+
+        r = await client.post("/kill-peer", json={"peer_identifier": peer_id})
+
+        assert r.status_code == 200
+        assert r.json()["tmux_killed"] is None
         assert await registry.get_peer(peer_id) is None
 
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -516,6 +516,7 @@ class TestMcpSpawnPeerReturn:
         from repowire.mcp.server import create_mcp_server
 
         mock_my_name.return_value = "orchestrator"
+        mock_request.return_value = {"ok": True, "tmux_killed": True}
         mcp = create_mcp_server()
         tools = {name: fn for name, fn in mcp._tool_manager._tools.items()}
         kill_tool = tools["kill_peer"]
@@ -530,7 +531,49 @@ class TestMcpSpawnPeerReturn:
                 "circle": "5",
             },
         )
-        assert result == "Killed peer repow-5-abc12345 in circle 5"
+        assert "Killed peer repow-5-abc12345 in circle 5" in result
+        assert "tmux pane killed" in result
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_kill_peer_surfaces_skipped_tmux_kill(
+        self, mock_request: AsyncMock, mock_my_name: AsyncMock,
+    ) -> None:
+        """When the daemon returns tmux_killed=None (ownership not proven),
+        the MCP tool must tell the caller — not silently report success."""
+        from repowire.mcp.server import create_mcp_server
+
+        mock_my_name.return_value = "orchestrator"
+        mock_request.return_value = {"ok": True, "tmux_killed": None}
+        mcp = create_mcp_server()
+        kill_tool = {name: fn for name, fn in mcp._tool_manager._tools.items()}["kill_peer"]
+        result = await kill_tool.fn(peer_identifier="repow-5-abc12345")
+
+        assert "Killed peer repow-5-abc12345" in result
+        assert "skipped" in result.lower()
+        assert "ownership not proven" in result.lower()
+        assert "tmux kill-pane" in result
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_kill_peer_surfaces_failed_tmux_kill(
+        self, mock_request: AsyncMock, mock_my_name: AsyncMock,
+    ) -> None:
+        """When the daemon returns tmux_killed=False (kill attempted but failed),
+        the MCP tool must surface the orphan-pane risk."""
+        from repowire.mcp.server import create_mcp_server
+
+        mock_my_name.return_value = "orchestrator"
+        mock_request.return_value = {"ok": True, "tmux_killed": False}
+        mcp = create_mcp_server()
+        kill_tool = {name: fn for name, fn in mcp._tool_manager._tools.items()}["kill_peer"]
+        result = await kill_tool.fn(peer_identifier="repow-5-abc12345")
+
+        assert "Killed peer repow-5-abc12345" in result
+        assert "failed" in result.lower()
+        assert "tmux list-panes" in result
 
 
 class TestMcpRegistration:


### PR DESCRIPTION
## Why

v0.11.1 (#101) fixed the orphan-pane bug but used `peer.tmux_session is not None` as the daemon-spawn gate, on the assumption only daemon-spawned peers populate it. **That assumption is wrong.** The OpenCode plugin derives `tmuxSession` from `TMUX_PANE` on every WS connect:

- `installers/opencode.py:613-622` — sets `tmuxSession = "${session}:${window}"` from any tmux env
- `installers/opencode.py:213-216` — sends it on every `ws.onopen`
- `daemon/routes/websocket.py:89,143` — daemon stores it

Result on v0.11.1: an externally-attached opencode session would have its user's tmux pane killed by `kill_peer`. The HTTP `/peers` endpoint also accepts `tmux_session`, so any future client could trigger the same.

Caught by `repowire.fix-kill-peer-codex` during PR #101 review (notif-6e676924).

## What

Track spawned `pane_id`s in a module-level `set[str]` populated at `/spawn` time. Check membership at `/kill-peer` time. Pane-id ownership is the **single source of truth** — neither `tmux_session` nor `pane_id` presence alone implies daemon ownership.

```python
# daemon/routes/spawn.py
_SPAWNED_PANE_IDS: set[str] = set()

# /spawn:
if result.pane_id:
    _SPAWNED_PANE_IDS.add(result.pane_id)

# /kill-peer:
tmux_killed: bool | None = None
if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
    tmux_killed = kill_pane(peer.pane_id)
    _SPAWNED_PANE_IDS.discard(peer.pane_id)
```

## Tradeoffs

- `_SPAWNED_PANE_IDS` lost on daemon restart → safe-fails (skips pane kill, returns `tmux_killed=None`, peer still unregisters). Matches pre-v0.11.1 behavior in that edge case. Caller can follow up with manual `tmux kill-pane`.
- The `kill_peer(tmux_session)` libtmux fallback in the route is removed — `pane_id` is always populated by `/spawn`, so the fallback was dead code in the new ownership model. `kill_peer` stays in `repowire/spawn.py` for legacy callers.

## Tests

8 route tests in `TestKillPeer`:
- `test_kill_peer_by_peer_id_kills_spawned_pane` — happy path
- `test_kill_peer_by_name_and_circle` — display-name resolution
- `test_kill_peer_ambiguous_display_name_returns_409` — unchanged
- `test_kill_peer_without_pane_id_unregisters` — no pane_id at all
- `test_kill_peer_opencode_attached_skips_tmux_kill` — **the regression case**: tmux_session + pane_id set, but not in spawned set → no kill
- `test_kill_peer_claude_sessionstart_skips_tmux_kill` — pane_id only, no spawn record → no kill
- `test_kill_peer_orphan_pane_surfaces_false` — kill_pane fails, peer still unregistered
- `test_kill_peer_post_restart_safefails` — empty spawned set → safe-fail

Plus the 4 `kill_pane` unit tests from #101.

## Live smoke

- **Case A (opencode-attached, must survive)**: registered fake opencode peer with both `tmux_session` and `pane_id` of a real tmux pane. Called `/kill-peer`. Response `{"ok":true,"tmux_killed":null}`. Pane verified alive via `tmux list-panes -a`. ✓
- **Case B (real spawn, must die)**: `POST /spawn` with claude command in this repo's path. Claude session spawned in `smoke-spawn-test:repowire.fix-kill-peer` window. Found peer_id via `/peers`. Called `/kill-peer`. Response `{"ok":true,"tmux_killed":true}`. Pane verified gone via `tmux list-panes -a`. Session auto-terminated when last window died. ✓

## Test plan

- [x] `uv run pytest` — 397 passed
- [x] `uv run ruff check` — clean on changed files
- [x] `uv run ty check` — clean
- [x] Live smoke: real /spawn → kill (pane dies); opencode-attached register → kill (pane survives)

## Followup (out of scope)

`protocol/peers.py:102` — `Peer.is_spawned` returns `tmux_session is not None`, same wrong assumption as v0.11.1. Not used by `/kill-peer` anymore but worth fixing in a separate PR. Filing as a bd issue.