### PR TITLE
docs: refresh README for v0.13 productized surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ repowire telegram start
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `list_peers` | Query | List peers with status, circle, path, description, `last_seen`, `turn_state`. Defaults to online + hides self; `show_offline=True` + `include_self=True` widen the view |
-| `ask` | Non-blocking | Open a thread. Returns a correlation_id immediately. Optional `reply_to=cid` chains a follow-up that closes the prior thread |
+| `list_peers` | Query | List peers with status, circle, path, description, `last_seen`, `turn_state`. Defaults to online + caller's circle + hides self. Pass `circle='*'` for mesh-wide, `show_offline=True` + `include_self=True` to widen. Orchestrator-role callers default to mesh-wide |
+| `ask` | Non-blocking | Open a thread. Returns a correlation_id immediately. Defaults to caller's circle; falls back to global lookup only when the target's role bypasses circles. Optional `reply_to=cid` chains a follow-up that closes the prior thread |
 | `ack` | Close | Close an open ask thread. Bare `ack(cid)` is "seen, no action"; `ack(cid, message)` delivers a reply to the asker |
 | `notify_peer` | Fire-and-forget | Send a notification (no lifecycle, no reply tracking) |
 | `broadcast` | Fire-and-forget | Message all online peers in your circle |
@@ -250,6 +250,8 @@ repowire telegram start
 **Reminder injection.** If an agent receives an ask but doesn't ack/reply, repowire injects a reminder block at the start of every subsequent prompt until the ask is acked. Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does. If a peer appears paused at the prompt (idle but with unhandled work), the daemon detects this and surfaces it on the dashboard.
 
 **Misroute refusal.** Ambiguous peer names (multiple peers sharing a display name across circles) cause `ask`/`notify_peer` to refuse with a hint, instead of routing to the wrong peer. Always pass explicit `circle=...` to disambiguate.
+
+**Circle scoping.** As of v0.13.4, the MCP surface defaults to the caller's own circle. Peers with role `service`, `orchestrator`, or `human` (e.g. the Telegram bot, the orchestrator, you) bypass circles and are always visible. Pass `circle='*'` to widen any call to mesh-wide. Orchestrator peers default to mesh-wide automatically — they need the full view.
 
 ## CLI Reference
 
@@ -272,7 +274,7 @@ repowire update                   # Upgrade package, reinstall hooks, restart da
 repowire uninstall                # Remove all components (--yes to skip prompts)
 ```
 
-`repowire peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP `list_peers` tool defaults to a peer-facing view (online only, caller hidden).
+`repowire peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP `list_peers` tool defaults to a peer-facing view (online only, caller's circle, caller hidden) — see [Circle scoping](#mcp-tools).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Have a different agent review your work. Peer A builds a feature, peer B runs a 
 <summary>Orchestrator</summary>
 
 A dedicated coordinator peer manages the mesh. It dispatches tasks, tracks progress, runs review cycles, and coordinates releases across multiple project peers. The pattern that makes 10+ agents manageable.
+
+The orchestrator loop:
+
+1. Scan a GitHub project board for `Todo` items.
+2. Claim by `notify_peer`-ing the target project peer with the task brief; flip the board item to `In Progress`.
+3. Receive `ask`/`notify` updates as work progresses (`set_description` keeps the dashboard honest).
+4. On peer reports `done`, review the PR (`review_queue` surfaces open PRs the peer touched), merge after sign-off, flip the board item to `Done`.
+5. Roll a release tag when a batch lands.
+
+A second orchestrator peer can co-exist as an observer/learner without colliding — use `orchestrator_status` to see open asks and avoid double-claiming. Pair a `claude-code` orchestrator with a `codex` or `gemini` one to keep the mesh moving when one runtime hits credit limits.
 </details>
 
 <details>
@@ -219,7 +229,7 @@ repowire telegram start
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `list_peers` | Query | List all peers with status, circle, path, description |
+| `list_peers` | Query | List peers with status, circle, path, description, `last_seen`. Defaults to online + circle-scoped + hides self; `show_offline=True` + `include_self=True` widen the view |
 | `ask` | Non-blocking | Open a thread. Returns a correlation_id immediately. Optional `reply_to=cid` chains a follow-up that closes the prior thread |
 | `ack` | Close | Close an open ask thread. Bare `ack(cid)` is "seen, no action"; `ack(cid, message)` delivers a reply to the asker |
 | `notify_peer` | Fire-and-forget | Send a notification (no lifecycle, no reply tracking) |
@@ -228,12 +238,18 @@ repowire telegram start
 | `set_description` | Mutation | Update your task description, visible to all peers and the dashboard |
 | `spawn_peer` | Mutation | Spawn a new agent session (requires [allowlist config](#configuration)) |
 | `kill_peer` | Mutation | Kill a previously spawned session |
+| `orchestrator_status` | Query | Snapshot of mesh state for an orchestrator peer: peers, open asks, recent activity |
+| `mark_reviewed` | Mutation | Mark a PR as reviewed at a given SHA. New commits on that PR re-surface it in your review queue |
+| `review_queue` | Query | List PRs awaiting your review (or another peer's). Filter by `peer_name=...` |
+| `schedule_create` | Mutation | Schedule a notification or ask to a peer at a future time (one-shot or recurring) |
+| `schedule_list` | Query | List your active schedules. `mine_only=False` shows all |
+| `schedule_delete` | Mutation | Remove a schedule |
 
 `list_peers` and `whoami` return TSV (more token-efficient than JSON).
 
-If an agent receives an ask but doesn't ack/reply, repowire injects a reminder block at the start of every subsequent prompt until the ask is acked. Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does.
+**Reminder injection.** If an agent receives an ask but doesn't ack/reply, repowire injects a reminder block at the start of every subsequent prompt until the ask is acked. Tool-call detection is the source of truth — prose `[ack #cid]` mentions don't close anything, only a real `ack()` call does. If a peer appears paused at the prompt (idle but with unhandled work), the daemon detects this and surfaces it on the dashboard.
 
-The legacy `ask_peer` (blocking, request/response) is removed in this release. The legacy `/query` + `/response` HTTP endpoints remain as compatibility shims for the telegram bot and CLI; they will be removed in v0.13.
+**Misroute refusal.** Ambiguous peer names (multiple peers sharing a display name across circles) cause `ask`/`notify_peer` to refuse with a hint, instead of routing to the wrong peer. Always pass explicit `circle=...` to disambiguate.
 
 ## CLI Reference
 
@@ -247,7 +263,7 @@ repowire serve --relay            # Run daemon with relay connection
 
 repowire peer new PATH            # Spawn new peer in tmux
 repowire peer new . --circle dev  # Spawn with custom circle
-repowire peer list                # List peers and their status
+repowire peer list                # List peers and their status (god-view, includes offline)
 repowire peer prune               # Remove offline peers
 
 repowire telegram start           # Run Telegram bot (config or env vars)
@@ -255,6 +271,8 @@ repowire slack start              # Run Slack bot (config or env vars)
 repowire update                   # Upgrade package, reinstall hooks, restart daemon
 repowire uninstall                # Remove all components (--yes to skip prompts)
 ```
+
+`repowire peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP `list_peers` tool defaults to a peer-facing view (online only, caller's circle, caller hidden).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ repowire telegram start
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `list_peers` | Query | List peers with status, circle, path, description, `last_seen`. Defaults to online + circle-scoped + hides self; `show_offline=True` + `include_self=True` widen the view |
+| `list_peers` | Query | List peers with status, circle, path, description, `last_seen`, `turn_state`. Defaults to online + hides self; `show_offline=True` + `include_self=True` widen the view |
 | `ask` | Non-blocking | Open a thread. Returns a correlation_id immediately. Optional `reply_to=cid` chains a follow-up that closes the prior thread |
 | `ack` | Close | Close an open ask thread. Bare `ack(cid)` is "seen, no action"; `ack(cid, message)` delivers a reply to the asker |
 | `notify_peer` | Fire-and-forget | Send a notification (no lifecycle, no reply tracking) |
@@ -238,10 +238,10 @@ repowire telegram start
 | `set_description` | Mutation | Update your task description, visible to all peers and the dashboard |
 | `spawn_peer` | Mutation | Spawn a new agent session (requires [allowlist config](#configuration)) |
 | `kill_peer` | Mutation | Kill a previously spawned session |
-| `orchestrator_status` | Query | Snapshot of mesh state for an orchestrator peer: peers, open asks, recent activity |
+| `orchestrator_status` | Query | Check whether a live orchestrator is present in a circle (`present`, `peer_name`, `last_seen`) |
 | `mark_reviewed` | Mutation | Mark a PR as reviewed at a given SHA. New commits on that PR re-surface it in your review queue |
 | `review_queue` | Query | List PRs awaiting your review (or another peer's). Filter by `peer_name=...` |
-| `schedule_create` | Mutation | Schedule a notification or ask to a peer at a future time (one-shot or recurring) |
+| `schedule_create` | Mutation | Schedule a notification or ask to a peer at a future time (one-shot) |
 | `schedule_list` | Query | List your active schedules. `mine_only=False` shows all |
 | `schedule_delete` | Mutation | Remove a schedule |
 
@@ -272,7 +272,7 @@ repowire update                   # Upgrade package, reinstall hooks, restart da
 repowire uninstall                # Remove all components (--yes to skip prompts)
 ```
 
-`repowire peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP `list_peers` tool defaults to a peer-facing view (online only, caller's circle, caller hidden).
+`repowire peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP `list_peers` tool defaults to a peer-facing view (online only, caller hidden).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Refreshes the README to match what shipped in v0.13.0–v0.13.3. Focused, not a rewrite — the existing structure (Why / Install / Quick Start / How It Works / Patterns / Control Plane / MCP / CLI / Config) holds up well; this fills in the v0.13 gaps and removes stale claims.

## What changes

- **MCP Tools table**: add `orchestrator_status`, `mark_reviewed`, `review_queue`, `schedule_create` / `schedule_list` / `schedule_delete`. Update `list_peers` row with the new `show_offline` / `include_self` params and the `last_seen` column.
- **Reminder injection + misroute refusal**: short paragraphs explaining the two new safety surfaces (paused-at-prompt detection on the dashboard side, ambiguous-recipient refusal on the routing side).
- **Orchestrator pattern**: expanded from one line to a board-driven dispatch walkthrough (scan board → notify peer → flip status → review via `review_queue` → tag release) + the co-orchestrator pattern (two orchestrators, different runtimes, observer/learner alongside a driver — what we've been running with claude + pi).
- **CLI peer list**: clarify it's god-view (all peers, all circles, includes caller), distinct from the MCP `list_peers` which defaults to a peer-facing view.
- **Drop stale paragraph**: the line claiming \`ask_peer\` is \"removed in this release\" + \"will be removed in v0.13\" — we're already on v0.13.3, so the framing is wrong.

## What stays out (and why)

- **Schedule semantics deep-dive** — the MCP tool row is enough; a real walkthrough belongs in the dedicated docs site (issue #126), not here.
- **Comparison table tweaks** — Happy / cloud coding services / Memory Bank comparisons land in docs site (per #126), out of scope here.
- **Dashboard screenshots refresh** — current set still represents v0.13 surfaces adequately; lower priority than the tools table being honest.

Once this lands, the next docs lane is #126 (audit → IA → comparison pages → MVP at docs.repowire.io, GKE-deployed).

## Test plan

- [ ] PR review: do the new tool names + params match the actual MCP surface (\`repowire/mcp/server.py\`)?
- [ ] README renders cleanly on github.com (no broken collapsible sections, table widths fine).