### PR TITLE
chore(relay): strip apex repowire.io from HTTPRoute (#147)

### DIFF
--- a/charts/repowire-relay/values.yaml
+++ b/charts/repowire-relay/values.yaml
@@ -36,7 +36,6 @@ httpRoute:
   enabled: true
   hostnames:
     - relay.repowire.io
-    - repowire.io
   gatewayNamespace: clusterkit
   gatewayName: clusterkit-gateway
   annotations:


### PR DESCRIPTION
## Summary
- One-line strip of `repowire.io` from `charts/repowire-relay/values.yaml` HTTPRoute hostnames. Relay keeps `relay.repowire.io` only.
- Resolves the latent landmine in #147: web chart (merged via #149) and relay chart both claimed apex on the same Gateway; HTTPRoute hostname collisions on a single Gateway have undefined precedence.

## Phase ordering
Per orchestrator plan:
1. ✅ #149 merged — web chart + image now installable.
2. ◀️ This PR — strip apex from relay.
3. After merge: `helm upgrade repowire-relay` to apply the strip.
4. Then web's HTTPRoute (already deployed by `web.yml` workflow post-#149 merge, or via `helm install` / `scripts/deploy-web.sh`) takes over apex.
5. Brief ambiguous-precedence window between (3) and the web HTTPRoute bind is acceptable — relay has been serving apex with the gate landing this whole time; worst case it continues to until web binds.

## Test plan
- [ ] Post-merge: `helm upgrade repowire-relay charts/repowire-relay -n repowire` applies clean
- [ ] `curl -sI https://relay.repowire.io/` → 200 (gate landing)
- [ ] `curl -sI https://repowire.io/` → 200 (web Hero, after web HTTPRoute binds)
- [ ] `curl -sI https://docs.repowire.io/` → 200 (unchanged)