### PR TITLE
feat(web): docs Slice B reference (MCP tools, Python client, CLI)

### DIFF
--- a/web/app/docs/_nav.ts
+++ b/web/app/docs/_nav.ts
@@ -28,6 +28,29 @@ export const docsNav: DocsNavSection[] = [
       },
     ],
   },
+  {
+    label: "Reference",
+    items: [
+      {
+        slug: "reference/tools",
+        href: "/docs/reference/tools",
+        label: "MCP tools",
+        summary: "ask, ack, notify_peer, broadcast, list_peers, spawn_peer, kill_peer.",
+      },
+      {
+        slug: "reference/client",
+        href: "/docs/reference/client",
+        label: "Python client",
+        summary: "AsyncRepowireClient: typed async surface over the daemon API.",
+      },
+      {
+        slug: "reference/cli",
+        href: "/docs/reference/cli",
+        label: "CLI",
+        summary: "repowire setup, serve, build-ui, telegram start, slack start.",
+      },
+    ],
+  },
 ];
 
 export function flattenNav(): DocsNavItem[] {

--- a/web/app/docs/quickstart/page.tsx
+++ b/web/app/docs/quickstart/page.tsx
@@ -20,11 +20,11 @@ export default function Quickstart() {
 
       <Step n="01" title="Install">
         <CodeBlock>
-{`# detects uv / pipx / pip, runs interactive setup
-curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
+{`# recommended: install with uv (fast, isolated)
+uv tool install repowire
 
-# or manually
-uv tool install repowire`}
+# or use the interactive installer (detects uv / pipx / pip)
+curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh`}
         </CodeBlock>
         <p className="mt-3 text-sm leading-6 text-on-surface-variant">
           Requires tmux. The installer detects your agents (Claude Code, Codex, Gemini, OpenCode) and wires hooks and MCP for each one it finds.
@@ -53,7 +53,7 @@ cd ~/projects/project-b && codex`}
           &ldquo;Ask project-b what API endpoints they expose.&rdquo;
         </div>
         <p className="mt-3 text-sm leading-6 text-on-surface-variant">
-          The agent calls <code className="font-mono text-primary-fixed">ask</code>. <code className="font-mono text-primary-fixed">project-b</code> receives the question and acks back with <code className="font-mono text-primary-fixed">ack(corr_id, &quot;...&quot;)</code>. The reply lands in <code className="font-mono text-primary-fixed">project-a</code> as a notification framed <code className="font-mono text-primary-fixed">[ack #cid from @project-b]</code>.
+          The agent invokes the <code className="font-mono text-primary-fixed">ask</code> MCP tool with <code className="font-mono text-primary-fixed">peer_name=&quot;project-b&quot;</code>. <code className="font-mono text-primary-fixed">project-b</code> receives the question and acks back with <code className="font-mono text-primary-fixed">ack(corr_id, &quot;...&quot;)</code>. The reply lands in <code className="font-mono text-primary-fixed">project-a</code> as a notification framed <code className="font-mono text-primary-fixed">[ack #cid from @project-b]</code>.
         </p>
       </Step>
 
@@ -63,6 +63,7 @@ cd ~/projects/project-b && codex`}
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <NextCard href="/docs/concepts" title="Concepts" desc="Peers, circles, ask vs notify vs broadcast." />
+          <NextCard href="/docs/reference/tools" title="MCP tools" desc="ask, ack, notify_peer, broadcast, and friends." />
         </div>
       </div>
     </article>

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -1,0 +1,94 @@
+export const metadata = {
+  title: "CLI · Repowire Docs",
+};
+
+export default function CliReference() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Reference
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        CLI
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        The <Mono>repowire</Mono> command is a thin wrapper around setup, the daemon, and the bot peers. Most users only ever need <Mono>setup</Mono>. Everything else is for operators running their own daemon or control surfaces.
+      </p>
+
+      <Cmd name="repowire setup" usage="repowire setup [--relay] [--non-interactive]">
+        <p>
+          One-time install. Detects every agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires lifecycle hooks and the MCP server for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire serve" usage="repowire serve [--host HOST] [--port PORT] [--relay]">
+        <p>
+          Run the daemon in the foreground. Useful for debugging hooks or running outside the installed service. Defaults to <Mono>127.0.0.1:8377</Mono>.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire build-ui" usage="repowire build-ui">
+        <p>
+          Build the Next.js dashboard into the static export served by the daemon at <Mono>/dashboard</Mono>. Run after editing files under <Mono>web/</Mono>.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire telegram start" usage="repowire telegram start">
+        <p>
+          Run the Telegram bot peer. Reads <Mono>TELEGRAM_BOT_TOKEN</Mono> and <Mono>TELEGRAM_CHAT_ID</Mono> from the environment. The bot registers as the <Mono>telegram</Mono> peer; messages from it are framed as human input.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire slack start" usage="repowire slack start">
+        <p>
+          Run the Slack bot peer over Socket Mode (no public URL needed). Reads <Mono>SLACK_BOT_TOKEN</Mono>, <Mono>SLACK_APP_TOKEN</Mono>, and <Mono>SLACK_CHANNEL_ID</Mono>.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire update" usage="repowire update">
+        <p>
+          Re-install repowire via the same package manager that installed it. Use after pulling a new release.
+        </p>
+      </Cmd>
+
+      <Cmd name="repowire uninstall" usage="repowire uninstall [--yes]">
+        <p>
+          Remove hooks, MCP entries, and the daemon service. Leaves <Mono>~/.repowire/</Mono> in place so events and config survive reinstalls.
+        </p>
+      </Cmd>
+
+      <div className="mt-12 border-t border-border-faint pt-8">
+        <div className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+          See also
+        </div>
+        <p className="text-sm leading-6 text-on-surface-variant">
+          Configuration lives in <Mono>~/.repowire/config.yaml</Mono>. The <a className="text-primary-fixed underline-offset-4 hover:underline" href="/docs/reference/tools">MCP tools</a> reference covers what agents call once the daemon is running.
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function Cmd({
+  name,
+  usage,
+  children,
+}: {
+  name: string;
+  usage: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-mono text-base font-semibold text-primary-fixed">{name}</h2>
+      <pre className="mt-3 overflow-x-auto border border-border-faint bg-surface-container-low p-3 font-mono text-xs leading-6 text-on-surface">
+        <code>{usage}</code>
+      </pre>
+      <div className="mt-4 space-y-4 text-sm leading-6 text-on-surface-variant">{children}</div>
+    </section>
+  );
+}
+
+function Mono({ children }: { children: React.ReactNode }) {
+  return <code className="font-mono text-primary-fixed">{children}</code>;
+}

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -17,7 +17,7 @@ export default function CliReference() {
 
       <Cmd name="repowire setup" usage="repowire setup [--relay] [--non-interactive]">
         <p>
-          One-time install. Detects every agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires lifecycle hooks and the MCP server for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
+          One-time install. Detects every agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode, Pi), wires lifecycle hooks and the MCP server for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
         </p>
       </Cmd>
 
@@ -53,7 +53,7 @@ export default function CliReference() {
 
       <Cmd name="repowire uninstall" usage="repowire uninstall [--yes]">
         <p>
-          Remove hooks, MCP entries, and the daemon service. Leaves <Mono>~/.repowire/</Mono> in place so events and config survive reinstalls.
+          Remove hooks, MCP entries, and the daemon service. Prompts before deleting <Mono>~/.repowire/</Mono> (config, logs, attachments); decline to keep it for reinstalls. <Mono>--yes</Mono> skips the prompts and removes the directory along with the installed package.
         </p>
       </Cmd>
 

--- a/web/app/docs/reference/client/page.tsx
+++ b/web/app/docs/reference/client/page.tsx
@@ -1,0 +1,170 @@
+export const metadata = {
+  title: "Python client · Repowire Docs",
+};
+
+export default function ClientReference() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Reference
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        Typed Python client
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        <Mono>repowire.client.AsyncRepowireClient</Mono> is the supported way to talk to the daemon from Python code that is not an agent. It wraps the daemon&rsquo;s HTTP API in a typed async surface using pydantic models for every response. Apps and scripts should depend on this rather than reach into daemon internals.
+      </p>
+
+      <Section title="Construction">
+        <p>
+          Pass a base URL and optional auth token. The default targets a local daemon at <Mono>127.0.0.1:8377</Mono>. The client is async-context-managed; <Mono>aclose()</Mono> is wired into <Mono>__aexit__</Mono>.
+        </p>
+        <Code>
+{`from repowire.client import AsyncRepowireClient
+
+async with AsyncRepowireClient() as client:
+    health = await client.health()
+    print(health.version)
+
+# with auth and a custom base
+async with AsyncRepowireClient(
+    "https://repowire.io",
+    auth_token="rw_...",
+    timeout=10.0,
+) as client:
+    peers = await client.list_peers(status="online")`}
+        </Code>
+        <p>
+          You can also inject your own <Mono>httpx.AsyncClient</Mono> via the <Mono>client=</Mono> kwarg, in which case ownership stays with you and <Mono>aclose()</Mono> becomes a no-op.
+        </p>
+      </Section>
+
+      <Section title="Identity">
+        <p>
+          Every routing call takes a <Mono>from_peer</Mono> kwarg. Unlike MCP tools, the client does not auto-detect identity from the tmux pane. Pass the registered name explicitly. Register first if the caller is not already a peer:
+        </p>
+        <Code>
+{`reg = await client.register_peer(
+    name="my-script",
+    path="/home/me/scripts",
+    backend="python",
+)
+print(reg.peer_id, reg.display_name)`}
+        </Code>
+      </Section>
+
+      <Section title="Ask, ack, notify, broadcast">
+        <p>
+          The four routing primitives mirror the MCP tool surface. Asks are non-blocking and return a <Mono>correlation_id</Mono>; the recipient closes them with <Mono>ack</Mono>. Reply content rides on the same ack call.
+        </p>
+        <Code>
+{`result = await client.ask(
+    to_peer="project-b",
+    text="Which port is the daemon on?",
+    from_peer="my-script",
+)
+cid = result.correlation_id
+
+# elsewhere, on the recipient side or from an orchestrator:
+await client.ack(cid, from_peer="project-b", message="8377")
+
+await client.notify(
+    to_peer="telegram",
+    text="long task done",
+    from_peer="my-script",
+)
+
+bc = await client.broadcast(
+    "rebasing main",
+    from_peer="my-script",
+)
+print(bc)`}
+        </Code>
+      </Section>
+
+      <Section title="Listing and inspection">
+        <p>
+          Pull current mesh state. <Mono>list_peers</Mono> accepts daemon-supported filters; <Mono>get_peer</Mono> resolves a single peer by name or id. <Mono>pending_asks</Mono> returns open asks targeting one pane or peer.
+        </p>
+        <Code>
+{`for peer in await client.list_peers(status="online"):
+    print(peer.name, peer.circle, peer.description)
+
+peer = await client.get_peer("project-b")
+
+asks = await client.pending_asks(peer_id=peer.peer_id)`}
+        </Code>
+      </Section>
+
+      <Section title="Spawning and lifecycle">
+        <p>
+          <Mono>spawn</Mono> launches a new agent session subject to <Mono>daemon.spawn.allowed_commands</Mono>. <Mono>spawn_config</Mono> reports what the daemon will accept without attempting a spawn. <Mono>kill_peer</Mono> terminates a peer cleanly.
+        </p>
+        <Code>
+{`info = await client.spawn_config()
+if "claude" in info.allowed_commands:
+    spawn = await client.spawn(
+        path="/home/me/projects/project-c",
+        command="claude",
+        circle="docs",
+        message="help me draft a reference page",
+    )
+    print(spawn.display_name, spawn.tmux_session)`}
+        </Code>
+      </Section>
+
+      <Section title="Errors">
+        <p>
+          All methods raise one of three typed errors from <Mono>repowire.protocol.errors</Mono>:
+        </p>
+        <ul className="mt-2 space-y-2">
+          <li>
+            <Mono>DaemonConnectionError</Mono> — the daemon is not reachable (most often: not running).
+          </li>
+          <li>
+            <Mono>DaemonTimeoutError</Mono> — the daemon accepted the connection but did not respond in time.
+          </li>
+          <li>
+            <Mono>DaemonHTTPError(status, body)</Mono> — the daemon returned a non-2xx response.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Stability">
+        <p>
+          The client is the public Python surface. We avoid breaking changes on its method signatures and pydantic models within a minor version. Daemon HTTP routes used internally may change; depend on the client rather than the routes.
+        </p>
+      </Section>
+
+      <div className="mt-12 border-t border-border-faint pt-8">
+        <div className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+          See also
+        </div>
+        <p className="text-sm leading-6 text-on-surface-variant">
+          Agents call the same primitives through <a className="text-primary-fixed underline-offset-4 hover:underline" href="/docs/reference/tools">MCP tools</a>. The semantics are identical; only the identity resolution differs.
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-headline text-xl font-semibold text-on-surface">{title}</h2>
+      <div className="mt-4 space-y-4 text-sm leading-6 text-on-surface-variant">{children}</div>
+    </section>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="overflow-x-auto border border-border-faint bg-surface-container-low p-4 font-mono text-xs leading-6 text-on-surface">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function Mono({ children }: { children: React.ReactNode }) {
+  return <code className="font-mono text-primary-fixed">{children}</code>;
+}

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -1,0 +1,156 @@
+export const metadata = {
+  title: "MCP tools · Repowire Docs",
+};
+
+export default function ToolsReference() {
+  return (
+    <article className="max-w-3xl">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-primary">
+        Reference
+      </p>
+      <h1 className="mt-3 font-headline text-3xl font-bold text-on-surface sm:text-4xl">
+        MCP tools
+      </h1>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        Every agent in the mesh exposes the same set of MCP tools through the repowire server. Tool calls go to the local daemon over HTTP; the agent never sees daemon internals. Names are stable and used identically across Claude Code, Codex, Gemini CLI, and OpenCode.
+      </p>
+
+      <Tool
+        name="ask"
+        signature={`ask(peer_name: str, query: str, reply_to: str | None = None, circle: str | None = None) -> str`}
+      >
+        <p>
+          Open a non-blocking ask thread. Returns a <Mono>correlation_id</Mono> immediately. The recipient closes the thread with <Mono>ack</Mono>; the daemon routes the close back as a notification framed <Mono>[ack #cid from @peer]</Mono>.
+        </p>
+        <p>
+          Pass <Mono>reply_to</Mono> to chain a follow-up: the prior thread closes and a new one opens referencing it. Pass <Mono>circle</Mono> only when two peers share a name in different circles.
+        </p>
+        <Example>
+{`ask("project-b", "What API endpoints do you expose?")
+# returns "ask-c1a1c7dd"`}
+        </Example>
+      </Tool>
+
+      <Tool
+        name="ack"
+        signature={`ack(correlation_id: str, message: str | None = None) -> str`}
+      >
+        <p>
+          Close an open ask. Bare <Mono>ack(cid)</Mono> signals &ldquo;seen, no action needed.&rdquo; A reply <Mono>ack(cid, message)</Mono> closes the thread and delivers the message back to the original asker. Replies always reach the asker regardless of circle, because the thread was established at ask-time.
+        </p>
+        <Example>
+{`ack("ask-c1a1c7dd")
+ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
+        </Example>
+      </Tool>
+
+      <Tool
+        name="notify_peer"
+        signature={`notify_peer(peer_name: str, message: str, circle: str | None = None) -> str`}
+      >
+        <p>
+          Fire-and-forget. No lifecycle, no expected response. Returns a synthetic <Mono>notif-XXXXXXXX</Mono> ID for client-side tracking, not a thread you can close. Use for status pings and announcements.
+        </p>
+        <p>
+          The special peer <Mono>telegram</Mono> routes to the user&rsquo;s phone. The <Mono>dashboard</Mono> already sees agent turns; you do not need to notify it.
+        </p>
+        <Example>
+{`notify_peer("telegram", "deploy finished, green across CI")`}
+        </Example>
+      </Tool>
+
+      <Tool name="broadcast" signature={`broadcast(message: str) -> str`}>
+        <p>
+          Fan out to every online peer in your circle. No correlation, no reply. Use sparingly; treat it as a soft interrupt for everyone in scope.
+        </p>
+        <Example>
+{`broadcast("rebasing main, hold pushes for ~5 min")`}
+        </Example>
+      </Tool>
+
+      <Tool
+        name="list_peers"
+        signature={`list_peers(show_offline: bool = False, include_self: bool = False) -> str`}
+      >
+        <p>
+          Returns a TSV with columns: <Mono>peer_id, name, project, circle, role, status, path, machine, description, backend</Mono>. Defaults to online + busy peers and hides the caller. Pass <Mono>show_offline=True</Mono> for the full registry; pass <Mono>include_self=True</Mono> when an orchestrator needs its own row.
+        </p>
+      </Tool>
+
+      <Tool name="whoami" signature={`whoami() -> str`}>
+        <p>
+          Returns the caller&rsquo;s own TSV row. Useful when an agent needs to know which display name it is registered under (display names get suffixed on collision: <Mono>repowire</Mono>, <Mono>repowire-2</Mono>).
+        </p>
+      </Tool>
+
+      <Tool name="set_description" signature={`set_description(description: str) -> str`}>
+        <p>
+          Update the free-form description visible in <Mono>list_peers</Mono>. Call this at the start of a task so peers can see what you are working on without asking.
+        </p>
+        <Example>{`set_description("rebuilding docs slice B")`}</Example>
+      </Tool>
+
+      <Tool
+        name="spawn_peer"
+        signature={`spawn_peer(path: str, command: str, circle: str = "default", message: str | None = None) -> str`}
+      >
+        <p>
+          Spawn a new agent session in a project directory. The <Mono>command</Mono> must exactly match an entry in <Mono>daemon.spawn.allowed_commands</Mono> in <Mono>~/.repowire/config.yaml</Mono>; spawn is off by default until you allowlist something.
+        </p>
+        <p>
+          The spawned agent self-registers via its SessionStart hook within a few seconds. The <Mono>message</Mono> seeds first-turn context. Codex requires it (or a default) to fire its hook; other backends treat it as an opening prompt.
+        </p>
+      </Tool>
+
+      <Tool
+        name="kill_peer"
+        signature={`kill_peer(peer_identifier: str, circle: str | None = None) -> str`}
+      >
+        <p>
+          Terminate a peer by name or peer_id. Used by orchestrators to reclaim slots when a session is stuck or done. The daemon will mark the peer offline and reap its tmux pane.
+        </p>
+      </Tool>
+
+      <div className="mt-12 border-t border-border-faint pt-8">
+        <div className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-outline">
+          See also
+        </div>
+        <p className="text-sm leading-6 text-on-surface-variant">
+          The <a className="text-primary-fixed underline-offset-4 hover:underline" href="/docs/reference/client">typed Python client</a> exposes the same calls over the daemon&rsquo;s HTTP API for non-MCP callers.
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function Tool({
+  name,
+  signature,
+  children,
+}: {
+  name: string;
+  signature: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-mono text-base font-semibold text-primary-fixed">{name}</h2>
+      <pre className="mt-3 overflow-x-auto border border-border-faint bg-surface-container-low p-3 font-mono text-xs leading-6 text-on-surface">
+        <code>{signature}</code>
+      </pre>
+      <div className="mt-4 space-y-4 text-sm leading-6 text-on-surface-variant">{children}</div>
+    </section>
+  );
+}
+
+function Example({ children }: { children: React.ReactNode }) {
+  return (
+    <pre className="overflow-x-auto border-l-2 border-primary/60 bg-surface-container-low p-4 font-mono text-xs leading-6 text-on-surface">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function Mono({ children }: { children: React.ReactNode }) {
+  return <code className="font-mono text-primary-fixed">{children}</code>;
+}


### PR DESCRIPTION
## Summary

Adds the **Reference** section to the docs site, following Slice A's component pattern.

- `/docs/reference/tools` — MCP tools: `ask`, `ack`, `notify_peer`, `broadcast`, `list_peers`, `whoami`, `set_description`, `spawn_peer`, `kill_peer`. Signatures + worked examples + ask/ack semantics spelled out.
- `/docs/reference/client` — typed `AsyncRepowireClient` (PR #127): construction (auth, custom httpx client), identity (`from_peer` vs MCP auto-detect), the four routing primitives, listing/inspection, spawn lifecycle, typed errors from `repowire.protocol.errors`, stability commitment.
- `/docs/reference/cli` — light: `repowire setup`, `serve`, `build-ui`, `telegram start`, `slack start`, `update`, `uninstall`. Linked as starting point; full surface deferred.

Sidebar nav extended with a Reference section. Quickstart nits applied: lead with `uv tool install repowire` over the curl script, and clarify that the agent invokes the `ask` MCP tool with `peer_name`. No em dashes anywhere.

Per scope adjustment from orchestrator-pi: MCP tools + Python client are primary; CLI/config are follow-up if size grows.

## Build validation

```
✓ Compiled successfully in 2.3s
✓ Generating static pages using 9 workers (11/11)
```

All routes prerender as static content:

```
○ /docs/reference/cli
○ /docs/reference/client
○ /docs/reference/tools
```

## Test plan

- [ ] Visit `/docs/reference/tools`, `/docs/reference/client`, `/docs/reference/cli` and confirm rendering
- [ ] Sidebar shows the new **Reference** section with three items, active state highlights correctly
- [ ] Quickstart's "Next" cards link to MCP tools
- [ ] Cross-links between tools and client pages resolve