### PR TITLE
docs(web): slice A — /docs shell + quickstart + concepts

### DIFF
--- a/web/app/docs/DocsSidebar.tsx
+++ b/web/app/docs/DocsSidebar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { DocsNavSection } from "./_nav";
+
+export default function DocsSidebar({ sections }: { sections: DocsNavSection[] }) {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden w-56 shrink-0 lg:block">
+      <nav className="sticky top-24 space-y-7">
+        {sections.map((section) => (
+          <div key={section.label}>
+            <div className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+              {section.label}
+            </div>
+            <ul className="space-y-1">
+              {section.items.map((item) => {
+                const active = pathname === item.href || pathname.startsWith(item.href + "/");
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={
+                        "block border-l-2 px-3 py-1.5 font-mono text-xs transition-colors " +
+                        (active
+                          ? "border-primary bg-surface-container-low text-primary-fixed"
+                          : "border-transparent text-on-surface-variant hover:border-border hover:text-on-surface")
+                      }
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/web/app/docs/_nav.ts
+++ b/web/app/docs/_nav.ts
@@ -28,40 +28,6 @@ export const docsNav: DocsNavSection[] = [
       },
     ],
   },
-  {
-    label: "Reference",
-    items: [
-      {
-        slug: "install",
-        href: "/docs/install",
-        label: "Install",
-        summary: "uv/pipx/pip, per-agent setup, transports, relay.",
-      },
-      {
-        slug: "tools",
-        href: "/docs/tools",
-        label: "Tools",
-        summary: "MCP tool reference: ask, ack, notify_peer, broadcast.",
-      },
-      {
-        slug: "troubleshooting",
-        href: "/docs/troubleshooting",
-        label: "Troubleshooting",
-        summary: "Hook failures, ghost peers, transport mismatch.",
-      },
-    ],
-  },
-  {
-    label: "Compare",
-    items: [
-      {
-        slug: "compare",
-        href: "/docs/compare",
-        label: "Compare",
-        summary: "Repowire vs Happy, Memory Bank, cloud agents.",
-      },
-    ],
-  },
 ];
 
 export function flattenNav(): DocsNavItem[] {

--- a/web/app/docs/_nav.ts
+++ b/web/app/docs/_nav.ts
@@ -1,0 +1,69 @@
+export type DocsNavItem = {
+  slug: string;
+  href: string;
+  label: string;
+  summary: string;
+};
+
+export type DocsNavSection = {
+  label: string;
+  items: DocsNavItem[];
+};
+
+export const docsNav: DocsNavSection[] = [
+  {
+    label: "Start",
+    items: [
+      {
+        slug: "quickstart",
+        href: "/docs/quickstart",
+        label: "Quickstart",
+        summary: "Install, set up, and route your first ask across two repos.",
+      },
+      {
+        slug: "concepts",
+        href: "/docs/concepts",
+        label: "Concepts",
+        summary: "Peers, circles, ask/notify/broadcast, control surfaces.",
+      },
+    ],
+  },
+  {
+    label: "Reference",
+    items: [
+      {
+        slug: "install",
+        href: "/docs/install",
+        label: "Install",
+        summary: "uv/pipx/pip, per-agent setup, transports, relay.",
+      },
+      {
+        slug: "tools",
+        href: "/docs/tools",
+        label: "Tools",
+        summary: "MCP tool reference: ask, ack, notify_peer, broadcast.",
+      },
+      {
+        slug: "troubleshooting",
+        href: "/docs/troubleshooting",
+        label: "Troubleshooting",
+        summary: "Hook failures, ghost peers, transport mismatch.",
+      },
+    ],
+  },
+  {
+    label: "Compare",
+    items: [
+      {
+        slug: "compare",
+        href: "/docs/compare",
+        label: "Compare",
+        summary: "Repowire vs Happy, Memory Bank, cloud agents.",
+      },
+    ],
+  },
+];
+
+export function flattenNav(): DocsNavItem[] {
+  return docsNav.flatMap((section) => section.items);
+}

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -1,0 +1,107 @@
+export const metadata = {
+  title: "Concepts · Repowire Docs",
+};
+
+export default function Concepts() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Concepts
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        How the mesh thinks
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        Repowire is a routing hub for live agent sessions. The daemon holds peer state; everything else is a transport. Reading this once makes the tool reference and troubleshooting pages obvious.
+      </p>
+
+      <Section title="Peers">
+        <p>
+          A peer is one running agent session. Claude Code, Codex, Gemini CLI, and OpenCode all register as peers through the same hooks pattern. Peers have a <Mono>name</Mono>, a <Mono>project</Mono>, a <Mono>circle</Mono>, a <Mono>status</Mono> (online / busy / offline), and a free-form <Mono>description</Mono> the agent sets via <Mono>set_description</Mono>.
+        </p>
+        <p>
+          Peer state lives in the local daemon at <Mono>127.0.0.1:8377</Mono>. It is not synced anywhere by default. Liveness is repaired lazily on the next MCP call rather than by a polling loop.
+        </p>
+      </Section>
+
+      <Section title="Circles">
+        <p>
+          A circle is a logical subnet. Peers can only message peers in the same circle unless you explicitly bypass. Circles map to tmux sessions by default, so opening agents in the same tmux session puts them in the same circle.
+        </p>
+        <p>
+          Use circles to keep work-domain peers from talking to home-project peers when you don&rsquo;t want them to. They are scoping, not authorization.
+        </p>
+      </Section>
+
+      <Section title="Message types">
+        <p>The daemon routes four message types. Pick by lifecycle, not by content.</p>
+        <dl className="mt-4 grid gap-px overflow-hidden border border-border-faint bg-border-faint">
+          <Row term="ask" def="Non-blocking. Returns a correlation_id immediately. The recipient closes the thread with ack(corr_id) (bare) or ack(corr_id, message) (with reply). Chain follow-ups with ask(reply_to=corr_id, ...)." />
+          <Row term="ack" def="Close an open ask thread. Bare close signals 'seen, no action needed'. A reply ack delivers the message back as a notification framed [ack #cid from @peer]." />
+          <Row term="notify_peer" def="Fire-and-forget. No lifecycle, no response expected. Use for status updates and announcements." />
+          <Row term="broadcast" def="Fan-out to all peers in your circle. Use sparingly." />
+        </dl>
+      </Section>
+
+      <Section title="Lazy repair">
+        <p>
+          Repowire avoids polling. Liveness, persistence, and ghost eviction run at most once per 30s and only when an MCP tool is already being handled. Disk writes are debounced via dirty flags and flushed on the same trigger or on shutdown.
+        </p>
+        <p>
+          The practical consequence: a fully idle mesh consumes near-zero CPU. Peers do not heartbeat. State catches up the moment something happens.
+        </p>
+      </Section>
+
+      <Section title="The orchestrator pattern">
+        <p>
+          An orchestrator is a peer whose job is coordinating other peers. Nothing in the daemon enforces this. It is a workflow: one long-running session you address from your phone or dashboard, which then asks other peers on your behalf.
+        </p>
+        <p>
+          Worth setting up when you have more than a few peers and find yourself routing decisions manually. Skip it for two-peer setups.
+        </p>
+      </Section>
+
+      <Section title="Control surfaces">
+        <p>
+          The dashboard, Telegram bot, and Slack bot are peers too. They show up in <Mono>list_peers</Mono> alongside agents and can ask, notify, and broadcast.
+        </p>
+        <ul className="mt-4 space-y-2 text-sm leading-6 text-on-surface-variant">
+          <li>
+            <Mono>dashboard</Mono> — Next.js UI at <Mono>localhost:8377/dashboard</Mono> with a live mesh log and per-peer chat.
+          </li>
+          <li>
+            <Mono>telegram</Mono> — bot you talk to from your phone. Sticky routing: <Mono>/select peer</Mono> sends subsequent messages to that peer.
+          </li>
+          <li>
+            <Mono>slack</Mono> — Socket Mode bot. Same sticky-routing pattern with Block Kit peer pickers.
+          </li>
+        </ul>
+        <p className="mt-4">
+          Messages from <Mono>@telegram</Mono> and <Mono>@dashboard</Mono> are humans. Agents treat them as direct user instructions.
+        </p>
+      </Section>
+    </article>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-headline text-xl font-semibold text-on-surface">{title}</h2>
+      <div className="mt-4 space-y-4 text-sm leading-6 text-on-surface-variant">{children}</div>
+    </section>
+  );
+}
+
+function Mono({ children }: { children: React.ReactNode }) {
+  return <code className="font-mono text-primary-fixed">{children}</code>;
+}
+
+function Row({ term, def }: { term: string; def: string }) {
+  return (
+    <div className="grid gap-2 bg-surface-container-low p-4 sm:grid-cols-[140px_1fr] sm:gap-6">
+      <dt className="font-mono text-xs font-semibold text-primary-fixed">{term}</dt>
+      <dd className="text-sm leading-6 text-on-surface-variant">{def}</dd>
+    </div>
+  );
+}

--- a/web/app/docs/layout.tsx
+++ b/web/app/docs/layout.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Github } from "lucide-react";
+import { docsNav } from "./_nav";
+import DocsSidebar from "./DocsSidebar";
+
+export const metadata = {
+  title: "Docs · Repowire",
+  description: "Repowire documentation: install, concepts, tools, comparisons.",
+};
+
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-surface text-on-surface selection:bg-primary/30 mesh-bg">
+      <nav className="fixed top-0 z-50 w-full border-b border-border-faint mesh-panel pt-[env(safe-area-inset-top)]">
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center gap-3">
+            <Image src="/brand/logo-mark-copper.svg" alt="" width={24} height={26} priority />
+            <span className="font-headline text-sm font-bold uppercase tracking-[0.2em] text-on-surface">
+              REPOWIRE
+            </span>
+          </Link>
+          <div className="flex items-center gap-5">
+            <Link
+              href="/docs/quickstart"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-primary-fixed"
+            >
+              Docs
+            </Link>
+            <Link
+              href="/dashboard"
+              className="hidden font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-outline transition-colors hover:text-primary-fixed sm:inline"
+            >
+              Dashboard
+            </Link>
+            <Link
+              href="https://github.com/prassanna-ravishankar/repowire"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-outline transition-colors hover:text-on-surface"
+            >
+              <span className="sr-only">GitHub</span>
+              <Github className="h-5 w-5" />
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <div className="mx-auto flex max-w-7xl gap-10 px-4 pb-24 pt-24 sm:px-6 lg:px-8 lg:pt-28">
+        <DocsSidebar sections={docsNav} />
+        <main className="min-w-0 flex-1">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { docsNav } from "./_nav";
+
+export default function DocsIndex() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Docs
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        Repowire documentation
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        Repowire routes messages between live AI coding agents on your machine. Start with the quickstart, then read concepts when you want to understand what the daemon is doing.
+      </p>
+
+      <div className="mt-10 space-y-8">
+        {docsNav.map((section) => (
+          <section key={section.label}>
+            <div className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+              {section.label}
+            </div>
+            <ul className="grid gap-px overflow-hidden border border-border-faint bg-border-faint sm:grid-cols-2">
+              {section.items.map((item) => (
+                <li key={item.href} className="bg-surface-container-low">
+                  <Link
+                    href={item.href}
+                    className="group block h-full p-5 transition-colors hover:bg-surface-container"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <h2 className="font-headline text-base font-semibold text-on-surface">
+                        {item.label}
+                      </h2>
+                      <ArrowRight className="h-4 w-4 text-outline transition-colors group-hover:text-primary" />
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-on-surface-variant">{item.summary}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/web/app/docs/quickstart/page.tsx
+++ b/web/app/docs/quickstart/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+export const metadata = {
+  title: "Quickstart · Repowire Docs",
+};
+
+export default function Quickstart() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Quickstart
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        First cross-repo ask in three steps
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        Install Repowire, run setup, open two agents in tmux. They auto-register and discover each other. Tested on macOS and Linux with Python 3.10+.
+      </p>
+
+      <Step n="01" title="Install">
+        <CodeBlock>
+{`# detects uv / pipx / pip, runs interactive setup
+curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
+
+# or manually
+uv tool install repowire`}
+        </CodeBlock>
+        <p className="mt-3 text-sm leading-6 text-on-surface-variant">
+          Requires tmux. The installer detects your agents (Claude Code, Codex, Gemini, OpenCode) and wires hooks and MCP for each one it finds.
+        </p>
+      </Step>
+
+      <Step n="02" title="Set up">
+        <CodeBlock>{`repowire setup`}</CodeBlock>
+        <p className="mt-3 text-sm leading-6 text-on-surface-variant">
+          One-time. Installs lifecycle hooks for every detected agent runtime and starts the local daemon on <code className="font-mono text-primary-fixed">127.0.0.1:8377</code>.
+        </p>
+      </Step>
+
+      <Step n="03" title="Open two agents and ask">
+        <CodeBlock>
+{`# window 1
+cd ~/projects/project-a && claude
+
+# window 2
+cd ~/projects/project-b && codex`}
+        </CodeBlock>
+        <p className="mt-3 text-sm leading-6 text-on-surface-variant">
+          Both sessions auto-register as peers. In <code className="font-mono text-primary-fixed">project-a</code>, ask:
+        </p>
+        <div className="mt-3 border-l-2 border-primary/60 bg-surface-container-low p-4 font-mono text-sm leading-6 text-on-surface">
+          &ldquo;Ask project-b what API endpoints they expose.&rdquo;
+        </div>
+        <p className="mt-3 text-sm leading-6 text-on-surface-variant">
+          The agent calls <code className="font-mono text-primary-fixed">ask</code>. <code className="font-mono text-primary-fixed">project-b</code> receives the question and acks back with <code className="font-mono text-primary-fixed">ack(corr_id, &quot;...&quot;)</code>. The reply lands in <code className="font-mono text-primary-fixed">project-a</code> as a notification framed <code className="font-mono text-primary-fixed">[ack #cid from @project-b]</code>.
+        </p>
+      </Step>
+
+      <div className="mt-12 border-t border-border-faint pt-8">
+        <div className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+          Next
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <NextCard href="/docs/concepts" title="Concepts" desc="Peers, circles, ask vs notify vs broadcast." />
+          <NextCard href="/docs/tools" title="Tools" desc="MCP tools your agent calls to route messages." />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Step({ n, title, children }: { n: string; title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-10 border-l-2 border-primary/40 pl-6">
+      <div className="mb-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-primary-fixed">
+        {n}
+      </div>
+      <h2 className="font-headline text-xl font-semibold text-on-surface">{title}</h2>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+function CodeBlock({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="overflow-x-auto border border-border-faint bg-surface-container-low p-4 font-mono text-xs leading-6 text-on-surface">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function NextCard({ href, title, desc }: { href: string; title: string; desc: string }) {
+  return (
+    <Link
+      href={href}
+      className="group block border border-border-faint bg-surface-container-low p-4 transition-colors hover:bg-surface-container"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="font-headline text-sm font-semibold text-on-surface">{title}</h3>
+        <ArrowRight className="h-4 w-4 text-outline transition-colors group-hover:text-primary" />
+      </div>
+      <p className="mt-2 text-xs leading-5 text-on-surface-variant">{desc}</p>
+    </Link>
+  );
+}

--- a/web/app/docs/quickstart/page.tsx
+++ b/web/app/docs/quickstart/page.tsx
@@ -63,7 +63,6 @@ cd ~/projects/project-b && codex`}
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <NextCard href="/docs/concepts" title="Concepts" desc="Peers, circles, ask vs notify vs broadcast." />
-          <NextCard href="/docs/tools" title="Tools" desc="MCP tools your agent calls to route messages." />
         </div>
       </div>
     </article>

--- a/web/components/Navbar.tsx
+++ b/web/components/Navbar.tsx
@@ -12,7 +12,13 @@ export default function Navbar() {
             REPOWIRE
           </span>
         </Link>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-5">
+          <Link
+            href="/docs/quickstart"
+            className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-outline transition-colors hover:text-primary-fixed"
+          >
+            Docs
+          </Link>
           <Link
             href="/dashboard"
             className="hidden font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-outline transition-colors hover:text-primary-fixed sm:inline"


### PR DESCRIPTION
## Summary
First slice of the docs/comparison work tracked in #126. Ships the `/docs` shell and the two start-of-funnel pages only.

- `/docs` index — links every section (start, reference, compare)
- `/docs/quickstart` — install → setup → first cross-repo ask, three steps
- `/docs/concepts` — peers, circles, ask/notify/broadcast, lazy repair, orchestrator pattern, control surfaces
- Sidebar shell (`DocsSidebar.tsx`), static nav config (`_nav.ts`), shared docs layout
- Navbar gains a top-level `Docs` link pointing at `/docs/quickstart`

Out of scope (later slices per the plan in #126): `/docs/install`, `/docs/tools`, `/docs/troubleshooting`, `/docs/compare` + subpages, homepage "Is this for you?" section.

Content rules from the plan are already in force here: no perf numbers, no E2E claims for relay, no "drop-in replacement" framing, no production-scale fleet claims, builder-to-builder voice, copper-mesh styling, mono for peer names/paths/commands.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint app/docs --max-warnings=0` clean
- [x] `npx next build` succeeds, all three docs routes prerender as static
- [ ] Visual check at `/docs`, `/docs/quickstart`, `/docs/concepts` (dev server)
- [ ] Sidebar active-state highlights the current page
- [ ] Mobile: sidebar hidden, content readable

Refs #126.