### PR TITLE
Collapse Stop reminder two-phase → single-phase additionalContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,10 @@ Claude Code → hooks → websocket_hook.py ←WebSocket→ Daemon
 - **Stop** →
   1. extracts response + tool calls from transcript, posts chat turns
   2. delivers legacy /query response (single-purpose `pending-query-{pane}.json` FIFO)
-  3. fetches `/asks/pending` → all open asks for this peer → writes to `reminder-{pane}.txt`
+  3. fetches `/asks/pending` → if open asks present, emits `{"decision": "block", "reason": <reminder>}` so Claude continues with the reminder as context (Stop event doesn't accept additionalContext)
   4. then `update_status(online)`
-- **UserPromptSubmit** → marks BUSY, consumes `reminder-{pane}.txt` and emits as `additionalContext`
-- **Notification** (idle_prompt) → resets ONLINE; also consumes the reminder buffer as a fallback path
+- **UserPromptSubmit** → marks BUSY (Claude Code only)
+- **Notification** (idle_prompt) → resets ONLINE
 - **ws-hook** → on `type=ask` arrival, injects `[ask #cid]` framed text. Daemon doesn't track pickup; the Stop hook reminder is the only way an un-acked ask is resurfaced.
 
 In channel mode, only the Stop hook is kept (for dashboard chat_turn events).

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -92,18 +92,30 @@ def fetch_and_filter_pending(
     return pending
 
 
-def format_reminder_block(asks: list[dict[str, Any]]) -> str:
-    """Terse reminder: just corr_ids + asker, no ask body.
+_BODY_SNIPPET_CHARS = 150
 
-    The original ask was already injected into the terminal by ws-hook at
-    delivery time, so it's in the agent's transcript/context. The reminder
-    only needs to nudge with the identifier — the agent can scroll back for
-    full text or just ack.
+
+def format_reminder_block(asks: list[dict[str, Any]]) -> str:
+    """Compact reminder: cid + asker + a snippet of body per ask.
+
+    The original ask was injected into the terminal by ws-hook at delivery
+    time, so the full body is usually still in the agent's transcript. The
+    snippet is a fallback for cases where the body fell out of context
+    (compaction, missed paste, restart) — enough to recall the ask without
+    the wall-of-text problem of re-pasting the full body every Stop cycle.
     """
     if not asks:
         return ""
-    cids = ", ".join(
-        f"#{a.get('correlation_id', '?')} from @{a.get('from_peer', '?')}"
-        for a in asks
-    )
-    return f"[repowire] {len(asks)} open ask(s): {cids}. ack(corr_id) each to close."
+    lines = [
+        f"[repowire] {len(asks)} open ask(s). Handle each: ack(corr_id) bare "
+        "if no reply needed, ack(corr_id, message) to reply.",
+    ]
+    for a in asks:
+        cid = a.get("correlation_id", "?")
+        from_peer = a.get("from_peer", "?")
+        body = (a.get("text") or "").strip().replace("\n", " ")
+        if len(body) > _BODY_SNIPPET_CHARS:
+            body = body[: _BODY_SNIPPET_CHARS - 1] + "…"
+        head = f"  - #{cid} from @{from_peer}"
+        lines.append(f"{head}: {body}" if body else head)
+    return "\n".join(lines)

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -93,17 +93,17 @@ def fetch_and_filter_pending(
 
 
 def format_reminder_block(asks: list[dict[str, Any]]) -> str:
-    """Format a context-injection block listing un-acked asks."""
+    """Terse reminder: just corr_ids + asker, no ask body.
+
+    The original ask was already injected into the terminal by ws-hook at
+    delivery time, so it's in the agent's transcript/context. The reminder
+    only needs to nudge with the identifier — the agent can scroll back for
+    full text or just ack.
+    """
     if not asks:
         return ""
-    lines = [
-        "[repowire] You have open asks awaiting your response. Each needs "
-        "ack(corr_id) to close (bare = seen-no-action), ack(corr_id, message) "
-        "to reply, or ask(reply_to=corr_id, ...) to chain a follow-up.",
-    ]
-    for ask in asks:
-        cid = ask.get("correlation_id", "")
-        from_peer = ask.get("from_peer", "?")
-        text = (ask.get("text") or "").strip()
-        lines.append(f"  - @{from_peer} [ask #{cid}]: {text}")
-    return "\n".join(lines)
+    cids = ", ".join(
+        f"#{a.get('correlation_id', '?')} from @{a.get('from_peer', '?')}"
+        for a in asks
+    )
+    return f"[repowire] {len(asks)} open ask(s): {cids}. ack(corr_id) each to close."

--- a/repowire/hooks/notification_handler.py
+++ b/repowire/hooks/notification_handler.py
@@ -12,7 +12,7 @@ import json
 import sys
 
 from repowire.hooks._tmux import get_pane_id
-from repowire.hooks.utils import consume_reminder_buffer, update_status
+from repowire.hooks.utils import update_status
 
 
 def main() -> int:
@@ -37,21 +37,6 @@ def main() -> int:
                 f"repowire notification: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
-
-        # Idle is the secondary injection path for ask-ack reminders. If the
-        # agent has gone idle (no follow-up user prompt) but has un-acked
-        # asks, surface the reminder via additionalContext so it lands the
-        # next time the agent does anything. Notification hooks support the
-        # same hookSpecificOutput shape as UserPromptSubmit on Claude Code.
-        reminder = consume_reminder_buffer(pane_id)
-        if reminder:
-            print(json.dumps({
-                "hookSpecificOutput": {
-                    "hookEventName": "Notification",
-                    "additionalContext": reminder,
-                }
-            }))
-            return 0
 
     return 0
 

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -8,7 +8,7 @@ import sys
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import consume_reminder_buffer, update_status
+from repowire.hooks.utils import update_status
 
 
 def main(backend: str = "claude-code") -> int:
@@ -31,22 +31,6 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire prompt: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
-
-    # Ask-ack reminder injection: surface any open asks the previous Stop
-    # hook found for this peer as additionalContext at the start of this
-    # turn. Buffer is consumed (deleted) on read; the next Stop will re-fetch
-    # if asks are still open.
-    reminder = consume_reminder_buffer(pane_id) if pane_id else None
-    if reminder and backend == "claude-code":
-        # Claude Code reads hookSpecificOutput.additionalContext on
-        # UserPromptSubmit and prepends it to the agent's context for the turn.
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "additionalContext": reminder,
-            }
-        }))
-        return 0
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -117,13 +117,13 @@ def main(backend: str = "claude-code") -> int:
             )
 
     if reminder_text and backend == "claude-code":
-        # Claude Code reads hookSpecificOutput.additionalContext on Stop and
-        # wraps it as a system reminder in the next model request.
+        # Stop hook supports decision=block to keep Claude generating with
+        # `reason` as continuation context. stop_hook_active=true on the
+        # follow-up Stop prevents an infinite loop: we early-returned for
+        # that case at the top of main().
         print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "Stop",
-                "additionalContext": reminder_text,
-            }
+            "decision": "block",
+            "reason": reminder_text,
         }))
         return 0
 

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -90,8 +90,11 @@ def main(backend: str = "claude-code") -> int:
     # Ask-ack reminder: poll daemon for open asks targeting this peer.
     # Backstop only — ws-hook already pasted the original ask into the
     # terminal; this catches missed/un-acked asks on every Stop fire.
-    # Surface via Stop's additionalContext so it lands directly in the next
-    # turn without a separate UserPromptSubmit consumer or buffer file.
+    # Surface via Stop's decision=block + reason: Stop doesn't accept
+    # additionalContext, but block+reason keeps Claude generating with
+    # the reason as continuation context. stop_hook_active=true on the
+    # follow-up Stop (we early-return at top of main()) bounds it to one
+    # nudge per response cycle.
     reminder_text: str | None = None
     if pane_id:
         transcript_path = (
@@ -116,16 +119,29 @@ def main(backend: str = "claude-code") -> int:
                 file=sys.stderr,
             )
 
-    if reminder_text and backend == "claude-code":
-        # Stop hook supports decision=block to keep Claude generating with
-        # `reason` as continuation context. stop_hook_active=true on the
-        # follow-up Stop prevents an infinite loop: we early-returned for
-        # that case at the top of main().
-        print(json.dumps({
-            "decision": "block",
-            "reason": reminder_text,
-        }))
-        return 0
+    if reminder_text:
+        # Per-backend reminder injection. Each backend's end-of-turn hook
+        # accepts a different decision keyword to inject `reason` as
+        # continuation context for the next prompt:
+        #   claude-code, codex: {"decision": "block", "reason": ...}
+        #     Reason becomes continuation context (Claude) or a new
+        #     continuation prompt (Codex). stop_hook_active=true on the
+        #     follow-up Stop bounds the loop (early-return at top of main).
+        #   gemini AfterAgent:  {"decision": "deny",  "reason": ...}
+        #     Reason becomes a new prompt to force a retry turn.
+        # opencode uses a plugin runtime, not this hook — see follow-up
+        # issue for plugin-side reminder path.
+        decision_keyword = {
+            "claude-code": "block",
+            "codex": "block",
+            "gemini": "deny",
+        }.get(backend)
+        if decision_keyword:
+            print(json.dumps({
+                "decision": decision_keyword,
+                "reason": reminder_text,
+            }))
+            return 0
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -15,7 +15,6 @@ from repowire.hooks.utils import (
     get_display_name,
     pop_query_cid,
     update_status,
-    write_reminder_buffer,
 )
 from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
 
@@ -88,11 +87,12 @@ def main(backend: str = "claude-code") -> int:
             resp_payload["correlation_id"] = cid
         daemon_post("/response", resp_payload)
 
-    # Ask-ack reminder: poll daemon for open asks targeting this peer and
-    # write them to the per-pane reminder buffer for the next prompt to
-    # inject. Backstop only — ws-hook already pasted the original ask into
-    # the terminal; this catches the case where the agent missed it or
-    # hasn't acked yet.
+    # Ask-ack reminder: poll daemon for open asks targeting this peer.
+    # Backstop only — ws-hook already pasted the original ask into the
+    # terminal; this catches missed/un-acked asks on every Stop fire.
+    # Surface via Stop's additionalContext so it lands directly in the next
+    # turn without a separate UserPromptSubmit consumer or buffer file.
+    reminder_text: str | None = None
     if pane_id:
         transcript_path = (
             Path(payload.transcript_path).expanduser().resolve()
@@ -100,7 +100,7 @@ def main(backend: str = "claude-code") -> int:
         )
         due = fetch_and_filter_pending(pane_id, transcript_path)
         if due:
-            write_reminder_buffer(pane_id, format_reminder_block(due))
+            reminder_text = format_reminder_block(due)
 
     # Mark peer online.
     if pane_id:
@@ -115,6 +115,17 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire stop: failed to update status for {peer_display}",
                 file=sys.stderr,
             )
+
+    if reminder_text and backend == "claude-code":
+        # Claude Code reads hookSpecificOutput.additionalContext on Stop and
+        # wraps it as a system reminder in the next model request.
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "Stop",
+                "additionalContext": reminder_text,
+            }
+        }))
+        return 0
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -153,41 +153,6 @@ def write_pane_runtime_metadata(pane_id: str | None, metadata: dict) -> None:
         ws_hook_legacy_cwd_path(pane_id).write_text(str(cwd))
 
 
-def reminder_buffer_path(pane_id: str | None) -> Path:
-    """Path to the pane's pending reminder text file.
-
-    The Stop hook writes ask-ack reminder text here when this peer has any
-    open asks. The next UserPromptSubmit (or Notification/idle_prompt) hook
-    reads it, injects, and deletes.
-    """
-    return pane_logs_dir() / f"reminder-{get_pane_file(pane_id)}.txt"
-
-
-def consume_reminder_buffer(pane_id: str | None) -> str | None:
-    """Read and remove the pending reminder for a pane. Returns None if empty."""
-    if not pane_id:
-        return None
-    path = reminder_buffer_path(pane_id)
-    try:
-        text = path.read_text().strip()
-    except OSError:
-        return None
-    with suppress(OSError):
-        path.unlink()
-    return text or None
-
-
-def write_reminder_buffer(pane_id: str | None, text: str) -> None:
-    """Persist reminder text for next-prompt injection. Skips if empty."""
-    if not pane_id or not text:
-        return
-    path = reminder_buffer_path(pane_id)
-    try:
-        path.write_text(text)
-    except OSError as e:
-        print(f"repowire: failed to write reminder buffer: {e}", file=sys.stderr)
-
-
 def clear_pending_cids(pane_id: str | None) -> None:
     """Remove any queued /query correlation IDs for a pane."""
     if not pane_id:
@@ -210,7 +175,6 @@ def clear_pane_runtime_state(pane_id: str | None) -> None:
         ws_hook_pid_path(pane_id),
         ws_hook_meta_path(pane_id),
         ws_hook_legacy_cwd_path(pane_id),
-        reminder_buffer_path(pane_id),
     ):
         with suppress(OSError):
             path.unlink()

--- a/tests/test_ask_lifecycle.py
+++ b/tests/test_ask_lifecycle.py
@@ -126,19 +126,31 @@ class TestFormatReminderBlock:
     def test_empty(self):
         assert format_reminder_block([]) == ""
 
-    def test_single(self):
+    def test_single_is_terse(self):
+        """Single ask: cid + asker, no body. Body is already in agent's transcript."""
         block = format_reminder_block([{
             "correlation_id": "ask-x", "from_peer": "alice", "text": "what's the status?",
         }])
         assert "ask-x" in block
         assert "@alice" in block
-        assert "what's the status?" in block
-        assert "ack(corr_id)" in block
+        assert "what's the status?" not in block  # body NOT re-included
 
-    def test_preserves_full_text(self):
-        """Reminder carries full ask text — no truncation."""
-        long_text = "x" * 500
+    def test_multiple_lists_cids(self):
+        block = format_reminder_block([
+            {"correlation_id": "ask-x", "from_peer": "alice", "text": "first"},
+            {"correlation_id": "ask-y", "from_peer": "bob", "text": "second"},
+        ])
+        assert "ask-x" in block
+        assert "ask-y" in block
+        assert "@alice" in block
+        assert "@bob" in block
+        # bodies not included
+        assert "first" not in block
+        assert "second" not in block
+
+    def test_does_not_balloon_with_long_text(self):
+        """Reminder size is independent of original ask body length."""
         block = format_reminder_block([{
-            "correlation_id": "ask-x", "from_peer": "a", "text": long_text,
+            "correlation_id": "ask-x", "from_peer": "a", "text": "x" * 5000,
         }])
-        assert long_text in block
+        assert len(block) < 200

--- a/tests/test_ask_lifecycle.py
+++ b/tests/test_ask_lifecycle.py
@@ -126,16 +126,17 @@ class TestFormatReminderBlock:
     def test_empty(self):
         assert format_reminder_block([]) == ""
 
-    def test_single_is_terse(self):
-        """Single ask: cid + asker, no body. Body is already in agent's transcript."""
+    def test_single_includes_snippet(self):
+        """Single ask: cid + asker + body snippet for compaction recovery."""
         block = format_reminder_block([{
             "correlation_id": "ask-x", "from_peer": "alice", "text": "what's the status?",
         }])
         assert "ask-x" in block
         assert "@alice" in block
-        assert "what's the status?" not in block  # body NOT re-included
+        assert "what's the status?" in block  # body included as snippet
+        assert "ack(corr_id)" in block
 
-    def test_multiple_lists_cids(self):
+    def test_multiple_lists_each(self):
         block = format_reminder_block([
             {"correlation_id": "ask-x", "from_peer": "alice", "text": "first"},
             {"correlation_id": "ask-y", "from_peer": "bob", "text": "second"},
@@ -144,13 +145,22 @@ class TestFormatReminderBlock:
         assert "ask-y" in block
         assert "@alice" in block
         assert "@bob" in block
-        # bodies not included
-        assert "first" not in block
-        assert "second" not in block
+        assert "first" in block
+        assert "second" in block
 
-    def test_does_not_balloon_with_long_text(self):
-        """Reminder size is independent of original ask body length."""
+    def test_truncates_long_body(self):
+        """Per-ask body snippet capped to bound block size under verbose asks."""
+        long_text = "x" * 5000
         block = format_reminder_block([{
-            "correlation_id": "ask-x", "from_peer": "a", "text": "x" * 5000,
+            "correlation_id": "ask-x", "from_peer": "a", "text": long_text,
         }])
-        assert len(block) < 200
+        # Truncated, not 5000 chars
+        assert len(block) < 400
+        assert "…" in block
+
+    def test_handles_empty_text(self):
+        block = format_reminder_block([{
+            "correlation_id": "ask-x", "from_peer": "a", "text": "",
+        }])
+        assert "ask-x" in block
+        assert "@a" in block

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -1,6 +1,8 @@
 """Tests for the stop hook handler."""
 
+import io
 import json
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -176,3 +178,117 @@ class TestStopHandler:
         payload = response_calls[0][0][1]
         assert payload["pane_id"] == "%42"
         assert payload["text"] == "I am finished."
+
+
+class TestReminderStopOutput:
+    """Stop hook emits decision=block + reason JSON when open asks exist (claude-code only)."""
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    @patch("repowire.hooks.stop_handler.get_display_name", return_value="alice")
+    @patch("repowire.hooks.stop_handler.fetch_and_filter_pending")
+    def test_block_decision_when_pending(
+        self, mock_pending, mock_name, mock_pane, mock_status, mock_post,
+    ):
+        mock_pending.return_value = [
+            {"correlation_id": "ask-x", "from_peer": "bob", "text": "status?"},
+        ]
+        buf = io.StringIO()
+        with patch("sys.stdin") as stdin, redirect_stdout(buf):
+            stdin.read.return_value = json.dumps({
+                "cwd": "/tmp/test",
+                "session_id": "s1",
+            })
+            assert main() == 0
+        out = buf.getvalue().strip()
+        assert out, "expected JSON output when pending asks present"
+        parsed = json.loads(out)
+        assert parsed["decision"] == "block"
+        assert "ask-x" in parsed["reason"]
+        assert "@bob" in parsed["reason"]
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    @patch("repowire.hooks.stop_handler.get_display_name", return_value="alice")
+    @patch("repowire.hooks.stop_handler.fetch_and_filter_pending", return_value=[])
+    def test_no_output_when_no_pending(
+        self, mock_pending, mock_name, mock_pane, mock_status, mock_post,
+    ):
+        buf = io.StringIO()
+        with patch("sys.stdin") as stdin, redirect_stdout(buf):
+            stdin.read.return_value = json.dumps({
+                "cwd": "/tmp/test",
+                "session_id": "s1",
+            })
+            assert main() == 0
+        # No JSON, no block
+        assert buf.getvalue().strip() == ""
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    @patch("repowire.hooks.stop_handler.get_display_name", return_value="alice")
+    @patch("repowire.hooks.stop_handler.fetch_and_filter_pending")
+    def test_no_block_when_stop_hook_active(
+        self, mock_pending, mock_name, mock_pane, mock_status, mock_post,
+    ):
+        """stop_hook_active=true on input → early-return, no reminder fetch, no block."""
+        buf = io.StringIO()
+        with patch("sys.stdin") as stdin, redirect_stdout(buf):
+            stdin.read.return_value = json.dumps({
+                "cwd": "/tmp/test",
+                "session_id": "s1",
+                "stop_hook_active": True,
+            })
+            assert main() == 0
+        assert buf.getvalue().strip() == ""
+        mock_pending.assert_not_called()
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    @patch("repowire.hooks.stop_handler.get_display_name", return_value="alice")
+    @patch("repowire.hooks.stop_handler.fetch_and_filter_pending")
+    def test_block_decision_for_codex_backend(
+        self, mock_pending, mock_name, mock_pane, mock_status, mock_post,
+    ):
+        """Codex Stop hook supports decision=block + reason (per docs)."""
+        mock_pending.return_value = [
+            {"correlation_id": "ask-x", "from_peer": "bob", "text": "status?"},
+        ]
+        buf = io.StringIO()
+        with patch("sys.stdin") as stdin, redirect_stdout(buf):
+            stdin.read.return_value = json.dumps({
+                "cwd": "/tmp/test",
+                "session_id": "s1",
+            })
+            assert main(backend="codex") == 0
+        parsed = json.loads(buf.getvalue().strip())
+        assert parsed["decision"] == "block"
+        assert "ask-x" in parsed["reason"]
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    @patch("repowire.hooks.stop_handler.get_display_name", return_value="alice")
+    @patch("repowire.hooks.stop_handler.fetch_and_filter_pending")
+    def test_deny_decision_for_gemini_backend(
+        self, mock_pending, mock_name, mock_pane, mock_status, mock_post,
+    ):
+        """Gemini AfterAgent uses decision=deny + reason to force retry prompt."""
+        mock_pending.return_value = [
+            {"correlation_id": "ask-x", "from_peer": "bob", "text": "status?"},
+        ]
+        buf = io.StringIO()
+        with patch("sys.stdin") as stdin, redirect_stdout(buf):
+            stdin.read.return_value = json.dumps({
+                "cwd": "/tmp/test",
+                "session_id": "s1",
+            })
+            assert main(backend="gemini") == 0
+        parsed = json.loads(buf.getvalue().strip())
+        assert parsed["decision"] == "deny"
+        assert "ask-x" in parsed["reason"]
+


### PR DESCRIPTION
## Summary

Follow-up rip on #104's two-phase reminder pattern. Single-phase now: Stop hook emits `decision: "block"` (or `"deny"` for gemini) + terse `reason` directly, no buffer file, no UserPromptSubmit consumer, no Notification fallback. Multi-backend coverage live-verified for claude-code and codex.

## What rips

- `stop_handler.py`: emits per-backend decision JSON when open asks present, instead of `write_reminder_buffer`
- `prompt_handler.py`: drops reminder buffer consumption (was the UserPromptSubmit injection path)
- `notification_handler.py`: drops reminder buffer consumption (was the idle_prompt fallback)
- `utils.py`: deletes `reminder_buffer_path`, `consume_reminder_buffer`, `write_reminder_buffer`, and the cleanup ref in `clear_pane_runtime_state`
- `ask_lifecycle.py`: `format_reminder_block` is now a compact form with header + per-ask `[#cid from @peer: <150-char snippet>]`. Body snippet retained per codex review (full body is in transcript from ws-hook delivery; snippet is fallback for compaction/restart recovery without ballooning the block).

## Per-backend decision keyword

| Backend | Hook event | JSON output | Verified |
|---------|-----------|-------------|----------|
| claude-code | Stop | `{"decision": "block", "reason": ...}` | live |
| codex | Stop | `{"decision": "block", "reason": ...}` | live (hook_prompt block visible in context) |
| gemini | AfterAgent | `{"decision": "deny", "reason": ...}` | coded per docs, no live peer |
| opencode | (plugin runtime, no Stop hook) | n/a | see follow-up issue |

## Why decision=block, not additionalContext

Initial attempt used `hookSpecificOutput.additionalContext` on Stop. Live schema validation rejected it: per the actual docs, `additionalContext` is gated to specific events (UserPromptSubmit, PostToolUse, PostToolBatch, SessionStart, Setup) — Stop is NOT in that list. Stop only supports `decision: "block"` + `reason` for control flow.

`decision: "block"` (or gemini's `deny`) keeps the agent generating with `reason` as continuation context. Bounded by `stop_hook_active` recursion guard — fresh user-driven Stop fires re-poll the tracker and re-block while asks remain open, but a follow-up Stop within the same continuation chain early-returns and lets the agent stop normally.

## Reminder format

Compact header + bounded per-ask line:

```
[repowire] N open ask(s). Handle each: ack(corr_id) bare if no reply needed, ack(corr_id, message) to reply.
  - #ask-cid from @asker: <up to 150 chars of body>...
```

Header explains both ack modes. Body snippet capped to bound block size under verbose asks — full body is already in the agent's transcript from ws-hook delivery, so the snippet is just a recall aid for compaction/restart cases.

## Verification

- pytest: 461 passed
- ruff check: clean for changed files
- ty check: clean
- Live smoke claude-code (multiple cycles): reminder fires every Stop, stops on ack, no buffer file artifacts
- Live smoke codex (web-ask-ack-2-codex peer): reason arrived as `<hook_prompt>` block visible in model context
- Codex re-review of d55cf2f: blessed

## References

- https://code.claude.com/docs/en/hooks#stop-decision-control
- https://developers.openai.com/codex/hooks#stop
- https://geminicli.com/docs/hooks/reference#afteragent

## Follow-ups (separate issues)

- opencode plugin-runtime reminder injection (#109)
- Gemini AfterAgent live-verification (TBD issue)