### PR TITLE
Rip ask BUSY queue + turn-counter grace + once-only reminders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,9 @@ The daemon is the single routing hub. It doesn't care how a peer connects — al
 - `channel/server.ts` — **experimental** Claude Code transport: MCP channel with reply tool, permission relay
 - `daemon/peer_registry.py` — peer state, circle access, events, lazy_repair, ghost eviction
 - `daemon/message_router.py` — sends `type=ask` / `notify` / `broadcast` over WebSocket; legacy `send_query` for /query shim
-- `daemon/ask_tracker.py` — non-blocking ask lifecycle (register/pickup/close/reminders, daemon-owned turn_seq under lock)
+- `daemon/ask_tracker.py` — slim ask state store: register, close, get, pending_for_peer. Open asks reappear in every Stop hook poll until acked.
 - `daemon/query_tracker.py` — legacy /query correlation ID tracking, asyncio Futures (async-locked)
-- `daemon/routes/asks.py` — `/ask`, `/ack`, `/asks/{cid}/picked_up`, `/asks/pending`, `/asks/{cid}/mark_reminded`
+- `daemon/routes/asks.py` — `/ask`, `/ack`, `/asks/pending`. `/asks/{cid}/picked_up` + `/asks/{cid}/mark_reminded` are deprecated no-op 200 endpoints kept for one release for transport compat.
 - `daemon/routes/` — other HTTP endpoints (peers, messages, websocket, spawn, health)
 - `mcp/server.py` — MCP tools (list_peers, ask, ack, notify_peer, broadcast, whoami, set_description, spawn_peer, kill_peer)
 - `relay/server.py` — hosted relay at repowire.io (WS bridge + HTTP tunnel)
@@ -81,11 +81,11 @@ Claude Code → hooks → websocket_hook.py ←WebSocket→ Daemon
 - **Stop** →
   1. extracts response + tool calls from transcript, posts chat turns
   2. delivers legacy /query response (single-purpose `pending-query-{pane}.json` FIFO)
-  3. fetches `/asks/pending` (bumps daemon turn_seq) and writes any due reminders to `reminder-{pane}.txt`
-  4. then `update_status(online)` (drains BUSY-buffered asks; deferred until after the bump so drained-asks snapshot N+1 and aren't reminded same-turn)
+  3. fetches `/asks/pending` → all open asks for this peer → writes to `reminder-{pane}.txt`
+  4. then `update_status(online)`
 - **UserPromptSubmit** → marks BUSY, consumes `reminder-{pane}.txt` and emits as `additionalContext`
 - **Notification** (idle_prompt) → resets ONLINE; also consumes the reminder buffer as a fallback path
-- **ws-hook** → on `type=ask` arrival, injects `[ask #cid]` framed text and POSTs `/asks/{cid}/picked_up` directly (transport-side pickup; daemon snapshots turn_seq under lock)
+- **ws-hook** → on `type=ask` arrival, injects `[ask #cid]` framed text. Daemon doesn't track pickup; the Stop hook reminder is the only way an un-acked ask is resurfaced.
 
 In channel mode, only the Stop hook is kept (for dashboard chat_turn events).
 `install_hooks(channel_mode=True)` installs only the Stop hook when using channel transport.
@@ -122,7 +122,7 @@ Claude Code <stdio> channel/server.ts <WebSocket> Daemon
 
 - Messages arrive as `<channel source="repowire" from_peer="..." msg_type="...">` tags
 - Queries (legacy /query shim) include `correlation_id` — Claude calls the `reply` tool to respond
-- Asks (`msg_type=ask`) include `correlation_id` (and optional `reply_to`) — Claude calls the `ack(correlation_id, message?)` tool to close. Channel server POSTs `/asks/{cid}/picked_up` after dispatch so the daemon can snapshot turn_seq for the grace window.
+- Asks (`msg_type=ask`) include `correlation_id` (and optional `reply_to`) — Claude calls the `ack(correlation_id, message?)` tool to close. Open asks reappear in every Stop hook reminder until acked.
 - Permission relay: forwards tool approval prompts to Telegram/dashboard
 - Requires claude.ai login (not API/Console key), Claude Code v2.1.80+, bun runtime
 - Opt-in only: `repowire setup --experimental-channels`

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ repowire telegram start
 
 `list_peers` and `whoami` return TSV (more token-efficient than JSON).
 
-If an agent picks up an ask but doesn't ack/reply within one full turn, repowire injects a reminder block at the start of the next prompt (capped to 3 most-recent, once-only). Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does.
+If an agent receives an ask but doesn't ack/reply, repowire injects a reminder block at the start of every subsequent prompt until the ask is acked. Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does.
 
 The legacy `ask_peer` (blocking, request/response) is removed in this release. The legacy `/query` + `/response` HTTP endpoints remain as compatibility shims for the telegram bot and CLI; they will be removed in v0.13.
 

--- a/repowire/channel/server.ts
+++ b/repowire/channel/server.ts
@@ -100,29 +100,6 @@ function connectDaemon(mcp: Server): void {
         },
       });
 
-      // Transport-side pickup: tell the daemon this ask was delivered so it
-      // can snapshot turn_seq for the grace-window check. Channel uses HTTP
-      // base URL (DAEMON_URL is a WebSocket-flavored value).
-      if (msg.type === "ask" && msg.correlation_id) {
-        const httpUrl = DAEMON_URL.replace("ws://", "http://").replace(
-          "wss://",
-          "https://"
-        );
-        try {
-          await fetch(
-            `${httpUrl}/asks/${encodeURIComponent(msg.correlation_id)}/picked_up`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ correlation_id: msg.correlation_id }),
-            }
-          );
-        } catch (e) {
-          console.error(
-            `repowire: failed to post ask pickup for ${msg.correlation_id}: ${e}`
-          );
-        }
-      }
     }
   });
 

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -1,20 +1,17 @@
 """Ask/ack lifecycle tracking for the Repowire daemon.
 
-The AskTracker manages the non-blocking ask/ack lifecycle introduced in the
-ask-ack-notify refactor. Asks are registered when a peer fires `ask()`, the
-target peer picks them up on its next Stop hook (turn boundary), and they
-are closed when the target either:
+The AskTracker is the source of truth for open ask threads. Asks are
+registered when a peer fires `ask()`, the recipient transport injects the
+wire frame on receipt, and the ask is closed when the recipient either:
 
   - calls `ack(corr_id)` — bare close, no content
   - calls `ack(corr_id, msg)` — close with reply content delivered to asker
   - calls `ask(reply_to=corr_id, ...)` — opens a new thread + closes this one
 
-If a peer picks up an ask but doesn't ack/reply within one full turn after
-pickup, the Stop hook injects a reminder (capped to 3 most recent, once-only).
-
-Unlike QueryTracker (which used asyncio Futures for synchronous blocking),
-AskTracker is purely a state store. Reply delivery is handled by the
-notification pipeline (so it inherits BUSY-buffering for free).
+Open asks targeting a peer are surfaced every Stop hook turn via
+`/asks/pending`, so an agent that hasn't acked will be reminded on every
+subsequent turn until they do. Reply delivery is handled by the
+notification pipeline (framed `[ack #cid from @peer] msg`).
 
 In-memory only. Asks are evicted after 24h via TTL sweep mirroring the
 config's prune_max_age_hours.
@@ -38,9 +35,7 @@ _EVICTION_INTERVAL_SECONDS = 300.0
 class Ask:
     """An open ask awaiting ack/reply.
 
-    picked_up_turn_seq: per-peer turn counter at pickup. Compared against the
-        next pending-poll's seq for the one-turn grace check. None until pickup.
-    close_reason: 'ack' | 'ack_with_msg' | 'reply_to' | 'evicted'.
+    close_reason: 'ack' | 'ack_with_msg' | 'reply_to' | 'evicted' | 'send_failed'.
     """
 
     correlation_id: str
@@ -51,16 +46,12 @@ class Ask:
     text: str
     reply_to: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    picked_up: bool = False
-    picked_up_at: datetime | None = None
-    picked_up_turn_seq: int | None = None
-    reminded: bool = False
     closed: bool = False
     close_reason: str | None = None
 
 
 class AskTracker:
-    """In-memory store for the ask/ack lifecycle.
+    """In-memory store of open ask threads.
 
     All mutating methods are async-locked. Read methods are unlocked snapshots
     (callers that need consistency should re-check after acting).
@@ -69,7 +60,6 @@ class AskTracker:
     def __init__(self, *, ttl_hours: float = 24.0) -> None:
         self._lock = asyncio.Lock()
         self._asks: dict[str, Ask] = {}
-        self._turn_seq: dict[str, int] = {}
         self._ttl = timedelta(hours=ttl_hours)
         self._last_eviction: float = 0.0
 
@@ -106,34 +96,6 @@ class AskTracker:
             logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)
             return cid
 
-    async def mark_picked_up(self, correlation_id: str) -> bool:
-        """Mark an ask as picked up by the recipient.
-
-        Snapshots the recipient's current turn_seq atomically (under the same
-        lock that increment_turn uses). Clients don't supply turn_seq — they
-        only signal "delivered." This keeps the grace-window math daemon-owned.
-
-        Idempotent — first call sticks; later calls are no-ops so replays
-        can't shift the grace window.
-        """
-        async with self._lock:
-            ask = self._asks.get(correlation_id)
-            if not ask or ask.closed or ask.picked_up:
-                return False
-            ask.picked_up = True
-            ask.picked_up_at = datetime.now(timezone.utc)
-            ask.picked_up_turn_seq = self._turn_seq.get(ask.to_peer_id, 0)
-            return True
-
-    async def mark_reminded(self, correlation_id: str) -> bool:
-        """Flip reminded=True. Once-only."""
-        async with self._lock:
-            ask = self._asks.get(correlation_id)
-            if not ask or ask.closed or ask.reminded:
-                return False
-            ask.reminded = True
-            return True
-
     async def close(self, correlation_id: str, reason: str) -> Ask | None:
         """Close an ask. Returns the Ask if it existed and wasn't already closed."""
         async with self._lock:
@@ -149,33 +111,12 @@ class AskTracker:
         """Look up an ask by corr_id."""
         return self._asks.get(correlation_id)
 
-    async def increment_turn(self, peer_id: str) -> int:
-        """Bump the per-peer turn counter and return the new value.
-
-        Called from the Stop hook intake path. Each Stop fire for a pane is
-        one turn. The counter is used to compare against picked_up_turn_seq
-        for the grace-window check.
-        """
-        async with self._lock:
-            self._turn_seq[peer_id] = self._turn_seq.get(peer_id, 0) + 1
-            return self._turn_seq[peer_id]
-
     async def pending_for_peer(
         self,
         peer_id: str,
-        current_turn_seq: int,
-        max_results: int = 3,
+        max_results: int = 10,
     ) -> list[Ask]:
-        """Return open asks targeting this peer that are due for a reminder.
-
-        Selects asks where:
-          - to_peer_id == peer_id
-          - picked_up == True
-          - reminded == False
-          - closed == False
-          - picked_up_turn_seq < current_turn_seq  (one full turn of grace)
-
-        Returns the most recent `max_results` asks, newest first.
+        """Return open asks targeting this peer, newest first, capped at max_results.
 
         Lazy-repair: opportunistically evicts TTL-expired asks at most once
         per _EVICTION_INTERVAL_SECONDS. Stop hooks call this on every turn,
@@ -185,12 +126,7 @@ class AskTracker:
         async with self._lock:
             candidates = [
                 ask for ask in self._asks.values()
-                if ask.to_peer_id == peer_id
-                and ask.picked_up
-                and not ask.reminded
-                and not ask.closed
-                and ask.picked_up_turn_seq is not None
-                and ask.picked_up_turn_seq < current_turn_seq
+                if ask.to_peer_id == peer_id and not ask.closed
             ]
             candidates.sort(key=lambda a: a.created_at, reverse=True)
             return candidates[:max_results]
@@ -204,7 +140,7 @@ class AskTracker:
         await self.evict_expired()
 
     async def forget_peer(self, peer_id: str) -> int:
-        """Drop turn counter and any asks involving this peer.
+        """Drop any asks involving this peer.
 
         Called by PeerRegistry when pruning offline peers, so the tracker's
         memory footprint is bounded by the live peer set.
@@ -212,7 +148,6 @@ class AskTracker:
         Returns the number of asks dropped.
         """
         async with self._lock:
-            self._turn_seq.pop(peer_id, None)
             doomed = [
                 cid for cid, ask in self._asks.items()
                 if ask.to_peer_id == peer_id or ask.from_peer_id == peer_id

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -8,7 +8,7 @@ wire frame on receipt, and the ask is closed when the recipient either:
   - calls `ack(corr_id, msg)` — close with reply content delivered to asker
   - calls `ask(reply_to=corr_id, ...)` — opens a new thread + closes this one
 
-Open asks targeting a peer are surfaced every Stop hook turn via
+Open asks targeting a peer are surfaced on every Stop hook poll via
 `/asks/pending`, so an agent that hasn't acked will be reminded on every
 subsequent turn until they do. Reply delivery is handled by the
 notification pipeline (framed `[ack #cid from @peer] msg`).
@@ -119,7 +119,7 @@ class AskTracker:
         """Return open asks targeting this peer, newest first, capped at max_results.
 
         Lazy-repair: opportunistically evicts TTL-expired asks at most once
-        per _EVICTION_INTERVAL_SECONDS. Stop hooks call this on every turn,
+        per _EVICTION_INTERVAL_SECONDS. Stop hooks call this on each response,
         so the dict gets swept regularly without a background timer.
         """
         await self._maybe_evict_expired()

--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -128,8 +128,10 @@ class MessageRouter:
         """Send a first-class ask wire message.
 
         Wire shape: {type: ask, correlation_id, from_peer, text, reply_to?}.
-        The receiving transport must dispatch type=ask explicitly and POST
-        /asks/{cid}/picked_up after presenting the message to the agent.
+        The receiving transport dispatches type=ask explicitly and surfaces
+        the message to the agent (e.g. tmux paste). The daemon doesn't track
+        pickup state — open asks reappear in every Stop hook reminder until
+        acked.
 
         Raises:
             TransportError: If send fails
@@ -145,38 +147,18 @@ class MessageRouter:
         await self._transport.send(to_session_id, message)
         logger.info(f"Ask sent: {from_peer} -> {to_peer_name} ({correlation_id[:8]})")
 
-    async def send_broadcast_to(
-        self,
-        from_peer: str,
-        to_session_id: str,
-        to_peer_name: str,
-        text: str,
-    ) -> None:
-        """Deliver a single broadcast copy to one peer. Used to replay buffered
-        broadcasts to a peer that was BUSY when the original fanout ran."""
-        message: dict[str, Any] = {
-            "type": "broadcast",
-            "from_peer": from_peer,
-            "text": text,
-        }
-        await self._transport.send(to_session_id, message)
-        logger.info(f"Broadcast (deferred) sent: {from_peer} -> {to_peer_name}")
-
     async def broadcast(
         self,
         from_peer: str,
         text: str,
         exclude: set[str] | None = None,
-    ) -> list[str]:
-        """Broadcast to all connected peers.
-
-        Args:
-            from_peer: Display name of sender
-            text: Broadcast text
-            exclude: Set of session IDs to exclude
+    ) -> tuple[list[str], list[dict[str, str]]]:
+        """Best-effort broadcast to all connected peers (minus excludes).
 
         Returns:
-            List of session IDs that received the broadcast
+            (sent_session_ids, failed) where failed is [{session_id, error}, ...]
+            for recipients whose transport raised. One failure does not abort
+            the rest of the fanout.
         """
         excluded = exclude or set()
         message: dict[str, Any] = {
@@ -185,18 +167,21 @@ class MessageRouter:
             "text": text,
         }
 
-        async def _send_one(session_id: str) -> str | None:
+        async def _send_one(session_id: str) -> tuple[str, str | None]:
             try:
                 await self._transport.send(session_id, message)
-                return session_id
+                return session_id, None
             except TransportError as e:
                 logger.warning(f"Broadcast to {session_id} failed: {e}")
-                return None
+                return session_id, str(e)
 
-        results = await asyncio.gather(
-            *(_send_one(sid) for sid in self._transport.get_all_sessions() if sid not in excluded),
+        targets = [sid for sid in self._transport.get_all_sessions() if sid not in excluded]
+        results = await asyncio.gather(*(_send_one(sid) for sid in targets))
+        sent_to = [sid for sid, err in results if err is None]
+        failed = [{"session_id": sid, "error": err} for sid, err in results if err is not None]
+
+        logger.info(
+            "Broadcast from %s: sent to %d peers, %d failed",
+            from_peer, len(sent_to), len(failed),
         )
-        sent_to = [r for r in results if r is not None]
-
-        logger.info(f"Broadcast from {from_peer}: sent to {len(sent_to)} peers")
-        return sent_to
+        return sent_to, failed

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -102,15 +102,6 @@ class PeerRegistry:
         self._last_repair: float = 0.0
         self._repair_lock = asyncio.Lock()
 
-        # Notifications/broadcasts buffered while a peer is BUSY. Issue #79:
-        # injecting during a busy turn drops the message into the active
-        # subagent's context instead of the human's main session. Drain on the
-        # BUSY -> ONLINE transition (see update_peer_status). In-memory only --
-        # buffered messages are best-effort and don't survive daemon restart.
-        # Cap per-peer to avoid unbounded growth if a peer never goes idle.
-        self._pending_messages: dict[str, list[dict[str, Any]]] = {}
-        self._pending_messages_max = 100
-
     # ------------------------------------------------------------------
     # Mapping persistence
     # ------------------------------------------------------------------
@@ -689,8 +680,14 @@ class PeerRegistry:
     ) -> None:
         """Send a notification to a peer (fire-and-forget).
 
+        Direct wire send via the router. No daemon-side queueing: BUSY peers
+        have a live WS and ws-hook buffers the tmux paste through the busy
+        turn, so direct send is sufficient. Offline peers raise TransportError
+        so callers can retry or escalate.
+
         Raises:
-            ValueError: If peer not found or circle boundary violated
+            ValueError: peer not found / circle boundary violated.
+            TransportError: peer has no live WS.
         """
         async with self._lock:
             peer = self._lookup_peer_unlocked(to_peer, circle=circle)
@@ -700,22 +697,14 @@ class PeerRegistry:
             peer_id = peer.peer_id
             peer_name = peer.display_name
             from_peer_id = from_obj.peer_id if from_obj else None
-            queued = self._enqueue_if_busy_unlocked(
-                peer,
-                {"kind": "notify", "from_peer": from_peer, "text": text},
-            )
 
         self.add_event(
             "notification",
             {
                 "from": from_peer, "to": to_peer, "text": text,
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
-                "queued": queued,
             },
         )
-
-        if queued:
-            return
 
         await self._router.send_notification(
             from_peer=from_peer,
@@ -734,11 +723,16 @@ class PeerRegistry:
         bypass_circle: bool = False,
         circle: str | None = None,
     ) -> None:
-        """Inject an ask to a peer as a first-class type=ask wire message.
+        """Inject an ask to a peer as a type=ask wire frame.
 
-        BUSY recipients get the ask buffered and drained on idle. Pickup is
-        always the recipient transport's job — never daemon-side — so this
-        method only writes the wire frame.
+        Direct wire send via the router. BUSY isn't a delivery barrier under
+        async ask semantics — ws-hook buffers the tmux paste through the busy
+        turn. Offline peers raise TransportError so the /ask route can roll
+        back the tracker registration and return an error to the caller.
+
+        Raises:
+            ValueError: peer not found / circle violation.
+            TransportError: peer has no live WS.
         """
         async with self._lock:
             peer = self._lookup_peer_unlocked(to_peer, circle=circle)
@@ -748,16 +742,6 @@ class PeerRegistry:
             peer_id = peer.peer_id
             peer_name = peer.display_name
             from_peer_id = from_obj.peer_id if from_obj else None
-            queued = self._enqueue_if_busy_unlocked(
-                peer,
-                {
-                    "kind": "ask",
-                    "from_peer": from_peer,
-                    "text": text,
-                    "correlation_id": correlation_id,
-                    "reply_to": reply_to,
-                },
-            )
 
         self.add_event(
             "ask",
@@ -766,12 +750,8 @@ class PeerRegistry:
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
                 "correlation_id": correlation_id,
                 "reply_to": reply_to,
-                "queued": queued,
             },
         )
-
-        if queued:
-            return
 
         await self._router.send_ask(
             from_peer=from_peer,
@@ -788,17 +768,16 @@ class PeerRegistry:
         text: str,
         exclude: list[str] | None = None,
         bypass_circle: bool = False,
-    ) -> list[str]:
-        """Broadcast a message to all peers.
+    ) -> tuple[list[str], list[dict[str, str]]]:
+        """Broadcast to all peers in sender's circle (or all, if sender bypasses).
 
-        Returns:
-            List of peer names that received the broadcast
+        Best-effort per-peer: a stale WS for one recipient doesn't fail the
+        whole call. Returns ([sent_to_names], [{peer, error}, ...]).
         """
         exclude_names = set(exclude or [])
         exclude_names.add(from_peer)
 
         exclude_session_ids: set[str] = set()
-        queued_peer_names: list[str] = []
         async with self._lock:
             from_peer_obj: Peer | None = None
             for name in exclude_names:
@@ -815,19 +794,9 @@ class PeerRegistry:
                     if peer.circle != from_circle and not peer.bypasses_circles:
                         exclude_session_ids.add(sid)
 
-            # Queue for any BUSY recipient so the broadcast lands in their main
-            # session after they finish, not in whatever subagent is running.
-            for sid, peer in self._peers.items():
-                if sid in exclude_session_ids:
-                    continue
-                if self._enqueue_if_busy_unlocked(
-                    peer,
-                    {"kind": "broadcast", "from_peer": from_peer, "text": text},
-                ):
-                    exclude_session_ids.add(sid)
-                    queued_peer_names.append(peer.display_name)
-
             from_peer_id = from_peer_obj.peer_id if from_peer_obj else None
+            id_to_name = {sid: p.display_name for sid, p in self._peers.items()}
+
         self.add_event(
             "broadcast",
             {
@@ -836,30 +805,25 @@ class PeerRegistry:
             },
         )
 
-        sent_session_ids = await self._router.broadcast(
+        sent_ids, failed = await self._router.broadcast(
             from_peer=from_peer,
             text=text,
             exclude=exclude_session_ids,
         )
 
-        async with self._lock:
-            sent_names = [
-                self._peers[sid].display_name
-                for sid in sent_session_ids
-                if sid in self._peers
-            ]
-        # Recipients we deferred while busy still count as "will receive."
-        return sent_names + queued_peer_names
+        sent_names = [id_to_name[sid] for sid in sent_ids if sid in id_to_name]
+        failed_named = [
+            {"peer": id_to_name.get(f["session_id"], f["session_id"]), "error": f["error"]}
+            for f in failed
+        ]
+        return sent_names, failed_named
 
     # ------------------------------------------------------------------
     # Status / metadata mutations
     # ------------------------------------------------------------------
 
     async def update_peer_status(self, identifier: str, status: PeerStatus) -> None:
-        """Update peer status, draining any buffered notifications on BUSY -> ONLINE."""
-        to_flush: list[dict[str, Any]] = []
-        flush_peer_id: str | None = None
-        flush_peer_name: str | None = None
+        """Update peer status + last_seen. No side effects beyond that."""
         async with self._lock:
             peer = self._lookup_peer_unlocked(identifier)
             if not peer:
@@ -869,90 +833,8 @@ class PeerRegistry:
                     status.value,
                 )
                 return
-            previous = peer.status
             peer.status = status
             peer.last_seen = datetime.now(timezone.utc)
-            # Drain on any non-BUSY transition out of BUSY. OFFLINE drops the
-            # queue (the peer is gone); ONLINE replays it.
-            if previous == PeerStatus.BUSY and status != PeerStatus.BUSY:
-                queued = self._pending_messages.pop(peer.peer_id, [])
-                if status == PeerStatus.ONLINE and queued:
-                    to_flush = queued
-                    flush_peer_id = peer.peer_id
-                    flush_peer_name = peer.display_name
-
-        if to_flush and flush_peer_id and flush_peer_name:
-            await self._flush_pending(flush_peer_id, flush_peer_name, to_flush)
-
-    def _enqueue_if_busy_unlocked(self, peer: Peer, message: dict[str, Any]) -> bool:
-        """If peer is BUSY, append to its pending queue. Returns True if queued.
-
-        Caller must hold self._lock. The queue is per-peer FIFO; flush order is
-        preserved by appending here and popping the whole list at flush time.
-        """
-        if peer.status != PeerStatus.BUSY:
-            return False
-        queue = self._pending_messages.setdefault(peer.peer_id, [])
-        if len(queue) >= self._pending_messages_max:
-            # Drop oldest to bound memory under stuck-busy peers. Better than
-            # blocking the sender or unbounded growth.
-            dropped = queue.pop(0)
-            logger.warning(
-                "Pending queue for %s full (%d) -- dropping oldest %s from %s",
-                peer.display_name,
-                self._pending_messages_max,
-                dropped.get("kind"),
-                dropped.get("from_peer"),
-            )
-        queue.append(message)
-        return True
-
-    async def _flush_pending(
-        self,
-        peer_id: str,
-        peer_name: str,
-        messages: list[dict[str, Any]],
-    ) -> None:
-        """Send buffered notify/broadcast messages in order. Single task,
-        sequential await -- preserves FIFO ordering even if a send fails or
-        is slow."""
-        for msg in messages:
-            try:
-                if msg["kind"] == "notify":
-                    await self._router.send_notification(
-                        from_peer=msg["from_peer"],
-                        to_session_id=peer_id,
-                        to_peer_name=peer_name,
-                        text=msg["text"],
-                    )
-                elif msg["kind"] == "ask":
-                    # Pickup remains the recipient transport's job; flushing
-                    # only writes the wire frame.
-                    await self._router.send_ask(
-                        from_peer=msg["from_peer"],
-                        to_session_id=peer_id,
-                        to_peer_name=peer_name,
-                        correlation_id=msg["correlation_id"],
-                        text=msg["text"],
-                        reply_to=msg.get("reply_to"),
-                    )
-                elif msg["kind"] == "broadcast":
-                    # The original broadcast fanout already ran for online
-                    # recipients; this is just the deferred copy for one
-                    # previously-busy peer.
-                    await self._router.send_broadcast_to(
-                        from_peer=msg["from_peer"],
-                        to_session_id=peer_id,
-                        to_peer_name=peer_name,
-                        text=msg["text"],
-                    )
-            except Exception as e:
-                logger.warning(
-                    "Failed to flush buffered %s to %s: %s",
-                    msg.get("kind"),
-                    peer_name,
-                    e,
-                )
 
     async def update_description(
         self, identifier: str, description: str, circle: str | None = None

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -4,15 +4,21 @@ The non-blocking ask/ack model:
 
   POST /ask                       — register an ask, inject to recipient, return corr_id
   POST /ack                       — close an ask (bare or with reply content)
-  POST /asks/{cid}/picked_up      — transport signals delivery (daemon snapshots turn_seq)
-  GET  /asks/pending              — recipient's Stop hook polls for due reminders
-  POST /asks/{cid}/mark_reminded  — recipient's Stop hook flips once-only reminder flag
+  GET  /asks/pending              — recipient's Stop hook polls for open asks
 
-The wire protocol carries these to peers as a first-class `type: ask`
+The wire protocol carries asks to peers as a first-class `type: ask`
 message: `{type: ask, correlation_id, from_peer, text, reply_to}`. Each
-transport (ws-hook, opencode plugin, channel server) dispatches `type=ask`
-explicitly and POSTs `/asks/{cid}/picked_up` after presenting the message
-to the agent.
+transport (ws-hook, opencode plugin, channel server) dispatches
+`type=ask` and the recipient agent acks via the `ack` MCP tool.
+
+Open asks are surfaced on every Stop hook poll until acked — no
+once-only reminder, no turn-counter grace window. The agent is free to
+ignore a reminder; it'll show up again next turn.
+
+`POST /asks/{cid}/picked_up` and `POST /asks/{cid}/mark_reminded` are
+kept as silent no-op 200 endpoints for one release so older transports
+(channel server, opencode plugin installs) don't see 404 noise during
+the upgrade.
 """
 
 from __future__ import annotations
@@ -25,7 +31,7 @@ from pydantic import BaseModel, Field
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.routes._shared import OkResponse
-from repowire.protocol.peers import PeerStatus
+from repowire.daemon.websocket_transport import TransportError
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["asks"])
@@ -49,7 +55,6 @@ class AskResponse(BaseModel):
     """Result of opening an ask."""
 
     correlation_id: str
-    status: str | None = None  # 'sent', 'queued' (recipient busy), or 'rejected'
     error: str | None = None
 
 
@@ -61,19 +66,10 @@ class AckRequest(BaseModel):
     from_peer: str = Field(..., description="Display name of the acking peer")
 
 
-class PickedUpRequest(BaseModel):
-    """Transport reports that an ask was delivered to its recipient.
+class _NoOpRequest(BaseModel):
+    """Compat shim: legacy clients may POST a body to deprecated endpoints."""
 
-    Daemon owns turn_seq sequencing — it snapshots its own per-peer counter
-    atomically when this endpoint is called. Clients only signal "delivered."
-    """
-
-    correlation_id: str
-    pane_id: str | None = Field(None, description="Pane that picked up (for logging)")
-
-
-class MarkRemindedRequest(BaseModel):
-    correlation_id: str
+    correlation_id: str | None = None
 
 
 class PendingAsk(BaseModel):
@@ -81,12 +77,10 @@ class PendingAsk(BaseModel):
     from_peer: str
     text: str
     created_at: str
-    picked_up_at: str | None = None
 
 
 class PendingAsksResponse(BaseModel):
     asks: list[PendingAsk]
-    current_turn_seq: int
 
 
 @router.post("/ask", response_model=AskResponse)
@@ -94,29 +88,23 @@ async def open_ask(
     request: AskRequest,
     _: str | None = Depends(require_auth),
 ) -> AskResponse:
-    """Open a non-blocking ask. Returns corr_id immediately."""
+    """Open a non-blocking ask.
+
+    Pre-registers in the tracker, attempts wire send. On TransportError the
+    newly-registered ask is closed (rollback) and 503 is returned so the
+    caller can retry when the recipient is back online.
+    """
     peer_registry = get_peer_registry()
     state = get_app_state()
     ask_tracker = state.ask_tracker
     await peer_registry.lazy_repair()
 
-    # Resolve target peer
     peer = await peer_registry.get_peer(request.to_peer, circle=request.circle)
     if not peer:
         raise HTTPException(status_code=404, detail=f"Unknown peer: {request.to_peer}")
 
-    # Resolve sender (best-effort — sender may be a CLI/external caller)
     from_peer_obj = await peer_registry.get_peer(request.from_peer)
     from_peer_id = from_peer_obj.peer_id if from_peer_obj else request.from_peer
-
-    # If reply_to is set, close that ask first as 'reply_to'
-    if request.reply_to:
-        prior = await ask_tracker.close(request.reply_to, reason="reply_to")
-        if prior is None:
-            logger.debug(
-                "ask reply_to=%s: prior ask not found or already closed",
-                request.reply_to,
-            )
 
     cid = await ask_tracker.register(
         from_peer_id=from_peer_id,
@@ -127,9 +115,6 @@ async def open_ask(
         reply_to=request.reply_to,
     )
 
-    # Deliver as a first-class type=ask wire message. The recipient transport
-    # (ws-hook / opencode plugin / channel server) POSTs /asks/{cid}/picked_up
-    # after presenting the message to its agent.
     try:
         await peer_registry.deliver_ask(
             from_peer=request.from_peer,
@@ -141,12 +126,25 @@ async def open_ask(
             circle=request.circle,
         )
     except ValueError as e:
-        # Peer not found by registry — close the ask we just opened
         await ask_tracker.close(cid, reason="evicted")
         raise HTTPException(status_code=404, detail=str(e))
+    except TransportError as e:
+        await ask_tracker.close(cid, reason="send_failed")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Peer {request.to_peer} has no live connection: {e}",
+        )
 
-    delivery_status = "queued" if peer.status == PeerStatus.BUSY else "sent"
-    return AskResponse(correlation_id=cid, status=delivery_status)
+    # Send succeeded: close any prior thread referenced by reply_to.
+    if request.reply_to:
+        prior = await ask_tracker.close(request.reply_to, reason="reply_to")
+        if prior is None:
+            logger.debug(
+                "ask reply_to=%s: prior ask not found or already closed",
+                request.reply_to,
+            )
+
+    return AskResponse(correlation_id=cid)
 
 
 @router.post("/ack", response_model=OkResponse)
@@ -162,8 +160,6 @@ async def ack_ask(
     reason = "ack_with_msg" if request.message else "ack"
     closed = await ask_tracker.close(request.correlation_id, reason=reason)
     if closed is None:
-        # Either unknown corr_id or already closed. Distinguish via get():
-        # idempotent re-ack returns 200, truly unknown returns 404.
         if await ask_tracker.get(request.correlation_id) is None:
             raise HTTPException(
                 status_code=404,
@@ -186,6 +182,11 @@ async def ack_ask(
             logger.warning(
                 "ack reply delivery failed for %s: %s", request.correlation_id, e,
             )
+        except TransportError as e:
+            logger.warning(
+                "ack reply delivery failed for %s (no live WS): %s",
+                request.correlation_id, e,
+            )
         except Exception as e:
             logger.exception(
                 "ack reply delivery error for %s: %s", request.correlation_id, e,
@@ -196,31 +197,30 @@ async def ack_ask(
 
 @router.post("/asks/{correlation_id}/picked_up", response_model=OkResponse)
 async def mark_picked_up(
-    correlation_id: str,
-    request: PickedUpRequest,
+    correlation_id: str,  # noqa: ARG001
+    request: _NoOpRequest,  # noqa: ARG001
     _: str | None = Depends(require_auth),
 ) -> OkResponse:
-    """Stop hook records that an ask was picked up at a given turn boundary."""
-    state = get_app_state()
-    ask_tracker = state.ask_tracker
-    if request.correlation_id != correlation_id:
-        raise HTTPException(status_code=400, detail="correlation_id mismatch")
-    await ask_tracker.mark_picked_up(correlation_id)
+    """Deprecated no-op kept for transport-compat during one release.
+
+    Old ws-hook / channel server / opencode plugin installs POST here after
+    delivering a type=ask. Under the simplified model the daemon no longer
+    tracks pickup state — reminders fire on every Stop hook for any open ask.
+    """
     return OkResponse()
 
 
 @router.post("/asks/{correlation_id}/mark_reminded", response_model=OkResponse)
 async def mark_reminded(
-    correlation_id: str,
-    request: MarkRemindedRequest,
+    correlation_id: str,  # noqa: ARG001
+    request: _NoOpRequest,  # noqa: ARG001
     _: str | None = Depends(require_auth),
 ) -> OkResponse:
-    """Flip the once-only reminded flag after the Stop hook injects a reminder."""
-    state = get_app_state()
-    ask_tracker = state.ask_tracker
-    if request.correlation_id != correlation_id:
-        raise HTTPException(status_code=400, detail="correlation_id mismatch")
-    await ask_tracker.mark_reminded(correlation_id)
+    """Deprecated no-op kept for hook-compat during one release.
+
+    Old Stop hooks POSTed here after writing the once-only reminder. Under
+    the simplified model open asks are reminded every turn until acked.
+    """
     return OkResponse()
 
 
@@ -229,12 +229,7 @@ async def pending_asks(
     pane_id: str,
     _: str | None = Depends(require_auth),
 ) -> PendingAsksResponse:
-    """Return asks targeting this pane that are due for a reminder.
-
-    Bumps the per-peer turn counter as a side effect (each Stop hook call =
-    one turn). Returns up to 3 most-recent picked-up-but-not-reminded asks
-    that have aged past the one-turn grace window.
-    """
+    """Return all open asks targeting this pane's peer, newest first."""
     peer_registry = get_peer_registry()
     state = get_app_state()
     ask_tracker = state.ask_tracker
@@ -243,8 +238,7 @@ async def pending_asks(
     if not peer:
         raise HTTPException(status_code=404, detail=f"No peer for pane: {pane_id}")
 
-    current_turn = await ask_tracker.increment_turn(peer.peer_id)
-    pending = await ask_tracker.pending_for_peer(peer.peer_id, current_turn)
+    pending = await ask_tracker.pending_for_peer(peer.peer_id)
 
     return PendingAsksResponse(
         asks=[
@@ -253,9 +247,7 @@ async def pending_asks(
                 from_peer=ask.from_peer_name,
                 text=ask.text,
                 created_at=ask.created_at.isoformat(),
-                picked_up_at=ask.picked_up_at.isoformat() if ask.picked_up_at else None,
             )
             for ask in pending
         ],
-        current_turn_seq=current_turn,
     )

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -252,7 +252,7 @@ async def mark_reminded(
     """Deprecated no-op kept for hook-compat during one release.
 
     Old Stop hooks POSTed here after writing the once-only reminder. Under
-    the simplified model open asks are reminded every turn until acked.
+    the simplified model open asks reappear in every Stop poll until acked.
     """
     return OkResponse()
 

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -152,19 +152,32 @@ async def ack_ask(
     request: AckRequest,
     _: str | None = Depends(require_auth),
 ) -> OkResponse:
-    """Close an ask. With `message`, delivers the reply to the original asker."""
+    """Close an ask. With `message`, delivers the reply to the original asker.
+
+    Bare ack: close the ask, return 200.
+
+    Ack-with-message: deliver the reply first; only close on successful
+    delivery. If the asker has no live WS the ask stays open and 503 is
+    returned so the recipient can retry (or drop the message and bare-ack
+    if they give up). This avoids closing the thread while silently dropping
+    the reply under the new fail-loud / no-queue contract.
+
+    Returns:
+        200 on success, 200 on idempotent re-ack (already closed), 404 if
+        unknown corr_id, 503 if reply delivery failed.
+    """
     peer_registry = get_peer_registry()
     state = get_app_state()
     ask_tracker = state.ask_tracker
 
-    reason = "ack_with_msg" if request.message else "ack"
-    closed = await ask_tracker.close(request.correlation_id, reason=reason)
-    if closed is None:
-        if await ask_tracker.get(request.correlation_id) is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No open ask with correlation_id: {request.correlation_id}",
-            )
+    existing = await ask_tracker.get(request.correlation_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No open ask with correlation_id: {request.correlation_id}",
+        )
+    if existing.closed:
+        # Idempotent re-ack: already closed, nothing to do.
         return OkResponse()
 
     if request.message:
@@ -174,23 +187,43 @@ async def ack_ask(
         try:
             await peer_registry.notify(
                 from_peer=request.from_peer,
-                to_peer=closed.from_peer_name,
+                to_peer=existing.from_peer_name,
                 text=framed,
                 bypass_circle=True,
             )
         except ValueError as e:
+            # Asker peer no longer in registry. Close as best-effort and
+            # log; nothing to retry against.
             logger.warning(
-                "ack reply delivery failed for %s: %s", request.correlation_id, e,
-            )
-        except TransportError as e:
-            logger.warning(
-                "ack reply delivery failed for %s (no live WS): %s",
+                "ack reply for %s: asker missing (%s); closing without delivery",
                 request.correlation_id, e,
             )
+            await ask_tracker.close(request.correlation_id, reason="ack_with_msg")
+            return OkResponse()
+        except TransportError as e:
+            # Asker has no live WS. Leave the ask open so the recipient can
+            # retry (and report 503 so the MCP caller knows the reply did
+            # not land).
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    f"Reply delivery failed for {existing.from_peer_name}: {e}. "
+                    "Ask remains open; retry when the asker reconnects."
+                ),
+            )
         except Exception as e:
+            # Unexpected error — also leave the ask open and surface a 500.
             logger.exception(
                 "ack reply delivery error for %s: %s", request.correlation_id, e,
             )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Reply delivery error: {e}",
+            )
+
+        await ask_tracker.close(request.correlation_id, reason="ack_with_msg")
+    else:
+        await ask_tracker.close(request.correlation_id, reason="ack")
 
     return OkResponse()
 

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -58,10 +58,11 @@ class BroadcastRequest(BaseModel):
 
 
 class BroadcastResponse(BaseModel):
-    """Response from a broadcast."""
+    """Response from a broadcast. Best-effort per-recipient."""
 
     ok: bool = True
     sent_to: list[str]
+    failed: list[dict[str, str]] = Field(default_factory=list)
 
 
 class SessionUpdateRequest(BaseModel):
@@ -124,7 +125,13 @@ async def notify_peer(
     request: NotifyRequest,
     _: str | None = Depends(require_auth),
 ) -> OkResponse:
-    """Send a notification to a peer (fire-and-forget)."""
+    """Send a notification to a peer (fire-and-forget).
+
+    Direct WS send. 503 if the recipient has no live connection so the
+    caller knows to retry later.
+    """
+    from repowire.daemon.websocket_transport import TransportError
+
     peer_registry = get_peer_registry()
     await peer_registry.lazy_repair()
 
@@ -142,6 +149,11 @@ async def notify_peer(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         )
+    except TransportError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Peer {request.to_peer} has no live connection: {e}",
+        )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -154,18 +166,18 @@ async def broadcast_message(
     request: BroadcastRequest,
     _: str | None = Depends(require_auth),
 ) -> BroadcastResponse:
-    """Broadcast a message to all peers."""
+    """Broadcast a message to all eligible peers. Best-effort per-recipient."""
     peer_registry = get_peer_registry()
     await peer_registry.lazy_repair()
 
-    sent_to = await peer_registry.broadcast(
+    sent_to, failed = await peer_registry.broadcast(
         from_peer=request.from_peer,
         text=request.text,
         exclude=request.exclude,
         bypass_circle=request.bypass_circle,
     )
 
-    return BroadcastResponse(sent_to=sent_to)
+    return BroadcastResponse(sent_to=sent_to, failed=failed)
 
 
 @router.post("/session/update", response_model=OkResponse)

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -42,8 +42,8 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     - connected: {type, session_id}
     - query: {type, correlation_id, from_peer, text}    (legacy blocking RPC)
     - ask: {type, correlation_id, from_peer, text, reply_to?}
-        Non-blocking ask. Recipient injects text, then POSTs
-        /asks/{cid}/picked_up (no body fields beyond cid + optional pane_id).
+        Non-blocking ask. Recipient injects text. Daemon doesn't track
+        pickup; open asks reappear in every Stop hook reminder until acked.
     - notify: {type, from_peer, text}    (plain FYI, no lifecycle)
     - broadcast: {type, from_peer, text}
     """

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -1,8 +1,11 @@
 """Stop-hook reminder logic for the ask/ack lifecycle.
 
 Each Stop hook polls the daemon for open asks targeting this peer and
-renders them as a reminder block for the next prompt. Open asks are
-nagged every turn until acked — no once-only flag, no grace window.
+renders them as a reminder block for the next prompt. Backstop only —
+the original ask was already pasted into the terminal by ws-hook when
+the WS frame arrived. The reminder catches missed asks and asks the
+agent hasn't yet acked. Open asks reappear in every Stop poll until
+acked — no once-only flag, no grace window.
 
 Client-side filter drops cids the agent already acked/replied to via
 tool calls in the just-completed turn (their MCP ack call is in flight

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -1,11 +1,13 @@
 """Stop-hook reminder logic for the ask/ack lifecycle.
 
-Pickup is reported transport-side at delivery time (see ws-hook /
-opencode plugin / channel server) — never from this module. The Stop
-hook's only role here is reminder fetch + injection: query the daemon
-for picked-up-but-not-acked asks past the grace window, filter out
-any cids the agent already acked/replied to in the just-completed turn,
-and persist the rendered reminder block for the next prompt to inject.
+Each Stop hook polls the daemon for open asks targeting this peer and
+renders them as a reminder block for the next prompt. Open asks are
+nagged every turn until acked — no once-only flag, no grace window.
+
+Client-side filter drops cids the agent already acked/replied to via
+tool calls in the just-completed turn (their MCP ack call is in flight
+to the daemon concurrently with this hook, so the daemon may not yet
+reflect closure).
 """
 
 from __future__ import annotations
@@ -15,7 +17,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-from repowire.hooks.utils import daemon_get, daemon_post
+from repowire.hooks.utils import daemon_get
 from repowire.session.transcript import extract_last_turn_raw_tool_calls
 
 logger = logging.getLogger(__name__)
@@ -60,12 +62,12 @@ def fetch_and_filter_pending(
     pane_id: str,
     transcript_path: Path | None,
 ) -> list[dict[str, Any]]:
-    """Fetch due reminders, filter out ones acked/replied this turn.
+    """Fetch open asks for this pane, filter out ones acked/replied this turn.
 
-    The daemon-side filter handles picked_up + reminded + grace-window. The
-    client-side filter here drops cids the agent already acked/replied to
-    via tool calls in the just-completed turn (the only signal visible from
-    the transcript).
+    The daemon returns every open ask for this peer. The client-side filter
+    here drops cids the agent already acked/replied to via tool calls in the
+    just-completed turn — those acks are in flight concurrently and the
+    daemon may not yet reflect closure.
     """
     result = daemon_get(f"/asks/pending?pane_id={quote(pane_id, safe='')}")
     if not result:
@@ -81,22 +83,8 @@ def fetch_and_filter_pending(
     for ask in asks:
         cid = ask.get("correlation_id", "")
         if cid in handled:
-            # Filter only — do NOT auto-close. The agent's ack() tool call
-            # is in flight to the daemon at the same time as this hook;
-            # racing /ack here can land first with no message body and
-            # close the ask before the real ack-with-msg arrives, dropping
-            # the reply. The MCP tool call is the source of truth for
-            # closure; this hook just prevents same-turn reminders.
             continue
         pending.append(ask)
-
-    for ask in pending:
-        cid = ask.get("correlation_id", "")
-        if cid:
-            daemon_post(
-                f"/asks/{cid}/mark_reminded",
-                {"correlation_id": cid},
-            )
 
     return pending
 
@@ -106,15 +94,13 @@ def format_reminder_block(asks: list[dict[str, Any]]) -> str:
     if not asks:
         return ""
     lines = [
-        "[repowire] You have un-acknowledged asks. Each needs ack(corr_id) "
-        "to close (bare = seen-no-action), ack(corr_id, message) to reply, "
-        "or ask(reply_to=corr_id, ...) to chain a follow-up.",
+        "[repowire] You have open asks awaiting your response. Each needs "
+        "ack(corr_id) to close (bare = seen-no-action), ack(corr_id, message) "
+        "to reply, or ask(reply_to=corr_id, ...) to chain a follow-up.",
     ]
     for ask in asks:
         cid = ask.get("correlation_id", "")
         from_peer = ask.get("from_peer", "?")
         text = (ask.get("text") or "").strip()
-        if len(text) > 200:
-            text = text[:197] + "..."
-        lines.append(f"  - #{cid} from @{from_peer}: {text}")
+        lines.append(f"  - @{from_peer} [ask #{cid}]: {text}")
     return "\n".join(lines)

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -32,10 +32,10 @@ def main(backend: str = "claude-code") -> int:
                 file=sys.stderr,
             )
 
-    # Ask-ack reminder injection: if the previous Stop hook flagged any
-    # un-acked asks past the grace window, surface them as additionalContext
-    # so the agent sees them at the start of this turn. Buffer is consumed
-    # (deleted) on read so the same reminder doesn't repeat.
+    # Ask-ack reminder injection: surface any open asks the previous Stop
+    # hook found for this peer as additionalContext at the start of this
+    # turn. Buffer is consumed (deleted) on read; the next Stop will re-fetch
+    # if asks are still open.
     reminder = consume_reminder_buffer(pane_id) if pane_id else None
     if reminder and backend == "claude-code":
         # Claude Code reads hookSpecificOutput.additionalContext on

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -90,7 +90,9 @@ def main(backend: str = "claude-code") -> int:
 
     # Ask-ack reminder: poll daemon for open asks targeting this peer and
     # write them to the per-pane reminder buffer for the next prompt to
-    # inject. Open asks are surfaced every turn until acked.
+    # inject. Backstop only — ws-hook already pasted the original ask into
+    # the terminal; this catches the case where the agent missed it or
+    # hasn't acked yet.
     if pane_id:
         transcript_path = (
             Path(payload.transcript_path).expanduser().resolve()

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -88,14 +88,9 @@ def main(backend: str = "claude-code") -> int:
             resp_payload["correlation_id"] = cid
         daemon_post("/response", resp_payload)
 
-    # Ask-ack reminder fetch MUST happen before update_status. update_status
-    # transitions the peer from BUSY to online, which drains the BUSY buffer
-    # in the daemon and triggers fresh ask deliveries. Those deliveries POST
-    # pickup at the daemon's current turn_seq. If we bumped turn_seq AFTER
-    # the drain, those pickups would snapshot N and the same Stop's pending
-    # poll would flag them (N<N+1) — same-turn reminder, exactly the bug
-    # we're trying to avoid. By bumping first, drained-asks snapshot N+1
-    # and don't become eligible until the NEXT Stop.
+    # Ask-ack reminder: poll daemon for open asks targeting this peer and
+    # write them to the per-pane reminder buffer for the next prompt to
+    # inject. Open asks are surfaced every turn until acked.
     if pane_id:
         transcript_path = (
             Path(payload.transcript_path).expanduser().resolve()
@@ -105,7 +100,7 @@ def main(backend: str = "claude-code") -> int:
         if due:
             write_reminder_buffer(pane_id, format_reminder_block(due))
 
-    # Mark peer online — drains BUSY buffer if any. Now safe re: above.
+    # Mark peer online.
     if pane_id:
         if not update_status(pane_id, "online", use_pane_id=True):
             print(

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -55,7 +55,8 @@ def pending_query_cid_path(pane_id: str | None) -> Path:
     """Path to the pending /query correlation_id file for a pane.
 
     Single-purpose: only legacy /query cids land here. Ask cids are handled
-    transport-side (POST /asks/{cid}/picked_up) and never use a FIFO.
+    transport-side (direct injection of type=ask wire frames) and never use
+    a FIFO.
     """
     return pane_logs_dir() / f"pending-query-{get_pane_file(pane_id)}.json"
 
@@ -155,9 +156,9 @@ def write_pane_runtime_metadata(pane_id: str | None, metadata: dict) -> None:
 def reminder_buffer_path(pane_id: str | None) -> Path:
     """Path to the pane's pending reminder text file.
 
-    The Stop hook writes ask-ack reminder text here when there are pending
-    asks past the grace window. The next UserPromptSubmit (or
-    Notification/idle_prompt) hook reads it, injects, and deletes.
+    The Stop hook writes ask-ack reminder text here when this peer has any
+    open asks. The next UserPromptSubmit (or Notification/idle_prompt) hook
+    reads it, injects, and deletes.
     """
     return pane_logs_dir() / f"reminder-{get_pane_file(pane_id)}.txt"
 

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -23,7 +23,6 @@ from repowire.config.models import AgentType
 from repowire.hooks._tmux import get_tmux_info
 from repowire.hooks.utils import (
     clear_pane_runtime_state,
-    daemon_post,
     get_display_name,
     push_query_cid,
     read_pane_runtime_metadata,
@@ -58,14 +57,6 @@ class PaneUnsafeError(RuntimeError):
 def _push_query_cid(pane_id: str, correlation_id: str) -> None:
     """Append a /query correlation_id to the per-pane FIFO."""
     push_query_cid(pane_id, correlation_id)
-
-
-def _post_ask_picked_up(pane_id: str, correlation_id: str) -> None:
-    """Tell the daemon this ask was delivered; daemon snapshots turn_seq."""
-    daemon_post(
-        f"/asks/{correlation_id}/picked_up",
-        {"correlation_id": correlation_id, "pane_id": pane_id},
-    )
 
 
 def _tmux_send_keys(pane_id: str, text: str) -> bool:
@@ -372,18 +363,15 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
                 raise PaneUnsafeError(str(e)) from e
 
     elif msg_type == "ask":
-        # First-class ask: inject framed text, then POST pickup so the daemon
-        # can snapshot turn_seq for the grace-window check. No FIFO involved.
+        # First-class ask: inject framed text. Daemon doesn't track pickup
+        # under the simplified model — open asks are surfaced via Stop hook
+        # reminders until acked.
         correlation_id = data.get("correlation_id", "")
         from_peer = data.get("from_peer", "unknown")
         text = data.get("text", "")
         injected_text = f"@{from_peer} [ask #{correlation_id}]: {text}"
         try:
             if await asyncio.to_thread(_tmux_send_keys, pane_id, injected_text):
-                if correlation_id:
-                    await asyncio.to_thread(
-                        _post_ask_picked_up, pane_id, correlation_id,
-                    )
                 logger.info(
                     f"Injected ask from {from_peer}: {correlation_id[:8]}",
                 )

--- a/repowire/installers/opencode.py
+++ b/repowire/installers/opencode.py
@@ -753,7 +753,13 @@ export const RepowirePlugin: Plugin = async ({ client, directory, ...rest }) => 
             from_peer: me.peerName,
             text: message,
           })
-          return `Broadcast sent to: ${result.sent_to?.join(", ") || "no peers"}`
+          const parts: string[] = []
+          parts.push(`Broadcast sent to: ${result.sent_to?.join(", ") || "no peers"}`)
+          if (result.failed?.length) {
+            const fails = result.failed.map((f: { peer: string; error: string }) => `${f.peer} (${f.error})`).join(", ")
+            parts.push(`Failed: ${fails}`)
+          }
+          return parts.join("; ")
         },
       }),
       whoami: tool({

--- a/repowire/installers/opencode.py
+++ b/repowire/installers/opencode.py
@@ -285,24 +285,15 @@ async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>
     await handleIncomingQuery(conn, correlationId, fromPeer, text)
   } else if (msgType === "ask") {
     // First-class ask: surface with [ask #cid] framing so the agent can
-    // ack via the ack tool. POST pickup ONLY if softInject succeeded —
-    // otherwise we'd be telling the daemon "delivered" without the agent
-    // having seen anything.
+    // ack via the ack tool. Daemon doesn't track pickup under the
+    // simplified model — open asks are surfaced via Stop hook reminders
+    // until acked.
     const correlationId = data.correlation_id as string
     const fromPeer = (data.from_peer as string) || "unknown"
     const text = data.text as string
-    const delivered = await softInject(
+    await softInject(
       `@${fromPeer} → ${conn.peerName} [ask #${correlationId}]: ${text}`,
     )
-    if (delivered && correlationId) {
-      try {
-        await daemon(`/asks/${encodeURIComponent(correlationId)}/picked_up`, {
-          correlation_id: correlationId,
-        })
-      } catch (e) {
-        console.debug("[repowire] failed to post ask pickup:", e)
-      }
-    }
   } else if (msgType === "ping") {
     if (conn.ws?.readyState === WebSocket.OPEN) {
       conn.ws.send(JSON.stringify({ type: "pong", pane_alive: true }))

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -384,7 +384,16 @@ def create_mcp_server() -> FastMCP:
             },
         )
         sent_to = result.get("sent_to", [])
-        return f"Broadcast sent to: {', '.join(sent_to) if sent_to else 'no peers online'}"
+        failed = result.get("failed", [])
+        parts = []
+        if sent_to:
+            parts.append(f"Broadcast sent to: {', '.join(sent_to)}")
+        else:
+            parts.append("Broadcast sent to: no peers online")
+        if failed:
+            failures = ", ".join(f"{f.get('peer', '?')} ({f.get('error', 'unknown')})" for f in failed)
+            parts.append(f"Failed: {failures}")
+        return "; ".join(parts)
 
     def _format_peer_tsv(result: dict) -> str:
         """Format a peer result dict as a TSV row with header."""

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -391,7 +391,10 @@ def create_mcp_server() -> FastMCP:
         else:
             parts.append("Broadcast sent to: no peers online")
         if failed:
-            failures = ", ".join(f"{f.get('peer', '?')} ({f.get('error', 'unknown')})" for f in failed)
+            failures = ", ".join(
+                f"{f.get('peer', '?')} ({f.get('error', 'unknown')})"
+                for f in failed
+            )
             parts.append(f"Failed: {failures}")
         return "; ".join(parts)
 

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -368,13 +368,13 @@ class TelegramPeer:
             await self._ack_ask(cid)
 
     async def _ack_ask(self, correlation_id: str) -> None:
-        """Bare-ack an open ask. POSTs /ack with from_peer=telegram."""
+        """Bare-ack an open ask. Uses the bot's configured display name."""
         try:
             r = await self._http.post(
                 f"{self._daemon_url}/ack",
                 json={
                     "correlation_id": correlation_id,
-                    "from_peer": "telegram",
+                    "from_peer": self._display_name,
                 },
                 timeout=5.0,
             )

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -280,6 +280,15 @@ class TelegramPeer:
         elif t == "query":
             self._touch_recent(who)
             await self._tg_send(f"❓ *@{_esc(who)}*\n{_esc(text)}")
+        elif t == "ask":
+            self._touch_recent(who)
+            cid = msg.get("correlation_id", "")
+            short_cid = cid[:12] if cid else "?"
+            markup = _kb([[("✓ Ack", f"ack:{cid}")]]) if cid else None
+            await self._tg_send(
+                f"❓ *@{_esc(who)}* `[ask #{_esc(short_cid)}]`\n{_esc(text)}",
+                markup=markup,
+            )
         elif t == "broadcast":
             self._touch_recent(who)
             await self._tg_send(f"📢 *@{_esc(who)}*\n{_esc(text)}")
@@ -354,6 +363,30 @@ class TelegramPeer:
             await self._tg_send("Cancelled\\.")
         elif data == "peers":
             await self._cmd_peers()
+        elif data.startswith("ack:"):
+            cid = data.split(":", 1)[1]
+            await self._ack_ask(cid)
+
+    async def _ack_ask(self, correlation_id: str) -> None:
+        """Bare-ack an open ask. POSTs /ack with from_peer=telegram."""
+        try:
+            r = await self._http.post(
+                f"{self._daemon_url}/ack",
+                json={
+                    "correlation_id": correlation_id,
+                    "from_peer": "telegram",
+                },
+                timeout=5.0,
+            )
+            short = correlation_id[:12]
+            if r.status_code == 200:
+                await self._tg_send(f"✓ Acked `#{_esc(short)}`")
+            elif r.status_code == 404:
+                await self._tg_send(f"`#{_esc(short)}` already closed or unknown")
+            else:
+                await self._tg_send(f"Ack failed for `#{_esc(short)}`: {r.status_code}")
+        except Exception as e:
+            await self._tg_send(f"Ack error: {_esc(str(e))}")
 
     async def _on_text(self, text: str, message_id: int | None = None) -> None:
         # Reply-keyboard taps

--- a/tests/test_ask_lifecycle.py
+++ b/tests/test_ask_lifecycle.py
@@ -135,10 +135,10 @@ class TestFormatReminderBlock:
         assert "what's the status?" in block
         assert "ack(corr_id)" in block
 
-    def test_truncates_long_text(self):
+    def test_preserves_full_text(self):
+        """Reminder carries full ask text — no truncation."""
         long_text = "x" * 500
         block = format_reminder_block([{
             "correlation_id": "ask-x", "from_peer": "a", "text": long_text,
         }])
-        assert "..." in block
-        assert len(block) < 500
+        assert long_text in block

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -197,6 +197,42 @@ class TestAck:
         })
         assert r.status_code == 404
 
+    async def test_ack_with_msg_503_when_reply_undeliverable(self, env):
+        """If reply delivery fails (no live WS), ack returns 503 and ask stays open."""
+        client, _, at, msg_router = env
+        alice = await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": alice, "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+
+        # Asker's notify path now fails
+        msg_router.send_notification.side_effect = TransportError("No connection")
+
+        r = await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob, "message": "all good",
+        })
+        assert r.status_code == 503
+        ask = await at.get(cid)
+        assert not ask.closed  # MUST remain open so recipient can retry
+
+    async def test_bare_ack_succeeds_even_if_router_would_fail(self, env):
+        """Bare ack doesn't deliver anything, so router state is irrelevant."""
+        client, _, at, msg_router = env
+        alice = await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": alice, "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        msg_router.send_notification.side_effect = TransportError("dead")
+
+        r = await client.post("/ack", json={"correlation_id": cid, "from_peer": bob})
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.closed
+
     async def test_ack_idempotent(self, env):
         client, _, _, _ = env
         await _register_peer(client, "alice")

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -16,7 +16,7 @@ from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.routes import asks, peers
-from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.daemon.websocket_transport import TransportError, WebSocketTransport
 
 
 def _make_app(tmp_path: Path):
@@ -54,15 +54,15 @@ def _make_app(tmp_path: Path):
     app = FastAPI()
     app.include_router(peers.router)
     app.include_router(asks.router)
-    return app, registry, at
+    return app, registry, at, router
 
 
 @pytest.fixture
 async def env(tmp_path):
-    app, registry, at = _make_app(tmp_path)
+    app, registry, at, msg_router = _make_app(tmp_path)
     t = ASGITransport(app=app)
     async with AsyncClient(transport=t, base_url="http://test") as c:
-        yield c, registry, at
+        yield c, registry, at, msg_router
     cleanup_deps()
 
 
@@ -82,7 +82,7 @@ async def _register_peer(client, name: str, pane_id: str | None = None) -> str:
 
 class TestAsk:
     async def test_returns_correlation_id(self, env):
-        client, _, _ = env
+        client, _, _, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob")
         r = await client.post("/ask", json={
@@ -93,17 +93,29 @@ class TestAsk:
         assert r.status_code == 200
         body = r.json()
         assert body["correlation_id"].startswith("ask-")
-        assert body["status"] in ("sent", "queued")
 
     async def test_unknown_peer_returns_404(self, env):
-        client, _, _ = env
+        client, _, _, _ = env
         r = await client.post("/ask", json={
             "from_peer": "alice", "to_peer": "ghost", "text": "?",
         })
         assert r.status_code == 404
 
+    async def test_transport_error_returns_503_and_rolls_back(self, env):
+        client, _, at, msg_router = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        msg_router.send_ask.side_effect = TransportError("No connection")
+
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        assert r.status_code == 503
+        # No phantom open ask should remain
+        assert at.open_count() == 0
+
     async def test_reply_to_closes_prior(self, env):
-        client, _, at = env
+        client, _, at, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob")
         r = await client.post("/ask", json={
@@ -120,10 +132,32 @@ class TestAsk:
         assert prior.closed
         assert prior.close_reason == "reply_to"
 
+    async def test_reply_to_not_closed_when_send_fails(self, env):
+        client, _, at, msg_router = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        # First ask succeeds
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "first",
+        })
+        first_cid = r.json()["correlation_id"]
+        prior = await at.get(first_cid)
+        assert not prior.closed
+
+        # Second ask with reply_to fails to send → prior must remain open
+        msg_router.send_ask.side_effect = TransportError("No connection")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "follow-up",
+            "reply_to": first_cid,
+        })
+        assert r.status_code == 503
+        prior = await at.get(first_cid)
+        assert not prior.closed
+
 
 class TestAck:
     async def test_bare_ack_closes(self, env):
-        client, _, at = env
+        client, _, at, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob")
         r = await client.post("/ask", json={
@@ -140,7 +174,7 @@ class TestAck:
         assert ask.close_reason == "ack"
 
     async def test_ack_with_msg_delivers_reply(self, env):
-        client, _, at = env
+        client, _, at, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob")
         r = await client.post("/ask", json={
@@ -157,14 +191,14 @@ class TestAck:
         assert ask.close_reason == "ack_with_msg"
 
     async def test_ack_unknown_id_404(self, env):
-        client, _, _ = env
+        client, _, _, _ = env
         r = await client.post("/ack", json={
             "correlation_id": "ask-never", "from_peer": "x",
         })
         assert r.status_code == 404
 
     async def test_ack_idempotent(self, env):
-        client, _, at = env
+        client, _, _, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob")
         r = await client.post("/ask", json={
@@ -177,32 +211,12 @@ class TestAck:
         r2 = await client.post("/ack", json={
             "correlation_id": cid, "from_peer": bob,
         })
-        # Idempotent: second ack returns 200 not 404
         assert r2.status_code == 200
 
 
-class TestPickedUp:
-    async def test_records_pickup(self, env):
-        client, _, at = env
-        await _register_peer(client, "alice")
-        bob = await _register_peer(client, "bob")
-        r = await client.post("/ask", json={
-            "from_peer": "alice", "to_peer": bob, "text": "?",
-        })
-        cid = r.json()["correlation_id"]
-        # Body no longer carries turn_seq; daemon snapshots its own counter.
-        r = await client.post(f"/asks/{cid}/picked_up", json={
-            "correlation_id": cid,
-        })
-        assert r.status_code == 200
-        ask = await at.get(cid)
-        assert ask.picked_up
-        assert ask.picked_up_turn_seq == 0  # no /asks/pending called yet
-
-
 class TestPendingAsks:
-    async def test_grace_window(self, env):
-        client, _, _ = env
+    async def test_returns_open_asks(self, env):
+        client, _, _, _ = env
         await _register_peer(client, "alice")
         bob = await _register_peer(client, "bob", pane_id="%50")
         r = await client.post("/ask", json={
@@ -210,57 +224,52 @@ class TestPendingAsks:
         })
         cid = r.json()["correlation_id"]
 
-        # Transport-style pickup at delivery: snapshots turn_seq=0 (no
-        # /asks/pending has been called yet).
-        await client.post(f"/asks/{cid}/picked_up", json={"correlation_id": cid})
-
-        # First /asks/pending bumps counter to 1. picked_up_turn_seq=0 < 1 true.
         r = await client.get("/asks/pending?pane_id=%2550")
         assert r.status_code == 200
         body = r.json()
-        assert body["current_turn_seq"] == 1
         assert len(body["asks"]) == 1
         assert body["asks"][0]["correlation_id"] == cid
+        # Slim shape — no current_turn_seq, no picked_up_at
+        assert "current_turn_seq" not in body
+        assert "picked_up_at" not in body["asks"][0]
 
-    async def test_pickup_after_pending_not_flagged_same_cycle(self, env):
-        """Race case: /asks/pending bumps before pickup → same cycle skips."""
-        client, _, _ = env
+    async def test_repeats_on_each_poll(self, env):
+        """Open asks reappear every poll until acked."""
+        client, _, _, _ = env
         await _register_peer(client, "alice")
-        bob = await _register_peer(client, "bob", pane_id="%51")
+        bob = await _register_peer(client, "bob", pane_id="%50")
         r = await client.post("/ask", json={
             "from_peer": "alice", "to_peer": bob, "text": "?",
         })
         cid = r.json()["correlation_id"]
-        # Stop hook fires first: /asks/pending bumps to 1. Ask not picked up
-        # yet → empty result.
-        r = await client.get("/asks/pending?pane_id=%2551")
+
+        for _ in range(3):
+            r = await client.get("/asks/pending?pane_id=%2550")
+            assert len(r.json()["asks"]) == 1
+
+        # After ack, gone
+        await client.post("/ack", json={"correlation_id": cid, "from_peer": bob})
+        r = await client.get("/asks/pending?pane_id=%2550")
         assert r.json()["asks"] == []
-        # Pickup arrives next: snapshots seq=1.
-        await client.post(f"/asks/{cid}/picked_up", json={"correlation_id": cid})
-        # Next Stop fire bumps to 2 → flagged.
-        r = await client.get("/asks/pending?pane_id=%2551")
-        body = r.json()
-        assert body["current_turn_seq"] == 2
-        assert len(body["asks"]) == 1
 
     async def test_unknown_pane(self, env):
-        client, _, _ = env
+        client, _, _, _ = env
         r = await client.get("/asks/pending?pane_id=%25nope")
         assert r.status_code == 404
 
 
-class TestMarkReminded:
-    async def test_flips_flag(self, env):
-        client, _, at = env
-        await _register_peer(client, "alice")
-        bob = await _register_peer(client, "bob")
-        r = await client.post("/ask", json={
-            "from_peer": "alice", "to_peer": bob, "text": "?",
-        })
-        cid = r.json()["correlation_id"]
-        r = await client.post(f"/asks/{cid}/mark_reminded", json={
-            "correlation_id": cid,
-        })
+class TestDeprecatedNoOps:
+    """Compat: legacy transports may still POST these. Should return 200 silently."""
+
+    async def test_picked_up_returns_200(self, env):
+        client, _, _, _ = env
+        r = await client.post("/asks/legacy-cid/picked_up", json={"correlation_id": "legacy-cid"})
         assert r.status_code == 200
-        ask = await at.get(cid)
-        assert ask.reminded
+
+    async def test_mark_reminded_returns_200(self, env):
+        client, _, _, _ = env
+        r = await client.post(
+            "/asks/legacy-cid/mark_reminded",
+            json={"correlation_id": "legacy-cid"},
+        )
+        assert r.status_code == 200

--- a/tests/test_ask_tracker.py
+++ b/tests/test_ask_tracker.py
@@ -1,4 +1,4 @@
-"""Tests for AskTracker — ask/ack lifecycle state."""
+"""Tests for AskTracker — slim ask/ack lifecycle state."""
 
 from datetime import datetime, timedelta, timezone
 
@@ -32,74 +32,15 @@ class TestRegister:
         assert ask.to_peer_name == "t"
         assert ask.text == "msg"
         assert ask.reply_to == "prior-cid"
-        assert ask.picked_up is False
         assert ask.closed is False
 
-
-class TestPickup:
-    async def test_first_call_snapshots_current_turn(self, tracker):
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        # Bump recipient's turn to 3
-        await tracker.increment_turn("b-id")
-        await tracker.increment_turn("b-id")
-        await tracker.increment_turn("b-id")
-        ok = await tracker.mark_picked_up(cid)
-        assert ok
+    async def test_retry_with_existing_id_returns_same(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x", correlation_id="ask-dup")
+        again = await tracker.register("a", "a", "b-id", "b", "different", correlation_id="ask-dup")
+        assert again == cid
+        # original entry preserved
         ask = await tracker.get(cid)
-        assert ask.picked_up
-        assert ask.picked_up_turn_seq == 3
-
-    async def test_idempotent_second_call(self, tracker):
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid)
-        # First call snapshotted seq=0; bump to 5 and try to repickup
-        for _ in range(5):
-            await tracker.increment_turn("b-id")
-        ok = await tracker.mark_picked_up(cid)
-        assert not ok
-        ask = await tracker.get(cid)
-        # Original seq must stick
-        assert ask.picked_up_turn_seq == 0
-
-    async def test_unknown_id(self, tracker):
-        assert not await tracker.mark_picked_up("never")
-
-    async def test_no_state_shift_on_closed(self, tracker):
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.close(cid, reason="ack")
-        ok = await tracker.mark_picked_up(cid)
-        assert not ok
-        ask = await tracker.get(cid)
-        assert ask.picked_up_turn_seq is None
-        assert not ask.picked_up
-
-    async def test_race_pickup_then_pending_increment(self, tracker):
-        """Pickup at seq=N, then /asks/pending bumps to N+1 → ask is due."""
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        # turn_seq starts at 0; pickup snapshots 0
-        await tracker.mark_picked_up(cid)
-        ask = await tracker.get(cid)
-        assert ask.picked_up_turn_seq == 0
-        # Stop hook calls /asks/pending → increment to 1
-        new_seq = await tracker.increment_turn("b-id")
-        assert new_seq == 1
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=new_seq)
-        assert len(result) == 1
-
-    async def test_race_increment_then_pickup_same_cycle(self, tracker):
-        """Same Stop fire bumps to N, pickup happens after, snapshots N → not due same cycle."""
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        new_seq = await tracker.increment_turn("b-id")
-        assert new_seq == 1
-        await tracker.mark_picked_up(cid)
-        ask = await tracker.get(cid)
-        assert ask.picked_up_turn_seq == 1
-        # Same cycle: 1 < 1 false → not flagged
-        assert await tracker.pending_for_peer("b-id", current_turn_seq=new_seq) == []
-        # Next cycle: 1 < 2 → flagged
-        next_seq = await tracker.increment_turn("b-id")
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=next_seq)
-        assert len(result) == 1
+        assert ask.text == "x"
 
 
 class TestClose:
@@ -122,70 +63,57 @@ class TestClose:
 
 
 class TestPendingForPeer:
-    async def test_filters_unpicked(self, tracker):
+    async def test_returns_open_asks(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
-        assert result == []
-        await tracker.mark_picked_up(cid)
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
+        result = await tracker.pending_for_peer("b-id")
         assert len(result) == 1
+        assert result[0].correlation_id == cid
 
-    async def test_grace_window_one_turn(self, tracker):
-        """picked_up_turn_seq < current_turn_seq is the rule."""
+    async def test_repeats_until_closed(self, tracker):
+        """Open asks reappear on every poll — no once-only flag."""
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        # Bump turn to 3, pickup snapshots 3
         for _ in range(3):
-            await tracker.increment_turn("b-id")
-        await tracker.mark_picked_up(cid)
-        # Same-turn check: 3 < 3 is false
-        assert await tracker.pending_for_peer("b-id", current_turn_seq=3) == []
-        # Next turn: 3 < 4 true
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=4)
-        assert len(result) == 1
-
-    async def test_skips_reminded(self, tracker):
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid)
-        await tracker.mark_reminded(cid)
-        assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
+            result = await tracker.pending_for_peer("b-id")
+            assert len(result) == 1
+        # After ack, gone
+        await tracker.close(cid, reason="ack")
+        assert await tracker.pending_for_peer("b-id") == []
 
     async def test_skips_closed(self, tracker):
         cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid)
         await tracker.close(cid, reason="ack")
-        assert await tracker.pending_for_peer("b-id", current_turn_seq=5) == []
+        assert await tracker.pending_for_peer("b-id") == []
 
     async def test_caps_to_max(self, tracker):
-        cids = []
-        for i in range(5):
-            cid = await tracker.register("a", "a", "b-id", "b", f"x{i}")
-            await tracker.mark_picked_up(cid)
-            cids.append(cid)
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=5, max_results=3)
-        assert len(result) == 3
+        for i in range(15):
+            await tracker.register("a", "a", "b-id", "b", f"x{i}")
+        result = await tracker.pending_for_peer("b-id", max_results=5)
+        assert len(result) == 5
 
     async def test_newest_first(self, tracker):
         cid_old = await tracker.register("a", "a", "b-id", "b", "old")
         cid_new = await tracker.register("a", "a", "b-id", "b", "new")
         ask_old = await tracker.get(cid_old)
         ask_old.created_at = datetime.now(timezone.utc) - timedelta(minutes=5)
-        await tracker.mark_picked_up(cid_old)
-        await tracker.mark_picked_up(cid_new)
-        result = await tracker.pending_for_peer("b-id", current_turn_seq=5)
+        result = await tracker.pending_for_peer("b-id")
         assert result[0].correlation_id == cid_new
 
     async def test_other_peer_excluded(self, tracker):
-        cid = await tracker.register("a", "a", "b-id", "b", "x")
-        await tracker.mark_picked_up(cid)
-        result = await tracker.pending_for_peer("other-id", current_turn_seq=5)
+        await tracker.register("a", "a", "b-id", "b", "x")
+        result = await tracker.pending_for_peer("other-id")
         assert result == []
 
 
-class TestTurnCounter:
-    async def test_increments_per_peer(self, tracker):
-        assert await tracker.increment_turn("p1") == 1
-        assert await tracker.increment_turn("p1") == 2
-        assert await tracker.increment_turn("p2") == 1
+class TestForgetPeer:
+    async def test_drops_asks_to_or_from_peer(self, tracker):
+        cid_to = await tracker.register("a", "a", "b-id", "b", "x")
+        cid_from = await tracker.register("b", "b", "c-id", "c", "y")
+        # Forget "b-id": cid_to (to_peer_id=b-id) drops; cid_from is unaffected
+        # (from_peer_id="b" not "b-id", to_peer_id="c-id").
+        dropped = await tracker.forget_peer("b-id")
+        assert dropped == 1
+        assert await tracker.get(cid_to) is None
+        assert await tracker.get(cid_from) is not None
 
 
 class TestEvictExpired:

--- a/tests/test_circles.py
+++ b/tests/test_circles.py
@@ -392,7 +392,7 @@ class TestRoleBasedCircleBypass:
         await self._register(pm, "sid-svc", "telegram", "default", role=PeerRole.SERVICE)
         await self._register(pm, "sid-other", "other-agent", "staging")
 
-        mock_message_router.broadcast = AsyncMock(return_value=["sid-svc"])
+        mock_message_router.broadcast = AsyncMock(return_value=(["sid-svc"], []))
         await pm.broadcast("worker", "hello everyone")
 
         # Service peer should NOT be excluded; staging agent should be excluded

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,19 +14,17 @@ from repowire.hooks.websocket_hook import _is_pane_safe, _tmux_send_keys
 
 
 class TestHandleAskAndNotify:
-    """type=ask must POST pickup directly (no FIFO). type=notify is plain FYI.
+    """type=ask injects framed text; type=notify is plain FYI.
 
-    Lifecycle invariant: pickup is reported transport-side at delivery time,
-    not via a per-pane FIFO. Ack-with-msg replies arrive as plain notify and
-    must not produce a pickup POST.
+    Under the simplified model the transport no longer POSTs pickup back
+    to the daemon — open asks are surfaced via Stop hook reminders.
     """
 
     @pytest.mark.asyncio
-    async def test_type_ask_posts_pickup(self):
+    async def test_type_ask_injects_framed_text(self):
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
-            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
         ):
             await websocket_hook.handle_message(
                 {
@@ -37,28 +35,30 @@ class TestHandleAskAndNotify:
                 },
                 "%5",
             )
-        mock_post.assert_called_once_with("%5", "ask-abc")
+        mock_send.assert_called_once()
+        injected = mock_send.call_args.args[1]
+        assert "@alice" in injected
+        assert "[ask #ask-abc]" in injected
+        assert "ping?" in injected
 
     @pytest.mark.asyncio
-    async def test_type_notify_does_not_post_pickup(self):
+    async def test_type_notify_injects_plain_text(self):
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
-            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
         ):
             await websocket_hook.handle_message(
                 {"type": "notify", "from_peer": "alice", "text": "fyi"},
                 "%5",
             )
-        mock_post.assert_not_called()
+        mock_send.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_ack_reply_arrives_as_plain_notify(self):
-        """Ack-with-msg replies are plain notifies, no lifecycle, no pickup."""
+        """Ack-with-msg replies are plain notifies."""
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
-            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
-            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
         ):
             await websocket_hook.handle_message(
                 {
@@ -68,16 +68,15 @@ class TestHandleAskAndNotify:
                 },
                 "%5",
             )
-        mock_post.assert_not_called()
+        mock_send.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_query_does_not_post_ask_pickup(self):
-        """Legacy /query path uses the query FIFO, not the ask pickup endpoint."""
+    async def test_query_pushes_cid_to_fifo(self):
+        """Legacy /query path uses the query FIFO."""
         with (
             patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
             patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True),
             patch("repowire.hooks.websocket_hook._push_query_cid") as mock_push,
-            patch("repowire.hooks.websocket_hook._post_ask_picked_up") as mock_post,
         ):
             await websocket_hook.handle_message(
                 {
@@ -89,7 +88,6 @@ class TestHandleAskAndNotify:
                 "%5",
             )
         mock_push.assert_called_once_with("%5", "query-abc")
-        mock_post.assert_not_called()
 
 
 class TestTmuxSendKeys:

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -75,20 +75,23 @@ class TestSendQuery:
 class TestBroadcast:
     async def test_broadcast_to_all(self, router, transport):
         transport.get_all_sessions.return_value = ["sid-1", "sid-2", "sid-3"]
-        sent = await router.broadcast("sender", "hello all")
+        sent, failed = await router.broadcast("sender", "hello all")
         assert len(sent) == 3
+        assert failed == []
         assert transport.send.call_count == 3
 
     async def test_broadcast_excludes(self, router, transport):
         transport.get_all_sessions.return_value = ["sid-1", "sid-2", "sid-3"]
-        sent = await router.broadcast("sender", "hello", exclude={"sid-2"})
+        sent, failed = await router.broadcast("sender", "hello", exclude={"sid-2"})
         assert len(sent) == 2
         assert "sid-2" not in sent
+        assert failed == []
 
     async def test_broadcast_empty(self, router, transport):
         transport.get_all_sessions.return_value = []
-        sent = await router.broadcast("sender", "hello")
+        sent, failed = await router.broadcast("sender", "hello")
         assert sent == []
+        assert failed == []
 
     async def test_broadcast_partial_failure(self, router, transport):
         transport.get_all_sessions.return_value = ["sid-1", "sid-2"]
@@ -102,8 +105,11 @@ class TestBroadcast:
                 raise TransportError("disconnected")
 
         transport.send.side_effect = fail_second
-        sent = await router.broadcast("sender", "hello")
+        sent, failed = await router.broadcast("sender", "hello")
         assert len(sent) == 1
+        assert len(failed) == 1
+        assert failed[0]["session_id"] == "sid-2"
+        assert "disconnected" in failed[0]["error"]
 
 
 class TestSendAsk:

--- a/tests/test_notification_buffer.py
+++ b/tests/test_notification_buffer.py
@@ -1,8 +1,9 @@
-"""Tests for buffering notify/broadcast while a peer is BUSY.
+"""Tests confirming notify/ask/broadcast no longer buffer for BUSY peers.
 
-Issue #79: messages injected during a busy turn land in the active subagent's
-context instead of the human's main session. The fix buffers at the registry
-and drains on BUSY -> ONLINE.
+The BUSY queue (formerly _pending_messages) was ripped: BUSY isn't a
+delivery barrier under async ask semantics. Daemon sends directly via
+the router; ws-hook buffers the tmux paste through the busy turn.
+TransportError (no live WS) bubbles to the route as 503.
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ import pytest
 from repowire.config.models import Config
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer, PeerStatus
 
 
@@ -22,8 +24,8 @@ def router():
     r = MagicMock(spec=MessageRouter)
     r.send_query = AsyncMock(return_value="mock")
     r.send_notification = AsyncMock()
-    r.send_broadcast_to = AsyncMock()
-    r.broadcast = AsyncMock(return_value=[])
+    r.send_ask = AsyncMock()
+    r.broadcast = AsyncMock(return_value=([], []))
     return r
 
 
@@ -43,23 +45,20 @@ def _add_peer(
     return peer
 
 
-class TestNotifyBuffersWhenBusy:
-    async def test_notify_to_busy_peer_is_queued(self, registry, router):
+class TestNotifyDirectSend:
+    async def test_notify_to_busy_peer_sends_directly(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
         recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
 
         await registry.notify(
             from_peer=sender.display_name,
             to_peer=recipient.display_name,
-            text="hi",
+        text="hi",
         )
 
-        router.send_notification.assert_not_awaited()
-        assert registry._pending_messages[recipient.peer_id] == [
-            {"kind": "notify", "from_peer": sender.display_name, "text": "hi"},
-        ]
+        router.send_notification.assert_awaited_once()
 
-    async def test_notify_to_online_peer_is_sent_directly(self, registry, router):
+    async def test_notify_to_online_peer_sends_directly(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
         recipient = _add_peer(registry, "bob", PeerStatus.ONLINE)
 
@@ -70,115 +69,75 @@ class TestNotifyBuffersWhenBusy:
         )
 
         router.send_notification.assert_awaited_once()
-        assert recipient.peer_id not in registry._pending_messages
 
-    async def test_busy_to_online_drains_in_order(self, registry, router):
-        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
-
-        await registry.notify(sender.display_name, recipient.display_name, "first")
-        await registry.notify(sender.display_name, recipient.display_name, "second")
-        await registry.notify(sender.display_name, recipient.display_name, "third")
-
-        router.send_notification.assert_not_awaited()
-
-        await registry.update_peer_status(recipient.peer_id, PeerStatus.ONLINE)
-
-        assert router.send_notification.await_count == 3
-        # Preserve FIFO order
-        texts = [c.kwargs["text"] for c in router.send_notification.await_args_list]
-        assert texts == ["first", "second", "third"]
-        # Queue cleared after drain
-        assert recipient.peer_id not in registry._pending_messages
-
-    async def test_busy_to_offline_drops_queue(self, registry, router):
-        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
-
-        await registry.notify(sender.display_name, recipient.display_name, "lost")
-        assert recipient.peer_id in registry._pending_messages
-
-        await registry.update_peer_status(recipient.peer_id, PeerStatus.OFFLINE)
-
-        router.send_notification.assert_not_awaited()
-        assert recipient.peer_id not in registry._pending_messages
-
-    async def test_status_unchanged_does_not_drain(self, registry, router):
-        # BUSY -> BUSY (no transition) should not trigger a flush.
-        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
-
-        await registry.notify(sender.display_name, recipient.display_name, "queued")
-
-        await registry.update_peer_status(recipient.peer_id, PeerStatus.BUSY)
-
-        router.send_notification.assert_not_awaited()
-        assert registry._pending_messages[recipient.peer_id]
-
-    async def test_queue_failure_does_not_block_subsequent_messages(self, registry, router):
-        # If a single flushed send raises, the rest of the queue must still go.
-        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
-
-        await registry.notify(sender.display_name, recipient.display_name, "first")
-        await registry.notify(sender.display_name, recipient.display_name, "second")
-
-        call_count = 0
-
-        async def maybe_fail(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise RuntimeError("transport flapped")
-
-        router.send_notification.side_effect = maybe_fail
-
-        await registry.update_peer_status(recipient.peer_id, PeerStatus.ONLINE)
-
-        # Both attempted, second still went through
-        assert router.send_notification.await_count == 2
-
-    async def test_queue_caps_at_max(self, registry, router):
-        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
-
-        registry._pending_messages_max = 3
-        for i in range(5):
-            await registry.notify(sender.display_name, recipient.display_name, f"msg-{i}")
-
-        queue = registry._pending_messages[recipient.peer_id]
-        assert len(queue) == 3
-        # Oldest dropped, newest preserved
-        assert [m["text"] for m in queue] == ["msg-2", "msg-3", "msg-4"]
-
-
-class TestBroadcastBuffersBusyRecipients:
-    async def test_busy_recipient_queued_not_sent(self, registry, router):
+    async def test_notify_propagates_transport_error(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
         _add_peer(registry, "bob", PeerStatus.ONLINE)
-        busy = _add_peer(registry, "carol", PeerStatus.BUSY)
+        router.send_notification.side_effect = TransportError("No connection")
 
-        # Make sure the live MessageRouter.broadcast skips the busy peer.
-        # Our router mock returns []; we just check the exclude set passed.
-        await registry.broadcast(from_peer=sender.display_name, text="all hands")
+        with pytest.raises(TransportError):
+            await registry.notify(
+                from_peer=sender.display_name,
+                to_peer="bob",
+                text="hi",
+            )
 
-        # busy peer was queued
-        assert registry._pending_messages[busy.peer_id] == [
-            {"kind": "broadcast", "from_peer": sender.display_name, "text": "all hands"},
-        ]
 
-        # Excluded from the live fanout
-        exclude = router.broadcast.await_args.kwargs["exclude"]
-        assert busy.peer_id in exclude
-
-    async def test_drain_uses_send_broadcast_to(self, registry, router):
+class TestAskDirectSend:
+    async def test_deliver_ask_to_busy_peer_sends_directly(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
-        busy = _add_peer(registry, "bob", PeerStatus.BUSY)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
 
-        await registry.broadcast(from_peer=sender.display_name, text="hi")
-        await registry.update_peer_status(busy.peer_id, PeerStatus.ONLINE)
+        await registry.deliver_ask(
+            from_peer=sender.display_name,
+            to_peer=recipient.display_name,
+            text="hi",
+            correlation_id="ask-test",
+        )
 
-        router.send_broadcast_to.assert_awaited_once()
-        kwargs = router.send_broadcast_to.await_args.kwargs
-        assert kwargs["text"] == "hi"
-        assert kwargs["to_session_id"] == busy.peer_id
+        router.send_ask.assert_awaited_once()
+
+    async def test_deliver_ask_propagates_transport_error(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        _add_peer(registry, "bob", PeerStatus.ONLINE)
+        router.send_ask.side_effect = TransportError("No connection")
+
+        with pytest.raises(TransportError):
+            await registry.deliver_ask(
+                from_peer=sender.display_name,
+                to_peer="bob",
+                text="hi",
+                correlation_id="ask-test",
+            )
+
+
+class TestBroadcastBestEffort:
+    async def test_broadcast_excludes_self_and_circles(self, registry, router):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE, circle="x")
+        _add_peer(registry, "bob", PeerStatus.ONLINE, circle="x")
+        _add_peer(registry, "carol", PeerStatus.ONLINE, circle="y")
+        router.broadcast.return_value = ([], [])
+
+        sent, failed = await registry.broadcast(
+            from_peer=sender.display_name,
+            text="hi",
+        )
+
+        # router.broadcast is called once with exclude including sender + cross-circle
+        router.broadcast.assert_awaited_once()
+        kwargs = router.broadcast.await_args.kwargs
+        assert sender.peer_id in kwargs["exclude"]
+        assert sent == []
+        assert failed == []
+
+
+class TestStatusUpdateNoSideEffects:
+    async def test_busy_to_online_does_nothing_extra(self, registry, router):
+        peer = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        await registry.update_peer_status(peer.display_name, PeerStatus.ONLINE)
+
+        # No drain — router shouldn't be touched
+        router.send_notification.assert_not_awaited()
+        router.send_ask.assert_not_awaited()
+        assert peer.status == PeerStatus.ONLINE


### PR DESCRIPTION
## Summary

Codex + I designed this rip together over four riffs. Net delete of ~320 LOC plus a simpler mental model.

**Behavior change**: open asks reappear in every Stop hook poll until acked. No turn-counter grace window, no once-only reminded flag, no daemon-side BUSY queue. `/ask` and `/notify` fail loudly with 503 if the recipient has no live WS (caller's responsibility to retry).

**Why this is OK**: BUSY isn't a delivery barrier — daemon has a live WS to BUSY peers, ws-hook buffers the tmux paste through the busy turn. The queue+drain machinery only protected a narrow disconnect-then-quick-reconnect window while masking delivery failures from callers. Fail-loud is the cleaner contract; durability is preserved for asks via the tracker (crash mid-life → restart → Stop hook reminder).

## What rips

**ask_tracker.py** (slim from 256 → ~180 LOC):
- Drop `picked_up`, `picked_up_at`, `picked_up_turn_seq`, `reminded` fields
- Drop `mark_picked_up`, `mark_reminded`, `increment_turn` methods
- Drop `_turn_seq` dict
- `pending_for_peer` → "all open asks targeting this peer, newest first"

**peer_registry.py** (-178 LOC):
- Drop `_pending_messages` dict + `_pending_messages_max`
- Drop `_enqueue_if_busy_unlocked`, `_flush_pending`
- `update_peer_status` no longer drains anything
- `deliver_ask` + `notify` always direct-send; let `TransportError` bubble
- `broadcast` returns `(sent_to, failed)` tuple, best-effort per-recipient

**message_router.py**:
- `broadcast` returns `(sent_session_ids, [{session_id, error}, ...])`
- Drop `send_broadcast_to` (only used by ripped `_flush_pending`)

**Routes**:
- `/ask`: pre-register, send, rollback (close `send_failed`) on TransportError → 503
- `/notify`: catch TransportError → 503
- `/broadcast`: returns `{sent_to, failed}`
- `/asks/{cid}/picked_up` + `/asks/{cid}/mark_reminded`: deprecated no-op 200 (kept for one release for transport compat)
- `/asks/pending` response loses `current_turn_seq`; `PendingAsk` loses `picked_up_at`
- `AskResponse` loses `status` field

**Hooks**:
- `stop_handler.py`: drop bump-then-drain ordering comment, simplify
- `ask_lifecycle.py`: drop `mark_reminded` POST, drop 200-char truncation, update prose
- `websocket_hook.py`: drop `_post_ask_picked_up` helper and POST after type=ask injection

**Transports**:
- `channel/server.ts`: drop `/asks/{cid}/picked_up` POST after ask dispatch
- `installers/opencode.py`: drop same in embedded plugin TS

**Telegram bot** (new):
- Handle inbound `type=ask` with display + inline Ack button (POSTs `/ack` with `from_peer=telegram`)
- Was a pre-existing leak — asks to `@telegram` were silently dropped on the bot side and leaked corr_ids forever in the daemon

**Tests**:
- `test_ask_tracker.py`: replace pickup/grace/reminded coverage with open-asks-repeatedly-until-closed
- `test_ask_routes.py`: drop pickup + mark_reminded behavior assertions; add 503 + rollback + reply_to-preserved-on-failure
- `test_notification_buffer.py`: repurposed to assert direct-send (no buffering) + TransportError propagation
- `test_hooks.py`: drop `_post_ask_picked_up` patches; assert injection only
- `test_message_router.py`: update for tuple broadcast return
- `test_ask_lifecycle.py`: drop truncation test, assert full text preservation

## Verification

- [x] `pytest`: 452 passed (up from 422)
- [x] `ruff check`: clean for changed files
- [x] `ty check`: All checks passed
- [x] Live smoke on running daemon:
  - `/ask` to online peer → 200 `{correlation_id, error: null}` (no `status`)
  - `/ask` to unknown peer → 404
  - `/notify` to online peer → 200
  - `/broadcast` → 200 `{sent_to: [...], failed: []}` (new shape)
  - Legacy `/asks/{cid}/picked_up` + `/mark_reminded` → 200 silent no-op

## Test plan

- [ ] Co-author codex (`repowire.web-ask-ack-codex`) reviews diff
- [ ] Smoke a real ask flow end-to-end: ask peer A → Stop hook reminder fires on subsequent turns → ack closes loop
- [ ] Smoke telegram inbound ask path → Ack button → `/ack` POST works