### PR TITLE
feat(peers): turn_state field for paused-at-prompt detection (#139)

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT, AgentType, Config
-from repowire.protocol.peers import Peer, PeerRole, PeerStatus
+from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 
 if TYPE_CHECKING:
     from repowire.daemon.ask_tracker import AskTracker
@@ -450,6 +450,7 @@ class PeerRegistry:
         machine: str = "unknown",
         role: PeerRole = PeerRole.AGENT,
         peer_id: str | None = None,
+        turn_state: TurnState | None = None,
     ) -> tuple[str, str]:
         """Allocate a peer_id and register the peer atomically.
 
@@ -467,6 +468,8 @@ class PeerRegistry:
                 old_status = existing.status
                 existing.status = PeerStatus.ONLINE
                 existing.last_seen = datetime.now(timezone.utc)
+                if turn_state is not None:
+                    existing.turn_state = turn_state
                 self._emit_status_change(existing, old_status, PeerStatus.ONLINE)
                 if pane_id:
                     self._release_pane(pane_id, peer_id)
@@ -509,6 +512,7 @@ class PeerRegistry:
                 machine=machine,
                 metadata=metadata or {},
                 description=restored_description,
+                turn_state=turn_state,
             )
             self._peers[allocated_id] = peer
             logger.info(f"Peer registered: {assigned_name} ({allocated_id})")
@@ -956,6 +960,26 @@ class PeerRegistry:
             peer.status = status
             peer.last_seen = datetime.now(timezone.utc)
             self._emit_status_change(peer, old_status, status)
+
+    async def update_peer_turn_state(
+        self, identifier: str, turn_state: TurnState | None,
+    ) -> None:
+        """Update peer turn_state (idle/working/awaiting_input/pending_first_turn).
+
+        Orthogonal to status; does not refresh last_seen on its own (the
+        accompanying status update typically does). No event is emitted for
+        v1 — list_peers consumers pick it up on next read.
+        """
+        async with self._lock:
+            peer = self._lookup_peer_unlocked(identifier)
+            if not peer:
+                logger.warning(
+                    "update_peer_turn_state: peer not found: %s (turn_state=%s not applied)",
+                    identifier,
+                    turn_state,
+                )
+                return
+            peer.turn_state = turn_state
 
     async def touch_last_seen(
         self, identifier: str, circle: str | None = None,

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -14,7 +14,7 @@ from repowire.config.models import DEFAULT_QUERY_TIMEOUT
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.routes._shared import OkResponse
-from repowire.protocol.peers import PeerStatus
+from repowire.protocol.peers import PeerStatus, TurnState
 
 router = APIRouter(tags=["messages"])
 
@@ -70,7 +70,20 @@ class SessionUpdateRequest(BaseModel):
 
     peer_name: str | None = Field(None, description="Peer name")
     pane_id: str | None = Field(None, description="Tmux pane ID (alternative to peer_name)")
-    status: str = Field(..., description="New status (online, busy, offline)")
+    status: str | None = Field(
+        None,
+        description=(
+            "New status (online, busy, offline). Optional when only "
+            "turn_state is being updated."
+        ),
+    )
+    turn_state: TurnState | None = Field(
+        None,
+        description=(
+            "New turn_state (idle, working, awaiting_input, "
+            "pending_first_turn). Orthogonal to status."
+        ),
+    )
     metadata: dict | None = Field(None, description="Optional metadata")
 
 
@@ -185,16 +198,24 @@ async def update_session(
     request: SessionUpdateRequest,
     _: str | None = Depends(require_auth),
 ) -> OkResponse:
-    """Update session status for a peer."""
+    """Update session status and/or turn_state for a peer."""
     peer_registry = get_peer_registry()
 
-    try:
-        peer_status = PeerStatus(request.status)
-    except ValueError:
+    if request.status is None and request.turn_state is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid status: {request.status}. Must be one of: online, busy, offline",
+            detail="At least one of status or turn_state is required",
         )
+
+    peer_status: PeerStatus | None = None
+    if request.status is not None:
+        try:
+            peer_status = PeerStatus(request.status)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid status: {request.status}. Must be one of: online, busy, offline",
+            )
 
     # Resolve peer identifier
     if request.peer_name:
@@ -213,7 +234,10 @@ async def update_session(
             detail="Either peer_name or pane_id required",
         )
 
-    await peer_registry.update_peer_status(identifier, peer_status)
+    if peer_status is not None:
+        await peer_registry.update_peer_status(identifier, peer_status)
+    if request.turn_state is not None:
+        await peer_registry.update_peer_turn_state(identifier, request.turn_state)
     return OkResponse()
 
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -14,7 +14,7 @@ from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
-from repowire.protocol.peers import Peer, PeerRole, PeerStatus
+from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 
 router = APIRouter(tags=["peers"])
 
@@ -32,6 +32,7 @@ class PeerInfo(BaseModel):
     circle: str = "global"
     role: PeerRole = PeerRole.AGENT
     status: str
+    turn_state: TurnState | None = None
     last_seen: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     description: str = ""
@@ -50,6 +51,7 @@ def _peer_to_info(p: Peer) -> PeerInfo:
         circle=p.circle,
         role=p.role,
         status=p.status.value,
+        turn_state=p.turn_state,
         last_seen=p.last_seen.isoformat() if p.last_seen else None,
         metadata=p.metadata,
         description=p.description,
@@ -73,6 +75,9 @@ class RegisterPeerRequest(BaseModel):
     backend: AgentType = Field(default=AgentType.CLAUDE_CODE, description="Agent type")
     circle: str | None = Field(None, description="Circle (logical subnet)")
     role: PeerRole = Field(default=PeerRole.AGENT, description="Peer role")
+    turn_state: TurnState | None = Field(
+        None, description="Initial per-turn progress (optional)"
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("circle")
@@ -186,6 +191,7 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
         metadata=request.metadata,
         machine=request.machine or socket.gethostname(),
         role=request.role,
+        turn_state=request.turn_state,
     )
     return peer_id, display_name
 

--- a/repowire/hooks/notification_handler.py
+++ b/repowire/hooks/notification_handler.py
@@ -32,7 +32,12 @@ def main() -> int:
 
     pane_id = get_pane_id()
     if pane_id:
-        if not update_status(pane_id, "online", use_pane_id=True):
+        # idle_prompt = agent's prompt is live and unconsumed (rate limit,
+        # permission, tool clarification). Distinct from "idle" (Stop fired,
+        # no turn in progress) -- this is mid-turn waiting on user input.
+        if not update_status(
+            pane_id, "online", use_pane_id=True, turn_state="awaiting_input",
+        ):
             print(
                 f"repowire notification: failed to update status for pane {pane_id}",
                 file=sys.stderr,

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -26,7 +26,7 @@ def main(backend: str = "claude-code") -> int:
 
     pane_id = get_pane_id()
     if pane_id:
-        if not update_status(pane_id, "busy", use_pane_id=True):
+        if not update_status(pane_id, "busy", use_pane_id=True, turn_state="working"):
             print(
                 f"repowire prompt: failed to update status for pane {pane_id}",
                 file=sys.stderr,

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -36,6 +36,7 @@ def _register_peer_http(
     pane_id: str | None = None,
     metadata: dict | None = None,
     role: str | None = None,
+    turn_state: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Register peer via HTTP POST /peers. Returns (peer_id, display_name)."""
     folder = Path(path).name
@@ -51,6 +52,8 @@ def _register_peer_http(
         payload["metadata"] = metadata
     if role:
         payload["role"] = role
+    if turn_state:
+        payload["turn_state"] = turn_state
     result = daemon_post("/peers", payload)
     if result:
         return result.get("peer_id"), result.get("display_name")
@@ -240,6 +243,12 @@ def main(backend: str = "claude-code") -> int:
             or "default"
         )
         hint_role = hint.get("role") if hint else None
+        # Spawn-seed-drop guard: if the daemon spawned this peer with a seed
+        # message, mark turn_state=pending_first_turn so orchestrators can
+        # see the brief never landed and re-send via notify_peer. The first
+        # UserPromptSubmit transitions this to "working".
+        hint_pending_first_turn = bool(hint and hint.get("pending_first_turn"))
+        initial_turn_state = "pending_first_turn" if hint_pending_first_turn else None
         metadata = {"project": folder_name}
         peer_id, display_name = _register_peer_http(
             cwd,
@@ -248,6 +257,7 @@ def main(backend: str = "claude-code") -> int:
             pane_id=pane_id,
             metadata=metadata,
             role=hint_role,
+            turn_state=initial_turn_state,
         )
         if not display_name:
             display_name = folder_name  # fallback if daemon unreachable

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -111,15 +111,15 @@ def main(backend: str = "claude-code") -> int:
         if due:
             reminder_text = format_reminder_block(due)
 
-    # Mark peer online.
+    # Mark peer online and turn_state=idle (turn finished cleanly).
     if pane_id:
-        if not update_status(pane_id, "online", use_pane_id=True):
+        if not update_status(pane_id, "online", use_pane_id=True, turn_state="idle"):
             print(
                 f"repowire stop: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
     else:
-        if not update_status(peer_display, "online"):
+        if not update_status(peer_display, "online", turn_state="idle"):
             print(
                 f"repowire stop: failed to update status for {peer_display}",
                 file=sys.stderr,

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -212,11 +212,36 @@ def daemon_get(path: str, *, timeout: float = 2.0) -> dict | None:
         return None
 
 
-def update_status(peer_identifier: str, status_value: str, *, use_pane_id: bool = False) -> bool:
-    """Update peer status via daemon HTTP API."""
+def update_status(
+    peer_identifier: str,
+    status_value: str,
+    *,
+    use_pane_id: bool = False,
+    turn_state: str | None = None,
+) -> bool:
+    """Update peer status (and optionally turn_state) via daemon HTTP API."""
+    payload: dict = {"status": status_value}
     if use_pane_id:
-        payload = {"pane_id": peer_identifier, "status": status_value}
+        payload["pane_id"] = peer_identifier
     else:
-        payload = {"peer_name": peer_identifier, "status": status_value}
+        payload["peer_name"] = peer_identifier
+    if turn_state is not None:
+        payload["turn_state"] = turn_state
+    result = daemon_post("/session/update", payload)
+    return result is not None
+
+
+def update_turn_state(
+    peer_identifier: str,
+    turn_state: str,
+    *,
+    use_pane_id: bool = False,
+) -> bool:
+    """Update peer turn_state alone (no status change) via daemon HTTP API."""
+    payload: dict = {"turn_state": turn_state}
+    if use_pane_id:
+        payload["pane_id"] = peer_identifier
+    else:
+        payload["peer_name"] = peer_identifier
     result = daemon_post("/session/update", payload)
     return result is not None

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -261,7 +261,7 @@ def create_mcp_server() -> FastMCP:
     mcp = FastMCP("repowire")
 
     tsv_header = (
-        "peer_id\tname\tproject\tcircle\trole\tstatus\tpath\t"
+        "peer_id\tname\tproject\tcircle\trole\tstatus\tturn_state\tpath\t"
         "machine\tdescription\tbackend\tlast_seen"
     )
 
@@ -276,6 +276,7 @@ def create_mcp_server() -> FastMCP:
                 p.get("circle", ""),
                 p.get("role", "agent"),
                 p.get("status", ""),
+                p.get("turn_state") or "",
                 p.get("path") or "",
                 p.get("machine") or "",
                 p.get("description") or "",
@@ -292,8 +293,12 @@ def create_mcp_server() -> FastMCP:
         (you). Set show_offline=True to include offline peers, or
         include_self=True to include yourself in the listing.
 
-        Returns TSV: peer_id, name, project, circle, role, status, path, machine,
-        description, backend, last_seen. Peers are reachable via ask/notify_peer. Do NOT
+        Returns TSV: peer_id, name, project, circle, role, status, turn_state,
+        path, machine, description, backend, last_seen. The turn_state column
+        is "" when unknown; otherwise idle, working, awaiting_input (peer is
+        waiting on user input mid-turn), or pending_first_turn (peer was
+        spawn-seeded but the seed never reached the agent -- re-send via
+        notify_peer). Peers are reachable via ask/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
         """
@@ -477,7 +482,7 @@ def create_mcp_server() -> FastMCP:
         """[Repowire mesh] Return your identity in the repowire mesh.
 
         Returns TSV with columns: peer_id, name, project, circle, role, status,
-        path, machine, description, backend, last_seen
+        turn_state, path, machine, description, backend, last_seen
         """
         await _ensure_registered(strict=True)
         pane_id = get_pane_id()

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -260,9 +260,12 @@ def create_mcp_server() -> FastMCP:
     """Create the MCP server."""
     mcp = FastMCP("repowire")
 
+    # New columns append at the end so positional-indexing TSV consumers
+    # survive across releases (same rule that put last_seen at the tail in
+    # #138). Keep turn_state last for the same reason.
     tsv_header = (
-        "peer_id\tname\tproject\tcircle\trole\tstatus\tturn_state\tpath\t"
-        "machine\tdescription\tbackend\tlast_seen"
+        "peer_id\tname\tproject\tcircle\trole\tstatus\tpath\t"
+        "machine\tdescription\tbackend\tlast_seen\tturn_state"
     )
 
     def _peer_to_tsv_row(p: dict) -> str:
@@ -276,12 +279,12 @@ def create_mcp_server() -> FastMCP:
                 p.get("circle", ""),
                 p.get("role", "agent"),
                 p.get("status", ""),
-                p.get("turn_state") or "",
                 p.get("path") or "",
                 p.get("machine") or "",
                 p.get("description") or "",
                 p.get("backend", ""),
                 p.get("last_seen") or "",
+                p.get("turn_state") or "",
             ]
         )
 
@@ -293,11 +296,11 @@ def create_mcp_server() -> FastMCP:
         (you). Set show_offline=True to include offline peers, or
         include_self=True to include yourself in the listing.
 
-        Returns TSV: peer_id, name, project, circle, role, status, turn_state,
-        path, machine, description, backend, last_seen. The turn_state column
-        is "" when unknown; otherwise idle, working, awaiting_input (peer is
-        waiting on user input mid-turn), or pending_first_turn (peer was
-        spawn-seeded but the seed never reached the agent -- re-send via
+        Returns TSV: peer_id, name, project, circle, role, status, path,
+        machine, description, backend, last_seen, turn_state. The turn_state
+        column is "" when unknown; otherwise idle, working, awaiting_input
+        (peer is waiting on user input mid-turn), or pending_first_turn (peer
+        was spawn-seeded but the seed never reached the agent -- re-send via
         notify_peer). Peers are reachable via ask/notify_peer. Do NOT
         use SendMessage to contact them -- SendMessage is a Claude Code harness
         tool for same-session teammates only.
@@ -482,7 +485,7 @@ def create_mcp_server() -> FastMCP:
         """[Repowire mesh] Return your identity in the repowire mesh.
 
         Returns TSV with columns: peer_id, name, project, circle, role, status,
-        turn_state, path, machine, description, backend, last_seen
+        path, machine, description, backend, last_seen, turn_state
         """
         await _ensure_registered(strict=True)
         pane_id = get_pane_id()

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -4,11 +4,22 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
 from repowire.config.models import AgentType
+
+# Per-turn progress, orthogonal to PeerStatus (online/busy/offline liveness).
+# - "idle":               Stop hook fired, no turn in progress
+# - "working":            UserPromptSubmit fired, mid-turn
+# - "awaiting_input":     Notification(idle_prompt) fired -- agent prompt is
+#                         live and unconsumed (rate limit, permission, tool
+#                         clarification, etc). Orchestrator should respond.
+# - "pending_first_turn": Peer was spawned with a seed message but the first
+#                         turn never started (spawn-seed drop). Orchestrator
+#                         should re-send the brief via notify_peer.
+TurnState = Literal["idle", "working", "awaiting_input", "pending_first_turn"]
 
 
 class PeerRole(str, Enum):
@@ -64,6 +75,14 @@ class Peer(BaseModel):
     role: PeerRole = Field(default=PeerRole.AGENT, description="Peer role")
 
     status: PeerStatus = Field(default=PeerStatus.OFFLINE, description="Current status")
+    turn_state: TurnState | None = Field(
+        None,
+        description=(
+            "Per-turn progress (orthogonal to status): idle | working | "
+            "awaiting_input | pending_first_turn. None when unknown (e.g. "
+            "pre-feature peers, or before any hook has fired)."
+        ),
+    )
     last_seen: datetime | None = Field(None, description="Last activity timestamp")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     description: str = Field(default="", description="Current task description (self-reported)")
@@ -135,6 +154,7 @@ class Peer(BaseModel):
             "circle": self.circle,
             "role": self.role.value,
             "status": self.status.value,
+            "turn_state": self.turn_state,
             "last_seen": self.last_seen.isoformat() if self.last_seen else None,
             "metadata": self.metadata,
             "description": self.description,

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -92,7 +92,11 @@ def spawn_peer(config: SpawnConfig) -> SpawnResult:
     # the requested circle when their MCP/hook subprocess registers. Role is
     # included for spawns that need a non-default role (e.g. orchestrator).
     write_hint(
-        config.path, config.backend.value, config.circle, role=config.role,
+        config.path,
+        config.backend.value,
+        config.circle,
+        role=config.role,
+        pending_first_turn=bool(config.message),
     )
 
     pane.send_keys(cmd, enter=True)

--- a/repowire/spawn_hints.py
+++ b/repowire/spawn_hints.py
@@ -49,10 +49,20 @@ def _hint_path(path: str, backend: str) -> Path:
 
 
 def write_hint(
-    path: str, backend: str, circle: str, *, role: str | None = None,
+    path: str,
+    backend: str,
+    circle: str,
+    *,
+    role: str | None = None,
+    pending_first_turn: bool = False,
 ) -> None:
     """Record spawn intent so a peer registering from this path+backend can
     discover its requested circle (and optionally role).
+
+    ``pending_first_turn=True`` marks spawned peers that have a seed message
+    in flight but no first turn yet -- the session handler uses it to set
+    the peer's initial turn_state, so orchestrators can spot
+    spawn-seed-drops and re-send the brief.
     """
     payload: dict = {
         "path": str(Path(path).resolve()),
@@ -62,6 +72,8 @@ def write_hint(
     }
     if role:
         payload["role"] = role
+    if pending_first_turn:
+        payload["pending_first_turn"] = True
     target = _hint_path(path, backend)
     try:
         target.write_text(json.dumps(payload))
@@ -119,4 +131,6 @@ def consume_hint_full(path: str, backend: str) -> dict | None:
     role = data.get("role")
     if isinstance(role, str) and role:
         out["role"] = role
+    if data.get("pending_first_turn") is True:
+        out["pending_first_turn"] = True
     return out

--- a/tests/test_hooks_handlers.py
+++ b/tests/test_hooks_handlers.py
@@ -31,14 +31,18 @@ class TestPromptHandler:
     def test_sets_busy(self, mock_pane, mock_status):
         result = _run_with_input(prompt_main, {"hook_event_name": "UserPromptSubmit"})
         assert result == 0
-        mock_status.assert_called_once_with("%42", "busy", use_pane_id=True)
+        mock_status.assert_called_once_with(
+            "%42", "busy", use_pane_id=True, turn_state="working",
+        )
 
     @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
     def test_gemini_before_agent(self, mock_pane, mock_status):
         result = _run_with_input(prompt_main, {"hook_event_name": "BeforeAgent"})
         assert result == 0
-        mock_status.assert_called_once_with("%42", "busy", use_pane_id=True)
+        mock_status.assert_called_once_with(
+            "%42", "busy", use_pane_id=True, turn_state="working",
+        )
 
     @patch("repowire.hooks.prompt_handler.update_status")
     @patch("repowire.hooks.prompt_handler.get_pane_id", return_value=None)
@@ -82,7 +86,9 @@ class TestNotificationHandler:
             "notification_type": "idle_prompt",
         })
         assert result == 0
-        mock_status.assert_called_once_with("%42", "online", use_pane_id=True)
+        mock_status.assert_called_once_with(
+            "%42", "online", use_pane_id=True, turn_state="awaiting_input",
+        )
 
     @patch("repowire.hooks.notification_handler.update_status")
     @patch("repowire.hooks.notification_handler.get_pane_id", return_value=None)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -845,7 +845,7 @@ class TestMcpListPeersSelfFilter:
 
 
 class TestMcpListPeersLastSeen:
-    """list_peers TSV must include last_seen as the trailing column."""
+    """list_peers TSV must include last_seen + turn_state as trailing columns."""
 
     @pytest.mark.asyncio
     @patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock)
@@ -859,10 +859,12 @@ class TestMcpListPeersLastSeen:
             "peers": [
                 {"peer_id": "repow-1-aa", "display_name": "alpha",
                  "circle": "main", "status": "online", "backend": "claude-code",
-                 "last_seen": "2026-05-14T12:00:00+00:00"},
+                 "last_seen": "2026-05-14T12:00:00+00:00",
+                 "turn_state": "awaiting_input"},
                 {"peer_id": "repow-1-bb", "display_name": "beta",
                  "circle": "main", "status": "online", "backend": "claude-code",
-                 "last_seen": None},
+                 "last_seen": None,
+                 "turn_state": None},
             ]
         }
 
@@ -871,10 +873,15 @@ class TestMcpListPeersLastSeen:
         result = await list_tool.fn()
         lines = result.splitlines()
         header = lines[0].split("\t")
-        assert header[-1] == "last_seen"
+        # turn_state appended after last_seen to keep positional TSV consumers
+        # of the pre-#139 layout stable (same rule that put last_seen last in #138).
+        assert header[-2] == "last_seen"
+        assert header[-1] == "turn_state"
         alpha_row = next(line for line in lines[1:] if "alpha" in line).split("\t")
         beta_row = next(line for line in lines[1:] if "beta" in line).split("\t")
-        assert alpha_row[-1] == "2026-05-14T12:00:00+00:00"
+        assert alpha_row[-2] == "2026-05-14T12:00:00+00:00"
+        assert alpha_row[-1] == "awaiting_input"
+        assert beta_row[-2] == ""
         assert beta_row[-1] == ""
 
 

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -162,7 +162,9 @@ class TestStopHandler:
         })
 
         # Should update status
-        mock_status.assert_called_once_with("%42", "online", use_pane_id=True)
+        mock_status.assert_called_once_with(
+            "%42", "online", use_pane_id=True, turn_state="idle",
+        )
 
         # Should post assistant turn for dashboard
         chat_calls = [c for c in mock_post.call_args_list if c[0][0] == "/events/chat"]

--- a/tests/test_turn_state.py
+++ b/tests/test_turn_state.py
@@ -1,0 +1,213 @@
+"""Tests for turn_state field on Peer + plumbing through registry, route, hints."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import messages, peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import Peer, PeerStatus
+from repowire.spawn_hints import consume_hint_full, write_hint
+
+# ---------- protocol model ----------
+
+def test_peer_default_turn_state_is_none() -> None:
+    p = Peer(peer_id="repow-x-aaaa", display_name="foo", path="/x", machine="m")
+    assert p.turn_state is None
+
+
+def test_peer_to_dict_includes_turn_state() -> None:
+    p = Peer(
+        peer_id="repow-x-aaaa", display_name="foo", path="/x", machine="m",
+        turn_state="awaiting_input",
+    )
+    assert p.to_dict()["turn_state"] == "awaiting_input"
+
+
+# ---------- spawn_hints ----------
+
+@pytest.fixture
+def tmp_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr("repowire.spawn_hints.CACHE_DIR", tmp_path)
+    return tmp_path
+
+
+def test_write_hint_pending_first_turn_roundtrips(tmp_cache: Path) -> None:
+    write_hint("/tmp/seeded", "claude-code", "default", pending_first_turn=True)
+    data = consume_hint_full("/tmp/seeded", "claude-code")
+    assert data is not None
+    assert data.get("pending_first_turn") is True
+
+
+def test_write_hint_without_pending_first_turn_omits_field(tmp_cache: Path) -> None:
+    write_hint("/tmp/plain", "claude-code", "default")
+    data = consume_hint_full("/tmp/plain", "claude-code")
+    assert data is not None
+    assert "pending_first_turn" not in data
+
+
+# ---------- peer_registry ----------
+
+def _make_registry(tmp_path: Path) -> PeerRegistry:
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    reg = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    reg._events_path = tmp_path / "events.json"
+    reg._events.clear()
+    reg._last_repair = time.monotonic() + 3600
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_update_peer_turn_state_applies(tmp_path: Path) -> None:
+    reg = _make_registry(tmp_path)
+    peer_id, _ = await reg.allocate_and_register(
+        circle="c", backend=AgentType.CLAUDE_CODE, path="/p",
+    )
+    await reg.update_peer_turn_state(peer_id, "awaiting_input")
+    peer = await reg.get_peer(peer_id)
+    assert peer is not None
+    assert peer.turn_state == "awaiting_input"
+
+    await reg.update_peer_turn_state(peer_id, None)
+    peer = await reg.get_peer(peer_id)
+    assert peer is not None
+    assert peer.turn_state is None
+
+
+@pytest.mark.asyncio
+async def test_update_peer_turn_state_does_not_change_status(tmp_path: Path) -> None:
+    """turn_state is orthogonal to status -- updating one must not move the other."""
+    reg = _make_registry(tmp_path)
+    peer_id, _ = await reg.allocate_and_register(
+        circle="c", backend=AgentType.CLAUDE_CODE, path="/p",
+    )
+    await reg.update_peer_status(peer_id, PeerStatus.BUSY)
+    await reg.update_peer_turn_state(peer_id, "working")
+    peer = await reg.get_peer(peer_id)
+    assert peer is not None
+    assert peer.status == PeerStatus.BUSY
+    assert peer.turn_state == "working"
+
+
+@pytest.mark.asyncio
+async def test_allocate_and_register_accepts_initial_turn_state(tmp_path: Path) -> None:
+    reg = _make_registry(tmp_path)
+    peer_id, _ = await reg.allocate_and_register(
+        circle="c",
+        backend=AgentType.CLAUDE_CODE,
+        path="/p",
+        turn_state="pending_first_turn",
+    )
+    peer = await reg.get_peer(peer_id)
+    assert peer is not None
+    assert peer.turn_state == "pending_first_turn"
+
+
+# ---------- HTTP routes ----------
+
+def _make_test_app(tmp_path: Path) -> FastAPI:
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=tracker,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    app_state = SimpleNamespace(
+        config=cfg, transport=transport, query_tracker=tracker,
+        message_router=router, peer_registry=registry, relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+    app = FastAPI()
+    app.include_router(peers.router)
+    app.include_router(messages.router)
+    return app
+
+
+@pytest.fixture
+async def client(tmp_path: Path):
+    app = _make_test_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as c:
+        yield c
+    cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_session_update_accepts_turn_state_alone(client) -> None:
+    resp = await client.post("/peers", json={
+        "name": "alpha", "path": "/p", "circle": "c", "backend": "claude-code",
+    })
+    assert resp.status_code == 200
+    peer_id = resp.json()["peer_id"]
+
+    resp = await client.post("/session/update", json={
+        "peer_name": peer_id, "turn_state": "working",
+    })
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/peers/{peer_id}")
+    assert resp.status_code == 200
+    assert resp.json()["turn_state"] == "working"
+
+
+@pytest.mark.asyncio
+async def test_session_update_requires_status_or_turn_state(client) -> None:
+    resp = await client.post("/peers", json={
+        "name": "beta", "path": "/p2", "circle": "c", "backend": "claude-code",
+    })
+    peer_id = resp.json()["peer_id"]
+    resp = await client.post("/session/update", json={"peer_name": peer_id})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_session_update_status_and_turn_state_together(client) -> None:
+    resp = await client.post("/peers", json={
+        "name": "gamma", "path": "/p3", "circle": "c", "backend": "claude-code",
+    })
+    peer_id = resp.json()["peer_id"]
+    resp = await client.post("/session/update", json={
+        "peer_name": peer_id, "status": "busy", "turn_state": "working",
+    })
+    assert resp.status_code == 200
+    body = (await client.get(f"/peers/{peer_id}")).json()
+    assert body["status"] == "busy"
+    assert body["turn_state"] == "working"
+
+
+@pytest.mark.asyncio
+async def test_register_peer_accepts_initial_turn_state(client) -> None:
+    """Session handler can register a spawn-seeded peer as pending_first_turn."""
+    resp = await client.post("/peers", json={
+        "name": "spawned", "path": "/sp", "circle": "c", "backend": "claude-code",
+        "turn_state": "pending_first_turn",
+    })
+    assert resp.status_code == 200
+    peer_id = resp.json()["peer_id"]
+    assert (await client.get(f"/peers/{peer_id}")).json()["turn_state"] == "pending_first_turn"

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -73,7 +73,7 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
         signature={`list_peers(show_offline: bool = False, include_self: bool = False) -> str`}
       >
         <p>
-          Returns a TSV with columns: <Mono>peer_id, name, project, circle, role, status, path, machine, description, backend, last_seen</Mono>. Defaults to online + busy peers and hides the caller. Pass <Mono>show_offline=True</Mono> for the full registry; pass <Mono>include_self=True</Mono> when an orchestrator needs its own row.
+          Returns a TSV with columns: <Mono>peer_id, name, project, circle, role, status, path, machine, description, backend, last_seen, turn_state</Mono>. The <Mono>turn_state</Mono> column is empty when unknown; otherwise <Mono>idle</Mono>, <Mono>working</Mono>, <Mono>awaiting_input</Mono> (peer is mid-turn waiting on user input), or <Mono>pending_first_turn</Mono> (spawn-seeded peer whose first prompt never landed). Defaults to online + busy peers and hides the caller. Pass <Mono>show_offline=True</Mono> for the full registry; pass <Mono>include_self=True</Mono> when an orchestrator needs its own row.
         </p>
       </Tool>
 


### PR DESCRIPTION
## Summary

Adds a `turn_state` field on `Peer`, orthogonal to liveness `status`, so other peers can distinguish:
- `idle` — Stop fired, no turn in progress
- `working` — UserPromptSubmit fired, mid-turn
- `awaiting_input` — Notification(idle_prompt) fired; agent's prompt is live, waiting on a human/orchestrator response mid-turn
- `pending_first_turn` — peer was daemon-spawned with a seed message but the first turn never started (spawn-seed-drop guard)
- `None` — unknown (default for pre-feature peers and pre-hook registrations)

Resolves #139.

## Design

Picked separate field over a new `PeerStatus` value: status is a liveness axis (online/busy/offline) used by routing decisions throughout the registry; collapsing turn progress into it would have broken the `p.status in (ONLINE, BUSY)` checks scattered through `peer_registry.py`. Separate field keeps invariants enforceable in one spot.

Hook surface (covers options #1 and #3 from the issue; option #2 heuristic intentionally skipped):
- `UserPromptSubmit` / `BeforeAgent` -> `turn_state=working` (with existing `status=busy`)
- `Stop` / `AfterAgent` -> `turn_state=idle` (with existing `status=online`)
- `Notification(idle_prompt)` -> `turn_state=awaiting_input` (with existing `status=online`)
- `/spawn` with `message` -> peer registers via SessionStart with `turn_state=pending_first_turn` (threaded through `spawn_hints` so it survives the spawn -> hook gap and Codex's stripped tmux env)

`list_peers` and `whoami` TSV now include a `turn_state` column (after `status`, before `path`). Empty string when unknown.

`/session/update` accepts `turn_state` independently of `status` (either or both, at least one required).

## Scope and follow-ups

- WS transport (channel mode) does not yet emit turn_state; would extend `websocket.py:231` `msg_type=="status"` handler. Out of scope for v1.
- No event bus emission for turn_state changes (per design discussion). If dashboard timeline highlights become useful, future PR can add a `TurnStateChanged` event type.
- Dashboard PeerInfo rendering not updated -- field is wired into the API response (`peer.turn_state`), UI side can pick it up in a separate change.

## Test plan

- [x] `pytest` (631 tests, +11 new in `test_turn_state.py`)
- [x] `ruff check repowire/`
- [x] `uv run ty check repowire/`
- [x] New test coverage: model defaults, `to_dict` serialization, `update_peer_turn_state` (including orthogonality to status), `allocate_and_register` initial turn_state, `/session/update` with turn_state alone / with status / requiring at least one, `/peers` POST accepting initial turn_state, spawn_hints `pending_first_turn` roundtrip
- [ ] Manual: spawn a peer with a seed message via `/spawn`, confirm `list_peers` shows `pending_first_turn`, send first prompt, confirm it transitions to `working`. (Deferred to integration test on daemon restart.)