### PR TITLE
fix(mcp): refresh last_seen on every MCP tool entry

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -877,6 +877,24 @@ class PeerRegistry:
             peer.status = status
             peer.last_seen = datetime.now(timezone.utc)
 
+    async def touch_last_seen(
+        self, identifier: str, circle: str | None = None,
+    ) -> bool:
+        """Refresh a peer's last_seen without changing status.
+
+        Outbound MCP traffic from a peer is a liveness signal even when the
+        peer's ws-hook has dropped (inbound is broken, but the agent is alive
+        and acting). Lets `is_orchestrator_present` and other last_seen-keyed
+        checks count that activity instead of going stale on the new wrinkle
+        introduced by the liveness slice.
+        """
+        async with self._lock:
+            peer = self._lookup_peer_unlocked(identifier, circle=circle)
+            if not peer:
+                return False
+            peer.last_seen = datetime.now(timezone.utc)
+            return True
+
     async def update_description(
         self, identifier: str, description: str, circle: str | None = None
     ) -> bool:

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -270,6 +270,29 @@ async def set_peer_description(
     return OkResponse()
 
 
+@router.post("/peers/{name}/touch", response_model=OkResponse)
+async def touch_peer_last_seen(
+    name: str,
+    circle: str | None = Query(None),
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Refresh a peer's last_seen without changing status.
+
+    Called by MCP tool entry so outbound MCP traffic counts as a liveness
+    signal — covers the case where a peer's ws-hook has dropped but the
+    agent is still alive and acting (otherwise `is_orchestrator_present`
+    and other last_seen-keyed checks go stale).
+    """
+    peer_registry = get_peer_registry()
+    found = await peer_registry.touch_last_seen(name, circle=circle)
+    if not found:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {name}",
+        )
+    return OkResponse()
+
+
 class SetCircleRequest(BaseModel):
     """Request to set peer's circle."""
 

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -141,15 +141,35 @@ def _hook_disconnect_message(pane_id: str) -> str:
     )
 
 
-async def _ensure_registered(*, strict: bool = False) -> None:
-    """Lazy-register this peer with the daemon on first MCP tool use.
+async def _touch_last_seen() -> None:
+    """Refresh this peer's last_seen on the daemon (best-effort).
 
-    Skips registration if the peer already exists (e.g. SessionStart hook
-    already registered it). Only registers as fallback for agents where
-    hooks don't fire (one-shot prompt mode).
+    Called from `_ensure_registered` so every MCP tool entry feeds the
+    liveness clock. Closes the "ws-hook dropped but agent is alive and
+    acting via MCP" gap that would otherwise leave `is_orchestrator_present`
+    (and other last_seen-keyed checks) stale.
+    """
+    if _cached_peer_name is None:
+        return
+    try:
+        await daemon_request(
+            "POST", f"/peers/{quote(_cached_peer_name, safe='')}/touch",
+        )
+    except Exception:
+        pass
+
+
+async def _ensure_registered(*, strict: bool = False) -> None:
+    """Lazy-register this peer with the daemon on first MCP tool use, and
+    refresh last_seen on every call.
+
+    Registration short-circuits after the first successful resolve; the
+    last_seen touch runs on every entry so MCP activity counts as a liveness
+    signal even when ws-hook has dropped.
     """
     global _registered, _cached_peer_name
     if _registered:
+        await _touch_last_seen()
         return
 
     tmux_info = get_tmux_info()
@@ -161,6 +181,7 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             if name:
                 _cached_peer_name = name
             _registered = True
+            await _touch_last_seen()
             return
         except Exception:
             pass
@@ -174,7 +195,9 @@ async def _ensure_registered(*, strict: bool = False) -> None:
         name = await _get_my_peer_name()
         try:
             await daemon_request("GET", f"/peers/{quote(name, safe='')}")
+            _cached_peer_name = name
             _registered = True
+            await _touch_last_seen()
             return
         except Exception:
             pass
@@ -203,6 +226,7 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             if assigned:
                 _cached_peer_name = assigned
                 _registered = True
+                await _touch_last_seen()
                 return
     except (DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError) as e:
         logger.debug("Path+backend peer lookup failed: %s", e)
@@ -227,6 +251,7 @@ async def _ensure_registered(*, strict: bool = False) -> None:
         if assigned:
             _cached_peer_name = assigned
         _registered = True
+        await _touch_last_seen()
     except Exception:
         pass  # Best-effort -- daemon may be down
 

--- a/tests/test_orchestrator_liveness.py
+++ b/tests/test_orchestrator_liveness.py
@@ -248,3 +248,63 @@ class TestCircleOrchestratorRoute:
         body = r.json()
         assert body["present"] is False
         assert body["peer_id"] is None
+
+
+class TestTouchLastSeen:
+    """MCP outbound traffic must keep `is_orchestrator_present` true even when
+    the peer's ws-hook is dead. The dead-ws-hook + active-MCP shape is the
+    bug the fix targets.
+    """
+
+    async def test_touch_resurrects_stale_orchestrator(self, tmp_path):
+        registry = _make_registry(tmp_path, heartbeat=30)
+        # Stale heartbeat: peer is "registered offline" by the liveness clock
+        # but ONLINE in status. ws-hook is also disconnected (default
+        # transport has no connection for this peer).
+        stale = datetime.now(timezone.utc) - timedelta(seconds=90)
+        await _register_orch(registry, circle="team", last_seen=stale)
+        transport = registry._transport
+        assert transport is not None
+        assert transport.is_connected("repow-team-orch1") is False
+        assert await registry.is_orchestrator_present("team") is False
+
+        # MCP traffic from the live agent touches last_seen via the new path.
+        touched = await registry.touch_last_seen("repow-team-orch1")
+        assert touched is True
+
+        assert await registry.is_orchestrator_present("team") is True
+
+    async def test_touch_does_not_change_status(self, tmp_path):
+        registry = _make_registry(tmp_path)
+        await _register_orch(
+            registry, circle="team", status=PeerStatus.OFFLINE,
+        )
+        await registry.touch_last_seen("repow-team-orch1")
+        async with registry._lock:
+            assert registry._peers["repow-team-orch1"].status == PeerStatus.OFFLINE
+
+    async def test_touch_returns_false_for_unknown_peer(self, tmp_path):
+        registry = _make_registry(tmp_path)
+        assert await registry.touch_last_seen("does-not-exist") is False
+
+    async def test_touch_route_404_for_unknown_peer(self, app_and_registry):
+        client, _ = app_and_registry
+        r = await client.post("/peers/nope/touch")
+        assert r.status_code == 404
+
+    async def test_touch_route_refreshes_last_seen(self, app_and_registry):
+        client, registry = app_and_registry
+        stale = datetime.now(timezone.utc) - timedelta(seconds=90)
+        await _register_orch(
+            registry, circle="team", name="orch", peer_id="orch-1", last_seen=stale,
+        )
+        r = await client.get("/circles/team/orchestrator")
+        assert r.json()["present"] is False
+
+        r = await client.post("/peers/orch-1/touch")
+        assert r.status_code == 200
+
+        r = await client.get("/circles/team/orchestrator")
+        body = r.json()
+        assert body["present"] is True
+        assert body["peer_id"] == "orch-1"

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -599,12 +599,13 @@ class TestMcpRegistration:
             Exception("not found"),  # /peers/by-pane lookup
             {"peers": []},  # /peers?path&backend fallback
             {"display_name": "repowire-codex"},  # POST /peers
+            {"ok": True},  # POST /peers/repowire-codex/touch
         ]
 
         with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
             await mcp_server._ensure_registered()
 
-        assert mock_request.await_count == 3
+        assert mock_request.await_count == 4
         assert mock_request.await_args_list[0].args == ("GET", "/peers/by-pane/%251")
         cwd = mcp_server.Path.cwd()
         assert mock_request.await_args_list[2].args == (
@@ -617,6 +618,9 @@ class TestMcpRegistration:
                 "backend": "codex",
                 "pane_id": "%1",
             },
+        )
+        assert mock_request.await_args_list[3].args == (
+            "POST", "/peers/repowire-codex/touch",
         )
         assert mcp_server._cached_peer_name == "repowire-codex"
 
@@ -638,6 +642,7 @@ class TestMcpRegistration:
         mock_request.side_effect = [
             Exception("name lookup fails"),  # GET /peers/<cwd-name>
             {"peers": [{"display_name": "torale-seo", "tmux_session": "0:0"}]},
+            {"ok": True},  # POST /peers/torale-seo/touch
         ]
 
         with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
@@ -645,9 +650,12 @@ class TestMcpRegistration:
 
         assert mcp_server._cached_peer_name == "torale-seo"
         assert mcp_server._registered is True
-        # Should NOT have made a POST to register a duplicate peer
-        post_calls = [c for c in mock_request.await_args_list if c.args[0] == "POST"]
-        assert len(post_calls) == 0
+        # Should NOT have made a POST to register a duplicate peer (touch is fine).
+        register_posts = [
+            c for c in mock_request.await_args_list
+            if c.args[0] == "POST" and c.args[1] == "/peers"
+        ]
+        assert len(register_posts) == 0
         # Path+backend query should have been made
         get_calls = [c for c in mock_request.await_args_list if c.args[0] == "GET"]
         path_backend_call = next(
@@ -674,12 +682,18 @@ class TestMcpRegistration:
 
         mcp_server._registered = False
         mcp_server._cached_peer_name = None
-        mock_request.return_value = {"display_name": "repowire-codex"}
+        mock_request.side_effect = [
+            {"display_name": "repowire-codex"},  # GET /peers/by-pane
+            {"ok": True},  # POST /peers/repowire-codex/touch
+        ]
 
         await mcp_server._ensure_registered()
 
-        assert mock_request.await_count == 1
+        assert mock_request.await_count == 2
         assert mock_request.await_args_list[0].args == ("GET", "/peers/by-pane/%251")
+        assert mock_request.await_args_list[1].args == (
+            "POST", "/peers/repowire-codex/touch",
+        )
         assert mcp_server._cached_peer_name == "repowire-codex"
 
         mcp_server._registered = False


### PR DESCRIPTION
## Summary
- Outbound MCP traffic now refreshes a peer's `last_seen` via a new `POST /peers/{name}/touch` route, called from `_ensure_registered` so every MCP tool entry feeds the liveness clock.
- Closes the gap (introduced by the liveness slice in #121) where a peer with a dead ws-hook but a live agent + active MCP calls would be ONLINE in status yet stale on `last_seen`, flipping `is_orchestrator_present` to false.
- Adds `PeerRegistry.touch_last_seen(identifier, circle=None)` — sibling of `update_peer_status`, status-free.

Follow-up (separate bug, not bundled): ws-hook auto-respawn for the historical dead-hook shape.

## Test plan
- [x] `pytest`: 577 passed (+4 new in `test_orchestrator_liveness.py`, 3 updated in `test_spawn.py` for the extra touch call)
- [x] `ruff check repowire/`: clean
- [x] `ty check repowire/`: clean
- [x] Headline test: dead ws-hook + stale `last_seen` + touch → `is_orchestrator_present=True`
- [x] Touch does not change status
- [x] `POST /peers/{name}/touch` returns 404 for unknown peer