### PR TITLE
fix(mcp): resolve own peer identity via ppid-chain + pane metadata (#107)

### DIFF
--- a/repowire/hooks/_tmux.py
+++ b/repowire/hooks/_tmux.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
 from typing import TypedDict
+
+logger = logging.getLogger(__name__)
 
 
 class TmuxInfo(TypedDict):
@@ -36,22 +39,110 @@ def is_tmux_available() -> bool:
         return False
 
 
+def _get_ppid_chain(max_depth: int = 16) -> list[int]:
+    """Walk getppid() ancestry. Returns pids from immediate parent upward."""
+    chain: list[int] = []
+    try:
+        pid = os.getppid()
+    except OSError:
+        return chain
+    seen: set[int] = set()
+    for _ in range(max_depth):
+        if pid <= 1 or pid in seen:
+            break
+        seen.add(pid)
+        chain.append(pid)
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "ppid=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            break
+        if result.returncode != 0:
+            break
+        try:
+            pid = int(result.stdout.strip())
+        except ValueError:
+            break
+    return chain
+
+
+def _resolve_pane_via_ppid_chain() -> str | None:
+    """Match an ancestor pid against tmux pane_pids to identify the spawning pane.
+
+    Returns the pane_id whose shell pid appears in our process ancestry, or
+    None if no match. Handles the multi-pane case where TMUX_PANE wasn't
+    inherited: `tmux display-message` would return the focused pane (often
+    a different peer's), but ancestor matching is unambiguous.
+
+    Caveat: if Claude Code's MCP subprocess re-parents to init/launchd
+    (daemonizes), the ancestor chain detaches from the pane shell and this
+    returns None — the caller falls through to `tmux display-message`, which
+    in multi-peer-same-cwd scenarios will mislabel the peer. There is no
+    known reliable workaround for the re-parented case; in practice Claude
+    Code keeps MCP subprocesses attached.
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
+        logger.debug("ppid-chain pane resolution: tmux list-panes failed: %s", e)
+        return None
+    if result.returncode != 0:
+        logger.debug(
+            "ppid-chain pane resolution: tmux list-panes rc=%d", result.returncode
+        )
+        return None
+
+    pane_by_pid: dict[int, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split()
+        if len(parts) != 2:
+            continue
+        try:
+            pane_by_pid[int(parts[1])] = parts[0]
+        except ValueError:
+            continue
+
+    for pid in _get_ppid_chain():
+        if pid in pane_by_pid:
+            return pane_by_pid[pid]
+
+    logger.debug("ppid-chain pane resolution: no ancestor pid matched any tmux pane")
+    return None
+
+
 def get_pane_id() -> str | None:
     """Get the current tmux pane ID.
 
-    Prefers TMUX_PANE env var, falls back to querying tmux directly.
-    The fallback handles agents (Codex, Gemini) whose hook subprocesses
-    may not inherit TMUX_PANE.
+    Resolution order:
+    1. TMUX_PANE env var (cheapest, authoritative when inherited)
+    2. ppid-chain match against `tmux list-panes` pane_pids (handles
+       MCP subprocesses that don't inherit TMUX_PANE — unambiguous even
+       when multiple panes are alive)
+    3. `tmux display-message` (last resort; returns focused pane, which
+       is wrong in multi-peer-same-cwd scenarios — see #107)
     """
     pane_id = os.environ.get("TMUX_PANE")
     if pane_id:
         return pane_id
 
-    # Fallback: query tmux directly. Only attempt if TMUX env var is set
-    # (proves we're inside a tmux session). Without this guard, we'd get
-    # the most-recently-active pane from a different session - wrong peer.
+    # Only attempt tmux queries if TMUX env var is set (proves we're inside a
+    # tmux session). Without this guard, we'd get a pane from an unrelated
+    # session.
     if not os.environ.get("TMUX"):
         return None
+
+    pane_id = _resolve_pane_via_ppid_chain()
+    if pane_id:
+        return pane_id
 
     try:
         result = subprocess.run(

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -61,16 +61,42 @@ async def daemon_request(
         raise DaemonTimeoutError()
 
 
+def _metadata_matches_current_process(pane_meta: dict) -> bool:
+    """Verify pane runtime metadata describes the *current* process.
+
+    Pane metadata can outlive the session that wrote it (no daemon
+    process owns the file; cleanup is best-effort via clear_pane_runtime_state).
+    If a daemon restart races with pane reuse, we could read stale metadata
+    pointing at a previous tenant's display_name.
+
+    Reject metadata whose cwd or backend mismatches what we observe now.
+    """
+    meta_cwd = pane_meta.get("cwd")
+    meta_backend = pane_meta.get("backend")
+    if not meta_cwd or not meta_backend:
+        return False
+    try:
+        current_cwd = str(Path.cwd())
+    except OSError:
+        return False
+    if str(meta_cwd) != current_cwd:
+        return False
+    return meta_backend == _detect_backend()
+
+
 async def _get_my_peer_name() -> str:
-    """Get own peer name. Cached after first resolution.
+    """Get own peer name. Cached after first successful resolution.
 
     Resolution order:
     1. pane-based daemon lookup (most authoritative — handles suffix collisions)
-    2. pane runtime metadata file (written by SessionStart; covers the case
-       where the daemon hasn't yet finished registration on the first MCP
-       call, but the hook already wrote display_name to disk)
+    2. pane runtime metadata file, validated against current cwd+backend
+       (covers daemon-not-yet-ready races; rejects stale metadata from a
+       prior tenant of a reused pane)
     3. REPOWIRE_DISPLAY_NAME env var or cwd folder name (collides for
        same-cwd peers — last resort, see #107)
+
+    The cwd-folder fallback is intentionally not cached, so a later call
+    that can reach the daemon can still resolve the correct suffixed name.
     """
     global _cached_peer_name
     if _cached_peer_name is not None:
@@ -86,12 +112,12 @@ async def _get_my_peer_name() -> str:
         except Exception:
             pass
         pane_meta = read_pane_runtime_metadata(pane_id)
-        name = pane_meta.get("display_name") or pane_meta.get("peer_id")
-        if name:
-            _cached_peer_name = name
-            return name
-    _cached_peer_name = get_display_name()
-    return _cached_peer_name
+        if _metadata_matches_current_process(pane_meta):
+            name = pane_meta.get("display_name") or pane_meta.get("peer_id")
+            if name:
+                _cached_peer_name = name
+                return name
+    return get_display_name()
 
 
 def _detect_backend() -> str:
@@ -529,6 +555,7 @@ def create_mcp_server() -> FastMCP:
             Confirmation describing both the deregistration and the tmux
             pane outcome.
         """
+        await _ensure_registered(strict=True)
         payload: dict[str, str] = {
             "peer_identifier": peer_identifier,
             "from_peer": await _get_my_peer_name(),

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -64,12 +64,17 @@ async def daemon_request(
 async def _get_my_peer_name() -> str:
     """Get own peer name. Cached after first resolution.
 
-    Priority: REPOWIRE_DISPLAY_NAME env var > pane-based daemon lookup > cwd folder name.
+    Resolution order:
+    1. pane-based daemon lookup (most authoritative — handles suffix collisions)
+    2. pane runtime metadata file (written by SessionStart; covers the case
+       where the daemon hasn't yet finished registration on the first MCP
+       call, but the hook already wrote display_name to disk)
+    3. REPOWIRE_DISPLAY_NAME env var or cwd folder name (collides for
+       same-cwd peers — last resort, see #107)
     """
     global _cached_peer_name
     if _cached_peer_name is not None:
         return _cached_peer_name
-    # Pane-based lookup is most authoritative (handles suffix collisions)
     pane_id = get_pane_id()
     if pane_id:
         try:
@@ -80,7 +85,11 @@ async def _get_my_peer_name() -> str:
                 return name
         except Exception:
             pass
-    # Fall back to env var (set by session handler) or cwd folder name
+        pane_meta = read_pane_runtime_metadata(pane_id)
+        name = pane_meta.get("display_name") or pane_meta.get("peer_id")
+        if name:
+            _cached_peer_name = name
+            return name
     _cached_peer_name = get_display_name()
     return _cached_peer_name
 

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -8,6 +8,7 @@ daemon /peers/by-pane lookup misses.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -20,6 +21,19 @@ def reset_cache():
     mcp_server._cached_peer_name = None
     yield
     mcp_server._cached_peer_name = None
+
+
+def _matching_meta(extra: dict | None = None) -> dict:
+    """Build a metadata dict whose cwd+backend match the current process."""
+    base = {
+        "display_name": "proj-2-claude-code",
+        "peer_id": "p-2",
+        "cwd": str(Path.cwd()),
+        "backend": mcp_server._detect_backend(),
+    }
+    if extra:
+        base.update(extra)
+    return base
 
 
 @pytest.mark.asyncio
@@ -48,10 +62,88 @@ async def test_falls_back_to_pane_metadata_when_daemon_misses():
          patch.object(
              mcp_server,
              "read_pane_runtime_metadata",
-             return_value={"display_name": "proj-2-claude-code", "peer_id": "p-2"},
+             return_value=_matching_meta(),
          ):
         name = await mcp_server._get_my_peer_name()
     assert name == "proj-2-claude-code"
+
+
+@pytest.mark.asyncio
+async def test_rejects_stale_metadata_with_cwd_mismatch():
+    """Pane metadata can outlive the session that wrote it (daemon restart
+    + pane reuse). Reject metadata pointing at a different cwd — fall
+    through to cwd-folder fallback rather than mis-claiming identity."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("nope")
+
+    stale = _matching_meta({"cwd": "/some/other/abandoned/path"})
+
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=stale), \
+         patch.object(mcp_server, "get_display_name", return_value="current-folder"):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "current-folder"
+
+
+@pytest.mark.asyncio
+async def test_rejects_stale_metadata_with_backend_mismatch():
+    """Backend mismatch (e.g. codex peer reused a pane previously held by
+    claude-code) also disqualifies the metadata."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("nope")
+
+    stale = _matching_meta({"backend": "some-other-backend"})
+
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=stale), \
+         patch.object(mcp_server, "get_display_name", return_value="current-folder"):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "current-folder"
+
+
+@pytest.mark.asyncio
+async def test_rejects_metadata_missing_cwd_or_backend():
+    """Metadata without cwd+backend fields can't be validated — reject it."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("nope")
+
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(
+             mcp_server,
+             "read_pane_runtime_metadata",
+             return_value={"display_name": "ghost", "peer_id": "g"},
+         ), \
+         patch.object(mcp_server, "get_display_name", return_value="current-folder"):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "current-folder"
+
+
+@pytest.mark.asyncio
+async def test_cwd_fallback_not_cached():
+    """If we fell through to cwd-folder, the next call should re-attempt
+    daemon/metadata resolution — caching cwd-folder forever would lock in
+    a wrong (un-suffixed) name even after the daemon is back."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("nope")
+
+    with patch.object(mcp_server, "get_pane_id", return_value=None), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(mcp_server, "get_display_name", return_value="fallback"):
+        await mcp_server._get_my_peer_name()
+    assert mcp_server._cached_peer_name is None
+
+    # Daemon comes back; second call resolves to suffixed name via daemon
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(
+             mcp_server,
+             "daemon_request",
+             new=AsyncMock(return_value={"display_name": "proj-2", "peer_id": "p"}),
+         ):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "proj-2"
 
 
 @pytest.mark.asyncio
@@ -63,8 +155,8 @@ async def test_two_peers_same_cwd_resolve_distinctly():
         raise RuntimeError("registration race")
 
     pane_to_meta = {
-        "%10": {"display_name": "proj-claude-code", "peer_id": "p-1"},
-        "%20": {"display_name": "proj-2-claude-code", "peer_id": "p-2"},
+        "%10": _matching_meta({"display_name": "proj-claude-code", "peer_id": "p-1"}),
+        "%20": _matching_meta({"display_name": "proj-2-claude-code", "peer_id": "p-2"}),
     }
 
     async def resolve_for_pane(pane_id: str) -> str:
@@ -99,6 +191,32 @@ async def test_falls_back_to_get_display_name_when_no_metadata():
          patch.object(mcp_server, "get_display_name", return_value="cwd-folder"):
         name = await mcp_server._get_my_peer_name()
     assert name == "cwd-folder"
+
+
+def test_all_outbound_tools_strict_register():
+    """Every MCP tool that sends from_peer to the daemon must gate on
+    _ensure_registered(strict=True). Without this, the first MCP call
+    after a hook drop can race the registration and emit fallback
+    (cwd-folder) identity. kill_peer was missing this gate pre-#108 —
+    this audit prevents the regression class from coming back.
+    """
+    import inspect
+
+    from repowire.mcp import server as mod
+
+    source = inspect.getsource(mod)
+    # Outbound mesh tools that put from_peer / mutate other peers
+    outbound_tools = ["ask", "ack", "notify_peer", "broadcast", "kill_peer"]
+    # Locate each tool def + the next 30 lines, check for strict register
+    for tool in outbound_tools:
+        idx = source.find(f"async def {tool}(")
+        assert idx >= 0, f"Could not find {tool} in mcp/server.py"
+        body = source[idx : idx + 1500]
+        assert "_ensure_registered(strict=True)" in body, (
+            f"MCP tool {tool} must call _ensure_registered(strict=True) "
+            f"before sending; otherwise from_peer can race a hook drop. "
+            f"See PR #108 / Issue #107."
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -1,0 +1,115 @@
+"""Tests for MCP server self-identity resolution.
+
+Covers #107: when two peers share (cwd, backend), MCP must resolve its
+own from_peer name correctly. The fix relies on (a) ppid-chain pane
+discovery in hooks._tmux and (b) reading pane runtime metadata when the
+daemon /peers/by-pane lookup misses.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.mcp import server as mcp_server
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    mcp_server._cached_peer_name = None
+    yield
+    mcp_server._cached_peer_name = None
+
+
+@pytest.mark.asyncio
+async def test_resolves_via_daemon_by_pane():
+    """Primary path: daemon /peers/by-pane returns the display_name."""
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(
+             mcp_server, "daemon_request", new=AsyncMock(
+                 return_value={"display_name": "proj-2-claude-code", "peer_id": "p-2"}
+             )
+         ):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "proj-2-claude-code"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_pane_metadata_when_daemon_misses():
+    """Secondary path: when /peers/by-pane fails, read the on-disk metadata
+    written by SessionStart. This is the #107 fix — without it, two peers
+    sharing (cwd, backend) collide on the cwd-folder-name fallback."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("daemon unreachable / pane not registered yet")
+
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(
+             mcp_server,
+             "read_pane_runtime_metadata",
+             return_value={"display_name": "proj-2-claude-code", "peer_id": "p-2"},
+         ):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "proj-2-claude-code"
+
+
+@pytest.mark.asyncio
+async def test_two_peers_same_cwd_resolve_distinctly():
+    """Smoke: simulate peer 1 and peer 2 both in the same cwd but with
+    different pane_ids. With the fix, each resolves to its own display_name
+    via the metadata file (not the un-suffixed cwd folder name)."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("registration race")
+
+    pane_to_meta = {
+        "%10": {"display_name": "proj-claude-code", "peer_id": "p-1"},
+        "%20": {"display_name": "proj-2-claude-code", "peer_id": "p-2"},
+    }
+
+    async def resolve_for_pane(pane_id: str) -> str:
+        mcp_server._cached_peer_name = None
+        with patch.object(mcp_server, "get_pane_id", return_value=pane_id), \
+             patch.object(
+                 mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)
+             ), \
+             patch.object(
+                 mcp_server,
+                 "read_pane_runtime_metadata",
+                 side_effect=lambda pid: pane_to_meta.get(pid, {}),
+             ):
+            return await mcp_server._get_my_peer_name()
+
+    name_peer1 = await resolve_for_pane("%10")
+    name_peer2 = await resolve_for_pane("%20")
+    assert name_peer1 == "proj-claude-code"
+    assert name_peer2 == "proj-2-claude-code"
+    assert name_peer1 != name_peer2
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_get_display_name_when_no_metadata():
+    """Last resort: no pane, no metadata — use env/cwd-folder. Pre-#107
+    behavior preserved for the single-peer-per-cwd case."""
+    async def daemon_miss(*_args, **_kw):
+        raise RuntimeError("nope")
+
+    with patch.object(mcp_server, "get_pane_id", return_value=None), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
+         patch.object(mcp_server, "get_display_name", return_value="cwd-folder"):
+        name = await mcp_server._get_my_peer_name()
+    assert name == "cwd-folder"
+
+
+@pytest.mark.asyncio
+async def test_caches_after_first_resolution():
+    with patch.object(mcp_server, "get_pane_id", return_value="%42") as mock_pane, \
+         patch.object(
+             mcp_server,
+             "daemon_request",
+             new=AsyncMock(return_value={"display_name": "p", "peer_id": "x"}),
+         ):
+        await mcp_server._get_my_peer_name()
+        await mcp_server._get_my_peer_name()
+    # Second call short-circuits via cache
+    assert mock_pane.call_count == 1

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -507,10 +506,11 @@ class TestMcpSpawnPeerReturn:
         assert result != "prod:alpha-svc"
 
     @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
     @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
     @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
     async def test_kill_peer_uses_peer_identifier_not_tmux_session(
-        self, mock_request: AsyncMock, mock_my_name: AsyncMock,
+        self, mock_request: AsyncMock, mock_my_name: AsyncMock, _mock_register: AsyncMock,
     ) -> None:
         """kill_peer MCP tool should send mesh identity to the safe kill route."""
         from repowire.mcp.server import create_mcp_server
@@ -535,10 +535,11 @@ class TestMcpSpawnPeerReturn:
         assert "tmux pane killed" in result
 
     @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
     @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
     @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
     async def test_kill_peer_surfaces_skipped_tmux_kill(
-        self, mock_request: AsyncMock, mock_my_name: AsyncMock,
+        self, mock_request: AsyncMock, mock_my_name: AsyncMock, _mock_register: AsyncMock,
     ) -> None:
         """When the daemon returns tmux_killed=None (ownership not proven),
         the MCP tool must tell the caller — not silently report success."""
@@ -556,10 +557,11 @@ class TestMcpSpawnPeerReturn:
         assert "tmux kill-pane" in result
 
     @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
     @patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock)
     @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
     async def test_kill_peer_surfaces_failed_tmux_kill(
-        self, mock_request: AsyncMock, mock_my_name: AsyncMock,
+        self, mock_request: AsyncMock, mock_my_name: AsyncMock, _mock_register: AsyncMock,
     ) -> None:
         """When the daemon returns tmux_killed=False (kill attempted but failed),
         the MCP tool must surface the orphan-pane risk."""

--- a/tests/test_tmux_pane_resolution.py
+++ b/tests/test_tmux_pane_resolution.py
@@ -1,0 +1,99 @@
+"""Tests for ppid-chain pane resolution in hooks._tmux.
+
+Covers the multi-peer-same-cwd case from #107: when TMUX_PANE isn't
+inherited by an MCP subprocess, `tmux display-message` would return the
+focused pane (wrong peer). ppid-chain matching against `tmux list-panes`
+pane_pids resolves unambiguously.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from repowire.hooks import _tmux
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestPpidChainResolution:
+    def test_matches_ancestor_to_pane(self, monkeypatch):
+        monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+
+        # Two panes alive, neither focused matches our ancestry — only %2 does
+        list_panes = _completed("%1 1000\n%2 2000\n%3 3000\n")
+
+        def fake_run(cmd, **_kw):
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return list_panes
+            if cmd[:3] == ["ps", "-o", "ppid="]:
+                pid = int(cmd[-1])
+                # ancestry: getppid() -> 5000 -> 2000 -> 1 (stops)
+                return _completed({5000: "2000", 2000: "1"}.get(pid, "1"))
+            if cmd[:2] == ["tmux", "display-message"]:
+                return _completed("%3\n")  # focused pane, should NOT be used
+            return _completed("", 1)
+
+        with patch.object(_tmux.os, "getppid", return_value=5000), \
+             patch.object(_tmux.subprocess, "run", side_effect=fake_run):
+            assert _tmux.get_pane_id() == "%2"
+
+    def test_falls_through_to_display_message_when_no_match(self, monkeypatch):
+        """If ppid-chain breaks (e.g. re-parented to init), fall through."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+
+        list_panes = _completed("%1 1000\n%2 2000\n")
+
+        def fake_run(cmd, **_kw):
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return list_panes
+            if cmd[:3] == ["ps", "-o", "ppid="]:
+                return _completed("1")  # immediate detach to init
+            if cmd[:2] == ["tmux", "display-message"]:
+                return _completed("%1\n")
+            return _completed("", 1)
+
+        with patch.object(_tmux.os, "getppid", return_value=9999), \
+             patch.object(_tmux.subprocess, "run", side_effect=fake_run):
+            assert _tmux.get_pane_id() == "%1"
+
+    def test_tmux_pane_env_short_circuits(self, monkeypatch):
+        monkeypatch.setenv("TMUX_PANE", "%7")
+        assert _tmux.get_pane_id() == "%7"
+
+    def test_not_in_tmux_returns_none(self, monkeypatch):
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+        monkeypatch.delenv("TMUX", raising=False)
+        assert _tmux.get_pane_id() is None
+
+    def test_list_panes_failure_falls_through(self, monkeypatch):
+        monkeypatch.setenv("TMUX", "x")
+        monkeypatch.delenv("TMUX_PANE", raising=False)
+
+        def fake_run(cmd, **_kw):
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return _completed("", 1)
+            if cmd[:2] == ["tmux", "display-message"]:
+                return _completed("%5\n")
+            return _completed("", 1)
+
+        with patch.object(_tmux.subprocess, "run", side_effect=fake_run):
+            assert _tmux.get_pane_id() == "%5"
+
+    def test_ppid_chain_max_depth(self):
+        """Chain walk must terminate even on cycles or deep ancestries."""
+        def fake_run(cmd, **_kw):
+            if cmd[:3] == ["ps", "-o", "ppid="]:
+                # Always return self -> would loop forever without max_depth/seen
+                return _completed(cmd[-1])
+            return _completed("", 1)
+
+        with patch.object(_tmux.os, "getppid", return_value=100), \
+             patch.object(_tmux.subprocess, "run", side_effect=fake_run):
+            chain = _tmux._get_ppid_chain(max_depth=8)
+            assert len(chain) <= 8
+            assert 100 in chain


### PR DESCRIPTION
Closes #107.

## Problem

When two peers share `(cwd, backend)` — e.g. `proj-claude-code` and `proj-2-claude-code` spawned in the same worktree — MCP `_get_my_peer_name()` resolves to the **first** peer registered. Cross-peer asks/notifies/acks get mislabeled `from_peer`.

Two compounding failure modes:

1. **`get_pane_id()` fallback returns the focused pane.** When `TMUX_PANE` isn't inherited by the MCP subprocess, the old fallback ran `tmux display-message -p '#{pane_id}'`, which returns whichever pane the user is *looking at*, not the pane that spawned us.
2. **`_get_my_peer_name()` falls through to `Path.cwd().name`.** Collides for same-cwd peers and resolves to the un-suffixed (first-registered) name.

## Fix

**`hooks/_tmux.get_pane_id()`** — insert a ppid-chain step before the `display-message` fallback. Walks `getppid()` ancestry and matches against `tmux list-panes -F '#{pane_id} #{pane_pid}'`. The spawning pane's shell pid appears in our process ancestry and uniquely identifies the pane regardless of focus. macOS-compatible (uses `ps`, no `/proc`).

**`mcp/server._get_my_peer_name()`** — read pane runtime metadata (already written by SessionStart in `session_handler.py:252`) between the daemon `/peers/by-pane` call and the cwd fallback. The metadata file already contained `display_name` + `peer_id`; MCP just wasn't using it for self-identity outside of `_ensure_registered`.

## Risk documented in code

If Claude Code's MCP subprocess re-parents to init/launchd (daemonizes), the ancestor chain detaches from the pane shell and ppid-chain returns `None`. The caller falls through to `display-message` — same wrong behavior as before in the multi-peer case. There is no reliable workaround for the re-parented case; in practice Claude Code keeps MCP subprocesses attached. Debug-level logging records when ppid-chain fails so we can grep for unexpected fallthroughs.

## Live verification (this machine)

```
TMUX_PANE present:     ppid-chain → %299, get_pane_id() → %299 ✓
TMUX_PANE stripped:    ppid-chain → %299, display-message → %292 (focused) ✗
                       → get_pane_id() correctly returns %299
```

The bug reproduces by stripping `TMUX_PANE` (simulating Claude Code's MCP subprocess env) and confirming `display-message` returns the wrong pane while ppid-chain returns the right one.

## Tests

- `tests/test_tmux_pane_resolution.py` — 6 tests covering ppid-chain match, fall-through when no ancestor matches, env-var short-circuit, no-tmux case, list-panes failure, max-depth termination on cycles.
- `tests/test_mcp_peer_identity.py` — 5 tests covering daemon-by-pane primary path, metadata-file secondary path (the #107 fix), two-peers-same-cwd distinct resolution, cwd-folder last resort, cache short-circuit.

All 465 tests pass. ruff + ty clean. NO TAG per standing rule.

## Test plan
- [x] ppid-chain unit tests
- [x] MCP identity unit tests
- [x] Live runtime check on this machine (multi-pane tmux session)
- [ ] Multi-peer smoke after merge: spawn two claude-code peers in same worktree, confirm distinct `from_peer` in each direction