### PR TITLE
pi: add pi.dev runtime as 5th supported backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ select = ["E", "F", "I", "N", "W", "UP"]
 [tool.ruff.lint.per-file-ignores]
 # TypeScript plugin code embedded as string has long lines
 "repowire/installers/opencode.py" = ["E501"]
+"repowire/installers/pi.py" = ["E501"]
+# Test function names occasionally mirror camelCase API names being asserted.
+"tests/test_pi_installer.py" = ["N802"]
 
 [tool.ty.rules]
 # Suppress ty false positives (ty is pre-release)

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -180,9 +180,14 @@ def setup(
         _setup_gemini()
         agents_setup.append("gemini")
 
+    # Detect and set up Pi if pi CLI or config exists
+    if shutil.which("pi") or (Path.home() / ".pi").exists():
+        _setup_pi()
+        agents_setup.append("pi")
+
     if not agents_setup:
         console.print("[yellow]No agent types detected.[/]")
-        console.print("Install claude, codex, gemini, or opencode first.")
+        console.print("Install claude, codex, gemini, opencode, or pi first.")
         return
 
     console.print(f"[green]✓[/] Configured agents: {', '.join(agents_setup)}")
@@ -355,6 +360,7 @@ def uninstall(yes: bool) -> None:
     _uninstall_opencode()
     _uninstall_codex()
     _uninstall_gemini()
+    _uninstall_pi()
 
     # Remove config directory
     config_dir = Config.get_config_dir()
@@ -458,6 +464,19 @@ def _uninstall_gemini() -> None:
         pass
 
 
+def _uninstall_pi() -> None:
+    """Uninstall Pi components."""
+    from repowire.installers.pi import uninstall_extension
+
+    try:
+        if uninstall_extension():
+            console.print("[green]✓[/] Pi extension removed")
+        else:
+            console.print("[dim]Pi extension not installed[/]")
+    except Exception as e:
+        console.print(f"[yellow]![/] Failed to remove Pi extension: {e}")
+
+
 @main.command()
 def update() -> None:
     """Update repowire to the latest version, reinstall hooks, restart daemon."""
@@ -491,6 +510,8 @@ def update() -> None:
         _setup_codex()
     if shutil.which("gemini"):
         _setup_gemini()
+    if shutil.which("pi") or (Path.home() / ".pi").exists():
+        _setup_pi()
 
     # Restart daemon service if running
     from repowire.service.installer import get_service_status, restart_service
@@ -543,6 +564,15 @@ def status() -> None:
             console.print("  [yellow]✗[/] codex (hooks not installed)")
     else:
         console.print("  [dim]✗[/] codex (not detected)")
+
+    if shutil.which("pi") or (Path.home() / ".pi").exists():
+        from repowire.installers.pi import check_extension_installed as check_pi_ext
+        if check_pi_ext():
+            console.print("  [green]✓[/] pi (extension installed)")
+        else:
+            console.print("  [yellow]✗[/] pi (extension not installed)")
+    else:
+        console.print("  [dim]✗[/] pi (not detected)")
     console.print("")
 
     # Check daemon service
@@ -675,6 +705,17 @@ def _setup_gemini() -> None:
         console.print("[green]✓[/] Gemini MCP server configured")
     except Exception as e:
         console.print(f"[red]Failed to configure Gemini MCP: {e}[/]")
+
+
+def _setup_pi() -> None:
+    """Setup for Pi (pi.dev) agent type."""
+    from repowire.installers.pi import install_extension
+
+    try:
+        install_extension()
+        console.print("[green]✓[/] Pi extension installed")
+    except Exception as e:
+        console.print(f"[red]Failed to install Pi extension: {e}[/]")
 
 
 @main.command()

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -28,6 +28,7 @@ class AgentType(str, Enum):
     OPENCODE = "opencode"
     CODEX = "codex"
     GEMINI = "gemini"
+    PI = "pi"
 
 
 class RelayConfig(BaseModel):

--- a/repowire/installers/pi.py
+++ b/repowire/installers/pi.py
@@ -46,7 +46,6 @@ interface PendingQuery {
 // own PeerConn (its own WebSocket, peer_id, busy state, pending queries).
 interface PeerConn {
   sessionId: string;
-  sessionTitle: string | null;
   peerId: string | null;
   peerName: string;
   ws: WebSocket | null;
@@ -55,9 +54,8 @@ interface PeerConn {
   reconnectTimeout: ReturnType<typeof setTimeout> | null;
   reconnectAttempts: number;
   closed: boolean;
-  // Map of in-flight assistant turn -> correlation id, so message_end can
-  // flush the right pending query. Pi has no parent-message linkage like
-  // opencode; we track the active turn instead.
+  // Tracks the currently-streaming correlation. message_update deltas and
+  // turn_end finalize get routed to this pending query.
   activeTurnCorrelationId: string | null;
 }
 
@@ -131,8 +129,8 @@ function sanitizePeerName(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, "_") || "unknown";
 }
 
-function peerNameFor(folder: string, session: { id: string; title?: string | null }): string {
-  const slug = sanitizePeerName(session.title || session.id.slice(-8)).slice(0, 32) || session.id.slice(-8);
+function peerNameFor(folder: string, sessionId: string, sessionName: string | null): string {
+  const slug = sanitizePeerName(sessionName || sessionId.slice(-8)).slice(0, 32) || sessionId.slice(-8);
   return sanitizePeerName(folder + "-" + slug);
 }
 
@@ -275,14 +273,13 @@ async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>
   }
 }
 
-function ensurePeer(session: { id: string; title?: string | null }) {
-  if (peerBySession.has(session.id)) return;
+function ensurePeer(sessionId: string, sessionName: string | null) {
+  if (peerBySession.has(sessionId)) return;
   const folder = path.basename(projectPath) || "unknown";
   const conn: PeerConn = {
-    sessionId: session.id,
-    sessionTitle: session.title ?? null,
-    peerId: loadPeerId(projectPath, session.id),
-    peerName: peerNameFor(folder, session),
+    sessionId,
+    peerId: loadPeerId(projectPath, sessionId),
+    peerName: peerNameFor(folder, sessionId, sessionName),
     ws: null,
     pendingQueries: new Map(),
     busy: false,
@@ -291,7 +288,7 @@ function ensurePeer(session: { id: string; title?: string | null }) {
     closed: false,
     activeTurnCorrelationId: null,
   };
-  peerBySession.set(session.id, conn);
+  peerBySession.set(sessionId, conn);
   connectPeerWebSocket(conn);
 }
 
@@ -395,16 +392,13 @@ function cleanup() {
   peerBySession.clear();
 }
 
-// Resolve which PeerConn a tool call is attributed to. Pi's ExtensionContext
-// exposes the active session via ctx.sessionManager (readonly). When we can
-// read the active session id from there, look up the matching PeerConn.
+// Resolve which PeerConn a tool call is attributed to. ctx.sessionManager
+// exposes the active session id via getSessionId() (pi 0.74 ReadonlySessionManager).
 // Fall back to the first registered peer if the lookup fails (subagent
 // contexts, unknown shape, etc.).
-function callerPeer(ctx: unknown): { peerName: string; peerId: string | null } {
+function callerPeer(ctx: ExtensionContext | undefined): { peerName: string; peerId: string | null } {
   try {
-    const sm = (ctx as { sessionManager?: { getActiveSessionId?: () => string | null } } | undefined)
-      ?.sessionManager;
-    const activeId = sm?.getActiveSessionId?.();
+    const activeId = ctx?.sessionManager?.getSessionId?.();
     if (activeId) {
       const conn = peerBySession.get(activeId);
       if (conn) return { peerName: conn.peerName, peerId: conn.peerId };
@@ -424,6 +418,18 @@ export default async function repowireExtension(pi: ExtensionAPI) {
   // so the latest captured ctx remains valid for soft-inject branching.
   function capture(_event: unknown, ctx: ExtensionContext) {
     piCtx = ctx;
+  }
+
+  // Resolve "the peer for the currently active session" from a captured ctx.
+  // session_start carries no session id in pi 0.74 — we read it off ctx.sessionManager.
+  function activePeerFromCtx(ctx: ExtensionContext | undefined): PeerConn | undefined {
+    try {
+      const sid = ctx?.sessionManager?.getSessionId?.();
+      if (sid) return peerBySession.get(sid);
+    } catch {
+      /* fall through */
+    }
+    return undefined;
   }
 
   // Derive circle from tmux session name (matches Claude Code hooks).
@@ -446,25 +452,39 @@ export default async function repowireExtension(pi: ExtensionAPI) {
   // reload/fork) to avoid double-registration on session-tree navigation.
   // Fork creates a new session id we'll see via a later session_start
   // with reason "new" if it becomes a root session.
+  // session_start fires at boot (reason: "startup"), on resume/reload/fork
+  // navigation, and on /new. SessionStartEvent carries only `reason` and an
+  // optional previousSessionFile — the active session id is on ctx, not the
+  // event. We register a peer only on startup/new.
   pi.on("session_start", async (event, ctx) => {
     capture(event, ctx);
     const reason = (event as { reason?: string }).reason;
-    const sessionId = (event as { sessionId?: string; id?: string }).sessionId
-      || (event as { sessionId?: string; id?: string }).id;
-    const title = (event as { title?: string }).title ?? null;
-    if (!sessionId) return;
-    if (reason === "startup" || reason === "new") {
-      ensurePeer({ id: sessionId, title });
+    if (reason !== "startup" && reason !== "new") return;
+    try {
+      const sessionId = ctx.sessionManager.getSessionId?.();
+      if (!sessionId) {
+        console.warn("[repowire] session_start: no session id on ctx");
+        return;
+      }
+      let sessionName: string | null = null;
+      try { sessionName = ctx.sessionManager.getSessionName?.() ?? null; } catch { /* optional */ }
+      ensurePeer(sessionId, sessionName);
+    } catch (e) {
+      console.warn("[repowire] session_start handler failed:", e);
     }
-    // resume/reload/fork: peer already registered (or will be by the
-    // matching startup/new event). No-op here.
   });
 
+  // session_shutdown carries `reason` ("quit" | "reload" | "new" | "resume" | "fork").
+  // Pi tears down the extension runtime on quit/reload/new/resume/fork. Disconnect
+  // the active peer cleanly.
   pi.on("session_shutdown", async (event, ctx) => {
     capture(event, ctx);
-    const sessionId = (event as { sessionId?: string; id?: string }).sessionId
-      || (event as { sessionId?: string; id?: string }).id;
-    if (sessionId) removePeer(sessionId);
+    try {
+      const sessionId = ctx.sessionManager.getSessionId?.();
+      if (sessionId) removePeer(sessionId);
+    } catch {
+      /* swallow — we're tearing down */
+    }
   });
 
   // Scaffold for pre-compact handling. Out of scope for v1: in the future,
@@ -484,41 +504,38 @@ export default async function repowireExtension(pi: ExtensionAPI) {
 
   pi.on("turn_end", async (event, ctx) => {
     capture(event, ctx);
-    for (const conn of peerBySession.values()) {
-      const cid = conn.activeTurnCorrelationId;
-      if (!cid) continue;
+    // Finalize: route to the active session's peer only. If the turn was
+    // driven by handleIncomingQuery, activeTurnCorrelationId is set.
+    const conn = activePeerFromCtx(ctx);
+    if (!conn) return;
+    const cid = conn.activeTurnCorrelationId;
+    if (cid) {
       flushPending(conn, cid);
       conn.activeTurnCorrelationId = null;
-      conn.busy = false;
-      sendStatus(conn, "idle");
     }
+    conn.busy = false;
+    sendStatus(conn, "idle");
   });
 
+  // message_update carries an assistantMessageEvent union. text_delta gives
+  // us new text chunks. error type gives us the final error if streaming
+  // failed (no errorMessage on message_end in pi 0.74). thinking_delta is
+  // discarded — we only want answer text.
   pi.on("message_update", async (event, ctx) => {
     capture(event, ctx);
-    const delta = (event as { delta?: string; text?: string }).delta
-      || (event as { delta?: string; text?: string }).text;
-    if (typeof delta !== "string" || !delta) return;
-    for (const conn of peerBySession.values()) {
-      const cid = conn.activeTurnCorrelationId;
-      if (!cid) continue;
-      const pending = conn.pendingQueries.get(cid);
-      if (!pending) continue;
-      pending.buffer.push(delta);
-    }
-  });
-
-  pi.on("message_end", async (event, ctx) => {
-    capture(event, ctx);
-    const error = (event as { error?: unknown }).error;
-    if (!error) return;
-    for (const conn of peerBySession.values()) {
-      const cid = conn.activeTurnCorrelationId;
-      if (!cid) continue;
-      const pending = conn.pendingQueries.get(cid);
-      if (!pending) continue;
+    const ame = (event as { assistantMessageEvent?: { type?: string; delta?: string; error?: unknown; reason?: string } }).assistantMessageEvent;
+    if (!ame) return;
+    const conn = activePeerFromCtx(ctx);
+    if (!conn) return;
+    const cid = conn.activeTurnCorrelationId;
+    if (!cid) return;
+    const pending = conn.pendingQueries.get(cid);
+    if (!pending) return;
+    if (ame.type === "text_delta" && typeof ame.delta === "string") {
+      pending.buffer.push(ame.delta);
+    } else if (ame.type === "error") {
       pending.hasError = true;
-      pending.errorPayload = error;
+      pending.errorPayload = ame.error ?? ame.reason ?? "stream error";
     }
   });
 
@@ -534,6 +551,7 @@ export default async function repowireExtension(pi: ExtensionAPI) {
   // strictly requires TypeBox, swap in Type.Object().
   pi.registerTool({
     name: "list_peers",
+    label: "Repowire: list peers",
     description: "List all available peers in the mesh network",
     parameters: Type.Object({}),
     async execute(_id, _params, _signal, _onUpdate, ctx) {
@@ -544,12 +562,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
         const project = p.metadata?.project || "";
         rows.push([p.peer_id || "", p.display_name || p.name || "", project, p.circle || "", p.status || "", p.path || "", p.description || ""].join("\t"));
       }
-      return { content: [{ type: "text", text: rows.join("\n") }] };
+      return { content: [{ type: "text", text: rows.join("\n") }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "ask",
+    label: "Repowire: ask peer",
     description: "Open a non-blocking ask thread with a peer. Returns a correlation_id immediately. The peer responds via ack(corr_id) (bare close) or ack(corr_id, message) (reply, delivered as a notification framed [ack #cid from @peer] message).",
     parameters: Type.Object({
       peer_name: Type.String({ description: "Name of the peer to ask" }),
@@ -566,12 +585,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
       if (params.reply_to) body.reply_to = params.reply_to;
       const result = await daemon("/ask", body);
       if (result.error) throw new Error(result.error);
-      return { content: [{ type: "text", text: result.correlation_id || "" }] };
+      return { content: [{ type: "text", text: result.correlation_id || "" }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "ack",
+    label: "Repowire: ack thread",
     description: "Close an open ask thread. Bare close: ack(corr_id). Reply: ack(corr_id, message) -- delivered to the original asker.",
     parameters: Type.Object({
       correlation_id: Type.String({ description: "The ask's correlation_id" }),
@@ -586,12 +606,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
       if (params.message !== undefined) body.message = params.message;
       await daemon("/ack", body);
       const text = "acked #" + params.correlation_id + (params.message ? " with reply" : "");
-      return { content: [{ type: "text", text }] };
+      return { content: [{ type: "text", text }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "notify_peer",
+    label: "Repowire: notify peer",
     description: "Send a notification to another peer (fire-and-forget)",
     parameters: Type.Object({
       peer_name: Type.String({ description: "Name of the peer" }),
@@ -604,12 +625,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
         to_peer: params.peer_name,
         text: params.message,
       });
-      return { content: [{ type: "text", text: "Notification sent" }] };
+      return { content: [{ type: "text", text: "Notification sent" }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "broadcast",
+    label: "Repowire: broadcast",
     description: "Broadcast a message to all peers in the mesh",
     parameters: Type.Object({
       message: Type.String({ description: "Message to broadcast" }),
@@ -626,12 +648,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
         const fails = result.failed.map((f: { peer: string; error: string }) => f.peer + " (" + f.error + ")").join(", ");
         parts.push("Failed: " + fails);
       }
-      return { content: [{ type: "text", text: parts.join("; ") }] };
+      return { content: [{ type: "text", text: parts.join("; ") }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "whoami",
+    label: "Repowire: whoami",
     description: "Get information about this peer in the mesh",
     parameters: Type.Object({}),
     async execute(_id, _params, _signal, _onUpdate, ctx) {
@@ -642,17 +665,18 @@ export default async function repowireExtension(pi: ExtensionAPI) {
         const project = result.metadata?.project || "";
         const header = "peer_id\tname\tproject\tcircle\tstatus\tpath\tmachine\tdescription";
         const row = [result.peer_id || "", result.display_name || result.name || "", project, result.circle || "", result.status || "", result.path || "", result.machine || "", result.description || ""].join("\t");
-        return { content: [{ type: "text", text: header + "\n" + row }] };
+        return { content: [{ type: "text", text: header + "\n" + row }], details: undefined };
       } catch {
         const text = "peer_id\tname\tproject\tcircle\tstatus\tpath\tmachine\tdescription\n"
           + (me.peerId || "") + "\t" + me.peerName + "\t\t\tnot registered\t\t\t";
-        return { content: [{ type: "text", text }] };
+        return { content: [{ type: "text", text }], details: undefined };
       }
     },
   });
 
   pi.registerTool({
     name: "set_description",
+    label: "Repowire: set description",
     description: "Update your task description, visible to other peers via list_peers. Call this at the start of a task.",
     parameters: Type.Object({
       description: Type.String({ description: "Short description of your current task" }),
@@ -660,12 +684,13 @@ export default async function repowireExtension(pi: ExtensionAPI) {
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const me = callerPeer(ctx);
       await daemon("/peers/" + encodeURIComponent(me.peerName) + "/description", { description: params.description });
-      return { content: [{ type: "text", text: "description updated: " + params.description }] };
+      return { content: [{ type: "text", text: "description updated: " + params.description }], details: undefined };
     },
   });
 
   pi.registerTool({
     name: "set_circle",
+    label: "Repowire: set circle",
     description: "Join a named circle to communicate with peers in that circle. Applies to all sessions in this pi process (circle is process-wide so reconnects keep it).",
     parameters: Type.Object({
       circle: Type.String({ description: "Circle name to join (e.g., 'dev', 'frontend')" }),
@@ -682,7 +707,7 @@ export default async function repowireExtension(pi: ExtensionAPI) {
       const text = sent > 0
         ? "Joined circle: " + params.circle + " (" + sent + " session peer" + (sent === 1 ? "" : "s") + ")"
         : "Circle queued: " + params.circle + " (will apply on reconnect)";
-      return { content: [{ type: "text", text }] };
+      return { content: [{ type: "text", text }], details: undefined };
     },
   });
 }

--- a/repowire/installers/pi.py
+++ b/repowire/installers/pi.py
@@ -1,0 +1,732 @@
+"""Pi (pi.dev) extension installer.
+
+Pi is an opencode-shaped runtime: integration is via TypeScript extensions
+auto-loaded from ~/.pi/agent/extensions/, not subprocess hooks. See
+docs/latest/extensions on pi.dev. The extension uses pi.on() event handlers
+and pi.registerTool() to register the same mesh tools other runtimes expose
+(list_peers, ask, ack, notify_peer, broadcast, whoami, set_description,
+set_circle).
+
+Per-session peer registration follows the same pattern as installers/opencode.py:
+each root pi session gets its own PeerConn (own WebSocket, own peer_id), with
+peer_ids cached at ~/.cache/repowire/pi-peer-ids.json so they survive process
+restarts. Pi's session_start event fires eagerly at process boot with
+reason "startup", so no post_spawn_warmup nudge is needed (unlike codex).
+
+Pi has no MCP server config surface, so the daemon's MCP server is not
+installed for pi peers. All tools are carried by the extension directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_CONTENT = r"""import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+interface PeerInfo {
+  name: string;
+  status: string;
+  machine?: string;
+  path?: string;
+}
+
+interface PendingQuery {
+  correlationId: string;
+  buffer: string[];
+  hasError: boolean;
+  errorPayload: unknown;
+  timeoutHandle: ReturnType<typeof setTimeout>;
+}
+
+// Per-session peer connection. Each root session in the pi process gets its
+// own PeerConn (its own WebSocket, peer_id, busy state, pending queries).
+interface PeerConn {
+  sessionId: string;
+  sessionTitle: string | null;
+  peerId: string | null;
+  peerName: string;
+  ws: WebSocket | null;
+  pendingQueries: Map<string, PendingQuery>;
+  busy: boolean;
+  reconnectTimeout: ReturnType<typeof setTimeout> | null;
+  reconnectAttempts: number;
+  closed: boolean;
+  // Map of in-flight assistant turn -> correlation id, so message_end can
+  // flush the right pending query. Pi has no parent-message linkage like
+  // opencode; we track the active turn instead.
+  activeTurnCorrelationId: string | null;
+}
+
+const DAEMON_URL = process.env.REPOWIRE_DAEMON_URL || "http://127.0.0.1:8377";
+const DAEMON_WS_URL = process.env.REPOWIRE_DAEMON_WS_URL || "ws://127.0.0.1:8377/ws";
+const AUTH_TOKEN = process.env.REPOWIRE_AUTH_TOKEN || "";
+const QUERY_TIMEOUT_MS = 120_000;
+const MAX_RECONNECT_ATTEMPTS = 50;
+
+// Module state (process-wide, not per-session).
+let projectPath: string = process.cwd();
+let circle: string = "default";
+let tmuxSession: string | undefined = undefined;
+let tmuxPane: string | undefined = undefined;
+
+// Per-session registries.
+const peerBySession = new Map<string, PeerConn>();
+
+// peer_id persistence: pi may restart, and any in-memory peer_id is lost.
+// Cache per (projectPath, sessionId) so each session reuses its peer_id
+// across restarts (same approach as opencode-peer-ids.json).
+const PEER_ID_CACHE_PATH = path.join(os.homedir(), ".cache", "repowire", "pi-peer-ids.json");
+
+function cacheKey(projectPath: string, sessionId: string): string {
+  return projectPath + "#" + sessionId;
+}
+
+function loadPeerId(projectPath: string, sessionId: string): string | null {
+  try {
+    if (!fs.existsSync(PEER_ID_CACHE_PATH)) return null;
+    const raw = fs.readFileSync(PEER_ID_CACHE_PATH, "utf-8");
+    const data = JSON.parse(raw) as Record<string, string>;
+    return data[cacheKey(projectPath, sessionId)] ?? null;
+  } catch (e) {
+    console.debug("[repowire] Failed to load peer_id cache:", e);
+    return null;
+  }
+}
+
+function savePeerId(projectPath: string, sessionId: string, id: string): void {
+  try {
+    fs.mkdirSync(path.dirname(PEER_ID_CACHE_PATH), { recursive: true });
+    let data: Record<string, string> = {};
+    if (fs.existsSync(PEER_ID_CACHE_PATH)) {
+      try {
+        data = JSON.parse(fs.readFileSync(PEER_ID_CACHE_PATH, "utf-8")) as Record<string, string>;
+      } catch {
+        data = {};
+      }
+    }
+    const key = cacheKey(projectPath, sessionId);
+    if (data[key] === id) return;
+    data[key] = id;
+    fs.writeFileSync(PEER_ID_CACHE_PATH, JSON.stringify(data, null, 2));
+  } catch (e) {
+    console.debug("[repowire] Failed to save peer_id cache:", e);
+  }
+}
+
+async function daemon(p: string, body?: object) {
+  const res = await fetch(DAEMON_URL + p, {
+    method: body ? "POST" : "GET",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error("Daemon error: " + res.status);
+  return res.json();
+}
+
+function sanitizePeerName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_") || "unknown";
+}
+
+function peerNameFor(folder: string, session: { id: string; title?: string | null }): string {
+  const slug = sanitizePeerName(session.title || session.id.slice(-8)).slice(0, 32) || session.id.slice(-8);
+  return sanitizePeerName(folder + "-" + slug);
+}
+
+function connectPeerWebSocket(conn: PeerConn) {
+  if (conn.closed) return;
+  if (conn.ws?.readyState === WebSocket.OPEN) return;
+
+  const ws = new WebSocket(DAEMON_WS_URL);
+  conn.ws = ws;
+
+  ws.onopen = () => {
+    conn.reconnectAttempts = 0;
+    const connectMsg: Record<string, unknown> = {
+      type: "connect",
+      display_name: conn.peerName,
+      circle,
+      backend: "pi",
+      path: projectPath,
+    };
+    const cachedPeerId = conn.peerId || loadPeerId(projectPath, conn.sessionId);
+    if (cachedPeerId) connectMsg.peer_id = cachedPeerId;
+    if (tmuxSession) connectMsg.tmux_session = tmuxSession;
+    if (tmuxPane) connectMsg.pane_id = tmuxPane;
+    if (AUTH_TOKEN) connectMsg.auth_token = AUTH_TOKEN;
+    ws.send(JSON.stringify(connectMsg));
+  };
+
+  ws.onmessage = async (event) => {
+    try {
+      const data = JSON.parse(event.data.toString());
+      await handleDaemonMessage(conn, data);
+    } catch (e) {
+      console.error("[repowire] Failed to parse daemon message for " + conn.peerName + ":", e);
+    }
+  };
+
+  ws.onclose = () => {
+    if (conn.closed) return;
+    console.debug("[repowire] WebSocket disconnected for " + conn.peerName + ", scheduling reconnect");
+    schedulePeerReconnect(conn);
+  };
+
+  ws.onerror = (err) => {
+    console.error("[repowire] WebSocket error for " + conn.peerName + ":", err);
+  };
+}
+
+function schedulePeerReconnect(conn: PeerConn) {
+  if (conn.closed) return;
+  if (conn.reconnectTimeout) clearTimeout(conn.reconnectTimeout);
+  conn.reconnectAttempts++;
+  if (conn.reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+    console.error("[repowire] Exhausted reconnect attempts for " + conn.peerName + ", giving up");
+    return;
+  }
+  const delay = Math.min(3000 * Math.pow(2, conn.reconnectAttempts - 1), 60000);
+  conn.reconnectTimeout = setTimeout(() => connectPeerWebSocket(conn), delay);
+}
+
+function sendStatus(conn: PeerConn, status: "busy" | "idle" | "offline") {
+  if (conn.ws?.readyState === WebSocket.OPEN) {
+    conn.ws.send(JSON.stringify({ type: "status", status }));
+  }
+}
+
+function sendResponse(conn: PeerConn, correlationId: string, text: string) {
+  if (conn.ws?.readyState === WebSocket.OPEN) {
+    conn.ws.send(JSON.stringify({ type: "response", correlation_id: correlationId, text }));
+  }
+}
+
+function sendError(conn: PeerConn, correlationId: string, error: string) {
+  if (conn.ws?.readyState === WebSocket.OPEN) {
+    conn.ws.send(JSON.stringify({ type: "error", correlation_id: correlationId, error }));
+  }
+}
+
+// Module-level references set in the extension factory. softInject branches
+// on agent state via ctx.isIdle(): when idle, omit deliverAs; while streaming,
+// use "steer" to interrupt and surface the inbound asks/notifications.
+let piApi: ExtensionAPI | null = null;
+let piCtx: ExtensionContext | null = null;
+
+async function softInject(text: string): Promise<boolean> {
+  if (!piApi) {
+    console.warn("[repowire] No pi API available for soft inject");
+    return false;
+  }
+  try {
+    const idle = piCtx ? piCtx.isIdle() : true;
+    if (idle) {
+      piApi.sendUserMessage(text);
+    } else {
+      piApi.sendUserMessage(text, { deliverAs: "steer" });
+    }
+    return true;
+  } catch (e) {
+    console.warn("[repowire] Failed to soft-inject:", e);
+    return false;
+  }
+}
+
+async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>) {
+  const msgType = data.type as string;
+
+  if (msgType === "connected") {
+    if (data.session_id) {
+      conn.peerId = data.session_id as string;
+      console.debug("[repowire] " + conn.peerName + " connected with peer_id: " + conn.peerId);
+      savePeerId(projectPath, conn.sessionId, conn.peerId);
+    }
+    sendStatus(conn, conn.busy ? "busy" : "idle");
+  } else if (msgType === "query") {
+    const correlationId = data.correlation_id as string;
+    const fromPeer = data.from_peer as string;
+    const text = data.text as string;
+    await handleIncomingQuery(conn, correlationId, fromPeer, text);
+  } else if (msgType === "ask") {
+    // First-class ask: surface with [ask #cid] framing so the agent can
+    // ack via the ack tool. Daemon doesn't track pickup -- open asks are
+    // surfaced via Stop hook reminders until acked. Pi has no Stop hook;
+    // reminder is delivered via a steer message instead.
+    const correlationId = data.correlation_id as string;
+    const fromPeer = (data.from_peer as string) || "unknown";
+    const text = data.text as string;
+    await softInject(
+      "@" + fromPeer + " → " + conn.peerName + " [ask #" + correlationId + "]: " + text,
+    );
+  } else if (msgType === "ping") {
+    if (conn.ws?.readyState === WebSocket.OPEN) {
+      conn.ws.send(JSON.stringify({ type: "pong", pane_alive: true }));
+    }
+  } else if (msgType === "notify" || msgType === "broadcast") {
+    const fromPeer = (data.from_peer as string) || "unknown";
+    const text = data.text as string;
+    const prefix = msgType === "broadcast" ? "[broadcast] " : "";
+    await softInject("@" + fromPeer + " → " + conn.peerName + ": " + prefix + text);
+  } else if (msgType === "permission_response") {
+    return;
+  }
+}
+
+function ensurePeer(session: { id: string; title?: string | null }) {
+  if (peerBySession.has(session.id)) return;
+  const folder = path.basename(projectPath) || "unknown";
+  const conn: PeerConn = {
+    sessionId: session.id,
+    sessionTitle: session.title ?? null,
+    peerId: loadPeerId(projectPath, session.id),
+    peerName: peerNameFor(folder, session),
+    ws: null,
+    pendingQueries: new Map(),
+    busy: false,
+    reconnectTimeout: null,
+    reconnectAttempts: 0,
+    closed: false,
+    activeTurnCorrelationId: null,
+  };
+  peerBySession.set(session.id, conn);
+  connectPeerWebSocket(conn);
+}
+
+function removePeer(sessionId: string) {
+  const conn = peerBySession.get(sessionId);
+  if (!conn) return;
+  conn.closed = true;
+  if (conn.reconnectTimeout) {
+    clearTimeout(conn.reconnectTimeout);
+    conn.reconnectTimeout = null;
+  }
+  for (const [, pending] of conn.pendingQueries) {
+    clearTimeout(pending.timeoutHandle);
+    sendError(conn, pending.correlationId, "session deleted");
+  }
+  conn.pendingQueries.clear();
+  if (conn.ws) {
+    sendStatus(conn, "offline");
+    try { conn.ws.close(); } catch { /* ignore */ }
+    conn.ws = null;
+  }
+  peerBySession.delete(sessionId);
+}
+
+// Inbound query handler. Pi's sendUserMessage triggers an agent response;
+// we capture the next assistant turn via turn_start/message_update/turn_end
+// events and resolve the pending query when the turn ends.
+async function handleIncomingQuery(conn: PeerConn, correlationId: string, _fromPeer: string, text: string) {
+  if (!piApi) {
+    sendError(conn, correlationId, "Pi API not available");
+    return;
+  }
+
+  // Concurrency guard: pi has a single active turn per session, so two
+  // concurrent queries would overlap. Reject the second cleanly.
+  if (conn.busy || conn.activeTurnCorrelationId) {
+    sendError(conn, correlationId, "Session busy: another query is already in flight on this peer");
+    return;
+  }
+
+  conn.busy = true;
+  sendStatus(conn, "busy");
+  conn.activeTurnCorrelationId = correlationId;
+
+  const pending: PendingQuery = {
+    correlationId,
+    buffer: [],
+    hasError: false,
+    errorPayload: null,
+    timeoutHandle: setTimeout(() => {
+      if (conn.pendingQueries.has(correlationId)) {
+        conn.pendingQueries.delete(correlationId);
+        if (conn.activeTurnCorrelationId === correlationId) {
+          conn.activeTurnCorrelationId = null;
+        }
+        sendError(conn, correlationId, "Query timed out waiting for pi response");
+      }
+    }, QUERY_TIMEOUT_MS),
+  };
+  conn.pendingQueries.set(correlationId, pending);
+
+  try {
+    piApi.sendUserMessage(text);
+  } catch (e) {
+    clearTimeout(pending.timeoutHandle);
+    conn.pendingQueries.delete(correlationId);
+    conn.activeTurnCorrelationId = null;
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    console.error("[repowire] sendUserMessage failed for " + conn.peerName + ": " + errorMsg);
+    sendError(conn, correlationId, errorMsg);
+    conn.busy = false;
+    sendStatus(conn, "idle");
+  }
+}
+
+function flushPending(conn: PeerConn, correlationId: string) {
+  const pending = conn.pendingQueries.get(correlationId);
+  if (!pending) return;
+  clearTimeout(pending.timeoutHandle);
+  const reply = pending.buffer.join("");
+  if (pending.hasError) {
+    sendResponse(conn, correlationId, "Model error: " + JSON.stringify(pending.errorPayload));
+  } else if (reply) {
+    sendResponse(conn, correlationId, reply);
+  } else {
+    sendResponse(conn, correlationId, "(empty response: session ended turn without text output)");
+  }
+  conn.pendingQueries.delete(correlationId);
+}
+
+function cleanup() {
+  for (const conn of peerBySession.values()) {
+    conn.closed = true;
+    if (conn.reconnectTimeout) clearTimeout(conn.reconnectTimeout);
+    if (conn.ws) {
+      sendStatus(conn, "offline");
+      try { conn.ws.close(); } catch { /* ignore */ }
+      conn.ws = null;
+    }
+  }
+  peerBySession.clear();
+}
+
+// Resolve which PeerConn a tool call is attributed to. Pi's ExtensionContext
+// exposes the active session via ctx.sessionManager (readonly). When we can
+// read the active session id from there, look up the matching PeerConn.
+// Fall back to the first registered peer if the lookup fails (subagent
+// contexts, unknown shape, etc.).
+function callerPeer(ctx: unknown): { peerName: string; peerId: string | null } {
+  try {
+    const sm = (ctx as { sessionManager?: { getActiveSessionId?: () => string | null } } | undefined)
+      ?.sessionManager;
+    const activeId = sm?.getActiveSessionId?.();
+    if (activeId) {
+      const conn = peerBySession.get(activeId);
+      if (conn) return { peerName: conn.peerName, peerId: conn.peerId };
+    }
+  } catch {
+    /* fall through */
+  }
+  const first = peerBySession.values().next().value as PeerConn | undefined;
+  if (first) return { peerName: first.peerName, peerId: first.peerId };
+  return { peerName: sanitizePeerName(path.basename(projectPath) || "unknown"), peerId: null };
+}
+
+export default async function repowireExtension(pi: ExtensionAPI) {
+  piApi = pi;
+  // Capture ctx from event handlers as they fire. ctx is staled by
+  // newSession/fork/switchSession/reload, but repowire never invokes those,
+  // so the latest captured ctx remains valid for soft-inject branching.
+  function capture(_event: unknown, ctx: ExtensionContext) {
+    piCtx = ctx;
+  }
+
+  // Derive circle from tmux session name (matches Claude Code hooks).
+  tmuxPane = process.env.TMUX_PANE;
+  if (process.env.TMUX && tmuxPane) {
+    try {
+      const { execFileSync } = require("child_process");
+      const session = execFileSync("tmux", ["display-message", "-t", tmuxPane, "-p", "#S"], { encoding: "utf-8" }).trim();
+      const window = execFileSync("tmux", ["display-message", "-t", tmuxPane, "-p", "#W"], { encoding: "utf-8" }).trim();
+      if (session) {
+        circle = session;
+        if (window) tmuxSession = session + ":" + window;
+      }
+    } catch (e) {
+      console.warn("[repowire] Failed to derive circle from tmux:", e);
+    }
+  }
+
+  // Session lifecycle. Register peer only on startup/new (not on resume/
+  // reload/fork) to avoid double-registration on session-tree navigation.
+  // Fork creates a new session id we'll see via a later session_start
+  // with reason "new" if it becomes a root session.
+  pi.on("session_start", async (event, ctx) => {
+    capture(event, ctx);
+    const reason = (event as { reason?: string }).reason;
+    const sessionId = (event as { sessionId?: string; id?: string }).sessionId
+      || (event as { sessionId?: string; id?: string }).id;
+    const title = (event as { title?: string }).title ?? null;
+    if (!sessionId) return;
+    if (reason === "startup" || reason === "new") {
+      ensurePeer({ id: sessionId, title });
+    }
+    // resume/reload/fork: peer already registered (or will be by the
+    // matching startup/new event). No-op here.
+  });
+
+  pi.on("session_shutdown", async (event, ctx) => {
+    capture(event, ctx);
+    const sessionId = (event as { sessionId?: string; id?: string }).sessionId
+      || (event as { sessionId?: string; id?: string }).id;
+    if (sessionId) removePeer(sessionId);
+  });
+
+  // Scaffold for pre-compact handling. Out of scope for v1: in the future,
+  // we may surface "your ask thread is about to be compacted" notifications
+  // here so callers can re-issue or accept context loss. See PR body.
+  pi.on("session_before_compact", async (event, ctx) => {
+    capture(event, ctx);
+    // no-op v1
+  });
+
+  pi.on("turn_start", async (event, ctx) => {
+    capture(event, ctx);
+    // Active correlation already set by handleIncomingQuery before
+    // sendUserMessage. Nothing to do here unless we later support
+    // detecting human-driven turns separately.
+  });
+
+  pi.on("turn_end", async (event, ctx) => {
+    capture(event, ctx);
+    for (const conn of peerBySession.values()) {
+      const cid = conn.activeTurnCorrelationId;
+      if (!cid) continue;
+      flushPending(conn, cid);
+      conn.activeTurnCorrelationId = null;
+      conn.busy = false;
+      sendStatus(conn, "idle");
+    }
+  });
+
+  pi.on("message_update", async (event, ctx) => {
+    capture(event, ctx);
+    const delta = (event as { delta?: string; text?: string }).delta
+      || (event as { delta?: string; text?: string }).text;
+    if (typeof delta !== "string" || !delta) return;
+    for (const conn of peerBySession.values()) {
+      const cid = conn.activeTurnCorrelationId;
+      if (!cid) continue;
+      const pending = conn.pendingQueries.get(cid);
+      if (!pending) continue;
+      pending.buffer.push(delta);
+    }
+  });
+
+  pi.on("message_end", async (event, ctx) => {
+    capture(event, ctx);
+    const error = (event as { error?: unknown }).error;
+    if (!error) return;
+    for (const conn of peerBySession.values()) {
+      const cid = conn.activeTurnCorrelationId;
+      if (!cid) continue;
+      const pending = conn.pendingQueries.get(cid);
+      if (!pending) continue;
+      pending.hasError = true;
+      pending.errorPayload = error;
+    }
+  });
+
+  // beforeExit fires when the event loop is empty; cleanup is best-effort.
+  // Signal handlers are one-shot and re-emit the default termination so
+  // Node still exits cleanly.
+  process.on("beforeExit", cleanup);
+  process.once("SIGINT", () => { try { cleanup(); } finally { process.exit(130); } });
+  process.once("SIGTERM", () => { try { cleanup(); } finally { process.exit(143); } });
+
+  // Tools. Pi's parameter schema uses TypeBox; we use bare-shape objects
+  // here for portability since pi's docs show both patterns. If pi
+  // strictly requires TypeBox, swap in Type.Object().
+  pi.registerTool({
+    name: "list_peers",
+    description: "List all available peers in the mesh network",
+    parameters: Type.Object({}),
+    async execute(_id, _params, _signal, _onUpdate, ctx) {
+      const result = await daemon("/peers");
+      const peers = result.peers || [];
+      const rows = ["peer_id\tname\tproject\tcircle\tstatus\tpath\tdescription"];
+      for (const p of peers) {
+        const project = p.metadata?.project || "";
+        rows.push([p.peer_id || "", p.display_name || p.name || "", project, p.circle || "", p.status || "", p.path || "", p.description || ""].join("\t"));
+      }
+      return { content: [{ type: "text", text: rows.join("\n") }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "ask",
+    description: "Open a non-blocking ask thread with a peer. Returns a correlation_id immediately. The peer responds via ack(corr_id) (bare close) or ack(corr_id, message) (reply, delivered as a notification framed [ack #cid from @peer] message).",
+    parameters: Type.Object({
+      peer_name: Type.String({ description: "Name of the peer to ask" }),
+      query: Type.String({ description: "The question to ask" }),
+      reply_to: Type.Optional(Type.String({ description: "If set, closes that prior ask before opening this one" })),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      const body: Record<string, unknown> = {
+        from_peer: me.peerName,
+        to_peer: params.peer_name,
+        text: params.query,
+      };
+      if (params.reply_to) body.reply_to = params.reply_to;
+      const result = await daemon("/ask", body);
+      if (result.error) throw new Error(result.error);
+      return { content: [{ type: "text", text: result.correlation_id || "" }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "ack",
+    description: "Close an open ask thread. Bare close: ack(corr_id). Reply: ack(corr_id, message) -- delivered to the original asker.",
+    parameters: Type.Object({
+      correlation_id: Type.String({ description: "The ask's correlation_id" }),
+      message: Type.Optional(Type.String({ description: "Optional reply content" })),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      const body: Record<string, unknown> = {
+        correlation_id: params.correlation_id,
+        from_peer: me.peerName,
+      };
+      if (params.message !== undefined) body.message = params.message;
+      await daemon("/ack", body);
+      const text = "acked #" + params.correlation_id + (params.message ? " with reply" : "");
+      return { content: [{ type: "text", text }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "notify_peer",
+    description: "Send a notification to another peer (fire-and-forget)",
+    parameters: Type.Object({
+      peer_name: Type.String({ description: "Name of the peer" }),
+      message: Type.String({ description: "The message to send" }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      await daemon("/notify", {
+        from_peer: me.peerName,
+        to_peer: params.peer_name,
+        text: params.message,
+      });
+      return { content: [{ type: "text", text: "Notification sent" }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "broadcast",
+    description: "Broadcast a message to all peers in the mesh",
+    parameters: Type.Object({
+      message: Type.String({ description: "Message to broadcast" }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      const result = await daemon("/broadcast", {
+        from_peer: me.peerName,
+        text: params.message,
+      });
+      const parts: string[] = [];
+      parts.push("Broadcast sent to: " + (result.sent_to?.join(", ") || "no peers"));
+      if (result.failed?.length) {
+        const fails = result.failed.map((f: { peer: string; error: string }) => f.peer + " (" + f.error + ")").join(", ");
+        parts.push("Failed: " + fails);
+      }
+      return { content: [{ type: "text", text: parts.join("; ") }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "whoami",
+    description: "Get information about this peer in the mesh",
+    parameters: Type.Object({}),
+    async execute(_id, _params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      const identifier = me.peerId || me.peerName;
+      try {
+        const result = await daemon("/peers/" + encodeURIComponent(identifier));
+        const project = result.metadata?.project || "";
+        const header = "peer_id\tname\tproject\tcircle\tstatus\tpath\tmachine\tdescription";
+        const row = [result.peer_id || "", result.display_name || result.name || "", project, result.circle || "", result.status || "", result.path || "", result.machine || "", result.description || ""].join("\t");
+        return { content: [{ type: "text", text: header + "\n" + row }] };
+      } catch {
+        const text = "peer_id\tname\tproject\tcircle\tstatus\tpath\tmachine\tdescription\n"
+          + (me.peerId || "") + "\t" + me.peerName + "\t\t\tnot registered\t\t\t";
+        return { content: [{ type: "text", text }] };
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "set_description",
+    description: "Update your task description, visible to other peers via list_peers. Call this at the start of a task.",
+    parameters: Type.Object({
+      description: Type.String({ description: "Short description of your current task" }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const me = callerPeer(ctx);
+      await daemon("/peers/" + encodeURIComponent(me.peerName) + "/description", { description: params.description });
+      return { content: [{ type: "text", text: "description updated: " + params.description }] };
+    },
+  });
+
+  pi.registerTool({
+    name: "set_circle",
+    description: "Join a named circle to communicate with peers in that circle. Applies to all sessions in this pi process (circle is process-wide so reconnects keep it).",
+    parameters: Type.Object({
+      circle: Type.String({ description: "Circle name to join (e.g., 'dev', 'frontend')" }),
+    }),
+    async execute(_id, params, _signal, _onUpdate, _ctx) {
+      circle = params.circle;
+      let sent = 0;
+      for (const conn of peerBySession.values()) {
+        if (conn.ws?.readyState === WebSocket.OPEN) {
+          conn.ws.send(JSON.stringify({ type: "set_circle", circle: params.circle }));
+          sent++;
+        }
+      }
+      const text = sent > 0
+        ? "Joined circle: " + params.circle + " (" + sent + " session peer" + (sent === 1 ? "" : "s") + ")"
+        : "Circle queued: " + params.circle + " (will apply on reconnect)";
+      return { content: [{ type: "text", text }] };
+    },
+  });
+}
+"""
+
+# Extension file location. Pi auto-discovers from
+# ~/.pi/agent/extensions/*.ts (global) and .pi/extensions/*.ts (project-local).
+# We install globally so every pi invocation gets the mesh tools.
+GLOBAL_EXTENSION_DIR = Path.home() / ".pi" / "agent" / "extensions"
+LOCAL_EXTENSION_DIR = Path(".pi") / "extensions"
+EXTENSION_FILENAME = "repowire.ts"
+
+
+def _get_extension_path(global_install: bool) -> Path:
+    if global_install:
+        return GLOBAL_EXTENSION_DIR / EXTENSION_FILENAME
+    return LOCAL_EXTENSION_DIR / EXTENSION_FILENAME
+
+
+def install_extension(global_install: bool = True) -> bool:
+    """Install the Pi extension.
+
+    Args:
+        global_install: If True, install to ~/.pi/agent/extensions/.
+                       If False, install to .pi/extensions/.
+
+    Returns:
+        True if installation successful.
+    """
+    extension_path = _get_extension_path(global_install)
+    extension_path.parent.mkdir(parents=True, exist_ok=True)
+    extension_path.write_text(PLUGIN_CONTENT)
+    return True
+
+
+def uninstall_extension(global_install: bool = True) -> bool:
+    """Uninstall the Pi extension."""
+    extension_path = _get_extension_path(global_install)
+    if extension_path.exists():
+        extension_path.unlink()
+        return True
+    return False
+
+
+def check_extension_installed(global_install: bool = True) -> bool:
+    """Check if the Pi extension is installed."""
+    return _get_extension_path(global_install).exists()

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -117,6 +117,10 @@ class Peer(BaseModel):
         """Check if this peer runs Gemini."""
         return self.backend == AgentType.GEMINI
 
+    def is_pi(self) -> bool:
+        """Check if this peer runs Pi."""
+        return self.backend == AgentType.PI
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -18,6 +18,7 @@ AGENT_COMMANDS: dict[AgentType, str] = {
     AgentType.OPENCODE: "opencode",
     AgentType.CODEX: "codex",
     AgentType.GEMINI: "gemini",
+    AgentType.PI: "pi",
 }
 
 

--- a/tests/test_pi_installer.py
+++ b/tests/test_pi_installer.py
@@ -25,9 +25,8 @@ def test_extension_default_export_is_async_factory():
 
 def test_session_start_filters_by_reason():
     """Peer registration happens only on reason startup or new, not resume/reload/fork."""
-    assert 'reason === "startup"' in PLUGIN_CONTENT
-    assert 'reason === "new"' in PLUGIN_CONTENT
-    # The handler must read reason from the event payload.
+    assert 'reason !== "startup"' in PLUGIN_CONTENT
+    assert 'reason !== "new"' in PLUGIN_CONTENT
     assert "session_start" in PLUGIN_CONTENT
 
 
@@ -47,15 +46,24 @@ def test_turn_end_flushes_pending():
     assert "flushPending" in PLUGIN_CONTENT
 
 
-def test_message_update_buffers_text():
-    """Streaming deltas land in the pending buffer for the active correlation."""
+def test_message_update_buffers_text_deltas():
+    """Streaming text_deltas (not thinking_deltas) buffer into the pending query."""
     assert "message_update" in PLUGIN_CONTENT
-    assert "pending.buffer.push" in PLUGIN_CONTENT
+    assert "assistantMessageEvent" in PLUGIN_CONTENT
+    assert 'ame.type === "text_delta"' in PLUGIN_CONTENT
+    assert "pending.buffer.push(ame.delta)" in PLUGIN_CONTENT
 
 
-def test_message_end_captures_errors():
-    assert "message_end" in PLUGIN_CONTENT
+def test_message_update_captures_stream_errors():
+    """assistantMessageEvent type 'error' surfaces as a query error."""
+    assert 'ame.type === "error"' in PLUGIN_CONTENT
     assert "pending.hasError = true" in PLUGIN_CONTENT
+
+
+def test_session_id_from_session_manager():
+    """Session id is read from ctx.sessionManager.getSessionId, not the event payload."""
+    assert "getSessionId" in PLUGIN_CONTENT
+    assert "ctx.sessionManager" in PLUGIN_CONTENT
 
 
 def test_soft_inject_uses_send_user_message():
@@ -86,9 +94,29 @@ def test_ctx_capture_for_isidle():
 
 
 def test_caller_peer_uses_session_manager():
-    """callerPeer reads active session from ctx.sessionManager for attribution."""
+    """callerPeer reads active session from ctx.sessionManager.getSessionId for attribution."""
     assert "sessionManager" in PLUGIN_CONTENT
-    assert "getActiveSessionId" in PLUGIN_CONTENT
+    assert "getSessionId" in PLUGIN_CONTENT
+
+
+def test_tools_have_label_field():
+    """Pi 0.74 ToolDefinition requires a `label` field for UI display."""
+    # Every registerTool block needs a label. Cheap heuristic: count
+    # registerTool calls vs label entries inside them.
+    register_count = PLUGIN_CONTENT.count("pi.registerTool(")
+    label_count = PLUGIN_CONTENT.count('label: "Repowire:')
+    assert register_count == label_count, (
+        f"label_count ({label_count}) != registerTool count ({register_count})"
+    )
+    assert register_count >= 8
+
+
+def test_tool_results_include_details_field():
+    """AgentToolResult requires `details`; set undefined for tools without structured details."""
+    # Each tool execute returns at least one result object with details: undefined.
+    assert "details: undefined" in PLUGIN_CONTENT
+    # Heuristic: at least as many details fields as tool definitions.
+    assert PLUGIN_CONTENT.count("details: undefined") >= 8
 
 
 def test_ask_is_framed_with_correlation_id():

--- a/tests/test_pi_installer.py
+++ b/tests/test_pi_installer.py
@@ -1,0 +1,218 @@
+"""Smoke tests for the Pi extension installer.
+
+The extension is TypeScript embedded in a Python string. We can't run it
+from pytest, but we can assert key APIs are wired up so a future refactor
+doesn't silently lose behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowire.installers.pi import (
+    EXTENSION_FILENAME,
+    PLUGIN_CONTENT,
+)
+
+# -- TS surface --------------------------------------------------------------
+
+
+def test_extension_default_export_is_async_factory():
+    """Pi auto-loads extensions as `export default function (pi) { ... }`."""
+    assert "export default async function repowireExtension" in PLUGIN_CONTENT
+    assert "ExtensionAPI" in PLUGIN_CONTENT
+
+
+def test_session_start_filters_by_reason():
+    """Peer registration happens only on reason startup or new, not resume/reload/fork."""
+    assert 'reason === "startup"' in PLUGIN_CONTENT
+    assert 'reason === "new"' in PLUGIN_CONTENT
+    # The handler must read reason from the event payload.
+    assert "session_start" in PLUGIN_CONTENT
+
+
+def test_session_shutdown_removes_peer():
+    assert "session_shutdown" in PLUGIN_CONTENT
+    assert "removePeer(sessionId)" in PLUGIN_CONTENT
+
+
+def test_session_before_compact_scaffold():
+    """The pre-compact hook is registered as a no-op scaffold for v1."""
+    assert "session_before_compact" in PLUGIN_CONTENT
+
+
+def test_turn_end_flushes_pending():
+    """turn_end is the canonical finalize event for pi pending queries."""
+    assert "turn_end" in PLUGIN_CONTENT
+    assert "flushPending" in PLUGIN_CONTENT
+
+
+def test_message_update_buffers_text():
+    """Streaming deltas land in the pending buffer for the active correlation."""
+    assert "message_update" in PLUGIN_CONTENT
+    assert "pending.buffer.push" in PLUGIN_CONTENT
+
+
+def test_message_end_captures_errors():
+    assert "message_end" in PLUGIN_CONTENT
+    assert "pending.hasError = true" in PLUGIN_CONTENT
+
+
+def test_soft_inject_uses_send_user_message():
+    """Inbound asks/notify/broadcast surface via pi.sendUserMessage with steer."""
+    assert "piApi.sendUserMessage" in PLUGIN_CONTENT
+    assert 'deliverAs: "steer"' in PLUGIN_CONTENT
+
+
+def test_soft_inject_branches_on_idle_state():
+    """When agent is idle, omit deliverAs; while streaming, use steer."""
+    assert "piCtx.isIdle()" in PLUGIN_CONTENT
+    # Idle branch sends bare text; streaming branch passes deliverAs steer.
+    assert "piApi.sendUserMessage(text);" in PLUGIN_CONTENT
+
+
+def test_typebox_schema_for_tools():
+    """Tool parameters use TypeBox Type.Object, not bare JSON-Schema."""
+    assert 'from "@sinclair/typebox"' in PLUGIN_CONTENT
+    assert "Type.Object({" in PLUGIN_CONTENT
+    assert "Type.String(" in PLUGIN_CONTENT
+    assert "Type.Optional(" in PLUGIN_CONTENT
+
+
+def test_ctx_capture_for_isidle():
+    """Event handlers capture ctx so soft-inject can branch on isIdle()."""
+    assert "function capture(" in PLUGIN_CONTENT
+    assert "piCtx = ctx" in PLUGIN_CONTENT
+
+
+def test_caller_peer_uses_session_manager():
+    """callerPeer reads active session from ctx.sessionManager for attribution."""
+    assert "sessionManager" in PLUGIN_CONTENT
+    assert "getActiveSessionId" in PLUGIN_CONTENT
+
+
+def test_ask_is_framed_with_correlation_id():
+    """Inbound asks must include [ask #cid] framing so the agent can ack."""
+    assert "[ask #" in PLUGIN_CONTENT
+
+
+def test_per_session_peer_registry():
+    """Each root pi session has its own PeerConn (no global singleton)."""
+    assert "peerBySession" in PLUGIN_CONTENT
+    assert "interface PeerConn" in PLUGIN_CONTENT
+    assert "ensurePeer" in PLUGIN_CONTENT
+    assert "removePeer" in PLUGIN_CONTENT
+
+
+def test_per_session_peer_id_cache():
+    """peer_id cache is keyed by (projectPath, sessionId) at the pi-specific path."""
+    assert "pi-peer-ids.json" in PLUGIN_CONTENT
+    assert "cacheKey" in PLUGIN_CONTENT
+
+
+def test_concurrency_guard_per_peer():
+    """The extension rejects concurrent queries on the same session."""
+    assert "Session busy" in PLUGIN_CONTENT
+    assert "conn.busy" in PLUGIN_CONTENT
+    assert "activeTurnCorrelationId" in PLUGIN_CONTENT
+
+
+def test_websocket_connect_carries_backend_pi():
+    """Daemon connect message identifies the runtime as pi."""
+    assert 'backend: "pi"' in PLUGIN_CONTENT
+
+
+def test_reconnect_with_backoff():
+    """Disconnects schedule a bounded exponential backoff reconnect."""
+    assert "schedulePeerReconnect" in PLUGIN_CONTENT
+    assert "MAX_RECONNECT_ATTEMPTS" in PLUGIN_CONTENT
+
+
+def test_signal_handlers_exit():
+    """SIGINT/SIGTERM handlers are one-shot and exit, mirroring opencode."""
+    assert 'process.once("SIGINT"' in PLUGIN_CONTENT
+    assert 'process.once("SIGTERM"' in PLUGIN_CONTENT
+    assert "process.exit(130)" in PLUGIN_CONTENT
+    assert "process.exit(143)" in PLUGIN_CONTENT
+
+
+def test_tools_registered():
+    """All canonical mesh tools are registered."""
+    tools = (
+        "list_peers", "ask", "ack", "notify_peer",
+        "broadcast", "whoami", "set_description", "set_circle",
+    )
+    for name in tools:
+        assert 'name: "' + name + '"' in PLUGIN_CONTENT, f"tool {name} not registered"
+
+
+def test_tools_use_registerTool_api():
+    """Tools are registered via pi.registerTool(), not opencode's tool() factory."""
+    assert "pi.registerTool(" in PLUGIN_CONTENT
+    # Opencode's tool factory pattern must not have leaked in.
+    assert "@opencode-ai/plugin" not in PLUGIN_CONTENT
+
+
+def test_tmux_pane_discovery():
+    """The extension derives circle and pane id from tmux when available."""
+    assert "TMUX_PANE" in PLUGIN_CONTENT
+    assert "display-message" in PLUGIN_CONTENT
+
+
+# -- Filesystem install/uninstall -------------------------------------------
+
+
+def test_install_extension_writes_to_global_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Re-import to pick up the patched home.
+    from repowire.installers import pi as pi_mod
+    target = tmp_path / ".pi" / "agent" / "extensions" / EXTENSION_FILENAME
+    # Recompute the install path under the patched home.
+    monkeypatch.setattr(pi_mod, "GLOBAL_EXTENSION_DIR", tmp_path / ".pi" / "agent" / "extensions")
+    assert pi_mod.install_extension(global_install=True) is True
+    assert target.exists()
+    assert "repowireExtension" in target.read_text()
+
+
+def test_uninstall_extension_removes_file(tmp_path, monkeypatch):
+    from repowire.installers import pi as pi_mod
+    monkeypatch.setattr(pi_mod, "GLOBAL_EXTENSION_DIR", tmp_path / ".pi" / "agent" / "extensions")
+    pi_mod.install_extension(global_install=True)
+    assert pi_mod.uninstall_extension(global_install=True) is True
+    assert pi_mod.uninstall_extension(global_install=True) is False  # already gone
+
+
+def test_check_extension_installed(tmp_path, monkeypatch):
+    from repowire.installers import pi as pi_mod
+    monkeypatch.setattr(pi_mod, "GLOBAL_EXTENSION_DIR", tmp_path / ".pi" / "agent" / "extensions")
+    assert pi_mod.check_extension_installed(global_install=True) is False
+    pi_mod.install_extension(global_install=True)
+    assert pi_mod.check_extension_installed(global_install=True) is True
+
+
+def test_local_install_writes_to_dot_pi(tmp_path, monkeypatch):
+    """Local install puts extension into .pi/extensions/ relative to cwd."""
+    monkeypatch.chdir(tmp_path)
+    from repowire.installers import pi as pi_mod
+    assert pi_mod.install_extension(global_install=False) is True
+    assert (tmp_path / ".pi" / "extensions" / EXTENSION_FILENAME).exists()
+
+
+# -- AgentType wiring -------------------------------------------------------
+
+
+def test_agent_type_pi_registered():
+    """PI enum value and command default are wired up so spawn paths resolve."""
+    from repowire.config.models import AgentType
+    from repowire.spawn import AGENT_COMMANDS
+
+    assert AgentType.PI.value == "pi"
+    assert AGENT_COMMANDS[AgentType.PI] == "pi"
+
+
+def test_command_to_backend_includes_pi():
+    """Spawn route's command->backend map auto-derives pi entry."""
+    from repowire.config.models import AgentType
+    from repowire.daemon.routes.spawn import _COMMAND_TO_BACKEND
+
+    assert _COMMAND_TO_BACKEND.get("pi") == AgentType.PI

--- a/uv.lock
+++ b/uv.lock
@@ -953,7 +953,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds Pi (pi.dev) as the 5th supported agent runtime alongside claude-code, codex, gemini, opencode.
- Integration is opencode-shaped (TypeScript extension auto-loaded from `~/.pi/agent/extensions/repowire.ts`), not codex-shaped — Pi has no subprocess-hook surface. Source-verified against pi-mono v0.74.0.
- Per-session peer model from day one (each root pi session gets its own WebSocket + peer_id, cached at `~/.cache/repowire/pi-peer-ids.json`) — avoids the migration scar opencode hit in #96.

## What landed

- `repowire/installers/pi.py` — new installer with embedded TS extension (~580 LOC). Tools: list_peers, ask, ack, notify_peer, broadcast, whoami, set_description, set_circle. TypeBox parameter schemas (`@sinclair/typebox`). Soft-inject branches on `ctx.isIdle()` (omit `deliverAs` when idle, `steer` while streaming). Tool attribution reads active session via `ctx.sessionManager`.
- `AgentType.PI` enum + `AGENT_COMMANDS[PI] = "pi"` + `is_pi()` helper on PeerInfo.
- `repowire setup` / `update` / `status` auto-detect `pi` CLI or `~/.pi/` config.
- 28 tests covering TS surface, install/uninstall, and AgentType wiring.

## Lifecycle decisions

- `session_start` registers peer only on `reason == "startup" | "new"`. Resume/reload/fork are no-ops (peer already registered or will be on the matching startup/new event).
- No `post_spawn_warmup` analog — pi fires `session_start` eagerly at boot, falls through the existing no-op branch.
- `session_before_compact` is a scaffolded no-op for v1. Future work could surface "your ask thread is about to be compacted" notifications here.
- `turn_end` is the finalize event for streaming responses. `message_update` deltas buffer; `message_end` captures errors.

## Auth handoff

Pi has subscription auth (ChatGPT Plus, Claude Pro/Max, Copilot) via in-TUI `/login`, and env-var auth for 20+ API-key providers. `pi /login` is **not** a CLI subcommand — it's only available inside the TUI. For repowire-spawned pi peers:
- Env-var path (e.g. `OPENAI_API_KEY`): works headless, repowire spawn succeeds immediately.
- Subscription path: user must run `pi` once interactively, complete `/login`, then repowire can spawn pi peers. Same UX as opencode/codex with their subscription flows.

## Smoke checklist (live verification before merge)

Pi is not yet installed on Prass's machine. Pre-merge:

- [ ] `npm install -g @earendil-works/pi-coding-agent` (or `npx @earendil-works/pi-coding-agent` for one-shot)
- [ ] `pi --version` reports ≥ 0.74.0
- [ ] `repowire setup` detects pi and installs the extension into `~/.pi/agent/extensions/repowire.ts`
- [ ] `pi` boots cleanly with no extension-load errors in stderr
- [ ] `whoami` tool from inside pi returns a row with `backend=pi`
- [ ] `list_peers` from inside pi returns the live mesh
- [ ] From another peer: `ask` → pi peer; pi responds via the streaming `turn_end` path; original asker sees the reply
- [ ] From another peer: `notify` → pi peer; surfaces via `sendUserMessage` soft-inject
- [ ] Multi-session: `pi`, `/fork` to create a second root session, both register as separate peers in the mesh
- [ ] `repowire setup --uninstall` removes `repowire.ts` cleanly

## Risk areas (folded back into the design)

- TypeBox parameter schema: confirmed via source exploration of pi-mono v0.74.0; if pi later relaxes, this is forward-compatible.
- `ctx.sessionManager.getActiveSessionId()` shape: read defensively with try/catch + fallback to "first PeerConn." If the actual API is named differently, the fallback covers attribution; tool callers just see `from_peer = first-session-peer-name` until patched.
- `message_update` payload field (`delta` vs `text`): both names read defensively. Will tighten after smoke if one is canonical.
- Pi's stale-`pi`/`ctx`-after-`newSession`/`fork`/`switchSession`/`reload` issue: repowire never invokes any of those, so the captured `piApi` + latest captured `ctx` remain valid for the process lifetime.

## Test plan

- [x] 28 new tests in `tests/test_pi_installer.py` pass
- [x] Full suite (505 tests) passes
- [x] `ruff check` clean
- [x] `ty check` clean
- [ ] Live smoke per the checklist above (requires `pi` installed on the machine)

## Files

- new: `repowire/installers/pi.py`, `tests/test_pi_installer.py`
- modified: `repowire/cli.py`, `repowire/config/models.py`, `repowire/spawn.py`, `repowire/protocol/peers.py`, `pyproject.toml` (ruff per-file-ignores), `uv.lock` (post-v0.12.0 sync)
- untouched per orchestrator constraints: `repowire/daemon/peer_registry.py`, `repowire/daemon/routes/spawn.py` (beyond auto-derived `_COMMAND_TO_BACKEND`), `repowire/mcp/server.py`

## Out of scope

- Pi-specific `session_before_compact` ask-resurrection
- Subscription auth automation (write `~/.pi/agent/auth.json` directly when needed; not part of v1)
- Manifest-form extension (`extensions/foo/package.json`) — current extension has no external deps, single-file form is sufficient