### PR TITLE
[codex] Surface orchestrator liveness

### DIFF
--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -61,7 +61,7 @@ _RELAY_PREFIXES = ("/api/v1/", "/d/", "/_next/")
 _TUNNEL_PREFIXES = (
     "/peers", "/events", "/query", "/notify", "/broadcast",
     "/session", "/response", "/spawn", "/ws", "/attachments",
-    "/ask", "/ack", "/asks",
+    "/ask", "/ack", "/asks", "/circles",
 )
 
 # Static file extensions served from web/out root (logos, favicon, images)

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -20,7 +20,7 @@ from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
 import websockets
@@ -71,6 +71,12 @@ class PendingRetry:
 
     def is_active(self, now: float) -> bool:
         return now < self.expires_at
+
+
+@dataclass
+class OrchestratorStatus:
+    present: bool
+    peer: str | None = None
 
 
 def compute_visible_recents(
@@ -279,24 +285,11 @@ class TelegramPeer:
         """
         if self._reply_target:
             return  # respect explicit prior selection
-        try:
-            peers = await self._fetch_online_peers(use_cache=False)
-        except Exception:
+        status = await self._fetch_orchestrator_status(use_cache=False)
+        if not status.present or not status.peer:
             return
-        orchestrators = [
-            p for p in peers
-            if p.get("role") == "orchestrator"
-            and p.get("status") in ("online", "busy")
-        ]
-        if not orchestrators:
-            return
-        # Prefer the local one if multiple exist (shouldn't happen, but defensive)
-        target = orchestrators[0]
-        name = target.get("name") or target.get("display_name")
-        if not name:
-            return
-        self._reply_target = name
-        logger.info("Default reply target seeded to orchestrator: %s", name)
+        self._reply_target = status.peer
+        logger.info("Default reply target seeded to orchestrator: %s", status.peer)
 
     async def _on_ws(self, msg: dict[str, Any]) -> None:
         t = msg.get("type", "")
@@ -481,6 +474,10 @@ class TelegramPeer:
 
         # No conversation active
         self._pending_retry = None
+        orchestrator = await self._fetch_orchestrator_status()
+        if not orchestrator.present:
+            await self._send_no_orchestrator()
+            return
         await self._tg_send(
             "No active conversation\\.\n\n"
             "`/peers` — list peers\n"
@@ -514,6 +511,10 @@ class TelegramPeer:
     async def _on_photo(self, photo: dict, caption: str, message_id: int | None = None) -> None:
         """Handle incoming Telegram photo — upload to daemon, notify peer."""
         if not self._reply_target:
+            orchestrator = await self._fetch_orchestrator_status()
+            if not orchestrator.present:
+                await self._send_no_orchestrator()
+                return
             await self._tg_send(
                 "Select a peer first with /select or /peers, then send the photo\\."
             )
@@ -584,6 +585,54 @@ class TelegramPeer:
         except Exception:
             logger.warning("Failed to fetch peers", exc_info=True)
             return []
+
+    async def _fetch_orchestrator_status(
+        self, *, use_cache: bool = True,
+    ) -> OrchestratorStatus:
+        """Return route-backed orchestrator presence for this bot's circle.
+
+        The daemon route is landing in a sibling branch. Until it is present,
+        fall back to the old peer-list scan so this surface remains testable.
+        """
+        try:
+            r = await self._http.get(
+                f"{self._daemon_url}/circles/{quote(self._circle, safe='')}/orchestrator",
+                timeout=5.0,
+            )
+            if r.status_code == 200:
+                data = r.json()
+                peer = (
+                    data.get("peer_id")
+                    or data.get("peer_name")
+                    or data.get("display_name")
+                    or data.get("name")
+                )
+                return OrchestratorStatus(
+                    present=bool(data.get("present")),
+                    peer=str(peer) if peer else None,
+                )
+        except Exception:
+            logger.debug("Failed to fetch orchestrator status route", exc_info=True)
+
+        peers = await self._fetch_online_peers(use_cache=use_cache)
+        orchestrators = [
+            p for p in peers
+            if p.get("role") == "orchestrator"
+            and p.get("circle", self._circle) == self._circle
+            and p.get("status") in ("online", "busy")
+        ]
+        if not orchestrators:
+            return OrchestratorStatus(present=False)
+
+        target = orchestrators[0]
+        peer = target.get("peer_id") or target.get("name") or target.get("display_name")
+        return OrchestratorStatus(present=True, peer=str(peer) if peer else None)
+
+    async def _send_no_orchestrator(self) -> None:
+        await self._tg_send(
+            f"No orchestrator online in circle `{_esc(self._circle)}`\\.\n"
+            "Spawn one with `repowire orchestrator start`\\."
+        )
 
     async def _cmd_peers(self) -> None:
         peers = await self._fetch_online_peers(use_cache=False)

--- a/tests/test_telegram_default_target.py
+++ b/tests/test_telegram_default_target.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from repowire.telegram.bot import TelegramPeer
+from repowire.telegram.bot import OrchestratorStatus, TelegramPeer
 
 
 @pytest.fixture
@@ -93,3 +93,40 @@ async def test_accepts_busy_orchestrator(
     )
     await bot._seed_default_target_from_orchestrator()
     assert bot._reply_target == "orchestrator"
+
+
+@pytest.mark.asyncio
+async def test_no_active_text_reports_missing_orchestrator(
+    bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bot,
+        "_fetch_orchestrator_status",
+        AsyncMock(return_value=OrchestratorStatus(present=False)),
+    )
+    send = AsyncMock()
+    monkeypatch.setattr(bot, "_tg_send", send)
+
+    await bot._on_text("hello mesh")
+
+    send.assert_awaited_once()
+    assert "No orchestrator online" in send.await_args.args[0]
+    assert "repowire orchestrator start" in send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_no_active_text_keeps_peer_picker_when_orchestrator_present(
+    bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bot,
+        "_fetch_orchestrator_status",
+        AsyncMock(return_value=OrchestratorStatus(present=True, peer="orchestrator")),
+    )
+    send = AsyncMock()
+    monkeypatch.setattr(bot, "_tg_send", send)
+
+    await bot._on_text("hello mesh")
+
+    send.assert_awaited_once()
+    assert "No active conversation" in send.await_args.args[0]

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -9,13 +9,14 @@ import { PeerRoster } from "./components/PeerRoster";
 import { PeerView } from "./components/PeerView";
 import { TopBar } from "./components/TopBar";
 import { WireTrace } from "./components/WireTrace";
-import type { Event, Peer } from "./types";
+import type { Event, OrchestratorStatus, Peer } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8377";
 
 export default function Dashboard() {
   const [peers, setPeers] = useState<Peer[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
+  const [orchestrators, setOrchestrators] = useState<OrchestratorStatus[]>([]);
   const [isConnected, setIsConnected] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [selectedPeerId, setSelectedPeerId] = useState<string | null>(null);
@@ -24,18 +25,65 @@ export default function Dashboard() {
   const [showSpawn, setShowSpawn] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const eventIdsRef = useRef<Set<string>>(new Set());
+  const peersRef = useRef<Peer[]>([]);
+
+  const fetchOrchestrators = useCallback(async (nextPeers?: Peer[]) => {
+    const sourcePeers = nextPeers ?? peersRef.current;
+    const circles = Array.from(
+      new Set(sourcePeers.map((peer) => peer.circle || "default"))
+    ).sort((a, b) => a.localeCompare(b));
+
+    if (circles.length === 0) {
+      setOrchestrators([]);
+      return;
+    }
+
+    const statuses = await Promise.all(
+      circles.map(async (circle): Promise<OrchestratorStatus> => {
+        try {
+          const res = await fetch(`${API_BASE}/circles/${encodeURIComponent(circle)}/orchestrator`);
+          if (res.ok) {
+            const data = await res.json();
+            return { circle, ...data };
+          }
+        } catch (error) {
+          console.debug("Falling back to peer-list orchestrator status:", error);
+        }
+
+        const peer = sourcePeers.find(
+          (candidate) =>
+            (candidate.circle || "default") === circle &&
+            candidate.role === "orchestrator" &&
+            (candidate.status === "online" || candidate.status === "busy")
+        );
+        return {
+          circle,
+          present: Boolean(peer),
+          peer_id: peer?.peer_id ?? null,
+          peer_name: peer?.name ?? null,
+          display_name: peer?.display_name ?? null,
+          last_seen: peer?.last_seen ?? null,
+          stale_after: null,
+        };
+      })
+    );
+    setOrchestrators(statuses);
+  }, []);
 
   const fetchPeers = useCallback(async () => {
     try {
       const res = await fetch(`${API_BASE}/peers`);
       if (res.ok) {
         const data = await res.json();
-        setPeers(data.peers || data);
+        const nextPeers: Peer[] = data.peers || data;
+        peersRef.current = nextPeers;
+        setPeers(nextPeers);
+        await fetchOrchestrators(nextPeers);
       }
     } catch (error) {
       console.error("Failed to fetch peers:", error);
     }
-  }, []);
+  }, [fetchOrchestrators]);
 
   const fetchEvents = useCallback(async () => {
     try {
@@ -105,6 +153,18 @@ export default function Dashboard() {
     [peers]
   );
 
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      void fetchOrchestrators();
+    }, 30_000);
+    return () => window.clearInterval(timer);
+  }, [fetchOrchestrators]);
+
+  const missingOrchestrators = useMemo(
+    () => orchestrators.filter((status) => !status.present),
+    [orchestrators]
+  );
+
   const filteredPeers = useMemo(() => {
     const term = filter.trim().toLowerCase();
     if (!term) return visiblePeers;
@@ -143,7 +203,7 @@ export default function Dashboard() {
 
   return (
     <div className="bg-surface text-on-surface font-body mesh-bg md:h-dvh md:overflow-hidden">
-      <div className="flex min-h-dvh flex-col md:grid md:h-full md:min-h-0 md:grid-cols-[420px_1fr] md:grid-rows-[52px_1fr]">
+      <div className="flex min-h-dvh flex-col md:grid md:h-full md:min-h-0 md:grid-cols-[420px_1fr] md:grid-rows-[52px_auto_1fr]">
         <TopBar
           counts={counts}
           isConnected={isConnected}
@@ -152,6 +212,22 @@ export default function Dashboard() {
           onSpawn={() => setShowSpawn(true)}
           onSettings={() => setShowSettings(true)}
         />
+
+        {missingOrchestrators.length > 0 && (
+          <div className="col-span-full border-b border-error/30 bg-error-container px-3 py-2 text-on-error-container md:px-5">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] leading-5">
+              <span className="font-bold uppercase tracking-[0.16em]">orchestrator offline</span>
+              {missingOrchestrators.map((status) => (
+                <span key={status.circle} className="rounded border border-error/35 bg-error/15 px-2 py-0.5">
+                  circle / {status.circle}
+                </span>
+              ))}
+              <span className="text-on-error-container/85">
+                spawn one with <code className="font-bold">repowire orchestrator start</code>
+              </span>
+            </div>
+          </div>
+        )}
 
         <div className={cn("min-h-0 flex-1 md:block", selectedPeer || mobileTab === "mesh" ? "hidden" : "block")}>
           <PeerRoster

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -17,6 +17,16 @@ export interface Peer {
   };
 }
 
+export interface OrchestratorStatus {
+  circle: string;
+  present: boolean;
+  peer_id?: string | null;
+  peer_name?: string | null;
+  display_name?: string | null;
+  last_seen?: string | null;
+  stale_after?: string | null;
+}
+
 /** Human-readable label: display_name is daemon-assigned and human-friendly. */
 export function peerLabel(peer: Peer): string {
   return peer.display_name || peer.name;


### PR DESCRIPTION
## Summary

- Add a dashboard red banner grouped by circle when orchestrator presence is missing.
- Fetch orchestrator presence from `GET /circles/{name}/orchestrator`, with a peer-list fallback until the daemon route lands.
- Make Telegram untargeted text/photo messages reply with an explicit `repowire orchestrator start` instruction when the circle has no orchestrator online.
- Allow `/circles` through the relay cookie tunnel so the remote dashboard can call the new daemon route.

## Validation

- `uv run pytest tests/test_telegram_default_target.py`
- `uv run ruff check repowire/telegram/bot.py repowire/relay/server.py tests/test_telegram_default_target.py`
- `uv run ty check repowire/telegram/bot.py repowire/relay/server.py`
- `cd web && npm run lint`
- `cd web && npm run build`

## Notes

The daemon orchestrator route is expected from the sibling slice. This PR is route-first and keeps a fallback mock based on `/peers` so the UI and Telegram surfaces behave before that route lands.