### PR TITLE
feat(hooks): ws-hook auto-respawn from Stop hook

### DIFF
--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -19,13 +19,12 @@ from repowire.hooks.utils import (
     clear_pane_runtime_state,
     daemon_get,
     daemon_post,
-    get_pane_file,
-    pane_logs_dir,
     read_pane_runtime_metadata,
     write_pane_runtime_metadata,
     ws_hook_lock_path,
     ws_hook_pid_path,
 )
+from repowire.hooks.ws_hook_supervisor import spawn_ws_hook
 from repowire.spawn_hints import consume_hint_full
 
 
@@ -188,8 +187,6 @@ def main(backend: str = "claude-code") -> int:
         # One ws-hook owns a pane at a time. A repeated SessionStart with the
         # same hook session_id is treated as an ephemeral sub-session of the
         # same live run. Anything else is a real takeover and starts fresh.
-        pane_file = get_pane_file(pane_id)
-        log_dir = pane_logs_dir()
         lock_path = ws_hook_lock_path(pane_id)
         pid_path = ws_hook_pid_path(pane_id)
         prior_peer_id: str | None = None
@@ -268,30 +265,19 @@ def main(backend: str = "claude-code") -> int:
 
         # Launch async WebSocket hook in background — one per pane.
         try:
-            hook_script = Path(__file__).parent / "websocket_hook.py"
-            if hook_script.exists():
-                log_file = open(log_dir / f"ws-hook-{pane_file}.log", "w")  # noqa: SIM115
-                try:
-                    env = os.environ.copy()
-                    env["REPOWIRE_DISPLAY_NAME"] = display_name
-                    if peer_id:
-                        env["REPOWIRE_PEER_ID"] = peer_id
-                    env["REPOWIRE_BACKEND"] = backend
-                    proc = subprocess.Popen(
-                        [sys.executable, str(hook_script)],
-                        stdout=log_file,
-                        stderr=log_file,
-                        start_new_session=True,
-                        cwd=cwd,
-                        env=env,
-                        pass_fds=(lock_fd.fileno(),),
-                    )
-                    pid_path.write_text(str(proc.pid))
-                finally:
-                    log_file.close()
-                    lock_fd.close()  # child inherits flock; parent releases fd
+            spawn_ws_hook(
+                pane_id=pane_id,
+                peer_id=peer_id,
+                display_name=display_name,
+                backend=backend,
+                cwd=cwd,
+                lock_fd=lock_fd,
+            )
         except Exception as e:
             print(f"repowire: failed to start WebSocket hook: {e}", file=sys.stderr)
+        finally:
+            # Child inherited the flock via pass_fds; release our copy.
+            lock_fd.close()
 
         # Fetch peers and output context for Claude
         peers = fetch_peers()

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -16,6 +16,7 @@ from repowire.hooks.utils import (
     pop_query_cid,
     update_status,
 )
+from repowire.hooks.ws_hook_supervisor import maybe_respawn
 from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
 
 
@@ -50,6 +51,11 @@ def main(backend: str = "claude-code") -> int:
 
     peer_display = get_display_name()
     pane_id = get_pane_id()
+
+    # Lazy-repair: if the ws-hook process for this pane died (OOM, SIGKILL,
+    # unhandled exception), Stop is the cheapest place to notice and relaunch.
+    # No new polling -- this piggy-backs on traffic that already runs every turn.
+    maybe_respawn(pane_id)
 
     # Get response text: adapter extracts from agent-specific fields,
     # fall back to transcript parsing for Claude Code

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -523,8 +523,16 @@ async def main() -> int:
                 # Message loop — fully reactive, no polling tasks
                 try:
                     async for message in websocket:
-                        data = json.loads(message)
-                        await handle_message(data, pane_id, websocket)
+                        try:
+                            data = json.loads(message)
+                            await handle_message(data, pane_id, websocket)
+                        except PaneUnsafeError:
+                            raise
+                        except Exception as exc:
+                            # A malformed payload or handler bug must not kill
+                            # the hook -- Stop-hook respawn is a safety net,
+                            # not a routine recovery path. Log and keep reading.
+                            logger.exception("Error handling message: %s", exc)
                 except PaneUnsafeError as e:
                     logger.info("%s", e)
                     clear_pane_runtime_state(pane_id)

--- a/repowire/hooks/ws_hook_supervisor.py
+++ b/repowire/hooks/ws_hook_supervisor.py
@@ -1,0 +1,164 @@
+"""Spawn and respawn the per-pane ws-hook process.
+
+The ws-hook is launched once at SessionStart and pinned to its pane via an
+exclusive flock plus a pid file. Its internal reconnect loop survives daemon
+restarts and transient network failures, but if the *process itself* dies
+(OOM, SIGKILL, unhandled exception in a handler) nothing brings it back
+until the next SessionStart -- the agent keeps running while inbound asks
+silently drop.
+
+`maybe_respawn` is the lazy-repair path: it piggy-backs on Stop hook traffic
+to detect a dead pid file, claim the flock, and relaunch the ws-hook using
+the persisted pane metadata. No new polling.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from repowire.hooks.utils import (
+    get_pane_file,
+    pane_logs_dir,
+    read_pane_runtime_metadata,
+    ws_hook_lock_path,
+    ws_hook_pid_path,
+)
+
+
+def spawn_ws_hook(
+    *,
+    pane_id: str | None,
+    peer_id: str | None,
+    display_name: str,
+    backend: str,
+    cwd: str,
+    lock_fd,
+) -> int | None:
+    """Launch websocket_hook.py in the background and write its pid file.
+
+    `lock_fd` must already hold an exclusive flock on `ws_hook_lock_path(pane_id)`.
+    The child inherits the flock via `pass_fds`; the caller is responsible for
+    closing its own copy of the fd after this returns.
+
+    Returns the child pid, or None if the hook script is missing.
+    """
+    hook_script = Path(__file__).parent / "websocket_hook.py"
+    if not hook_script.exists():
+        return None
+
+    pane_file = get_pane_file(pane_id)
+    log_dir = pane_logs_dir()
+    log_file = open(log_dir / f"ws-hook-{pane_file}.log", "a")  # noqa: SIM115
+    try:
+        env = os.environ.copy()
+        env["REPOWIRE_DISPLAY_NAME"] = display_name
+        if peer_id:
+            env["REPOWIRE_PEER_ID"] = peer_id
+        env["REPOWIRE_BACKEND"] = backend
+        # ws-hook reads TMUX_PANE for its pane id. Stop hook respawn runs in
+        # a different subprocess context than SessionStart, so set explicitly.
+        if pane_id:
+            env["TMUX_PANE"] = pane_id
+        proc = subprocess.Popen(
+            [sys.executable, str(hook_script)],
+            stdout=log_file,
+            stderr=log_file,
+            start_new_session=True,
+            cwd=cwd,
+            env=env,
+            pass_fds=(lock_fd.fileno(),),
+        )
+        ws_hook_pid_path(pane_id).write_text(str(proc.pid))
+        return proc.pid
+    finally:
+        log_file.close()
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` exists. EPERM also counts as alive (foreign owner)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def maybe_respawn(pane_id: str | None) -> bool:
+    """Restart the ws-hook for `pane_id` iff its prior process is dead.
+
+    Lazy-repair path triggered from the Stop hook. Returns True when a fresh
+    ws-hook was launched, False otherwise (no pane, pid still alive, lock
+    contested, missing metadata, or hook script absent).
+
+    Best-effort: any failure is swallowed so the Stop hook never breaks an
+    agent turn over a respawn miss.
+    """
+    if not pane_id:
+        return False
+
+    try:
+        pid_path = ws_hook_pid_path(pane_id)
+        try:
+            pid_text = pid_path.read_text().strip()
+        except OSError:
+            # No pid file: either ws-hook was never started for this pane, or
+            # it shut down cleanly (e.g. PaneUnsafeError clears state). Either
+            # way, respawning here would race with SessionStart. Skip.
+            return False
+
+        try:
+            old_pid = int(pid_text)
+        except ValueError:
+            return False
+
+        if _pid_alive(old_pid):
+            return False
+
+        # Claim the pane's lock non-blocking. If contested, some other
+        # ws-hook is in the middle of starting or already alive -- leave it.
+        lock_path = ws_hook_lock_path(pane_id)
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+        try:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                lock_fd.close()
+                return False
+
+            metadata = read_pane_runtime_metadata(pane_id)
+            cwd = metadata.get("cwd")
+            display_name = metadata.get("display_name")
+            backend = metadata.get("backend") or "claude-code"
+            peer_id = metadata.get("peer_id")
+            if not cwd or not display_name:
+                # Without these we can't recreate the prior connect state.
+                # Drop the stale pid file so a future SessionStart isn't
+                # confused, but don't spawn blindly.
+                try:
+                    pid_path.unlink()
+                except OSError:
+                    pass
+                return False
+
+            new_pid = spawn_ws_hook(
+                pane_id=pane_id,
+                peer_id=peer_id,
+                display_name=display_name,
+                backend=backend,
+                cwd=cwd,
+                lock_fd=lock_fd,
+            )
+            return new_pid is not None
+        finally:
+            # Child inherited the flock via pass_fds; releasing our copy is
+            # safe and required so we don't leak the descriptor.
+            lock_fd.close()
+    except Exception as e:
+        print(f"repowire: ws-hook respawn failed: {e}", file=sys.stderr)
+        return False

--- a/tests/test_ws_hook_supervisor.py
+++ b/tests/test_ws_hook_supervisor.py
@@ -1,0 +1,113 @@
+"""Tests for the ws-hook supervisor (auto-respawn from the Stop hook)."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from unittest.mock import patch
+
+import pytest
+
+from repowire.hooks import ws_hook_supervisor
+from repowire.hooks.utils import (
+    write_pane_runtime_metadata,
+    ws_hook_lock_path,
+    ws_hook_pid_path,
+)
+
+PANE_ID = "%99"
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("repowire.config.models.CACHE_DIR", tmp_path)
+    return tmp_path
+
+
+def _write_meta(pane_id: str, cwd: str) -> None:
+    write_pane_runtime_metadata(
+        pane_id,
+        {
+            "backend": "claude-code",
+            "cwd": cwd,
+            "display_name": "respawn-test",
+            "hook_session_id": "sess-1",
+            "peer_id": "repow-default-deadbeef",
+        },
+    )
+
+
+class TestMaybeRespawn:
+    def test_no_pane_id_short_circuits(self, cache_dir):
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(None) is False
+            mock_spawn.assert_not_called()
+
+    def test_missing_pid_file_does_not_spawn(self, cache_dir):
+        # No pid file written: ws-hook was never started or was cleaned up.
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+            mock_spawn.assert_not_called()
+
+    def test_skips_when_pid_alive(self, cache_dir):
+        # Our own pid is guaranteed alive.
+        ws_hook_pid_path(PANE_ID).write_text(str(os.getpid()))
+        _write_meta(PANE_ID, str(cache_dir))
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+            mock_spawn.assert_not_called()
+
+    def test_respawns_when_pid_dead_and_lock_free(self, cache_dir):
+        # PID 1 (init) cannot be ours, so os.kill(1, 0) raises PermissionError,
+        # which counts as alive. Use a sentinel pid that's guaranteed dead.
+        ws_hook_pid_path(PANE_ID).write_text("99999999")
+        _write_meta(PANE_ID, str(cache_dir))
+
+        with patch.object(
+            ws_hook_supervisor, "spawn_ws_hook", return_value=12345,
+        ) as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is True
+            mock_spawn.assert_called_once()
+            kwargs = mock_spawn.call_args.kwargs
+            assert kwargs["pane_id"] == PANE_ID
+            assert kwargs["display_name"] == "respawn-test"
+            assert kwargs["backend"] == "claude-code"
+            assert kwargs["peer_id"] == "repow-default-deadbeef"
+            assert kwargs["cwd"] == str(cache_dir)
+
+    def test_does_not_respawn_when_lock_contested(self, cache_dir):
+        ws_hook_pid_path(PANE_ID).write_text("99999999")
+        _write_meta(PANE_ID, str(cache_dir))
+
+        # Hold the flock from this test process to simulate another ws-hook
+        # owning the pane.
+        lock_path = ws_hook_lock_path(PANE_ID)
+        contender = open(lock_path, "w")
+        try:
+            fcntl.flock(contender, fcntl.LOCK_EX)
+            with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+                assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+                mock_spawn.assert_not_called()
+        finally:
+            fcntl.flock(contender, fcntl.LOCK_UN)
+            contender.close()
+
+    def test_clears_pid_file_when_metadata_missing(self, cache_dir):
+        # Dead pid but no usable metadata -- can't reconstruct the connect
+        # payload, so drop the stale pid file and stay out of the way.
+        pid_path = ws_hook_pid_path(PANE_ID)
+        pid_path.write_text("99999999")
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+            mock_spawn.assert_not_called()
+            assert not pid_path.exists()
+
+    def test_garbled_pid_file_does_not_spawn(self, cache_dir):
+        ws_hook_pid_path(PANE_ID).write_text("not-a-number")
+        _write_meta(PANE_ID, str(cache_dir))
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+            mock_spawn.assert_not_called()


### PR DESCRIPTION
## Summary

The per-pane ws-hook process is launched once at SessionStart and pinned via flock + pid file. Its internal reconnect loop survives daemon restarts and network blips, but if the **process itself** dies (OOM, SIGKILL, unhandled exception in a handler) there is no respawn until the next SessionStart — the agent keeps running while inbound asks silently drop.

Slice 1 closes that gap with a lazy-repair path, no new polling:

- **`repowire/hooks/ws_hook_supervisor.py`** (new): factored `spawn_ws_hook()` out of `session_handler` so the launch is reusable; added `maybe_respawn(pane_id)` which reads the pid file, verifies it's dead via `os.kill(pid, 0)`, claims the pane's flock non-blocking, rehydrates connect state from `read_pane_runtime_metadata`, and relaunches via `spawn_ws_hook`. Stale pid + missing metadata → drops the pid file and bows out. Any failure is swallowed best-effort so Stop never breaks an agent turn.
- **`stop_handler.main`**: now calls `maybe_respawn(pane_id)` right after pane resolution. Piggy-backs on Stop traffic that already runs every turn — matches the lazy-repair rule in `CLAUDE.md` ("nothing polls").
- **`websocket_hook.py` message loop**: wraps each `handle_message` call so non-`PaneUnsafeError` exceptions log + continue instead of killing the process. `PaneUnsafeError` stays terminal (correct — pane takeover should exit cleanly).
- **`session_handler`**: now delegates to `spawn_ws_hook`, dropping the duplicated Popen block.

## Validation

- `uv run pytest`: **607 passed** (7 new in `tests/test_ws_hook_supervisor.py`)
- `uv run ruff check repowire/ tests/test_ws_hook_supervisor.py tests/test_session_handler.py tests/test_stop_handler.py`: clean
- `uv run ty check repowire/`: All checks passed

New test coverage in `test_ws_hook_supervisor.py`:
- no-pane short-circuit
- missing pid file → no spawn
- live pid → no spawn
- dead pid + free flock → respawn with correct kwargs from metadata
- dead pid + contested flock → no spawn
- dead pid + missing metadata → drops stale pid file, no spawn
- garbled pid file → no spawn

## Test plan

- [x] Unit tests for all `maybe_respawn` branches
- [x] Full suite green
- [x] ruff + ty clean on touched files
- [ ] Live test: install via `uv tool install --force --reinstall .`, kill the ws-hook process (`kill -9 \$(cat ~/.repowire/logs/ws-hook-*.pid)`), trigger a Stop turn, verify a new ws-hook process is spawned and inbound asks resume

## Follow-ups (not in this slice)

- Daemon-side liveness signal: daemon could mark peers degraded when their ws-hook stops responding to pings, surfacing the gap to other peers before the next Stop fires.
- MCP-triggered respawn: an MCP tool call is another cheap lazy-repair touchpoint, symmetric with what Stop does here.
- Channel transport parity: `channel/server.ts` has the same single-process exposure; needs a similar supervisor pattern.
- OpenCode plugin parity: the OpenCode plugin runtime doesn't currently call into this path.