### PR TITLE
feat(mcp): circle-scoped peer surface (#125 slice 2)

### DIFF
--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -105,6 +105,14 @@ async def list_peers(
     status: str | None = Query(None, description="Filter by status", enum=["online", "offline"]),
     path: str | None = Query(None, description="Filter by absolute path"),
     backend: AgentType | None = Query(None, description="Filter by backend"),
+    circle: str | None = Query(
+        None,
+        description=(
+            "Filter by circle. Omit or '*' for mesh-wide. A concrete name returns peers "
+            "in that circle plus any peer whose role bypasses circles (service, "
+            "orchestrator, human)."
+        ),
+    ),
     _: str | None = Depends(require_auth),
 ) -> PeersResponse:
     """Get list of all registered peers, optionally filtered."""
@@ -128,6 +136,8 @@ async def list_peers(
         peers = string_matches + [p for p in mismatched if resolved_map.get(p.path) == target]
     if backend:
         peers = [p for p in peers if p.backend == backend]
+    if circle is not None and circle != "*":
+        peers = [p for p in peers if p.circle == circle or p.bypasses_circles]
 
     return PeersResponse(peers=[_peer_to_info(p) for p in peers])
 

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -27,8 +27,79 @@ _http_client: httpx.AsyncClient | None = None
 # Cached peer name: resolved lazily from env var, pane lookup, or registration
 _cached_peer_name: str | None = None
 
+# Cached caller identity (circle + role), populated alongside _cached_peer_name.
+# Used by list_peers/ask/notify_peer to scope to the caller's circle by default
+# and to widen the default when the caller's role is orchestrator. Avoids
+# re-hitting the daemon for whoami on every list_peers call.
+_cached_my_circle: str | None = None
+_cached_my_role: str | None = None
+
 # Lazy registration: ensure peer is registered on first MCP tool use
 _registered: bool = False
+
+
+_BYPASS_ROLES = {"service", "orchestrator", "human"}
+
+
+async def _resolve_circle_for_send(
+    peer_name: str, explicit_circle: str | None, my_circle: str | None
+) -> str | None:
+    """Resolve which circle to pass to /ask or /notify for `peer_name`.
+
+    - Explicit circle wins.
+    - Otherwise try caller's circle; if a peer is found there, use it.
+    - Otherwise fall back to a global lookup, but only accept the match
+      when its role bypasses circles (service/orchestrator/human).
+    - Returns None to mean "let the daemon resolve globally without a
+      circle hint" — the daemon's ambiguous-name refusal then applies.
+    """
+    if explicit_circle is not None:
+        return explicit_circle
+    if my_circle:
+        try:
+            await daemon_request(
+                "GET",
+                f"/peers/{quote(peer_name, safe='')}",
+                params={"circle": my_circle},
+            )
+            return my_circle
+        except DaemonHTTPError as e:
+            if e.status != 404:
+                raise
+        try:
+            result = await daemon_request(
+                "GET", f"/peers/{quote(peer_name, safe='')}"
+            )
+        except DaemonHTTPError as e:
+            if e.status == 404:
+                return my_circle  # let daemon return its own 404 on the send
+            raise
+        role = (result.get("role") or "").lower()
+        if role in _BYPASS_ROLES:
+            return result.get("circle")
+        return my_circle  # no bypass match; force daemon to 404 in caller's circle
+    return None
+
+
+async def _get_my_identity() -> tuple[str | None, str | None, str | None]:
+    """Return (name, circle, role) for the calling peer.
+
+    Cached after first resolve; safe to call from every MCP entry. Returns
+    Nones when the daemon can't be reached or the peer hasn't registered yet.
+    """
+    global _cached_my_circle, _cached_my_role
+    name = await _get_my_peer_name()
+    if _cached_my_circle is not None and _cached_my_role is not None:
+        return name, _cached_my_circle, _cached_my_role
+    if not name:
+        return name, _cached_my_circle, _cached_my_role
+    try:
+        result = await daemon_request("GET", f"/peers/{quote(name, safe='')}")
+        _cached_my_circle = result.get("circle") or _cached_my_circle
+        _cached_my_role = result.get("role") or _cached_my_role
+    except Exception:
+        pass
+    return name, _cached_my_circle, _cached_my_role
 
 
 def _get_http_client() -> httpx.AsyncClient:
@@ -169,7 +240,7 @@ async def _ensure_registered(*, strict: bool = False) -> None:
     last_seen touch runs on every entry so MCP activity counts as a liveness
     signal even when ws-hook has dropped.
     """
-    global _registered, _cached_peer_name
+    global _registered, _cached_peer_name, _cached_my_circle, _cached_my_role
     if _registered:
         await _touch_last_seen()
         return
@@ -182,6 +253,10 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             name = result.get("display_name") or result.get("peer_id")
             if name:
                 _cached_peer_name = name
+            if result.get("circle"):
+                _cached_my_circle = result.get("circle")
+            if result.get("role"):
+                _cached_my_role = result.get("role")
             _registered = True
             await _touch_last_seen()
             return
@@ -196,8 +271,12 @@ async def _ensure_registered(*, strict: bool = False) -> None:
     else:
         name = await _get_my_peer_name()
         try:
-            await daemon_request("GET", f"/peers/{quote(name, safe='')}")
+            result = await daemon_request("GET", f"/peers/{quote(name, safe='')}")
             _cached_peer_name = name
+            if result.get("circle"):
+                _cached_my_circle = result.get("circle")
+            if result.get("role"):
+                _cached_my_role = result.get("role")
             _registered = True
             await _touch_last_seen()
             return
@@ -227,6 +306,10 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             assigned = candidates[0].get("display_name")
             if assigned:
                 _cached_peer_name = assigned
+                if candidates[0].get("circle"):
+                    _cached_my_circle = candidates[0].get("circle")
+                if candidates[0].get("role"):
+                    _cached_my_role = candidates[0].get("role")
                 _registered = True
                 await _touch_last_seen()
                 return
@@ -252,6 +335,8 @@ async def _ensure_registered(*, strict: bool = False) -> None:
         assigned = result.get("display_name")
         if assigned:
             _cached_peer_name = assigned
+        _cached_my_circle = circle
+        _cached_my_role = "agent"
         _registered = True
         await _touch_last_seen()
     except Exception:
@@ -291,12 +376,24 @@ def create_mcp_server() -> FastMCP:
         )
 
     @mcp.tool()
-    async def list_peers(show_offline: bool = False, include_self: bool = False) -> str:
-        """[Repowire mesh] List all peers across projects and machines.
+    async def list_peers(
+        show_offline: bool = False,
+        include_self: bool = False,
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] List peers, scoped to your circle by default.
 
-        By default shows only online/busy peers and hides the calling peer
-        (you). Set show_offline=True to include offline peers, or
-        include_self=True to include yourself in the listing.
+        By default shows only online/busy peers in your own circle and hides
+        the calling peer (you). Peers whose role bypasses circles (service,
+        orchestrator, human) are always visible regardless of the circle
+        filter. Pass `circle='*'` for a mesh-wide listing, or a concrete
+        circle name to scope to that circle.
+
+        Callers with role=orchestrator default to mesh-wide (`*`) when no
+        explicit circle is passed — orchestrators need the full view.
+
+        Set show_offline=True to include offline peers, or include_self=True
+        to include yourself in the listing.
 
         Returns TSV: peer_id, name, project, circle, role, status, path,
         machine, description, backend, last_seen, turn_state. The turn_state
@@ -308,16 +405,28 @@ def create_mcp_server() -> FastMCP:
         tool for same-session teammates only.
         """
         await _ensure_registered()
-        params = None if show_offline else {"status": "online"}
-        result = await daemon_request("GET", "/peers", params=params)
+        my_name, my_circle, my_role = await _get_my_identity()
+
+        effective_circle: str | None
+        if circle is not None:
+            effective_circle = circle
+        elif my_role == "orchestrator":
+            effective_circle = "*"
+        else:
+            effective_circle = my_circle
+
+        params: dict[str, str] = {}
+        if not show_offline:
+            params["status"] = "online"
+        if effective_circle is not None and effective_circle != "*":
+            params["circle"] = effective_circle
+        result = await daemon_request("GET", "/peers", params=params or None)
         peers = result.get("peers", [])
-        if not include_self:
-            my_name = _cached_peer_name
-            if my_name:
-                peers = [
-                    p for p in peers
-                    if (p.get("display_name") or p.get("name")) != my_name
-                ]
+        if not include_self and my_name:
+            peers = [
+                p for p in peers
+                if (p.get("display_name") or p.get("name")) != my_name
+            ]
         rows = [tsv_header]
         for p in peers:
             rows.append(_peer_to_tsv_row(p))
@@ -351,13 +460,17 @@ def create_mcp_server() -> FastMCP:
             peer_name: Name of the peer to ask
             query: The question or request to send
             reply_to: If set, closes that prior ask before opening this one
-            circle: Circle to scope the lookup (optional)
+            circle: Circle to scope the lookup. Defaults to your own circle,
+                    with fallback to peers whose role bypasses circles
+                    (service, orchestrator, human). Pass explicitly to target
+                    a peer in a different circle.
 
         Returns:
             correlation_id for tracking this ask thread
         """
         await _ensure_registered(strict=True)
-        from_peer = await _get_my_peer_name()
+        from_peer, my_circle, _ = await _get_my_identity()
+        effective_circle = await _resolve_circle_for_send(peer_name, circle, my_circle)
         body: dict = {
             "from_peer": from_peer,
             "to_peer": peer_name,
@@ -365,8 +478,8 @@ def create_mcp_server() -> FastMCP:
         }
         if reply_to is not None:
             body["reply_to"] = reply_to
-        if circle is not None:
-            body["circle"] = circle
+        if effective_circle is not None:
+            body["circle"] = effective_circle
         result = await daemon_request("POST", "/ask", body)
         if result.get("error"):
             raise Exception(result["error"])
@@ -418,22 +531,25 @@ def create_mcp_server() -> FastMCP:
         Args:
             peer_name: Name of the peer to notify
             message: The notification message
-            circle: Circle to scope the lookup (optional, required when multiple
-                    peers share the same name in different circles)
+            circle: Circle to scope the lookup. Defaults to your own circle,
+                    with fallback to peers whose role bypasses circles
+                    (service, orchestrator, human). Pass explicitly to target
+                    a peer in a different circle.
 
         Returns:
             Correlation ID (format: notif-XXXXXXXX) for tracking.
         """
         await _ensure_registered(strict=True)
-        from_peer = await _get_my_peer_name()
+        from_peer, my_circle, _ = await _get_my_identity()
+        effective_circle = await _resolve_circle_for_send(peer_name, circle, my_circle)
         correlation_id = f"notif-{uuid4().hex[:8]}"
         body: dict = {
             "from_peer": from_peer,
             "to_peer": peer_name,
             "text": f"[#{correlation_id}] {message}",
         }
-        if circle is not None:
-            body["circle"] = circle
+        if effective_circle is not None:
+            body["circle"] = effective_circle
         await daemon_request("POST", "/notify", body)
         return correlation_id
 

--- a/tests/test_mcp_circle_scope.py
+++ b/tests/test_mcp_circle_scope.py
@@ -1,0 +1,262 @@
+"""Tests for circle-scoped MCP peer surface (#125 slice 2).
+
+Covers:
+- list_peers defaults to caller's circle, surfaces bypass-roles always
+- list_peers `circle='*'` returns mesh-wide
+- list_peers for orchestrator role defaults to mesh-wide
+- ask/notify_peer default circle to caller's, fall back to bypass-only
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.mcp import server as mcp_server
+from repowire.protocol.errors import DaemonHTTPError
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    mcp_server._cached_peer_name = None
+    mcp_server._cached_my_circle = None
+    mcp_server._cached_my_role = None
+    mcp_server._registered = True  # bypass _ensure_registered side effects
+    yield
+    mcp_server._cached_peer_name = None
+    mcp_server._cached_my_circle = None
+    mcp_server._cached_my_role = None
+    mcp_server._registered = False
+
+
+def _seed_identity(name: str, circle: str, role: str) -> None:
+    mcp_server._cached_peer_name = name
+    mcp_server._cached_my_circle = circle
+    mcp_server._cached_my_role = role
+
+
+def _peers_response(*display_names: str) -> dict:
+    return {"peers": [{"display_name": n, "circle": "x"} for n in display_names]}
+
+
+def _get_list_peers_tool():
+    server = mcp_server.create_mcp_server()
+    tool = server._tool_manager._tools["list_peers"]
+    return tool.fn
+
+
+def _get_ask_tool():
+    server = mcp_server.create_mcp_server()
+    tool = server._tool_manager._tools["ask"]
+    return tool.fn
+
+
+def _get_notify_tool():
+    server = mcp_server.create_mcp_server()
+    tool = server._tool_manager._tools["notify_peer"]
+    return tool.fn
+
+
+class TestListPeersCircleScope:
+    @pytest.mark.asyncio
+    async def test_default_scopes_to_callers_circle(self):
+        _seed_identity("me", "team-a", "agent")
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers()
+
+        assert captured["params"]["circle"] == "team-a"
+        assert captured["params"]["status"] == "online"
+
+    @pytest.mark.asyncio
+    async def test_star_widens_to_mesh(self):
+        _seed_identity("me", "team-a", "agent")
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params or {}
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers(circle="*")
+
+        assert "circle" not in captured["params"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_concrete_circle_overrides_default(self):
+        _seed_identity("me", "team-a", "agent")
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers(circle="team-b")
+
+        assert captured["params"]["circle"] == "team-b"
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_role_defaults_to_mesh_wide(self):
+        _seed_identity("orch", "default", "orchestrator")
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params or {}
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers()
+
+        assert "circle" not in captured["params"]
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_can_still_scope_explicitly(self):
+        _seed_identity("orch", "default", "orchestrator")
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers(circle="team-a")
+
+        assert captured["params"]["circle"] == "team-a"
+
+    @pytest.mark.asyncio
+    async def test_no_identity_no_circle_param(self):
+        """If we can't resolve caller's circle, fall through to global lookup
+        rather than dropping a bogus filter."""
+        list_peers = _get_list_peers_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            captured["params"] = params or {}
+            return _peers_response()
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await list_peers()
+
+        assert "circle" not in captured["params"]
+
+
+class TestAskNotifyCircleResolution:
+    @pytest.mark.asyncio
+    async def test_ask_uses_callers_circle_when_peer_found_locally(self):
+        _seed_identity("me", "team-a", "agent")
+        ask = _get_ask_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            if path.startswith("/peers/") and method == "GET":
+                # caller's circle lookup hits
+                return {"display_name": "bob", "circle": "team-a", "role": "agent"}
+            if path == "/ask":
+                captured["body"] = body
+                return {"correlation_id": "ask-1"}
+            return {}
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await ask("bob", "hi")
+
+        assert captured["body"]["circle"] == "team-a"
+
+    @pytest.mark.asyncio
+    async def test_ask_falls_back_to_bypass_role_globally(self):
+        _seed_identity("me", "team-a", "agent")
+        ask = _get_ask_tool()
+        captured: dict = {}
+        calls: list[tuple] = []
+
+        async def fake_request(method, path, body=None, params=None):
+            calls.append((method, path, params))
+            if path.startswith("/peers/") and method == "GET":
+                if params and params.get("circle") == "team-a":
+                    raise DaemonHTTPError(404, "not in team-a")
+                # global lookup finds telegram in 'default' with role=service
+                return {"display_name": "telegram", "circle": "default", "role": "service"}
+            if path == "/ask":
+                captured["body"] = body
+                return {"correlation_id": "ask-2"}
+            return {}
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await ask("telegram", "ping")
+
+        # Sent with the resolved bypass-role peer's circle, not team-a.
+        assert captured["body"]["circle"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_ask_does_not_fall_back_to_non_bypass_peer(self):
+        """Cross-circle agent must NOT be reachable via implicit fallback."""
+        _seed_identity("me", "team-a", "agent")
+        ask = _get_ask_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            if path.startswith("/peers/") and method == "GET":
+                if params and params.get("circle") == "team-a":
+                    raise DaemonHTTPError(404, "miss")
+                # global lookup finds an agent in another circle
+                return {"display_name": "alien", "circle": "team-b", "role": "agent"}
+            if path == "/ask":
+                captured["body"] = body
+                return {"correlation_id": "ask-3"}
+            return {}
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await ask("alien", "hi")
+
+        # Forced to caller's circle so the daemon will 404 — no implicit
+        # cross-circle leak.
+        assert captured["body"]["circle"] == "team-a"
+
+    @pytest.mark.asyncio
+    async def test_ask_explicit_circle_passes_through(self):
+        _seed_identity("me", "team-a", "agent")
+        ask = _get_ask_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            if path == "/ask":
+                captured["body"] = body
+                return {"correlation_id": "ask-4"}
+            return {}
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await ask("bob", "hi", circle="team-c")
+
+        assert captured["body"]["circle"] == "team-c"
+
+    @pytest.mark.asyncio
+    async def test_notify_peer_uses_same_fallback(self):
+        _seed_identity("me", "team-a", "agent")
+        notify_peer = _get_notify_tool()
+        captured: dict = {}
+
+        async def fake_request(method, path, body=None, params=None):
+            if path.startswith("/peers/") and method == "GET":
+                if params and params.get("circle") == "team-a":
+                    raise DaemonHTTPError(404, "miss")
+                return {"display_name": "telegram", "circle": "default", "role": "service"}
+            if path == "/notify":
+                captured["body"] = body
+                return {}
+            return {}
+
+        with patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=fake_request)):
+            await notify_peer("telegram", "hello")
+
+        assert captured["body"]["circle"] == "default"

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -213,7 +213,7 @@ def test_all_outbound_tools_strict_register():
     for tool in outbound_tools:
         idx = source.find(f"async def {tool}(")
         assert idx >= 0, f"Could not find {tool} in mcp/server.py"
-        body = source[idx : idx + 1500]
+        body = source[idx : idx + 2200]
         assert "_ensure_registered(strict=True)" in body, (
             f"MCP tool {tool} must call _ensure_registered(strict=True) "
             f"before sending; otherwise from_peer can race a hook drop. "

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -259,6 +259,43 @@ class TestPeers:
         assert peers[0]["path"] == "/tmp/proj-x"
         assert peers[0]["backend"] == "claude-code"
 
+    async def test_list_peers_circle_filter(self, client):
+        r = await client.post("/peers", json={
+            "name": "alpha", "path": "/tmp/alpha",
+            "circle": "team-a", "backend": "claude-code",
+        })
+        alpha = r.json()["display_name"]
+        r = await client.post("/peers", json={
+            "name": "beta", "path": "/tmp/beta",
+            "circle": "team-b", "backend": "claude-code",
+        })
+        beta = r.json()["display_name"]
+        # Service peer bypasses circles — should appear under any circle filter.
+        r = await client.post("/peers", json={
+            "name": "telegram", "path": "/tmp/telegram",
+            "circle": "global", "backend": "claude-code",
+            "role": "service",
+        })
+        telegram = r.json()["display_name"]
+
+        # No circle param: back-compat — return everyone.
+        r = await client.get("/peers")
+        assert {p["display_name"] for p in r.json()["peers"]} == {alpha, beta, telegram}
+
+        # Explicit '*' is mesh-wide.
+        r = await client.get("/peers", params={"circle": "*"})
+        assert {p["display_name"] for p in r.json()["peers"]} == {alpha, beta, telegram}
+
+        # Concrete circle: returns that circle plus bypass-roles.
+        r = await client.get("/peers", params={"circle": "team-a"})
+        assert {p["display_name"] for p in r.json()["peers"]} == {alpha, telegram}
+        r = await client.get("/peers", params={"circle": "team-b"})
+        assert {p["display_name"] for p in r.json()["peers"]} == {beta, telegram}
+
+        # A circle no peer belongs to still surfaces bypass-roles.
+        r = await client.get("/peers", params={"circle": "nobody"})
+        assert {p["display_name"] for p in r.json()["peers"]} == {telegram}
+
 
 # -- Spawn / kill --
 


### PR DESCRIPTION
Closes the second slice of #125 — list_peers / ask / notify_peer become circle-aware at the MCP and daemon layers without any protocol change.

## Behavior

**Daemon `GET /peers`** gains an optional `circle=` query param:
- omitted or absent → mesh-wide (back-compat)
- `*` → mesh-wide (explicit)
- concrete name → peers in that circle UNION peers whose role bypasses circles (service/orchestrator/human)

**MCP `list_peers(circle=None)`**:
- default → caller's own circle (resolved + cached from registration / pane lookup)
- `*` → mesh-wide
- concrete name → that circle
- callers with `role=orchestrator` default to mesh-wide when no explicit `circle` is passed — orchestrators need the full view

**MCP `ask` / `notify_peer`**:
- default circle → caller's own circle
- if `peer_name` is not found in caller's circle, falls back to a global lookup but only forwards when the resolved peer's role bypasses circles
- otherwise forces the call into the caller's circle so the daemon's existing 404 / ambiguous-resolve refusal applies — no implicit cross-circle leak to plain agents
- explicit `circle=` always wins

## Implementation notes

- `_cached_my_circle` / `_cached_my_role` follow the `_cached_peer_name` precedent; populated opportunistically from existing daemon GETs in `_ensure_registered` so no extra round-trip on the hot path.
- `_resolve_circle_for_send` handles the two-step circle resolution for ask / notify_peer.
- `broadcast` left mesh-wide (out of scope for this slice).

## Tests

- daemon route: `test_list_peers_circle_filter` — back-compat (none = all), `*` widens, concrete filter UNION bypass roles, circle-with-no-peers still surfaces bypass roles
- new `tests/test_mcp_circle_scope.py`:
  - default scopes to caller's circle
  - `*` widens to mesh
  - explicit concrete circle overrides default
  - `role=orchestrator` ⇒ mesh-wide default
  - orchestrator can still scope explicitly
  - ask uses caller's circle when target is local
  - ask falls back to bypass-role peer globally
  - ask does NOT fall back to a non-bypass peer in another circle
  - explicit circle passes through
  - notify_peer uses the same fallback

All 690 tests pass, ruff clean, ty clean.

## Out of scope

- README / docs (separate lane)
- no version bump (target v0.13.4 after merge)
- no protocol change, no new daemon endpoints, no registry mutations