### PR TITLE
fix(relay): tunnel ask/ack endpoints to daemon

### DIFF
--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -61,6 +61,7 @@ _RELAY_PREFIXES = ("/api/v1/", "/d/", "/_next/")
 _TUNNEL_PREFIXES = (
     "/peers", "/events", "/query", "/notify", "/broadcast",
     "/session", "/response", "/spawn", "/ws", "/attachments",
+    "/ask", "/ack", "/asks",
 )
 
 # Static file extensions served from web/out root (logos, favicon, images)


### PR DESCRIPTION
## Summary
- Dashboard POSTs to `/ask`, `/ack`, `/asks/pending` were 404'ing on `repowire.io` because those prefixes were missing from `_TUNNEL_PREFIXES` in `relay/server.py`, so the relay returned its own generic `Not Found` instead of proxying to the daemon.
- The user-visible symptom was a literal "Not Found" red error under the ComposeBar with a Retry button when sending an ask from the hosted dashboard on mobile (and desktop). Diagnosis confirmed: the bare `{"detail":"Not Found"}` is Starlette's default 404, distinct from the daemon's own `{"detail":"Unknown peer: <name>"}` which the dashboard would have surfaced via `data.detail`.
- Fix adds `/ask`, `/ack`, and `/asks` to the tunnel prefix tuple alongside `/notify` and `/attachments`.

## Test plan
- [ ] On hosted dashboard, open a peer and send an ask — should round-trip successfully (no "Not Found")
- [ ] Verify ack reply lands back in the ComposeBar pending-ask card
- [ ] Local-daemon dashboard (no relay) still works (unaffected path)