### PR TITLE
fix(daemon): refuse ambiguous peer name resolves + add to_peer to wire frames (#136)

### DIFF
--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -111,6 +111,7 @@ class MessageRouter:
         message: dict[str, Any] = {
             "type": "notify",
             "from_peer": from_peer,
+            "to_peer": to_peer_name,
             "text": text,
         }
         await self._transport.send(to_session_id, message)
@@ -144,6 +145,7 @@ class MessageRouter:
             "type": "ask",
             "correlation_id": correlation_id,
             "from_peer": from_peer,
+            "to_peer": to_peer_name,
             "text": hinted_text,
         }
         if reply_to is not None:

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -253,7 +253,9 @@ class PeerRegistry:
         """Lookup peer by session_id or display_name. Must be called with lock held.
 
         When multiple peers share a display_name (different circles), filters by
-        circle if provided, otherwise prefers online ones.
+        circle if provided. If circle is unspecified and multiple *online*
+        peers share the name, raises ValueError instead of silently picking
+        one (see issue #136: misroute via ambiguous resolve).
         """
         if identifier in self._peers:
             return self._peers[identifier]
@@ -270,6 +272,21 @@ class PeerRegistry:
             return matches[0]
         active = [p for p in matches if p.status != PeerStatus.OFFLINE]
         candidates = active or matches
+
+        # Ambiguous: >1 viable candidate and no explicit circle to disambiguate.
+        # Pane ownership is the only safe tiebreaker — a pane-owned peer is
+        # locally bound to a live tmux pane, so picking it over a pane-less
+        # twin is unambiguous. Anything else (e.g. last_seen) is a guess and
+        # caused issue #136 misroutes. Refuse to guess in that case.
+        if circle is None and len(candidates) > 1:
+            paned = [p for p in candidates if p.pane_id]
+            if len(paned) == 1:
+                return paned[0]
+            circles = sorted({p.circle for p in candidates})
+            raise ValueError(
+                f"Ambiguous peer name {identifier!r}: matches in circles "
+                f"{circles}. Specify a circle= or pass a peer_id."
+            )
 
         def preference(peer: Peer) -> tuple[bool, bool, float]:
             connected = bool(self._transport and self._transport.is_connected(peer.peer_id))

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -368,8 +368,13 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         # reminders until acked.
         correlation_id = data.get("correlation_id", "")
         from_peer = data.get("from_peer", "unknown")
+        to_peer = data.get("to_peer", "")
         text = data.get("text", "")
-        injected_text = f"@{from_peer} [ask #{correlation_id}]: {text}"
+        # `to_peer` is included so a recipient can spot misroutes when two
+        # peers share a display_name across circles (issue #136). Older
+        # daemons may omit it — keep the legacy frame in that case.
+        to_label = f" → @{to_peer}" if to_peer else ""
+        injected_text = f"@{from_peer}{to_label} [ask #{correlation_id}]: {text}"
         try:
             if await asyncio.to_thread(_tmux_send_keys, pane_id, injected_text):
                 logger.info(
@@ -382,9 +387,11 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         # Plain FYI, no lifecycle.
         try:
             from_peer = data.get("from_peer", "unknown")
+            to_peer = data.get("to_peer", "")
             text = data.get("text", "")
+            to_label = f" → @{to_peer}" if to_peer else ""
             if await asyncio.to_thread(
-                _tmux_send_keys, pane_id, f"@{from_peer}: {text}",
+                _tmux_send_keys, pane_id, f"@{from_peer}{to_label}: {text}",
             ):
                 logger.info(f"Injected notification from {from_peer}")
         except Exception as e:

--- a/tests/test_circles.py
+++ b/tests/test_circles.py
@@ -246,6 +246,92 @@ class TestSameNameDifferentCircles:
 
 
 # ---------------------------------------------------------------------------
+# Misroute repros: ambiguous display_name across circles when circle=None
+# (issue #136)
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousDisplayNameNoSilentWinner:
+    """When two *online* peers share a display_name across circles and the
+    caller doesn't specify circle, the daemon must NOT silently pick one.
+
+    A peer_id hit is unambiguous and continues to resolve.
+    Pure offline/online disambiguation is unchanged: a single viable target
+    wins even without an explicit circle.
+    """
+
+    @staticmethod
+    async def _register(pm: PeerRegistry, session_id: str, name: str, circle: str) -> None:
+        peer = Peer(
+            peer_id=session_id,
+            display_name=name,
+            path=f"/{name}",
+            machine="localhost",
+            circle=circle,
+        )
+        await pm.register_peer(peer)
+
+    async def test_notify_ambiguous_name_no_circle_raises(
+        self, mock_message_router):
+        """Two online peers share a display_name across circles → notify must error."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-a", "myproject", "teamA")
+        await self._register(pm, "sid-b", "myproject", "teamB")
+
+        with pytest.raises(ValueError, match="[Aa]mbiguous"):
+            await pm.notify("cli", "myproject", "hi")
+
+        mock_message_router.send_notification.assert_not_called()
+
+    async def test_ask_ambiguous_name_no_circle_raises(
+        self, mock_message_router):
+        """Same shape for asks: ambiguous targets must not silently route."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-a", "myproject", "teamA")
+        await self._register(pm, "sid-b", "myproject", "teamB")
+
+        mock_message_router.send_ask = AsyncMock()
+        with pytest.raises(ValueError, match="[Aa]mbiguous"):
+            await pm.deliver_ask("cli", "myproject", "hi", correlation_id="ask-1")
+
+        mock_message_router.send_ask.assert_not_called()
+
+    async def test_query_ambiguous_name_no_circle_raises(
+        self, mock_message_router):
+        """Same shape for legacy queries."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-a", "myproject", "teamA")
+        await self._register(pm, "sid-b", "myproject", "teamB")
+
+        with pytest.raises(ValueError, match="[Aa]mbiguous"):
+            await pm.query("cli", "myproject", "hello")
+
+        mock_message_router.send_query.assert_not_called()
+
+    async def test_ambiguous_name_with_explicit_circle_resolves(
+        self, mock_message_router):
+        """Explicit circle disambiguates — no error, routes to the right peer."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-a", "myproject", "teamA")
+        await self._register(pm, "sid-b", "myproject", "teamB")
+
+        await pm.notify("cli", "myproject", "hi", circle="teamB")
+        _, kwargs = mock_message_router.send_notification.call_args
+        assert kwargs["to_session_id"] == "sid-b"
+
+    async def test_peer_id_resolution_is_unambiguous(
+        self, mock_message_router):
+        """A peer_id lookup always wins — peer_ids are globally unique."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-a", "myproject", "teamA")
+        await self._register(pm, "sid-b", "myproject", "teamB")
+
+        await pm.notify("cli", "sid-b", "hi")
+        _, kwargs = mock_message_router.send_notification.call_args
+        assert kwargs["to_session_id"] == "sid-b"
+
+
+# ---------------------------------------------------------------------------
 # from_peer circle-preferred lookup (Fix 3 regression)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -55,6 +55,78 @@ class TestHandleAskAndNotify:
         mock_send.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_notify_injection_includes_recipient_when_provided(self):
+        """When the daemon includes `to_peer`, the injected frame labels the
+        recipient so the receiver can spot misroutes at a glance (issue #136).
+        """
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "notify",
+                    "from_peer": "alice",
+                    "to_peer": "bob",
+                    "text": "fyi",
+                },
+                "%5",
+            )
+        injected = mock_send.call_args.args[1]
+        assert "@alice" in injected
+        assert "bob" in injected, (
+            "recipient label missing — receiver can't tell who the message "
+            f"was addressed to: {injected!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ask_injection_includes_recipient_when_provided(self):
+        """Asks also carry the recipient label so cross-circle/dup-name
+        misroutes are visible to the receiver.
+        """
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "ask",
+                    "correlation_id": "ask-xyz",
+                    "from_peer": "alice",
+                    "to_peer": "bob",
+                    "text": "ping?",
+                },
+                "%5",
+            )
+        injected = mock_send.call_args.args[1]
+        assert "@alice" in injected
+        assert "[ask #ask-xyz]" in injected
+        assert "bob" in injected, (
+            "recipient label missing from ask injection: " f"{injected!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_notify_injection_omits_recipient_when_absent(self):
+        """Backward-compatible: frames without `to_peer` still inject cleanly.
+
+        Older daemons (or out-of-band test fixtures) don't populate `to_peer`;
+        the hook must not crash or inject an empty label.
+        """
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=True) as mock_send,
+        ):
+            await websocket_hook.handle_message(
+                {"type": "notify", "from_peer": "alice", "text": "fyi"},
+                "%5",
+            )
+        injected = mock_send.call_args.args[1]
+        assert "@alice" in injected
+        assert "fyi" in injected
+        # no stray "to:" label when to_peer missing
+        assert "to:" not in injected.lower() or "to:None" not in injected
+
+    @pytest.mark.asyncio
     async def test_ack_reply_arrives_as_plain_notify(self):
         """Ack-with-msg replies are plain notifies."""
         with (


### PR DESCRIPTION
## Summary

Two root causes for the misroute symptoms in #136:

- **(a) Ambiguous-display-name silent winner.** `_lookup_peer_unlocked` picked a peer by liveness preference when `circle=None` and multiple online peers shared a `display_name` across circles. MCP `notify_peer`/`ask` default `circle=None`, so duplicate names across circles (the common `*-claude-code` pattern) silently misrouted.
- **(b) No recipient label in injected wire frame.** ws-hook injected `@{from_peer}: text` with no `to_peer` field, so even *correctly*-routed status notifies looked misaddressed to receivers — they had no signal whether the message was for them.

The daemon's resolution was already exact-match (no substring, no broadcast fallback), so issue hypotheses #1 and #3 turned out to be wrong at the daemon level. The actual bugs were the silent winner and the missing recipient label.

## Fix shape

- `_lookup_peer_unlocked` raises `ValueError("Ambiguous peer name ...")` when `circle is None` and >1 viable candidates remain, *unless* exactly one candidate has a `pane_id` (locality tiebreaker — keeps pane-owned name lookup unambiguous).
- `MessageRouter.send_notification` and `send_ask` now include `to_peer` in the wire frame.
- `websocket_hook` injection prepends `→ @{to_peer}` to the frame when present; falls back to the legacy `@{from_peer}: text` shape when `to_peer` is missing (backward-compat with older daemons).

Scope kept tight per orchestrator's guidance — no pipeline restructure.

## Test plan

- [x] `tests/test_circles.py::TestAmbiguousDisplayNameNoSilentWinner` — 5 new tests covering notify/ask/query ambiguity raise, explicit circle disambiguates, peer_id resolves cleanly.
- [x] `tests/test_hooks.py::TestHandleAskAndNotify` — 3 new tests covering recipient label in notify/ask injection + backward-compat when `to_peer` absent.
- [x] Existing `test_lookup_prefers_pane_owned_peer_when_names_collide` still passes (pane-owned tiebreak preserved).
- [x] Full suite: 620 passed.
- [x] `ruff check repowire/` clean.
- [x] `uv run ty check repowire/` clean.

Closes #136.