### PR TITLE
fix(web): mobile dashboard + marketing whole-page-scroll restructure

### DIFF
--- a/web/app/dashboard/components/MeshFeed.tsx
+++ b/web/app/dashboard/components/MeshFeed.tsx
@@ -5,15 +5,14 @@ import { peerLabel } from "../types";
 import { formatTime } from "./status";
 
 export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers: Peer[]; onPickPeer: (peer: Peer) => void }) {
-  const scrollerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
   const feedEvents = useMemo(
     () => events.filter((event) => event.type !== "chat_turn").sort((a, b) => a.timestamp.localeCompare(b.timestamp)),
     [events]
   );
 
   useEffect(() => {
-    const scroller = scrollerRef.current;
-    if (scroller) scroller.scrollTop = scroller.scrollHeight;
+    bottomRef.current?.scrollIntoView({ block: "end" });
   }, [feedEvents.length]);
 
   const pickPeerByName = (name?: string) => {
@@ -25,7 +24,7 @@ export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers
 
   return (
     <>
-      <div className="flex items-baseline justify-between border-b border-border-faint px-4 py-3 md:px-6">
+      <div className="sticky top-[var(--topbar-offset)] z-10 flex items-baseline justify-between border-b border-border-faint bg-surface-dim px-4 py-3 md:static md:px-6">
         <div>
           <div className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-primary">LIVE / mesh.log</div>
           <h1 className="mt-1 font-headline text-2xl font-bold text-on-surface">tail -f</h1>
@@ -35,7 +34,7 @@ export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers
           <span className="text-outline">select a peer to chat ↳</span>
         </div>
       </div>
-      <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto bg-surface-dim px-4 py-3 md:px-5">
+      <div className="min-h-0 flex-1 bg-surface-dim px-4 py-3 md:overflow-y-auto md:px-5">
         {feedEvents.length === 0 ? (
           <div className="py-14 text-center font-mono text-xs leading-6 text-outline">
             <div className="text-on-surface-variant">&gt; no mesh events yet</div>
@@ -46,6 +45,7 @@ export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers
             <EventRow key={event.id} event={event} onPickPeer={pickPeerByName} />
           ))
         )}
+        <div ref={bottomRef} />
       </div>
     </>
   );
@@ -77,16 +77,18 @@ function EventRow({ event, onPickPeer }: { event: Event; onPickPeer: (name?: str
   }
 
   return (
-    <div className="grid grid-cols-[62px_minmax(70px,120px)_18px_minmax(70px,120px)_1fr] gap-2 border-b border-border-faint/70 py-1.5 font-mono text-xs leading-5 md:gap-3">
-      <span className="text-outline tabular-nums">{formatTime(event.timestamp)}</span>
-      <button onClick={() => onPickPeer(event.from)} className={cn("truncate text-left", color)}>
-        {event.from || "unknown"}
-      </button>
-      <span className="text-center text-outline">{route}</span>
-      <button onClick={() => onPickPeer(event.to)} className="truncate text-left text-primary-fixed">
-        {to}
-      </button>
-      <span className={cn("min-w-0 break-words", event.status === "error" ? "text-error" : "text-on-surface-variant")}>
+    <div className="border-b border-border-faint/70 py-1.5 font-mono text-xs leading-5 md:grid md:grid-cols-[62px_minmax(70px,120px)_18px_minmax(70px,120px)_1fr] md:gap-3">
+      <div className="flex items-center gap-2 md:contents">
+        <span className="shrink-0 text-outline tabular-nums">{formatTime(event.timestamp)}</span>
+        <button onClick={() => onPickPeer(event.from)} className={cn("min-w-0 truncate text-left", color)}>
+          {event.from || "unknown"}
+        </button>
+        <span className="shrink-0 text-center text-outline">{route}</span>
+        <button onClick={() => onPickPeer(event.to)} className="min-w-0 truncate text-left text-primary-fixed">
+          {to}
+        </button>
+      </div>
+      <span className={cn("mt-0.5 block min-w-0 break-words [overflow-wrap:anywhere] md:mt-0", event.status === "error" ? "text-error" : "text-on-surface-variant")}>
         {event.text}
       </span>
     </div>

--- a/web/app/dashboard/components/MobileTabs.tsx
+++ b/web/app/dashboard/components/MobileTabs.tsx
@@ -14,7 +14,7 @@ export function MobileTabs({
   onChange: (tab: MobileTab) => void;
 }) {
   return (
-    <nav className="col-span-full flex border-t border-border-faint bg-surface-dim md:hidden">
+    <nav className="sticky bottom-0 z-30 col-span-full flex border-t border-border-faint bg-surface-dim pb-[env(safe-area-inset-bottom)] md:hidden">
       <MobileTabButton active={activeTab === "peers"} label="PEERS" sub={`${counts.online} online · ${counts.busy} busy`} onClick={() => onChange("peers")} />
       <MobileTabButton active={activeTab === "mesh"} label="MESH" sub={`${eventCount} events`} onClick={() => onChange("mesh")} />
     </nav>

--- a/web/app/dashboard/components/PeerRoster.tsx
+++ b/web/app/dashboard/components/PeerRoster.tsx
@@ -33,8 +33,8 @@ export function PeerRoster({
   }, [peers]);
 
   return (
-    <aside className="flex h-full min-h-0 flex-col overflow-hidden bg-surface-dim">
-      <div className="flex items-center gap-2 border-b border-border-faint px-3 py-2">
+    <aside className="flex min-h-0 flex-col bg-surface-dim md:h-full md:overflow-hidden">
+      <div className="sticky top-[var(--topbar-offset)] z-20 flex items-center gap-2 border-b border-border-faint bg-surface-dim px-3 py-2 md:static">
         <Search className="h-3.5 w-3.5 shrink-0 text-outline" />
         <input
           value={filter}
@@ -45,7 +45,7 @@ export function PeerRoster({
         <span className="font-mono text-[10px] text-outline tabular-nums">{peers.length}/{allCount}</span>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 md:overflow-y-auto">
         {byCircle.map(([circle, list]) => (
           <section key={circle}>
             <div className="flex items-baseline justify-between px-3.5 pb-1.5 pt-3 font-mono text-[9px] font-semibold uppercase tracking-[0.2em] text-outline">

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -33,7 +33,7 @@ export function PeerView({
   onClose: () => void;
   onSent: () => void;
 }) {
-  const scrollerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
   const thread = useMemo(() => {
     const id = peer.peer_id;
     return events
@@ -45,15 +45,14 @@ export function PeerView({
   }, [events, peer.peer_id]);
 
   useEffect(() => {
-    const scroller = scrollerRef.current;
-    if (scroller) scroller.scrollTop = scroller.scrollHeight;
+    bottomRef.current?.scrollIntoView({ block: "end" });
   }, [thread.length]);
 
   const { folder, parent } = peer.path ? shortPath(peer.path) : { folder: "", parent: "" };
 
   return (
     <>
-      <div className="flex items-center gap-3 border-b border-border-faint px-4 py-3 md:px-6">
+      <div className="sticky top-[var(--topbar-offset)] z-10 flex items-center gap-3 border-b border-border-faint bg-surface-dim px-4 py-3 md:static md:px-6">
         <span className={cn("h-2.5 w-2.5 rounded-full", statusDot(peer.status))} />
         <div className="min-w-0 flex-1">
           <h1 className="truncate font-headline text-lg font-bold text-on-surface">{peerLabel(peer)}</h1>
@@ -79,7 +78,7 @@ export function PeerView({
         </div>
       )}
 
-      <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+      <div className="min-h-0 flex-1 px-4 py-4 md:overflow-y-auto md:px-6">
         {thread.length === 0 ? (
           <div className="py-10 font-mono text-xs leading-6 text-outline">
             &gt; no messages with {peerLabel(peer)}.<br />
@@ -88,6 +87,7 @@ export function PeerView({
         ) : (
           thread.map((event) => <ThreadItem key={event.id} event={event} peer={peer} />)
         )}
+        <div ref={bottomRef} />
       </div>
 
       <ComposeBar peer={peer} apiBase={apiBase} events={events} onSent={onSent} />
@@ -105,16 +105,16 @@ function ThreadItem({ event, peer }: { event: Event; peer: Peer }) {
         </div>
         <div
           className={cn(
-            "max-w-[82%] rounded p-3 font-mono text-[13px] leading-6 text-on-surface",
+            "max-w-[82%] min-w-0 rounded p-3 font-mono text-[13px] leading-6 text-on-surface [overflow-wrap:anywhere]",
             isUser
               ? "border-r-2 border-primary bg-primary/10"
               : "border-l-2 border-primary/70 bg-surface-container-high"
           )}
         >
           {isUser ? (
-            <p className="whitespace-pre-wrap">{event.text}</p>
+            <p className="whitespace-pre-wrap break-words">{event.text}</p>
           ) : (
-            <div className="prose prose-invert prose-sm max-w-none">
+            <div className="prose prose-invert prose-sm max-w-none break-words [&_pre]:overflow-x-auto">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{event.text}</ReactMarkdown>
             </div>
           )}
@@ -325,7 +325,7 @@ function ComposeBar({
   const visibleAsks = pendingAsks.filter((a) => a.to_peer === peer.name);
 
   return (
-    <div className="border-t border-border-faint bg-surface-dim p-3 md:p-4">
+    <div className="sticky bottom-0 z-10 border-t border-border-faint bg-surface-dim p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] md:static md:p-4">
       <div className="mb-2 flex items-center gap-2">
         <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-outline">
           ask &rarr; {peerLabel(peer)}
@@ -417,8 +417,8 @@ function ComposeBar({
                 <span className="shrink-0 text-[10px] uppercase tracking-[0.14em] text-outline">
                   #{a.correlation_id.slice(0, 8)}
                 </span>
-                <span className="flex-1 truncate text-on-surface-variant">{a.preview}</span>
-                <span className="shrink-0 text-[10px] text-outline">
+                <span className="hidden flex-1 truncate text-on-surface-variant md:inline">{a.preview}</span>
+                <span className="ml-auto shrink-0 text-[10px] text-outline md:ml-0">
                   {a.state === "pending"
                     ? "pending"
                     : a.state === "delivered"
@@ -432,6 +432,9 @@ function ComposeBar({
                 >
                   <X className="h-3 w-3" aria-hidden="true" />
                 </button>
+              </div>
+              <div className="mt-1 pl-5 text-on-surface-variant [overflow-wrap:anywhere] md:hidden">
+                {a.preview}
               </div>
               {a.state === "delivered" && a.reply && (
                 <div className="mt-1.5 max-h-24 overflow-y-auto whitespace-pre-wrap pl-5 text-on-surface-variant">

--- a/web/app/dashboard/components/TopBar.tsx
+++ b/web/app/dashboard/components/TopBar.tsx
@@ -18,7 +18,7 @@ export function TopBar({
   onSettings: () => void;
 }) {
   return (
-    <header className="col-span-full flex h-12 items-center gap-3 border-b border-border-faint bg-surface-dim px-3 md:h-[52px] md:px-5">
+    <header className="sticky top-0 z-30 col-span-full flex h-12 items-center gap-3 border-b border-border-faint bg-surface-dim px-3 pt-[env(safe-area-inset-top)] md:static md:h-[52px] md:px-5 md:pt-0">
       <div className="flex min-w-0 items-center gap-3 md:w-[397px]">
         <Image src="/brand/logo-mark-copper.svg" alt="" width={22} height={24} priority />
         <span className="font-headline text-xs font-bold tracking-[0.2em] text-on-surface">REPOWIRE</span>

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -142,8 +142,8 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <div className="h-dvh overflow-hidden bg-surface text-on-surface font-body mesh-bg">
-      <div className="grid h-full grid-rows-[48px_1fr_56px] md:grid-cols-[420px_1fr] md:grid-rows-[52px_1fr]">
+    <div className="bg-surface text-on-surface font-body mesh-bg md:h-dvh md:overflow-hidden">
+      <div className="flex min-h-dvh flex-col md:grid md:h-full md:min-h-0 md:grid-cols-[420px_1fr] md:grid-rows-[52px_1fr]">
         <TopBar
           counts={counts}
           isConnected={isConnected}
@@ -153,7 +153,7 @@ export default function Dashboard() {
           onSettings={() => setShowSettings(true)}
         />
 
-        <div className={cn("min-h-0 md:block", selectedPeer || mobileTab === "mesh" ? "hidden" : "block")}>
+        <div className={cn("min-h-0 flex-1 md:block", selectedPeer || mobileTab === "mesh" ? "hidden" : "block")}>
           <PeerRoster
             peers={filteredPeers}
             allCount={visiblePeers.length}
@@ -164,7 +164,7 @@ export default function Dashboard() {
           />
         </div>
 
-        <main className={cn("relative min-h-0 overflow-hidden border-l border-border-faint bg-surface-dim", !selectedPeer && mobileTab === "peers" ? "hidden md:flex" : "flex", "flex-col")}>
+        <main className={cn("relative min-h-0 flex-1 border-l border-border-faint bg-surface-dim md:overflow-hidden", !selectedPeer && mobileTab === "peers" ? "hidden md:flex" : "flex", "flex-col")}>
           <WireTrace active={Boolean(selectedPeer)} />
           {selectedPeer ? (
             <PeerView

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -124,6 +124,15 @@
   --shadow-2: 0 2px 0 0 rgba(0, 0, 0, 0.4), 0 6px 20px -8px rgba(0, 0, 0, 0.6);
   --shadow-3: 0 24px 48px -12px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(199, 123, 61, 0.06) inset;
   --ease: cubic-bezier(0.2, 0.6, 0.2, 1);
+
+  /* Sticky-below-TopBar offset. Mobile: 48px topbar + iOS notch. Desktop overrides below. */
+  --topbar-offset: calc(48px + env(safe-area-inset-top));
+}
+
+@media (min-width: 768px) {
+  :root {
+    --topbar-offset: 52px;
+  }
 }
 
 html,

--- a/web/components/Features.tsx
+++ b/web/components/Features.tsx
@@ -35,7 +35,7 @@ const features = [
 
 export default function Features() {
   return (
-    <section className="border-b border-border-faint bg-surface py-20 sm:py-24">
+    <section className="border-b border-border-faint bg-surface py-14 sm:py-20 lg:py-24">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="max-w-2xl">
           <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">

--- a/web/components/Hero.tsx
+++ b/web/components/Hero.tsx
@@ -7,7 +7,7 @@ import { motion } from "framer-motion";
 
 export default function Hero() {
   return (
-    <section className="relative min-h-[92vh] overflow-hidden border-b border-border-faint pt-28">
+    <section className="relative overflow-hidden border-b border-border-faint pt-24 sm:min-h-[92svh] sm:pt-28">
       <Image
         src="/brand/repowire-arch.webp"
         alt=""
@@ -18,7 +18,7 @@ export default function Hero() {
       />
       <div className="absolute inset-0 bg-surface/85" />
 
-      <div className="relative z-10 mx-auto flex min-h-[calc(92vh-7rem)] max-w-7xl flex-col justify-center px-4 pb-20 sm:px-6 lg:px-8">
+      <div className="relative z-10 mx-auto flex max-w-7xl flex-col justify-center px-4 pb-14 sm:min-h-[calc(92svh-7rem)] sm:px-6 sm:pb-20 lg:px-8">
         <motion.div
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}

--- a/web/components/HowItWorks.tsx
+++ b/web/components/HowItWorks.tsx
@@ -25,7 +25,7 @@ const steps = [
 
 export default function HowItWorks() {
   return (
-    <section className="border-b border-border-faint bg-surface-dim py-20 sm:py-24">
+    <section className="border-b border-border-faint bg-surface-dim py-14 sm:py-20 lg:py-24">
       <div className="mx-auto grid max-w-7xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.9fr_1.1fr] lg:px-8">
         <div>
           <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
@@ -51,7 +51,7 @@ export default function HowItWorks() {
           </div>
         </div>
 
-        <div className="relative min-h-[360px] overflow-hidden border border-border-faint bg-surface-container-low p-4">
+        <div className="relative overflow-hidden border border-border-faint bg-surface-container-low p-4 sm:min-h-[360px]">
           <div className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-outline">
             System architecture
           </div>
@@ -60,9 +60,9 @@ export default function HowItWorks() {
             alt="Repowire architecture"
             width={1000}
             height={700}
-            className="h-full min-h-[300px] w-full object-cover opacity-80"
+            className="h-auto w-full object-cover opacity-80 sm:h-full sm:min-h-[300px]"
           />
-          <div className="absolute inset-x-4 bottom-4 border-l-2 border-primary bg-surface-dim/95 p-4">
+          <div className="mt-4 border-l-2 border-primary bg-surface-dim/95 p-4 sm:absolute sm:inset-x-4 sm:bottom-4 sm:mt-0">
             <p className="font-mono text-xs leading-6 text-on-surface-variant">
               daemon/ws {">"} hooks/channel {">"} peer session {">"} response capture
             </p>

--- a/web/components/Installation.tsx
+++ b/web/components/Installation.tsx
@@ -13,7 +13,7 @@ export default function Installation() {
   };
 
   return (
-    <section id="installation" className="border-b border-border-faint bg-surface py-20 sm:py-24">
+    <section id="installation" className="border-b border-border-faint bg-surface py-14 sm:py-20 lg:py-24">
       <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
         <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
           Install

--- a/web/components/Navbar.tsx
+++ b/web/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { Github } from "lucide-react";
 
 export default function Navbar() {
   return (
-    <nav className="fixed top-0 z-50 w-full border-b border-border-faint mesh-panel">
+    <nav className="fixed top-0 z-50 w-full border-b border-border-faint mesh-panel pt-[env(safe-area-inset-top)]">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-3">
           <Image src="/brand/logo-mark-copper.svg" alt="" width={24} height={26} priority />


### PR DESCRIPTION
## Summary

Mobile UX fixes for `/dashboard` and the marketing landing page. Structural change: mobile switches from the app-shell-with-inner-scrollers layout to whole-page-scroll with sticky-positioned controls. Desktop (md+) unchanged.

This addresses every finding from the earlier mobile audit at the source rather than patching around them. The 🔴 bottom void was a consequence of `grid-rows-[48px_1fr_56px]` reserving the MobileTabs row even when the tabs weren't rendered; killing the grid on mobile eliminates the void structurally.

## Dashboard

- Root: drop `h-dvh overflow-hidden` on mobile; flex column instead of grid-with-reserved-rows. Desktop keeps `md:h-dvh md:overflow-hidden md:grid`.
- TopBar `sticky top-0` on mobile with `pt-[env(safe-area-inset-top)]`; static (in grid) on md+.
- New `--topbar-offset` CSS var (48px + safe-area on mobile, 52px on md+) used by all sticky-below-TopBar headers (PeerRoster filter, MeshFeed header, PeerView header) for a correct sticky stack regardless of safe-area height.
- ComposeBar `sticky bottom-0` + `pb-[max(env(safe-area-inset-bottom),0.75rem)]` on mobile.
- MobileTabs `sticky bottom-0` + `pb-[env(safe-area-inset-bottom)]`. Only renders when no peer selected (existing logic), no longer leaves a hole.
- Auto-scroll: switched MeshFeed + PeerView from `scroller.scrollTop = scrollHeight` to a bottom-sentinel `scrollIntoView({block:"end"})`. Works in both page-scroll and inner-scroll modes.
- Chat bubbles: `[overflow-wrap:anywhere]` + `break-words`; markdown `pre` gets `overflow-x-auto`.
- Pending ask chips: hide preview on mobile, render it on its own row below the status header. md+ stays single-line.
- MeshFeed event rows: collapse the 5-col grid to a 2-row flex layout on mobile (header row + wrapped text row). 5-col grid restored on md+ via `md:contents`. Without this, long unbroken tokens hit a 0-width `1fr` column and produced 10k+ px row heights (latent bug exposed by the page-scroll change).

## Marketing

- Hero: collapse the duplicated `min-h-[92vh]` + `min-h-[calc(92vh-7rem)]` math. Mobile sizes to content (`pt-24 pb-14`); `sm+` gets the 92svh hero feel. Using `svh` so iOS toolbar expansion doesn't reflow.
- Navbar: `pt-[env(safe-area-inset-top)]` so the iOS notch doesn't eat the fixed nav.
- Features / HowItWorks / Installation: `py-14 sm:py-20 lg:py-24` (was `py-20 sm:py-24`).
- HowItWorks architecture visual: drop fixed `min-h-[360px]` on mobile; flow the caption below the image on mobile, keep absolute overlay on `sm+`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean (TypeScript + static export)
- [x] Browser emulator smoke at 320 / 375 / 414 widths:
  - No horizontal overflow on `/` or `/dashboard`
  - No bottom void when a peer is selected (ComposeBar pinned to viewport bottom)
  - Sticky stack correct under deep scroll: TopBar at top, section header at `--topbar-offset`, ComposeBar/MobileTabs at bottom
  - MeshFeed event rows no longer expand to thousands of pixels when text is long
- [x] Desktop (1440px): app-shell preserved — body height == viewport, inner scrollers active, ComposeBar static, MobileTabs hidden
- [ ] Real iOS device verification (deferred to merge — no obvious blockers from emulator)

## Notes

- No backend touched. Pure `web/` change.
- `--topbar-offset` CSS var added in `globals.css` so the sticky stack stays correct as the safe-area changes per device. Mobile and desktop overrides via media query.
- One unflagged latent bug fixed along the way: MeshFeed grid columns summed to 320px before the `1fr` text column, which produced runaway row heights at the smallest mobile width once whole-page-scroll exposed it. Collapsed to a 2-row flex on mobile.