### PR TITLE
refactor(orchestrator): heartbeat_tolerance() accessor

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -556,6 +556,15 @@ class PeerRegistry:
         async with self._lock:
             return list(self._peers.values())
 
+    def heartbeat_tolerance(self) -> int:
+        """Seconds a peer's last_seen may lag before it's considered dead.
+
+        Two heartbeat intervals: one missed beat is tolerated (normal jitter),
+        two means the wire is dead. Public accessor so callers (routes, MCP)
+        don't reach into `_config`.
+        """
+        return self._config.daemon.heartbeat_interval * 2
+
     async def get_orchestrator(self, circle: str) -> Peer | None:
         """Return the live orchestrator for a circle, or None.
 
@@ -563,7 +572,7 @@ class PeerRegistry:
         2 * heartbeat_interval (one missed beat tolerated, two means dead). If
         multiple match, returns the most recently seen.
         """
-        tolerance = self._config.daemon.heartbeat_interval * 2
+        tolerance = self.heartbeat_tolerance()
         now = datetime.now(timezone.utc)
         async with self._lock:
             candidates = [

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -310,7 +310,7 @@ async def get_circle_orchestrator(
     and last_seen within 2 * heartbeat_interval (one missed beat tolerated).
     """
     peer_registry = get_peer_registry()
-    tolerance = peer_registry._config.daemon.heartbeat_interval * 2
+    tolerance = peer_registry.heartbeat_tolerance()
     orch = await peer_registry.get_orchestrator(name)
     if orch is None:
         return OrchestratorStatusResponse(

--- a/tests/test_orchestrator_liveness.py
+++ b/tests/test_orchestrator_liveness.py
@@ -69,6 +69,16 @@ async def _register_orch(
     return peer
 
 
+class TestHeartbeatTolerance:
+    def test_returns_double_heartbeat_interval(self, tmp_path):
+        registry = _make_registry(tmp_path, heartbeat=30)
+        assert registry.heartbeat_tolerance() == 60
+
+    def test_tracks_config_change(self, tmp_path):
+        registry = _make_registry(tmp_path, heartbeat=5)
+        assert registry.heartbeat_tolerance() == 10
+
+
 class TestIsOrchestratorPresent:
     async def test_returns_false_when_no_orchestrator(self, tmp_path):
         registry = _make_registry(tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #121 addressing the review nit: route was reaching into `PeerRegistry._config.daemon.heartbeat_interval` directly.

- Adds `PeerRegistry.heartbeat_tolerance() -> int` returning `2 * heartbeat_interval`.
- Route `GET /circles/{name}/orchestrator` uses the accessor instead of `_config`.
- `get_orchestrator()` also uses it, so the "2× heartbeat" rule has one source.

## Test plan
- [x] Two new cases covering the accessor (default 30s → 60s; custom 5s → 10s).
- [x] `pytest tests/test_orchestrator_liveness.py` — 13/13 pass.
- [x] `ruff check` + `ty check` clean.