### PR TITLE
feat(docs): chart + nginx image for docs.repowire.io

### DIFF
--- a/charts/repowire-docs/Chart.yaml
+++ b/charts/repowire-docs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: repowire-docs
+description: docs.repowire.io (mkdocs-material static site)
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/repowire-docs/templates/deployment.yaml
+++ b/charts/repowire-docs/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      containers:
+        - name: nginx
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/repowire-docs/templates/httproute.yaml
+++ b/charts/repowire-docs/templates/httproute.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}
+  namespace: clusterkit
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: clusterkit-gateway
+      namespace: clusterkit
+  hostnames:
+    - {{ .Values.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Release.Name }}
+          namespace: {{ .Release.Namespace }}
+          port: {{ .Values.service.port }}

--- a/charts/repowire-docs/templates/service.yaml
+++ b/charts/repowire-docs/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/charts/repowire-docs/values.yaml
+++ b/charts/repowire-docs/values.yaml
@@ -1,0 +1,30 @@
+replicaCount: 1
+
+image:
+  repository: us-docker.pkg.dev/baldmaninc/gcr.io/repowire-docs
+  tag: latest
+  pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 80
+
+hostname: docs.repowire.io
+wwwRedirect: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+nodeSelector:
+  cloud.google.com/gke-spot: "true"
+
+tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/gke-spot
+    operator: Equal
+    value: "true"

--- a/docs-image/Dockerfile
+++ b/docs-image/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-slim AS build
+
+RUN pip install --no-cache-dir uv==0.5.4
+
+WORKDIR /src
+COPY pyproject.toml uv.lock README.md ./
+COPY docs ./docs
+COPY mkdocs.yml ./
+
+# --no-install-project: docs build only needs mkdocs + mkdocs-material +
+# pymdown-extensions from the [docs] extra. Skipping the project install
+# avoids pulling repowire's hatch build, which force-includes web/out
+# (a Next.js export artifact unrelated to the docs site).
+RUN uv sync --extra docs --frozen --no-install-project
+RUN .venv/bin/mkdocs build --strict
+
+FROM nginx:alpine
+
+COPY --from=build /src/site/ /usr/share/nginx/html/
+COPY docs-image/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docs-image/security-headers.conf /etc/nginx/conf.d/security-headers.conf
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://localhost/health || exit 1
+
+EXPOSE 80

--- a/docs-image/nginx.conf
+++ b/docs-image/nginx.conf
@@ -1,0 +1,31 @@
+server {
+  listen 80 default_server;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+  error_page 404 /404.html;
+
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "interest-cohort=()" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
+  add_header Cache-Control "no-cache" always;
+
+  location = /health {
+    access_log off;
+    include /etc/nginx/conf.d/security-headers.conf;
+    add_header Cache-Control "no-store" always;
+    return 200 "ok\n";
+  }
+
+  # mkdocs use_directory_urls=true serves /page as /page/index.html
+  location / {
+    try_files $uri $uri/ $uri.html $uri/index.html =404;
+  }
+
+  location /assets/ {
+    include /etc/nginx/conf.d/security-headers.conf;
+    add_header Cache-Control "public, max-age=86400" always;
+  }
+}

--- a/docs-image/security-headers.conf
+++ b/docs-image/security-headers.conf
@@ -1,0 +1,5 @@
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "interest-cohort=()" always;
+add_header X-Frame-Options "DENY" always;
+add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Manual deploy for docs.repowire.io.
+# Adapt nothing — run from repowire repo root.
+# Requires: gcloud authed against baldmaninc, docker running, helm installed.
+
+set -euo pipefail
+
+APP_NAME=repowire-docs
+NAMESPACE=repowire
+DOCKERFILE=docs-image/Dockerfile
+CHART_PATH=charts/repowire-docs
+
+PROJECT_ID=baldmaninc
+CLUSTER=clusterkit
+REGION=us-central1
+REGISTRY=us-docker.pkg.dev/${PROJECT_ID}/gcr.io
+SHA=$(git rev-parse --short HEAD)
+
+echo "==> SHA=${SHA}  APP=${APP_NAME}  NS=${NAMESPACE}"
+
+echo "==> Configuring Docker for Artifact Registry"
+gcloud auth configure-docker us-docker.pkg.dev --quiet
+
+echo "==> Getting GKE credentials"
+gcloud container clusters get-credentials "${CLUSTER}" --region "${REGION}" --project "${PROJECT_ID}"
+
+echo "==> Building + pushing ${APP_NAME}"
+docker build --platform linux/amd64 \
+  -t "${REGISTRY}/${APP_NAME}:${SHA}" \
+  -t "${REGISTRY}/${APP_NAME}:latest" \
+  -f "${DOCKERFILE}" .
+docker push "${REGISTRY}/${APP_NAME}:${SHA}"
+docker push "${REGISTRY}/${APP_NAME}:latest"
+
+echo "==> helm upgrade ${APP_NAME}"
+helm upgrade --install "${APP_NAME}" "${CHART_PATH}" \
+  --namespace "${NAMESPACE}" \
+  --set image.tag="${SHA}" \
+  --wait --timeout 5m
+
+echo "==> Verifying"
+kubectl rollout status "deployment/${APP_NAME}" -n "${NAMESPACE}" --timeout=3m
+
+echo "==> Smoke checks for https://docs.repowire.io"
+curl -sS -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" https://docs.repowire.io || true
+echo "--- TLS issuer (Cloudflare edge cert; Origin CA validates server-side under Full Strict)"
+echo | openssl s_client -connect docs.repowire.io:443 -servername docs.repowire.io 2>/dev/null \
+  | openssl x509 -noout -issuer -subject 2>/dev/null || true
+
+echo "==> Done."


### PR DESCRIPTION
## Summary

Adds an isolated Helm chart and nginx image for serving the docs.repowire.io static site. Does not touch `charts/repowire-relay` or `charts/repowire-web`.

- `docs-image/`: multi-stage Dockerfile. Stage 1 uses `python:3.12-slim` + uv to build the mkdocs site; stage 2 is `nginx:alpine` serving `/usr/share/nginx/html`. Final image ~64 MB.
- `docs-image/nginx.conf` + `security-headers.conf`: CSP, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy. `try_files` handles mkdocs `use_directory_urls=true`. `/health` for probes. `/assets/` cached 24h.
- `charts/repowire-docs/`: Deployment + Service in `repowire` namespace, HTTPRoute in `clusterkit` namespace with cross-ns backendRef. Spot pods, modest resource requests. `wwwRedirect=false` (subdomain).
- `scripts/deploy-docs.sh`: manual deploy script (linux/amd64 platform flag baked in). Not wired into CI — manual `docker push` + `helm upgrade` by maintainer.

Refs #126.

## Dependency

**Depends on #145** (mkdocs scaffold + `[docs]` optional-dependency group + `docs/` content). The Dockerfile runs `uv sync --extra docs` and `mkdocs build --strict`, neither of which will succeed until #145 lands on main. **Will move out of draft after #145 merges.**

## Local verification

- `helm lint charts/repowire-docs/` → 0 failed (info-only nit re: icon)
- `helm template charts/repowire-docs/` → renders Service, Deployment, HTTPRoute cleanly
- `docker build -f docs-image/Dockerfile .` → success, 64 MB final
- Smoke (`docker run -p 18080:80`):
  - `GET /` → 200 with full security header set
  - `GET /quickstart/` → 200 (pretty URL via `try_files`)
  - `GET /nope` → 404
  - `GET /health` → "ok"
  - `GET /assets/...` → `Cache-Control: public, max-age=86400`

## Test plan

- [ ] CI: `ruff check`, `ty check`, `pytest` pass (chart-only PR, no Python changes — should be no-op)
- [ ] After #145 merges, rebase and confirm `docker build` succeeds in a CI or local dry-run
- [ ] After draft → ready, maintainer runs `scripts/deploy-docs.sh` to push image and deploy chart to GKE
- [ ] Post-deploy smoke: `curl https://docs.repowire.io/` returns 200 with security headers