### PR TITLE
feat(daemon): scheduled check-ins MVP (one-shot, create/list/delete)

### DIFF
--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -36,9 +36,12 @@ from repowire.daemon.routes import (
     messages,
     peers,
     reviews,
+    schedules,
     websocket,
 )
 from repowire.daemon.routes import spawn as spawn_routes
+from repowire.daemon.schedule_store import ScheduleStore
+from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.websocket_transport import WebSocketTransport
 
 logger = logging.getLogger(__name__)
@@ -99,6 +102,15 @@ def create_app(
         )
         peer_registry.prune_offline(max_age_hours=cfg.daemon.prune_max_age_hours)
 
+        schedule_store = ScheduleStore(
+            persistence_path=Path.home() / ".repowire" / "schedules.json",
+        )
+        scheduler = Scheduler(
+            store=schedule_store,
+            peer_registry=peer_registry,
+            ask_tracker=ask_tracker,
+        )
+
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -111,6 +123,8 @@ def create_app(
         app.state.review_queue_store = ReviewQueueStore(
             Path.home() / ".repowire" / "review_queue.json"
         )
+        app.state.schedule_store = schedule_store
+        app.state.scheduler = scheduler
 
         lifecycle_handler = LifecycleHandler(
             peer_registry=peer_registry,
@@ -119,6 +133,7 @@ def create_app(
         )
 
         await peer_registry.start()
+        await scheduler.start()
         init_deps(
             cfg, peer_registry, app.state,
             lifecycle_handler=lifecycle_handler,
@@ -180,6 +195,7 @@ def create_app(
             logger.info("%s service stopped", name)
         if relay_client:
             await relay_client.stop()
+        await scheduler.stop()
         peer_registry._save_events()
         peer_registry._persist_mappings()
         await peer_registry.stop()
@@ -224,6 +240,7 @@ def create_app(
     app.include_router(spawn_routes.router)
     app.include_router(attachments.router)
     app.include_router(lifecycle.router)
+    app.include_router(schedules.router)
 
     # --- Static File Serving (Dashboard) ---
     web_out = _find_web_output_dir()
@@ -321,6 +338,16 @@ def create_test_app(
             event_bus=event_bus,
         )
 
+        schedule_store = ScheduleStore(
+            persistence_path=(persistence_path.parent if persistence_path else Path("/tmp"))
+            / "schedules.json",
+        )
+        scheduler = Scheduler(
+            store=schedule_store,
+            peer_registry=registry,
+            ask_tracker=ask_tracker,
+        )
+
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -331,6 +358,8 @@ def create_test_app(
         app.state.relay_mode = cfg.relay.enabled
         rq_dir = persistence_path.parent if persistence_path else Path.home() / ".repowire"
         app.state.review_queue_store = ReviewQueueStore(rq_dir / "review_queue.json")
+        app.state.schedule_store = schedule_store
+        app.state.scheduler = scheduler
 
         lh = LifecycleHandler(
             peer_registry=registry,
@@ -339,10 +368,12 @@ def create_test_app(
         )
 
         await registry.start()
+        await scheduler.start()
         init_deps(cfg, registry, app.state, lifecycle_handler=lh)
 
         yield
 
+        await scheduler.stop()
         await registry.stop()
         cleanup_deps()
 
@@ -361,6 +392,7 @@ def create_test_app(
     app.include_router(spawn_routes.router)
     app.include_router(attachments.router)
     app.include_router(lifecycle.router)
+    app.include_router(schedules.router)
 
     return app
 

--- a/repowire/daemon/deps.py
+++ b/repowire/daemon/deps.py
@@ -18,6 +18,8 @@ class AppState(Protocol):
     ask_tracker: Any
     peer_registry: PeerRegistry
     config: Config
+    schedule_store: Any
+    scheduler: Any
 
 
 # Global state - initialized by lifespan

--- a/repowire/daemon/routes/schedules.py
+++ b/repowire/daemon/routes/schedules.py
@@ -1,0 +1,127 @@
+"""Scheduled check-in HTTP routes.
+
+POST   /schedules              Create a one-shot scheduled check-in.
+GET    /schedules              List schedules (optionally filtered by from_peer).
+DELETE /schedules/{id}         Cancel a pending schedule.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state
+from repowire.daemon.routes._shared import OkResponse
+from repowire.daemon.schedule_store import Schedule
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["schedules"])
+
+
+class ScheduleCreateRequest(BaseModel):
+    from_peer: str = Field(..., description="Display name of the scheduler")
+    to_peer: str = Field(..., description="Display name of the recipient")
+    text: str = Field(..., description="Message to deliver")
+    fire_at: str = Field(..., description="ISO-8601 datetime (UTC or with offset)")
+    kind: str = Field("notify", description='"notify" or "ask"')
+    circle: str | None = Field(None)
+
+
+class ScheduleResponse(BaseModel):
+    schedule_id: str
+    from_peer: str
+    to_peer: str
+    text: str
+    fire_at: str
+    kind: str
+    circle: str | None
+    created_at: str
+
+    @classmethod
+    def from_schedule(cls, s: Schedule) -> ScheduleResponse:
+        return cls(
+            schedule_id=s.schedule_id,
+            from_peer=s.from_peer,
+            to_peer=s.to_peer,
+            text=s.text,
+            fire_at=s.fire_at,
+            kind=s.kind,
+            circle=s.circle,
+            created_at=s.created_at,
+        )
+
+
+class ScheduleListResponse(BaseModel):
+    schedules: list[ScheduleResponse]
+
+
+def _parse_fire_at(raw: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"fire_at must be ISO-8601: {e}",
+        ) from e
+    if dt.tzinfo is None:
+        # Treat naive datetimes as UTC; explicit is better but tolerate it.
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+@router.post("/schedules", response_model=ScheduleResponse)
+async def create_schedule(
+    request: ScheduleCreateRequest,
+    _: str | None = Depends(require_auth),
+) -> ScheduleResponse:
+    state = get_app_state()
+    store = state.schedule_store
+    scheduler = state.scheduler
+
+    fire_at = _parse_fire_at(request.fire_at)
+    try:
+        sched = store.create(
+            from_peer=request.from_peer,
+            to_peer=request.to_peer,
+            text=request.text,
+            fire_at=fire_at,
+            kind=request.kind,
+            circle=request.circle,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    store.persist()
+    scheduler.notify_changed()
+    return ScheduleResponse.from_schedule(sched)
+
+
+@router.get("/schedules", response_model=ScheduleListResponse)
+async def list_schedules(
+    from_peer: str | None = None,
+    _: str | None = Depends(require_auth),
+) -> ScheduleListResponse:
+    state = get_app_state()
+    store = state.schedule_store
+    return ScheduleListResponse(
+        schedules=[ScheduleResponse.from_schedule(s) for s in store.list_all(from_peer)],
+    )
+
+
+@router.delete("/schedules/{schedule_id}", response_model=OkResponse)
+async def delete_schedule(
+    schedule_id: str,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    state = get_app_state()
+    store = state.schedule_store
+    scheduler = state.scheduler
+    removed = store.delete(schedule_id)
+    if removed is None:
+        raise HTTPException(status_code=404, detail=f"No schedule: {schedule_id}")
+    store.persist()
+    scheduler.notify_changed()
+    return OkResponse()

--- a/repowire/daemon/schedule_store.py
+++ b/repowire/daemon/schedule_store.py
@@ -1,0 +1,140 @@
+"""Scheduled check-in persistence.
+
+A scheduled check-in is a one-shot future delivery: at `fire_at`, the daemon
+injects a `notify` or `ask` to `to_peer` on behalf of `from_peer`. Recurring
+schedules are intentionally out of scope for the MVP.
+
+Persistence mirrors PeerRegistry's pattern: in-memory dict + dirty flag +
+debounced atomic-rename writes triggered at mutation time and on shutdown.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+ScheduleKind = str  # "ask" | "notify"
+_VALID_KINDS = frozenset({"ask", "notify"})
+
+
+@dataclass
+class Schedule:
+    """A single one-shot scheduled delivery."""
+
+    schedule_id: str
+    from_peer: str
+    to_peer: str
+    text: str
+    fire_at: str  # ISO-8601 UTC
+    kind: ScheduleKind = "notify"
+    circle: str | None = None
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(),
+    )
+
+    def fire_at_dt(self) -> datetime:
+        return datetime.fromisoformat(self.fire_at)
+
+
+class ScheduleStore:
+    """In-memory schedule registry with disk persistence.
+
+    Not thread-safe across coroutines that need consistency; the caller
+    (Scheduler) holds the lock that matters. Disk writes are debounced via a
+    dirty flag.
+    """
+
+    def __init__(self, persistence_path: Path) -> None:
+        self._path = persistence_path
+        self._schedules: dict[str, Schedule] = {}
+        self._dirty = False
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+            for sid, raw in data.items():
+                self._schedules[sid] = Schedule(**raw)
+            logger.info("Loaded %d scheduled check-ins", len(self._schedules))
+        except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+            logger.error("Corrupt schedules file (%s); starting empty", e)
+            self._schedules = {}
+            self._dirty = True
+        except OSError as e:
+            logger.error("Failed to read schedules: %s", e)
+
+    def persist(self) -> None:
+        """Flush to disk if dirty."""
+        if not self._dirty:
+            return
+        tmp = self._path.with_suffix(".json.tmp")
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            data = {sid: asdict(s) for sid, s in self._schedules.items()}
+            tmp.write_text(json.dumps(data, indent=2))
+            os.replace(str(tmp), str(self._path))
+            self._dirty = False
+        except OSError as e:
+            logger.error("Failed to save schedules: %s", e)
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def create(
+        self,
+        from_peer: str,
+        to_peer: str,
+        text: str,
+        fire_at: datetime,
+        kind: ScheduleKind = "notify",
+        circle: str | None = None,
+    ) -> Schedule:
+        if kind not in _VALID_KINDS:
+            raise ValueError(f"kind must be one of {sorted(_VALID_KINDS)}; got {kind!r}")
+        if fire_at.tzinfo is None:
+            raise ValueError("fire_at must be timezone-aware")
+        sid = f"sched-{uuid4().hex[:8]}"
+        sched = Schedule(
+            schedule_id=sid,
+            from_peer=from_peer,
+            to_peer=to_peer,
+            text=text,
+            fire_at=fire_at.astimezone(timezone.utc).isoformat(),
+            kind=kind,
+            circle=circle,
+        )
+        self._schedules[sid] = sched
+        self._dirty = True
+        return sched
+
+    def delete(self, schedule_id: str) -> Schedule | None:
+        s = self._schedules.pop(schedule_id, None)
+        if s is not None:
+            self._dirty = True
+        return s
+
+    def get(self, schedule_id: str) -> Schedule | None:
+        return self._schedules.get(schedule_id)
+
+    def list_all(self, from_peer: str | None = None) -> list[Schedule]:
+        items = list(self._schedules.values())
+        if from_peer is not None:
+            items = [s for s in items if s.from_peer == from_peer]
+        items.sort(key=lambda s: s.fire_at)
+        return items
+
+    def next_due(self) -> Schedule | None:
+        """Return the schedule with the earliest fire_at, or None if empty."""
+        if not self._schedules:
+            return None
+        return min(self._schedules.values(), key=lambda s: s.fire_at)

--- a/repowire/daemon/scheduler.py
+++ b/repowire/daemon/scheduler.py
@@ -141,6 +141,15 @@ class Scheduler:
                 "Fired schedule %s: %s -> %s (%s)",
                 sched.schedule_id, sched.from_peer, sched.to_peer, sched.kind,
             )
+        except Exception as e:
+            # Catch-all so a misbehaving delivery (anything beyond the inner
+            # ValueError/TransportError handlers above) doesn't escape and
+            # kill the scheduler task. The loop continues to the next
+            # schedule; this one still gets dropped via the finally block.
+            logger.exception(
+                "Scheduled %s %s: unexpected error during fire (%s); dropping",
+                sched.kind, sched.schedule_id, e,
+            )
         finally:
             # One-shot: always drop from the store after firing (success or
             # delivery failure). Retry policy is out of scope for the MVP.

--- a/repowire/daemon/scheduler.py
+++ b/repowire/daemon/scheduler.py
@@ -1,0 +1,148 @@
+"""One-shot scheduled check-in dispatcher.
+
+A single background task sleeps until the next-due schedule's `fire_at`, then
+fires it and removes it. No polling: the wake event is only set when the
+schedule set changes (create/delete) or when something fires. Past-due
+schedules at startup fire immediately.
+
+Delivery reuses the existing peer-registry primitives:
+  - kind="notify" -> PeerRegistry.notify (fire-and-forget)
+  - kind="ask"    -> PeerRegistry.deliver_ask (registers in AskTracker first)
+
+On delivery failure (peer missing or no live WS) the schedule is dropped
+rather than retried — the MVP is one-shot. We log loudly so misfires are
+visible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from repowire.daemon.schedule_store import Schedule, ScheduleStore
+from repowire.daemon.websocket_transport import TransportError
+
+if TYPE_CHECKING:
+    from repowire.daemon.ask_tracker import AskTracker
+    from repowire.daemon.peer_registry import PeerRegistry
+
+logger = logging.getLogger(__name__)
+
+# Cap a single sleep so a long horizon doesn't outlive a clock jump unnoticed.
+_MAX_SLEEP_SECONDS = 3600.0
+
+
+class Scheduler:
+    """Drives one-shot scheduled check-ins."""
+
+    def __init__(
+        self,
+        store: ScheduleStore,
+        peer_registry: PeerRegistry,
+        ask_tracker: AskTracker,
+    ) -> None:
+        self._store = store
+        self._peer_registry = peer_registry
+        self._ask_tracker = ask_tracker
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._stopped = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopped = False
+        self._task = asyncio.create_task(self._run(), name="scheduler")
+
+    async def stop(self) -> None:
+        self._stopped = True
+        self._wake.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        self._store.persist()
+
+    def notify_changed(self) -> None:
+        """Signal the loop that the schedule set changed (create/delete)."""
+        self._wake.set()
+
+    async def _run(self) -> None:
+        while not self._stopped:
+            self._wake.clear()
+            nxt = self._store.next_due()
+            if nxt is None:
+                await self._wake.wait()
+                continue
+            now = datetime.now(timezone.utc)
+            delay = (nxt.fire_at_dt() - now).total_seconds()
+            if delay > 0:
+                try:
+                    await asyncio.wait_for(
+                        self._wake.wait(),
+                        timeout=min(delay, _MAX_SLEEP_SECONDS),
+                    )
+                    # Woken by a change — reloop and recompute next due.
+                    continue
+                except asyncio.TimeoutError:
+                    pass
+            # Re-check that this schedule still exists (delete may have raced).
+            current = self._store.get(nxt.schedule_id)
+            if current is None:
+                continue
+            await self._fire(current)
+
+    async def _fire(self, sched: Schedule) -> None:
+        try:
+            if sched.kind == "ask":
+                cid = f"ask-{uuid4().hex[:8]}"
+                await self._ask_tracker.register(
+                    from_peer_id=sched.from_peer,
+                    from_peer_name=sched.from_peer,
+                    to_peer_id=sched.to_peer,
+                    to_peer_name=sched.to_peer,
+                    text=sched.text,
+                    correlation_id=cid,
+                )
+                try:
+                    await self._peer_registry.deliver_ask(
+                        from_peer=sched.from_peer,
+                        to_peer=sched.to_peer,
+                        text=sched.text,
+                        correlation_id=cid,
+                        circle=sched.circle,
+                    )
+                except (ValueError, TransportError) as e:
+                    await self._ask_tracker.close(cid, reason="send_failed")
+                    logger.warning(
+                        "Scheduled ask %s failed to deliver: %s",
+                        sched.schedule_id, e,
+                    )
+            else:
+                try:
+                    await self._peer_registry.notify(
+                        from_peer=sched.from_peer,
+                        to_peer=sched.to_peer,
+                        text=sched.text,
+                        circle=sched.circle,
+                    )
+                except (ValueError, TransportError) as e:
+                    logger.warning(
+                        "Scheduled notify %s failed to deliver: %s",
+                        sched.schedule_id, e,
+                    )
+            logger.info(
+                "Fired schedule %s: %s -> %s (%s)",
+                sched.schedule_id, sched.from_peer, sched.to_peer, sched.kind,
+            )
+        finally:
+            # One-shot: always drop from the store after firing (success or
+            # delivery failure). Retry policy is out of scope for the MVP.
+            self._store.delete(sched.schedule_id)
+            self._store.persist()

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -48,6 +48,8 @@ async def daemon_request(
         url = f"{DAEMON_URL}{path}"
         if method == "GET":
             resp = await client.get(url, params=params)
+        elif method == "DELETE":
+            resp = await client.delete(url, params=params)
         else:
             resp = await client.post(url, json=body or {})
         resp.raise_for_status()
@@ -724,6 +726,100 @@ def create_mcp_server() -> FastMCP:
                 )
             )
         return "\n".join(rows)
+
+    @mcp.tool()
+    async def schedule_create(
+        to_peer: str,
+        text: str,
+        fire_at: str,
+        kind: str = "notify",
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] Schedule a one-shot future message to a peer.
+
+        At `fire_at` the daemon will deliver `text` to `to_peer` on your
+        behalf. `kind="notify"` is fire-and-forget; `kind="ask"` opens an
+        ask thread (recipient must `ack`). Recurring schedules are not
+        supported in the MVP.
+
+        Use this for self-wake reminders, post-stand-up nudges, or future
+        check-ins that don't need a live caller waiting.
+
+        Args:
+            to_peer: Display name of the recipient. Use your own peer name
+                     to schedule a self-wake.
+            text: Message body to deliver.
+            fire_at: ISO-8601 datetime (e.g. "2026-05-14T09:00:00Z" or
+                     "2026-05-14T09:00:00+00:00"). Naive datetimes are
+                     interpreted as UTC.
+            kind: "notify" (default) or "ask".
+            circle: Circle to scope recipient lookup.
+
+        Returns:
+            schedule_id (format: sched-XXXXXXXX). Use it with
+            schedule_delete to cancel.
+        """
+        await _ensure_registered(strict=True)
+        from_peer = await _get_my_peer_name()
+        body: dict = {
+            "from_peer": from_peer,
+            "to_peer": to_peer,
+            "text": text,
+            "fire_at": fire_at,
+            "kind": kind,
+        }
+        if circle is not None:
+            body["circle"] = circle
+        result = await daemon_request("POST", "/schedules", body)
+        return result.get("schedule_id", "")
+
+    @mcp.tool()
+    async def schedule_list(mine_only: bool = True) -> str:
+        """[Repowire mesh] List pending scheduled check-ins.
+
+        Returns TSV with columns: schedule_id, from_peer, to_peer, kind,
+        fire_at, text. Schedules are sorted by fire_at ascending.
+
+        Args:
+            mine_only: If True (default), return only schedules you
+                       created. If False, return all schedules on the
+                       daemon.
+        """
+        await _ensure_registered()
+        params: dict | None = None
+        if mine_only:
+            params = {"from_peer": await _get_my_peer_name()}
+        result = await daemon_request("GET", "/schedules", params=params)
+        header = "schedule_id\tfrom_peer\tto_peer\tkind\tfire_at\ttext"
+        rows = [header]
+        for s in result.get("schedules", []):
+            rows.append(
+                "\t".join(
+                    [
+                        s.get("schedule_id", ""),
+                        s.get("from_peer", ""),
+                        s.get("to_peer", ""),
+                        s.get("kind", ""),
+                        s.get("fire_at", ""),
+                        (s.get("text", "") or "").replace("\t", " ").replace("\n", " "),
+                    ]
+                )
+            )
+        return "\n".join(rows)
+
+    @mcp.tool()
+    async def schedule_delete(schedule_id: str) -> str:
+        """[Repowire mesh] Cancel a pending scheduled check-in.
+
+        Args:
+            schedule_id: ID returned by schedule_create.
+
+        Returns:
+            Confirmation message.
+        """
+        await _ensure_registered(strict=True)
+        await daemon_request("DELETE", f"/schedules/{quote(schedule_id, safe='')}")
+        return f"deleted schedule {schedule_id}"
 
     return mcp
 

--- a/tests/test_schedule_routes.py
+++ b/tests/test_schedule_routes.py
@@ -1,0 +1,150 @@
+"""Tests for /schedules HTTP routes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import schedules
+from repowire.daemon.schedule_store import ScheduleStore
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+
+    store = ScheduleStore(tmp_path / "schedules.json")
+    # Mock scheduler — routes only need .notify_changed()
+    scheduler = MagicMock()
+    scheduler.notify_changed = MagicMock()
+
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        schedule_store=store,
+        scheduler=scheduler,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+
+    app = FastAPI()
+    app.include_router(schedules.router)
+    return app, store, scheduler
+
+
+@pytest.fixture
+async def env(tmp_path):
+    app, store, scheduler = _make_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as c:
+        yield c, store, scheduler
+    cleanup_deps()
+
+
+def _future_iso(seconds: float = 60.0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+class TestCreate:
+    async def test_returns_schedule_id_and_wakes_scheduler(self, env):
+        client, store, scheduler = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice",
+            "to_peer": "bob",
+            "text": "ping",
+            "fire_at": _future_iso(),
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["schedule_id"].startswith("sched-")
+        assert body["kind"] == "notify"
+        assert store.get(body["schedule_id"]) is not None
+        scheduler.notify_changed.assert_called_once()
+
+    async def test_rejects_invalid_fire_at(self, env):
+        client, _, _ = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice", "to_peer": "bob",
+            "text": "x", "fire_at": "not-a-date",
+        })
+        assert r.status_code == 400
+
+    async def test_rejects_unknown_kind(self, env):
+        client, _, _ = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice", "to_peer": "bob",
+            "text": "x", "fire_at": _future_iso(), "kind": "cron",
+        })
+        assert r.status_code == 400
+
+
+class TestList:
+    async def test_empty(self, env):
+        client, _, _ = env
+        r = await client.get("/schedules")
+        assert r.status_code == 200
+        assert r.json()["schedules"] == []
+
+    async def test_filter_by_from_peer(self, env):
+        client, _, _ = env
+        await client.post("/schedules", json={
+            "from_peer": "alice", "to_peer": "bob",
+            "text": "a", "fire_at": _future_iso(60),
+        })
+        await client.post("/schedules", json={
+            "from_peer": "eve", "to_peer": "bob",
+            "text": "e", "fire_at": _future_iso(30),
+        })
+        r = await client.get("/schedules", params={"from_peer": "alice"})
+        items = r.json()["schedules"]
+        assert len(items) == 1
+        assert items[0]["from_peer"] == "alice"
+
+
+class TestDelete:
+    async def test_removes_and_wakes(self, env):
+        client, store, scheduler = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice", "to_peer": "bob",
+            "text": "x", "fire_at": _future_iso(),
+        })
+        sid = r.json()["schedule_id"]
+        scheduler.notify_changed.reset_mock()
+
+        r = await client.delete(f"/schedules/{sid}")
+        assert r.status_code == 200
+        assert store.get(sid) is None
+        scheduler.notify_changed.assert_called_once()
+
+    async def test_unknown_returns_404(self, env):
+        client, _, _ = env
+        r = await client.delete("/schedules/sched-nope")
+        assert r.status_code == 404

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -1,0 +1,101 @@
+"""Tests for ScheduleStore: in-memory + persistence behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from repowire.daemon.schedule_store import ScheduleStore
+
+
+def _ts(seconds_from_now: float = 60.0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds_from_now)
+
+
+def test_create_assigns_id_and_marks_dirty(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    sched = store.create(
+        from_peer="alice", to_peer="bob", text="ping", fire_at=_ts(),
+    )
+    assert sched.schedule_id.startswith("sched-")
+    assert store.get(sched.schedule_id) is sched
+
+
+def test_create_rejects_naive_datetime(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    with pytest.raises(ValueError):
+        store.create(
+            from_peer="alice", to_peer="bob", text="x",
+            fire_at=datetime(2030, 1, 1),
+        )
+
+
+def test_create_rejects_unknown_kind(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    with pytest.raises(ValueError):
+        store.create(
+            from_peer="alice", to_peer="bob", text="x",
+            fire_at=_ts(), kind="recurring",
+        )
+
+
+def test_delete_returns_schedule_and_removes(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    sched = store.create("a", "b", "t", _ts())
+    removed = store.delete(sched.schedule_id)
+    assert removed is sched
+    assert store.get(sched.schedule_id) is None
+    assert store.delete(sched.schedule_id) is None
+
+
+def test_list_all_filters_by_from_peer_and_sorts(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    later = store.create("alice", "bob", "later", _ts(120))
+    sooner = store.create("alice", "bob", "sooner", _ts(60))
+    store.create("eve", "bob", "third-party", _ts(30))
+
+    mine = store.list_all(from_peer="alice")
+    assert [s.schedule_id for s in mine] == [sooner.schedule_id, later.schedule_id]
+    all_ids = {s.schedule_id for s in store.list_all()}
+    assert len(all_ids) == 3
+
+
+def test_next_due_returns_earliest(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    assert store.next_due() is None
+    store.create("a", "b", "late", _ts(300))
+    early = store.create("a", "b", "early", _ts(10))
+    nxt = store.next_due()
+    assert nxt is not None and nxt.schedule_id == early.schedule_id
+
+
+def test_persist_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "schedules.json"
+    s1 = ScheduleStore(path)
+    sched = s1.create("alice", "bob", "ping", _ts(60), kind="ask", circle="default")
+    s1.persist()
+    assert path.exists()
+
+    s2 = ScheduleStore(path)
+    loaded = s2.get(sched.schedule_id)
+    assert loaded is not None
+    assert loaded.from_peer == "alice"
+    assert loaded.to_peer == "bob"
+    assert loaded.kind == "ask"
+    assert loaded.circle == "default"
+
+
+def test_persist_noop_when_clean(tmp_path: Path) -> None:
+    path = tmp_path / "schedules.json"
+    store = ScheduleStore(path)
+    store.persist()  # nothing to write
+    assert not path.exists()
+
+
+def test_corrupt_file_recovers_empty(tmp_path: Path) -> None:
+    path = tmp_path / "schedules.json"
+    path.write_text("{not json")
+    store = ScheduleStore(path)
+    assert store.list_all() == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -119,3 +119,27 @@ async def test_earlier_schedule_added_after_later_fires_first(env) -> None:
     args = registry.notify.await_args
     assert args.kwargs["text"] == "sooner"
     await scheduler.stop()
+
+
+async def test_unexpected_exception_does_not_kill_loop(env) -> None:
+    """A delivery that raises something other than ValueError/TransportError
+    must not propagate up to _run and kill the scheduler. The bad schedule
+    gets dropped; the next one still fires."""
+    scheduler, store, registry, _ = env
+    # First call raises something the inner except blocks DON'T catch
+    # (TypeError stands in for any unexpected exception type).
+    registry.notify.side_effect = [TypeError("unexpected"), None]
+    await scheduler.start()
+    bad = store.create("a", "b", "first-bad", _now_plus(0.05))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    # Bad schedule got dropped despite the exception.
+    assert store.get(bad.schedule_id) is None
+    # Scheduler still alive — second schedule fires successfully.
+    good = store.create("a", "b", "second-good", _now_plus(0.05))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    assert store.get(good.schedule_id) is None
+    # Both fires were attempted (and second one succeeded).
+    assert registry.notify.await_count == 2
+    await scheduler.stop()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,121 @@
+"""Tests for the one-shot Scheduler dispatcher."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.schedule_store import ScheduleStore
+from repowire.daemon.scheduler import Scheduler
+
+
+def _now_plus(seconds: float) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.notify = AsyncMock()
+        self.deliver_ask = AsyncMock()
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    store = ScheduleStore(tmp_path / "schedules.json")
+    registry = _FakeRegistry()
+    at = AskTracker()
+    scheduler = Scheduler(
+        store=store,
+        peer_registry=cast(PeerRegistry, registry),
+        ask_tracker=at,
+    )
+    return scheduler, store, registry, at
+
+
+async def test_starts_and_stops_cleanly(env) -> None:
+    scheduler, _, _, _ = env
+    await scheduler.start()
+    await asyncio.sleep(0)  # let task park on the wake event
+    await scheduler.stop()
+
+
+async def test_fires_notify_at_due_time(env) -> None:
+    scheduler, store, registry, _ = env
+    await scheduler.start()
+    sched = store.create("alice", "bob", "wake up", _now_plus(0.05), kind="notify")
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    registry.notify.assert_awaited_once()
+    assert store.get(sched.schedule_id) is None
+    await scheduler.stop()
+
+
+async def test_fires_ask_and_registers_with_tracker(env) -> None:
+    scheduler, store, registry, ask_tracker = env
+    await scheduler.start()
+    sched = store.create("alice", "bob", "?", _now_plus(0.05), kind="ask")
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    registry.deliver_ask.assert_awaited_once()
+    # tracker should have seen the registration (closed on success path is fine)
+    assert ask_tracker.total_count() == 1
+    assert store.get(sched.schedule_id) is None
+    await scheduler.stop()
+
+
+async def test_delete_before_fire_cancels(env) -> None:
+    scheduler, store, registry, _ = env
+    await scheduler.start()
+    sched = store.create("alice", "bob", "x", _now_plus(0.3))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.05)
+    store.delete(sched.schedule_id)
+    scheduler.notify_changed()
+    await asyncio.sleep(0.4)
+    registry.notify.assert_not_called()
+    await scheduler.stop()
+
+
+async def test_past_due_fires_immediately(env) -> None:
+    scheduler, store, registry, _ = env
+    await scheduler.start()
+    store.create("alice", "bob", "late", _now_plus(-60.0))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.15)
+    registry.notify.assert_awaited_once()
+    await scheduler.stop()
+
+
+async def test_delivery_failure_drops_schedule(env) -> None:
+    """One-shot MVP: failures are logged and the schedule is removed."""
+    scheduler, store, registry, _ = env
+    registry.notify.side_effect = ValueError("no such peer")
+    await scheduler.start()
+    sched = store.create("alice", "ghost", "x", _now_plus(0.05))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    assert store.get(sched.schedule_id) is None
+    await scheduler.stop()
+
+
+async def test_earlier_schedule_added_after_later_fires_first(env) -> None:
+    scheduler, store, registry, _ = env
+    await scheduler.start()
+    store.create("a", "b", "later", _now_plus(0.4))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.05)
+    store.create("a", "b", "sooner", _now_plus(0.05))
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    # "sooner" should have fired; "later" still pending
+    assert registry.notify.await_count == 1
+    args = registry.notify.await_args
+    assert args.kwargs["text"] == "sooner"
+    await scheduler.stop()


### PR DESCRIPTION
## Summary
- One-shot scheduled check-ins: at `fire_at`, the daemon delivers `text` to `to_peer` on behalf of `from_peer`, via existing `peer_registry.notify` (kind=`notify`) or `peer_registry.deliver_ask` (kind=`ask`).
- New surface: `POST /schedules`, `GET /schedules?from_peer=...`, `DELETE /schedules/{id}`, plus MCP tools `schedule_create`, `schedule_list`, `schedule_delete`.
- Persistence at `~/.repowire/schedules.json` with the existing debounced atomic-rename pattern. Single background task sleeps until next-due (no polling); `notify_changed()` wakes it on add/delete.
- Recurring schedules + edit/pause intentionally deferred. Delete is required and covered by tests.

## Scope notes
- Approved scope (orchestrator-pi): create / list / delete, one-shot only, reuse ask/notify lifecycle, no polling excess.
- On delivery failure the schedule is dropped with a warning. Retry/recurrence are out of scope for this MVP.
- `_MAX_SLEEP_SECONDS = 3600` caps single sleep so a clock jump doesn't strand a long horizon.

## Test plan
- [x] `tests/test_schedule_store.py` (9 tests): create/list/delete/persist roundtrip, naive-datetime + kind validation, corrupt-file recovery.
- [x] `tests/test_scheduler.py` (7 tests): notify + ask fire paths, delete-before-fire cancels, past-due fires immediately, delivery failure drops, schedule inserted earlier than pending fires first.
- [x] `tests/test_schedule_routes.py` (7 tests): create returns id + wakes scheduler, invalid fire_at / unknown kind rejected, list filter by from_peer, delete wakes scheduler, 404 on unknown id.
- [x] Full suite: 623 passing.
- [x] `ruff check` + `ty check` clean on touched files.