### PR TITLE
[claude] Hide caller from MCP list_peers by default

### DIFF
--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -281,11 +281,12 @@ def create_mcp_server() -> FastMCP:
         )
 
     @mcp.tool()
-    async def list_peers(show_offline: bool = False) -> str:
+    async def list_peers(show_offline: bool = False, include_self: bool = False) -> str:
         """[Repowire mesh] List all peers across projects and machines.
 
-        By default shows only online/busy peers. Set show_offline=True to include
-        offline peers.
+        By default shows only online/busy peers and hides the calling peer
+        (you). Set show_offline=True to include offline peers, or
+        include_self=True to include yourself in the listing.
 
         Returns TSV: peer_id, name, project, circle, role, status, path, machine,
         description, backend. Peers are reachable via ask/notify_peer. Do NOT
@@ -296,6 +297,13 @@ def create_mcp_server() -> FastMCP:
         params = None if show_offline else {"status": "online"}
         result = await daemon_request("GET", "/peers", params=params)
         peers = result.get("peers", [])
+        if not include_self:
+            my_name = _cached_peer_name
+            if my_name:
+                peers = [
+                    p for p in peers
+                    if (p.get("display_name") or p.get("name")) != my_name
+                ]
         rows = [tsv_header]
         for p in peers:
             rows.append(_peer_to_tsv_row(p))

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -764,6 +764,86 @@ class TestSpawnRouteBackendFromCommand:
         assert _backend_from_command("") is AgentType.CLAUDE_CODE
 
 
+class TestMcpListPeersSelfFilter:
+    """list_peers should hide the calling peer by default (QoL)."""
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_list_peers_hides_self_by_default(
+        self, mock_request: AsyncMock, _mock_register: AsyncMock,
+    ) -> None:
+        import repowire.mcp.server as mcp_server
+        mcp_server._cached_peer_name = "orchestrator"
+        mock_request.return_value = {
+            "peers": [
+                {"peer_id": "repow-1-aa", "display_name": "orchestrator",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+                {"peer_id": "repow-1-bb", "display_name": "alpha",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+            ]
+        }
+
+        try:
+            mcp = mcp_server.create_mcp_server()
+            list_tool = mcp._tool_manager._tools["list_peers"]
+            result = await list_tool.fn()
+            assert "alpha" in result
+            assert "orchestrator" not in result
+        finally:
+            mcp_server._cached_peer_name = None
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_list_peers_include_self_opt_in(
+        self, mock_request: AsyncMock, _mock_register: AsyncMock,
+    ) -> None:
+        import repowire.mcp.server as mcp_server
+        mcp_server._cached_peer_name = "orchestrator"
+        mock_request.return_value = {
+            "peers": [
+                {"peer_id": "repow-1-aa", "display_name": "orchestrator",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+                {"peer_id": "repow-1-bb", "display_name": "alpha",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+            ]
+        }
+
+        try:
+            mcp = mcp_server.create_mcp_server()
+            list_tool = mcp._tool_manager._tools["list_peers"]
+            result = await list_tool.fn(include_self=True)
+            assert "orchestrator" in result
+            assert "alpha" in result
+        finally:
+            mcp_server._cached_peer_name = None
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_list_peers_no_self_filter_when_name_unknown(
+        self, mock_request: AsyncMock, _mock_register: AsyncMock,
+    ) -> None:
+        """If _cached_peer_name is None, no filtering happens (don't accidentally drop peers)."""
+        import repowire.mcp.server as mcp_server
+        mcp_server._cached_peer_name = None
+        mock_request.return_value = {
+            "peers": [
+                {"peer_id": "repow-1-aa", "display_name": "alpha",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+                {"peer_id": "repow-1-bb", "display_name": "beta",
+                 "circle": "main", "status": "online", "backend": "claude-code"},
+            ]
+        }
+
+        mcp = mcp_server.create_mcp_server()
+        list_tool = mcp._tool_manager._tools["list_peers"]
+        result = await list_tool.fn()
+        assert "alpha" in result
+        assert "beta" in result
+
+
 class TestRunMcpServer:
     """Sanity check that run_mcp_server enters the stdio loop."""
 


### PR DESCRIPTION
## Summary

- Make MCP `list_peers` hide the calling peer by default.
- Add `include_self` opt-in to restore prior behavior for callers that need it.
- Keep CLI/operator behavior unchanged.

## Validation

- `uv run pytest` (580 passed)
- `uv run ruff check repowire/mcp/server.py tests/test_spawn.py`

## Notes

Circle-scoping semantics are intentionally not implemented here. Issue #125 tracks the plan-first design for circle-scoped peer surfaces and orchestrator exceptions.
