### PR TITLE
feat(mcp): include last_seen in list_peers TSV output

### DIFF
--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -260,7 +260,10 @@ def create_mcp_server() -> FastMCP:
     """Create the MCP server."""
     mcp = FastMCP("repowire")
 
-    tsv_header = "peer_id\tname\tproject\tcircle\trole\tstatus\tpath\tmachine\tdescription\tbackend"
+    tsv_header = (
+        "peer_id\tname\tproject\tcircle\trole\tstatus\tpath\t"
+        "machine\tdescription\tbackend\tlast_seen"
+    )
 
     def _peer_to_tsv_row(p: dict) -> str:
         """Format a single peer dict as a TSV row."""
@@ -277,6 +280,7 @@ def create_mcp_server() -> FastMCP:
                 p.get("machine") or "",
                 p.get("description") or "",
                 p.get("backend", ""),
+                p.get("last_seen") or "",
             ]
         )
 
@@ -289,7 +293,7 @@ def create_mcp_server() -> FastMCP:
         include_self=True to include yourself in the listing.
 
         Returns TSV: peer_id, name, project, circle, role, status, path, machine,
-        description, backend. Peers are reachable via ask/notify_peer. Do NOT
+        description, backend, last_seen. Peers are reachable via ask/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
         """
@@ -472,7 +476,8 @@ def create_mcp_server() -> FastMCP:
     async def whoami() -> str:
         """[Repowire mesh] Return your identity in the repowire mesh.
 
-        Returns TSV with columns: peer_id, name, project, circle, status, path, machine, description
+        Returns TSV with columns: peer_id, name, project, circle, role, status,
+        path, machine, description, backend, last_seen
         """
         await _ensure_registered(strict=True)
         pane_id = get_pane_id()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -844,6 +844,40 @@ class TestMcpListPeersSelfFilter:
         assert "beta" in result
 
 
+class TestMcpListPeersLastSeen:
+    """list_peers TSV must include last_seen as the trailing column."""
+
+    @pytest.mark.asyncio
+    @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
+    @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
+    async def test_list_peers_includes_last_seen_column(
+        self, mock_request: AsyncMock, _mock_register: AsyncMock,
+    ) -> None:
+        import repowire.mcp.server as mcp_server
+        mcp_server._cached_peer_name = None
+        mock_request.return_value = {
+            "peers": [
+                {"peer_id": "repow-1-aa", "display_name": "alpha",
+                 "circle": "main", "status": "online", "backend": "claude-code",
+                 "last_seen": "2026-05-14T12:00:00+00:00"},
+                {"peer_id": "repow-1-bb", "display_name": "beta",
+                 "circle": "main", "status": "online", "backend": "claude-code",
+                 "last_seen": None},
+            ]
+        }
+
+        mcp = mcp_server.create_mcp_server()
+        list_tool = mcp._tool_manager._tools["list_peers"]
+        result = await list_tool.fn()
+        lines = result.splitlines()
+        header = lines[0].split("\t")
+        assert header[-1] == "last_seen"
+        alpha_row = next(line for line in lines[1:] if "alpha" in line).split("\t")
+        beta_row = next(line for line in lines[1:] if "beta" in line).split("\t")
+        assert alpha_row[-1] == "2026-05-14T12:00:00+00:00"
+        assert beta_row[-1] == ""
+
+
 class TestRunMcpServer:
     """Sanity check that run_mcp_server enters the stdio loop."""
 

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -73,7 +73,7 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
         signature={`list_peers(show_offline: bool = False, include_self: bool = False) -> str`}
       >
         <p>
-          Returns a TSV with columns: <Mono>peer_id, name, project, circle, role, status, path, machine, description, backend</Mono>. Defaults to online + busy peers and hides the caller. Pass <Mono>show_offline=True</Mono> for the full registry; pass <Mono>include_self=True</Mono> when an orchestrator needs its own row.
+          Returns a TSV with columns: <Mono>peer_id, name, project, circle, role, status, path, machine, description, backend, last_seen</Mono>. Defaults to online + busy peers and hides the caller. Pass <Mono>show_offline=True</Mono> for the full registry; pass <Mono>include_self=True</Mono> when an orchestrator needs its own row.
         </p>
       </Tool>
 


### PR DESCRIPTION
Closes #135.

## Summary
- Append `last_seen` as the trailing column in the `list_peers` TSV (and `whoami`, which reuses the same row formatter).
- Empty string when the peer has no `last_seen`; otherwise the ISO-8601 UTC timestamp already on the `Peer` model.
- Updated docs reference page and added a focused test asserting both the header column and populated/empty values.

Appended-at-end keeps existing TSV consumers (dashboard, telegram bot, prior tests) working unchanged.

## Test plan
- [x] `uv run pytest` (608 passed)
- [x] `uv run ruff check repowire/`
- [x] `uv run ty check repowire/`