### PR TITLE
Dashboard: migrate ComposeBar from /query to /ask

### DIFF
--- a/web/app/dashboard/components/ComposeBar.tsx
+++ b/web/app/dashboard/components/ComposeBar.tsx
@@ -28,7 +28,6 @@ const BARE_ACK_TIMEOUT_MS = 120_000;
 
 export function ComposeBar({ peer, apiBase, events, onSent }: ComposeBarProps) {
   const [text, setText] = useState("");
-  const [mode, setMode] = useState<"notify" | "ask">("notify");
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pendingAsks, setPendingAsks] = useState<PendingAsk[]>([]);
@@ -131,52 +130,34 @@ export function ComposeBar({ peer, apiBase, events, onSent }: ComposeBarProps) {
         msg = msg ? `${msg}\n[Attachment: ${path}]` : `[Attachment: ${path}]`;
       }
 
-      const body = JSON.stringify({
-        from_peer: "dashboard",
-        to_peer: peer.name,
-        text: msg + hint,
-        bypass_circle: true,
+      const res = await fetch(`${apiBase}/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          from_peer: "dashboard",
+          to_peer: peer.name,
+          text: msg + hint,
+          bypass_circle: true,
+        }),
       });
-
-      if (mode === "notify") {
-        const res = await fetch(`${apiBase}/notify`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body,
-        });
-        if (!res.ok) {
-          const errBody = await res.json().catch(() => ({}));
-          setError(errBody.detail || `Error ${res.status}`);
-        } else {
-          setText("");
-          setFile(null);
-          if (onSent) setTimeout(onSent, 1000);
-        }
-      } else {
-        const res = await fetch(`${apiBase}/ask`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body,
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok || data.error) {
-          setError(data.error || data.detail || `Error ${res.status}`);
-        } else if (data.correlation_id) {
-          const preview = msg.length > 60 ? msg.slice(0, 60) + "…" : msg;
-          setPendingAsks((prev) => [
-            ...prev,
-            {
-              correlation_id: data.correlation_id,
-              to_peer: peer.name,
-              preview,
-              sent_at: Date.now(),
-              state: "pending",
-            },
-          ]);
-          setText("");
-          setFile(null);
-          if (onSent) setTimeout(onSent, 1000);
-        }
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.error) {
+        setError(data.error || data.detail || `Error ${res.status}`);
+      } else if (data.correlation_id) {
+        const preview = msg.length > 60 ? msg.slice(0, 60) + "…" : msg;
+        setPendingAsks((prev) => [
+          ...prev,
+          {
+            correlation_id: data.correlation_id,
+            to_peer: peer.name,
+            preview,
+            sent_at: Date.now(),
+            state: "pending",
+          },
+        ]);
+        setText("");
+        setFile(null);
+        if (onSent) setTimeout(onSent, 1000);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Request failed");
@@ -195,29 +176,10 @@ export function ComposeBar({ peer, apiBase, events, onSent }: ComposeBarProps) {
   return (
     <div className="shrink-0 px-4 pb-4">
       <div className="bg-surface-container-low/95 backdrop-blur-xl border border-outline-variant/30 rounded-xl p-3 shadow-2xl">
-        {/* Mode toggle + scope */}
+        {/* Scope label */}
         <div className="flex items-center gap-2 mb-3">
-          <div className="flex bg-surface-container-lowest p-1 rounded-lg border border-outline-variant/10">
-            {(["notify", "ask"] as const).map((m) => (
-              <button
-                key={m}
-                onClick={() => setMode(m)}
-                aria-label={`${m} mode`}
-                aria-pressed={mode === m}
-                className={cn(
-                  "px-3 py-1 text-[9px] font-bold uppercase tracking-wider rounded transition-colors",
-                  mode === m
-                    ? "bg-cyan-400 text-on-primary-fixed-variant"
-                    : "text-slate-500 hover:text-slate-300"
-                )}
-              >
-                {m === "notify" ? "Notify" : "Ask"}
-              </button>
-            ))}
-          </div>
-          <div className="h-4 w-[1px] bg-outline-variant/30 mx-1" />
           <span className="text-[9px] font-mono text-outline uppercase tracking-tighter">
-            → {peerLabel(peer)}
+            ask → {peerLabel(peer)}
           </span>
         </div>
 
@@ -262,7 +224,7 @@ export function ComposeBar({ peer, apiBase, events, onSent }: ComposeBarProps) {
           <button
             onClick={submit}
             disabled={(!text.trim() && !file) || isPending}
-            aria-label={mode === "notify" ? "Send message" : "Ask peer"}
+            aria-label="Ask peer"
             aria-busy={isPending}
             className={cn(
               "w-11 h-11 rounded-lg flex items-center justify-center shadow-lg active:scale-90 transition-transform shrink-0",

--- a/web/app/dashboard/components/ComposeBar.tsx
+++ b/web/app/dashboard/components/ComposeBar.tsx
@@ -1,23 +1,37 @@
 "use client";
 
-import { useState, useRef, useEffect, KeyboardEvent } from "react";
-import { Paperclip, RefreshCw, Send, X } from "lucide-react";
+import { useState, useRef, useEffect, useMemo, KeyboardEvent } from "react";
+import { Paperclip, RefreshCw, Send, X, Check, Clock } from "lucide-react";
 import { cn } from "../lib/utils";
-import type { Peer } from "../types";
+import type { Event, Peer } from "../types";
 import { peerLabel } from "../types";
 
 interface ComposeBarProps {
   peer: Peer;
   apiBase: string;
+  events: Event[];
   onSent?: () => void;
 }
 
-export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
+interface PendingAsk {
+  correlation_id: string;
+  to_peer: string;
+  preview: string;
+  sent_at: number;
+  state: "pending" | "delivered" | "timed_out";
+  reply?: string;
+  reply_from?: string;
+}
+
+const ACK_FRAME_RE = /^\[ack #([^\]\s]+) from @([^\]\s]+)\]\s?([\s\S]*)$/;
+const BARE_ACK_TIMEOUT_MS = 120_000;
+
+export function ComposeBar({ peer, apiBase, events, onSent }: ComposeBarProps) {
   const [text, setText] = useState("");
   const [mode, setMode] = useState<"notify" | "ask">("notify");
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [response, setResponse] = useState<string | null>(null);
+  const [pendingAsks, setPendingAsks] = useState<PendingAsk[]>([]);
   const [file, setFile] = useState<File | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -28,6 +42,55 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
   }, [text]);
+
+  // Match incoming notification events to pending asks via [ack #cid from @peer] framing.
+  const openCids = useMemo(
+    () => pendingAsks.filter((a) => a.state === "pending").map((a) => a.correlation_id),
+    [pendingAsks]
+  );
+  useEffect(() => {
+    if (openCids.length === 0) return;
+    for (const ev of events) {
+      if (ev.type !== "notification" || !ev.text) continue;
+      const m = ev.text.match(ACK_FRAME_RE);
+      if (!m) continue;
+      const [, cid, from, body] = m;
+      if (!openCids.includes(cid)) continue;
+      setPendingAsks((prev) =>
+        prev.map((a) =>
+          a.correlation_id === cid && a.state === "pending"
+            ? { ...a, state: "delivered", reply: body, reply_from: from }
+            : a
+        )
+      );
+    }
+  }, [events, openCids]);
+
+  // Bare-ack soft timeout: flip pending → timed_out after 120s.
+  useEffect(() => {
+    if (openCids.length === 0) return;
+    const timers = openCids.map((cid) => {
+      const ask = pendingAsks.find((a) => a.correlation_id === cid);
+      if (!ask) return null;
+      const elapsed = Date.now() - ask.sent_at;
+      const remaining = Math.max(0, BARE_ACK_TIMEOUT_MS - elapsed);
+      return window.setTimeout(() => {
+        setPendingAsks((prev) =>
+          prev.map((a) =>
+            a.correlation_id === cid && a.state === "pending"
+              ? { ...a, state: "timed_out" }
+              : a
+          )
+        );
+      }, remaining);
+    });
+    return () => {
+      for (const t of timers) if (t !== null) window.clearTimeout(t);
+    };
+  }, [openCids, pendingAsks]);
+
+  const dismissAsk = (cid: string) =>
+    setPendingAsks((prev) => prev.filter((a) => a.correlation_id !== cid));
 
   const uploadFile = async (f: File): Promise<string | null> => {
     const formData = new FormData();
@@ -52,7 +115,6 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
   const submit = async () => {
     if ((!text.trim() && !file) || isPending) return;
     setError(null);
-    setResponse(null);
     setIsPending(true);
 
     try {
@@ -69,31 +131,48 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
         msg = msg ? `${msg}\n[Attachment: ${path}]` : `[Attachment: ${path}]`;
       }
 
+      const body = JSON.stringify({
+        from_peer: "dashboard",
+        to_peer: peer.name,
+        text: msg + hint,
+        bypass_circle: true,
+      });
+
       if (mode === "notify") {
         const res = await fetch(`${apiBase}/notify`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ from_peer: "dashboard", to_peer: peer.name, text: msg + hint, bypass_circle: true }),
+          body,
         });
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
-          setError(body.detail || `Error ${res.status}`);
+          const errBody = await res.json().catch(() => ({}));
+          setError(errBody.detail || `Error ${res.status}`);
         } else {
           setText("");
           setFile(null);
           if (onSent) setTimeout(onSent, 1000);
         }
       } else {
-        const res = await fetch(`${apiBase}/query`, {
+        const res = await fetch(`${apiBase}/ask`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ from_peer: "dashboard", to_peer: peer.name, text: msg + hint, bypass_circle: true }),
+          body,
         });
-        const data = await res.json();
-        if (data.error) {
-          setError(data.error);
-        } else {
-          setResponse(data.text ?? null);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || data.error) {
+          setError(data.error || data.detail || `Error ${res.status}`);
+        } else if (data.correlation_id) {
+          const preview = msg.length > 60 ? msg.slice(0, 60) + "…" : msg;
+          setPendingAsks((prev) => [
+            ...prev,
+            {
+              correlation_id: data.correlation_id,
+              to_peer: peer.name,
+              preview,
+              sent_at: Date.now(),
+              state: "pending",
+            },
+          ]);
           setText("");
           setFile(null);
           if (onSent) setTimeout(onSent, 1000);
@@ -132,7 +211,7 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
                     : "text-slate-500 hover:text-slate-300"
                 )}
               >
-                {m === "notify" ? "Notify" : "Query"}
+                {m === "notify" ? "Notify" : "Ask"}
               </button>
             ))}
           </div>
@@ -197,7 +276,7 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
         </div>
       </div>
 
-      {/* Error / Response */}
+      {/* Error */}
       {error && (
         <div className="flex items-center gap-2 mt-2 px-3">
           <p className="text-xs text-error font-mono flex-1">{error}</p>
@@ -209,9 +288,58 @@ export function ComposeBar({ peer, apiBase, onSent }: ComposeBarProps) {
           </button>
         </div>
       )}
-      {response && (
-        <div className="text-xs text-on-surface-variant bg-surface-container-lowest border border-outline-variant/20 rounded-lg p-2 mt-2 max-h-24 overflow-y-auto font-mono whitespace-pre-wrap">
-          {response}
+
+      {/* Pending / delivered asks for this peer */}
+      {pendingAsks.filter((a) => a.to_peer === peer.name).length > 0 && (
+        <div className="flex flex-col gap-1.5 mt-2">
+          {pendingAsks
+            .filter((a) => a.to_peer === peer.name)
+            .map((a) => (
+              <div
+                key={a.correlation_id}
+                className={cn(
+                  "border rounded-lg px-3 py-2 text-xs font-mono",
+                  a.state === "delivered"
+                    ? "bg-surface-container-lowest border-cyan-400/30"
+                    : a.state === "timed_out"
+                      ? "bg-surface-container-lowest border-outline-variant/20 text-outline"
+                      : "bg-surface-container-lowest border-outline-variant/30"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  {a.state === "delivered" ? (
+                    <Check className="w-3 h-3 text-cyan-400 shrink-0" aria-hidden="true" />
+                  ) : a.state === "timed_out" ? (
+                    <Check className="w-3 h-3 text-outline shrink-0" aria-hidden="true" />
+                  ) : (
+                    <Clock className="w-3 h-3 text-outline shrink-0 animate-pulse" aria-hidden="true" />
+                  )}
+                  <span className="text-[10px] uppercase tracking-wider text-outline shrink-0">
+                    #{a.correlation_id.slice(0, 8)}
+                  </span>
+                  <span className="text-on-surface-variant truncate flex-1">{a.preview}</span>
+                  <span className="text-[10px] text-outline shrink-0">
+                    {a.state === "pending"
+                      ? "pending"
+                      : a.state === "delivered"
+                        ? `reply from @${a.reply_from}`
+                        : "acked (no reply)"}
+                  </span>
+                  <button
+                    onClick={() => dismissAsk(a.correlation_id)}
+                    aria-label="Dismiss"
+                    className="p-0.5 text-outline hover:text-on-surface shrink-0"
+                  >
+                    <X className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </div>
+                {a.state === "delivered" && a.reply && (
+                  <div className="mt-1.5 pl-5 text-on-surface-variant whitespace-pre-wrap max-h-24 overflow-y-auto">
+                    {a.reply}
+                  </div>
+                )}
+              </div>
+            ))}
         </div>
       )}
     </div>

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -265,7 +265,7 @@ export default function Dashboard() {
                 <div className="flex-1 overflow-y-auto">
                   <ChatPanel peer={selectedPeer} events={events} />
                 </div>
-                <ComposeBar key={selectedPeer.peer_id} peer={selectedPeer} apiBase={API_BASE} onSent={refreshData} />
+                <ComposeBar key={selectedPeer.peer_id} peer={selectedPeer} apiBase={API_BASE} events={events} onSent={refreshData} />
               </div>
             ) : (
               <div className="flex-1 overflow-y-auto px-4 py-4">

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -24,7 +24,7 @@ export function peerLabel(peer: Peer): string {
 
 export interface Event {
   id: string;
-  type: "query" | "response" | "notification" | "broadcast" | "status_change" | "chat_turn";
+  type: "query" | "response" | "notification" | "broadcast" | "status_change" | "chat_turn" | "ask";
   timestamp: string;
   from?: string;
   to?: string;


### PR DESCRIPTION
## Summary
- ComposeBar now calls `/ask` for the ask path (was `/query`, deprecated, removed v0.13). Notify path unchanged, FYI smoke-tested against running daemon.
- Submitting an ask immediately clears the textarea and pushes a pending chip showing `#cid → preview · pending`. When a notification event arriving on the existing SSE stream matches `^\[ack #cid from @peer\] body`, the matching chip flips to delivered and expands the reply inline.
- Bare-ack soft timeout: 120s (per orchestrator brief — codex peers can be slow). If no notification matches within the window, chip flips to "acked (no reply)". User can dismiss any chip with the X.
- `Event["type"]` union widened to include `"ask"` so future ask SSE events (emitted by daemon) don't break the type guard.
- `events` prop drilled into ComposeBar from `page.tsx` rather than introducing a context — single consumer, scoped to one component.

## Out of scope
- No "asks I sent" panel, no reminders UI, no `reply_to` chaining, no localStorage persistence across reload (per orchestrator: scope creep for v1).
- No daemon changes.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] Live `/notify` smoke against running daemon (200 OK)
- [ ] Live `/ask` smoke (requires post-PR-99 daemon — running daemon predates the route; will smoke once rebuilt)
- [ ] UI: submit ask → pending chip appears → ack arrives → chip flips to delivered + reply expands
- [ ] UI: submit ask → wait 120s with bare-ack → chip flips to "acked (no reply)"
- [ ] UI: notify path still works (FYI smoke)