### PR TITLE
fix(daemon): persist peer circle + description across restart

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -49,6 +49,7 @@ class SessionMapping:
     path: str | None = None
     role: PeerRole = PeerRole.AGENT
     updated_at: str | None = None
+    description: str = ""
 
     def __post_init__(self) -> None:
         if self.updated_at is None:
@@ -363,6 +364,27 @@ class PeerRegistry:
                 self._mappings_dirty = True
                 return sid
 
+        # Cross-circle adoption: when the caller supplied the fallback circle
+        # ("default") but a prior mapping exists for the same (name, backend,
+        # path), reuse it so the peer's prior circle and description survive
+        # restarts where the tmux session name didn't propagate (e.g. claude
+        # --continue). Strictly gated on circle == "default" to avoid
+        # collapsing genuinely separate same-path peers in different circles.
+        if circle == "default" and path:
+            for sid, mapping in self._mappings.items():
+                if (
+                    mapping.display_name == display_name
+                    and mapping.backend == backend
+                    and mapping.path == path
+                ):
+                    mapping.updated_at = datetime.now(timezone.utc).isoformat()
+                    self._mappings_dirty = True
+                    logger.info(
+                        f"Adopted prior session {sid} for {display_name} "
+                        f"(restored circle={mapping.circle})"
+                    )
+                    return sid
+
         session_id = f"repow-{circle}-{uuid4().hex[:8]}"
         self._mappings[session_id] = SessionMapping(
             session_id=session_id,
@@ -447,11 +469,19 @@ class PeerRegistry:
             if pane_id:
                 self._release_pane(pane_id, allocated_id)
 
+            # Restore circle + description from persisted mapping. The
+            # mapping is the durable source of truth for these fields; when
+            # _find_or_allocate_mapping adopted a prior session, its stored
+            # circle may differ from the caller-supplied one and should win.
+            restored = self._mappings.get(allocated_id)
+            effective_circle = restored.circle if restored else circle
+            restored_description = restored.description if restored else ""
+
             # --- create and insert Peer ---
             peer = Peer(
                 peer_id=allocated_id,
                 display_name=assigned_name,
-                circle=circle,
+                circle=effective_circle,
                 backend=backend,
                 role=role,
                 status=PeerStatus.ONLINE,
@@ -461,6 +491,7 @@ class PeerRegistry:
                 path=path or "",
                 machine=machine,
                 metadata=metadata or {},
+                description=restored_description,
             )
             self._peers[allocated_id] = peer
             logger.info(f"Peer registered: {assigned_name} ({allocated_id})")
@@ -937,6 +968,11 @@ class PeerRegistry:
                 return False
             peer.description = description
             peer.last_seen = datetime.now(timezone.utc)
+            mapping = self._mappings.get(peer.peer_id)
+            if mapping and mapping.description != description:
+                mapping.description = description
+                mapping.updated_at = datetime.now(timezone.utc).isoformat()
+                self._mappings_dirty = True
             return True
 
     async def set_peer_circle(self, identifier: str, circle: str) -> None:

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -173,3 +173,96 @@ async def test_lookup_prefers_pane_owned_peer_when_names_collide(tmp_path):
     peer = await registry.get_peer("repowire-codex")
     assert peer is not None
     assert peer.peer_id == pane_peer_id
+
+
+@pytest.mark.asyncio
+async def test_circle_and_description_persist_across_restart(tmp_path):
+    """A peer re-registering after restart restores its prior circle + description.
+
+    Reproduces issue #134: `claude --continue` loses tmux session context, so
+    the new registration arrives with circle="default" even though the peer
+    was previously moved to a non-default circle. The persisted mapping should
+    bring both circle and description back without manual /peers/circle calls.
+    """
+    path = tmp_path / "sessions.json"
+    orch_dir = tmp_path / "orchproj"
+    orch_dir.mkdir()
+    registry = PeerRegistry(
+        config=__import__("repowire.config.models", fromlist=["Config"]).Config(),
+        message_router=__import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(),
+        persistence_path=path,
+    )
+
+    peer_id, name = await registry.allocate_and_register(
+        circle="5", backend=AgentType.CLAUDE_CODE, path=str(orch_dir),
+    )
+    await registry.update_description(peer_id, "watching the mesh")
+    await registry.mark_offline(peer_id)
+    # Flush to disk so a fresh registry can load it.
+    registry._persist_mappings()
+
+    # Simulate daemon restart: brand new registry reading the same file.
+    registry2 = PeerRegistry(
+        config=__import__("repowire.config.models", fromlist=["Config"]).Config(),
+        message_router=__import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(),
+        persistence_path=path,
+    )
+    # claude --continue: tmux session name didn't propagate, so the hook
+    # falls back to circle="default".
+    new_id, new_name = await registry2.allocate_and_register(
+        circle="default", backend=AgentType.CLAUDE_CODE, path=str(orch_dir),
+    )
+    assert new_name == name
+    assert new_id == peer_id, "should adopt the prior session id"
+    peer = await registry2.get_peer(new_id)
+    assert peer is not None
+    assert peer.circle == "5"
+    assert peer.description == "watching the mesh"
+
+
+@pytest.mark.asyncio
+async def test_fresh_peer_with_no_prior_record_gets_defaults(tmp_path):
+    """A brand new path/backend gets default circle and empty description."""
+    registry = _make_registry(tmp_path)
+    peer_id, _name = await registry.allocate_and_register(
+        circle="default", backend=AgentType.CLAUDE_CODE, path="/tmp/freshproj",
+    )
+    peer = await registry.get_peer(peer_id)
+    assert peer is not None
+    assert peer.circle == "default"
+    assert peer.description == ""
+
+
+@pytest.mark.asyncio
+async def test_non_default_circle_does_not_collapse_other_circle_peer(tmp_path):
+    """Two peers at the same path in different non-default circles stay distinct.
+
+    Adoption is gated on the incoming circle being "default" precisely to
+    avoid this case: a second orchestrator registering with an explicit
+    different circle must not be folded into the first one's mapping.
+    """
+    registry = _make_registry(tmp_path)
+    first_id, _ = await registry.allocate_and_register(
+        circle="A", backend=AgentType.CLAUDE_CODE, path="/tmp/shared",
+    )
+    second_id, _ = await registry.allocate_and_register(
+        circle="B", backend=AgentType.CLAUDE_CODE, path="/tmp/shared",
+    )
+    assert first_id != second_id
+    first_peer = await registry.get_peer(first_id)
+    second_peer = await registry.get_peer(second_id)
+    assert first_peer is not None and first_peer.circle == "A"
+    assert second_peer is not None and second_peer.circle == "B"
+
+
+@pytest.mark.asyncio
+async def test_description_update_persists_to_mapping(tmp_path):
+    """update_description writes through to the SessionMapping for durability."""
+    registry = _make_registry(tmp_path)
+    peer_id, _ = await registry.allocate_and_register(
+        circle="default", backend=AgentType.CLAUDE_CODE, path="/tmp/descproj",
+    )
+    await registry.update_description(peer_id, "doing the thing")
+    mapping = registry.get_mapping(peer_id)
+    assert mapping is not None
+    assert mapping.description == "doing the thing"

--- a/uv.lock
+++ b/uv.lock
@@ -953,7 +953,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #134.

## Why

When a Claude Code peer restarts via `claude --continue`, tmux session context isn't always re-propagated to the SessionStart hook, so the new registration arrives with `circle="default"`. The peer's previously-set circle (e.g. `5`) and description (`set_description` value) were both lost, requiring a manual `POST /peers/circle` + `set_description` to recover.

The orchestrator observed this loss twice in one session.

## What

- `SessionMapping` gains a `description: str = ""` field.
- `_find_or_allocate_mapping` now does a second-pass adoption: when the incoming `circle == "default"` and a prior mapping exists for the same `(display_name, backend, path)`, it reuses that mapping (and its session id).
- `allocate_and_register` reads the (possibly adopted) mapping after allocation and uses its `circle` and `description` on the new `Peer`, so a restart restores both fields automatically.
- `update_description` writes through to the mapping so the next persist captures it.

Adoption is strictly gated on `circle == "default"` to preserve the multi-orchestrator-same-path-different-circles case: an explicit non-default circle still produces a distinct peer.

## Tests

`tests/test_session_mapper.py` adds four cases:

- Restart with prior circle `5` + description → adopted across a fresh `PeerRegistry`; circle and description restored.
- Fresh peer with no prior record gets `circle="default"` and empty description.
- Two peers at the same path in non-default circles `A` and `B` stay distinct (no cross-collapse).
- `update_description` persists to the mapping.

Full suite: 612 passing. Lint + type checks clean on changed files.