### PR TITLE
feat(cli): add 'repowire doctor' diagnostic command (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ repowire setup                    # Install hooks, MCP server, daemon service
 repowire setup --relay            # Same + enable remote dashboard via repowire.io
 repowire setup --experimental-channels  # Use channel transport (needs claude.ai login + bun)
 repowire status                   # Show what's installed and running
+repowire doctor                   # Diagnostic checks (daemon, hooks, runtimes, relay, ...)
 repowire serve                    # Run daemon in foreground
 repowire serve --relay            # Run daemon with relay connection
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,6 +30,26 @@ repowire status
 
 Show what's installed, which agents were detected, and whether the daemon is running.
 
+## `repowire doctor`
+
+```bash
+repowire doctor
+```
+
+Run a battery of diagnostic checks and print color-coded results. Each check reports `✓` (ok), `⚠` (warn, non-fatal), `✗` (fail), or `·` (skip, not applicable).
+
+Checks include:
+
+- Daemon reachable (`GET /health`, prints version)
+- Per-runtime hook + MCP install state (claude-code, codex, gemini, opencode, pi)
+- `tmux`, Python, and package-manager (`uv`/`pipx`/`pip`) availability
+- Spawn allowlist resolves (commands on `PATH`, paths exist as directories)
+- WebSocket auth token state
+- Relay reachable (when `relay.enabled`)
+- Channel transport (when configured via `--experimental-channels`)
+
+Exits 0 if all checks pass (or only warn/skip). Exits 1 if any check fails — suitable for `bash`-style health gates.
+
 ## `repowire peer`
 
 ```bash

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -630,6 +630,84 @@ def status() -> None:
         pass
 
 
+# =============================================================================
+# doctor command - diagnostic checks
+# =============================================================================
+
+
+_STATUS_GLYPHS = {
+    "ok": ("[green]✓[/]", "green"),
+    "warn": ("[yellow]⚠[/]", "yellow"),
+    "fail": ("[red]✗[/]", "red"),
+    "skip": ("[dim]·[/]", "dim"),
+}
+
+
+def _render_result(result: object, indent: int = 0) -> None:
+    """Print a CheckResult and its children."""
+    from repowire.doctor import CheckResult, Status  # local import to keep top tidy
+
+    assert isinstance(result, CheckResult)
+    glyph, _ = _STATUS_GLYPHS[result.status.value]
+    pad = "  " * indent
+    line = f"{pad}{glyph} {result.name}"
+    if result.detail:
+        # Dim the detail so the status+name pop
+        line += f"  [dim]{result.detail}[/]"
+    console.print(line)
+    for child in result.children:
+        _render_result(child, indent=indent + 1)
+    # Mark unused import shim (Status referenced only via .value above)
+    _ = Status
+
+
+@main.command()
+def doctor() -> None:
+    """Run diagnostic checks and report repowire health."""
+    from repowire.config.models import load_config
+    from repowire.doctor import Status, exit_code, run_all
+
+    config = load_config()
+    daemon_url = _get_daemon_url()
+
+    console.print("[cyan]repowire doctor[/]")
+    console.print("")
+
+    results = run_all(config, daemon_url)
+    for r in results:
+        _render_result(r)
+
+    console.print("")
+
+    code = exit_code(results)
+    counts = {s: 0 for s in Status}
+
+    def _walk(r: object) -> None:
+        from repowire.doctor import CheckResult
+
+        assert isinstance(r, CheckResult)
+        counts[r.status] += 1
+        for c in r.children:
+            _walk(c)
+
+    for r in results:
+        _walk(r)
+
+    summary = (
+        f"[green]{counts[Status.OK]} ok[/]  "
+        f"[yellow]{counts[Status.WARN]} warn[/]  "
+        f"[red]{counts[Status.FAIL]} fail[/]  "
+        f"[dim]{counts[Status.SKIP]} skip[/]"
+    )
+    console.print(summary)
+
+    if code != 0:
+        console.print("[red]doctor: failing checks present[/]")
+    import sys
+
+    sys.exit(code)
+
+
 def _cleanup_legacy_artifacts() -> None:
     """Remove file artifacts from pre-lazy-repair versions.
 

--- a/repowire/daemon/routes/health.py
+++ b/repowire/daemon/routes/health.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
+from repowire import __version__
+
 router = APIRouter(tags=["health"])
 
 
@@ -23,6 +25,6 @@ async def health_check(request: Request) -> HealthResponse:
 
     return HealthResponse(
         status="ok",
-        version="0.1.0",
+        version=__version__,
         relay_mode=relay_mode,
     )

--- a/repowire/doctor.py
+++ b/repowire/doctor.py
@@ -1,0 +1,385 @@
+"""Diagnostic checks for `repowire doctor`.
+
+Each check is a pure function returning a CheckResult. The CLI layer
+(see cli.py `doctor` command) handles printing and exit codes.
+
+Status semantics:
+- OK    — green ✓ — all good
+- WARN  — yellow ⚠ — degraded/non-fatal (missing optional feature, soft config issue)
+- FAIL  — red ✗ — broken; doctor exits 1 if any FAIL present
+- SKIP  — dim ·  — check not applicable in this environment
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+import httpx
+
+from repowire import __version__
+from repowire.config.models import Config
+
+
+class Status(str, Enum):
+    OK = "ok"
+    WARN = "warn"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Status
+    detail: str = ""
+    children: list[CheckResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_python_version(min_version: tuple[int, int] = (3, 10)) -> CheckResult:
+    cur = sys.version_info[:2]
+    if cur >= min_version:
+        return CheckResult(
+            "Python version",
+            Status.OK,
+            f"{cur[0]}.{cur[1]} (>= {min_version[0]}.{min_version[1]})",
+        )
+    return CheckResult(
+        "Python version",
+        Status.FAIL,
+        f"{cur[0]}.{cur[1]} — requires >= {min_version[0]}.{min_version[1]}",
+    )
+
+
+def check_tmux() -> CheckResult:
+    path = shutil.which("tmux")
+    if not path:
+        return CheckResult("tmux available", Status.WARN, "not found on PATH")
+    try:
+        result = subprocess.run(
+            ["tmux", "-V"], capture_output=True, text=True, timeout=5,
+        )
+        version = result.stdout.strip() or "unknown version"
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        version = "version check failed"
+    return CheckResult("tmux available", Status.OK, version)
+
+
+def check_package_manager() -> CheckResult:
+    for tool in ("uv", "pipx", "pip"):
+        if shutil.which(tool):
+            return CheckResult("Package manager (for updates)", Status.OK, tool)
+    return CheckResult(
+        "Package manager (for updates)",
+        Status.WARN,
+        "none of uv/pipx/pip found on PATH",
+    )
+
+
+def check_daemon(daemon_url: str, timeout: float = 2.0) -> CheckResult:
+    """GET /health on the configured daemon URL."""
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(f"{daemon_url}/health")
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.ConnectError:
+        return CheckResult("Daemon reachable", Status.FAIL, f"connect failed: {daemon_url}")
+    except httpx.HTTPError as exc:
+        return CheckResult("Daemon reachable", Status.FAIL, f"{daemon_url}: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult("Daemon reachable", Status.FAIL, f"{daemon_url}: {exc}")
+
+    version = payload.get("version", "?")
+    relay_mode = " (relay mode)" if payload.get("relay_mode") else ""
+    return CheckResult(
+        "Daemon reachable",
+        Status.OK,
+        f"{daemon_url} — v{version}{relay_mode}",
+    )
+
+
+def check_runtimes() -> CheckResult:
+    """Per-runtime hook + MCP install state. Aggregated into one parent result."""
+    children: list[CheckResult] = []
+
+    children.append(_check_claude_code())
+    children.append(_check_codex())
+    children.append(_check_gemini())
+    children.append(_check_opencode())
+    children.append(_check_pi())
+
+    detected = [c for c in children if c.status is not Status.SKIP]
+    if not detected:
+        return CheckResult(
+            "Agent runtimes",
+            Status.WARN,
+            "no runtimes detected",
+            children=children,
+        )
+
+    worst = _worst(detected)
+    detail = f"{len(detected)} detected"
+    return CheckResult("Agent runtimes", worst, detail, children=children)
+
+
+def _check_claude_code() -> CheckResult:
+    if not shutil.which("claude"):
+        return CheckResult("claude-code", Status.SKIP, "CLI not on PATH")
+    from repowire.installers.claude_code import (
+        check_channel_installed,
+        check_hooks_installed,
+        get_claude_version,
+    )
+
+    version = get_claude_version()
+    ver_str = ".".join(str(x) for x in version) if version else "unknown"
+
+    if not check_hooks_installed():
+        return CheckResult(
+            "claude-code",
+            Status.FAIL,
+            f"v{ver_str} — hooks not installed (run `repowire setup`)",
+        )
+    channel = " + channel" if check_channel_installed() else ""
+    return CheckResult("claude-code", Status.OK, f"v{ver_str} — hooks{channel} installed")
+
+
+def _check_codex() -> CheckResult:
+    if not shutil.which("codex") and not (Path.home() / ".codex").exists():
+        return CheckResult("codex", Status.SKIP, "not detected")
+    from repowire.installers.codex import (
+        check_hooks_installed,
+        check_mcp_installed,
+        get_codex_version,
+    )
+
+    version = get_codex_version()
+    ver_str = ".".join(str(x) for x in version) if version else "unknown"
+
+    hooks_ok = check_hooks_installed()
+    mcp_ok = check_mcp_installed()
+    if hooks_ok and mcp_ok:
+        return CheckResult("codex", Status.OK, f"v{ver_str} — hooks + MCP installed")
+    missing = []
+    if not hooks_ok:
+        missing.append("hooks")
+    if not mcp_ok:
+        missing.append("MCP")
+    return CheckResult(
+        "codex",
+        Status.FAIL,
+        f"v{ver_str} — missing: {', '.join(missing)} (run `repowire setup`)",
+    )
+
+
+def _check_gemini() -> CheckResult:
+    if not shutil.which("gemini") and not (Path.home() / ".gemini").exists():
+        return CheckResult("gemini", Status.SKIP, "not detected")
+    from repowire.installers.gemini import (
+        check_hooks_installed,
+        check_mcp_installed,
+        get_gemini_version,
+    )
+
+    version = get_gemini_version()
+    ver_str = ".".join(str(x) for x in version) if version else "unknown"
+
+    hooks_ok = check_hooks_installed()
+    mcp_ok = check_mcp_installed()
+    if hooks_ok and mcp_ok:
+        return CheckResult("gemini", Status.OK, f"v{ver_str} — hooks + MCP installed")
+    missing = []
+    if not hooks_ok:
+        missing.append("hooks")
+    if not mcp_ok:
+        missing.append("MCP")
+    return CheckResult(
+        "gemini",
+        Status.FAIL,
+        f"v{ver_str} — missing: {', '.join(missing)} (run `repowire setup`)",
+    )
+
+
+def _check_opencode() -> CheckResult:
+    if not shutil.which("opencode") and not (Path.home() / ".config" / "opencode").exists():
+        return CheckResult("opencode", Status.SKIP, "not detected")
+    from repowire.installers.opencode import check_plugin_installed
+
+    if check_plugin_installed():
+        return CheckResult("opencode", Status.OK, "plugin installed")
+    return CheckResult(
+        "opencode",
+        Status.FAIL,
+        "plugin not installed (run `repowire opencode install`)",
+    )
+
+
+def _check_pi() -> CheckResult:
+    if not shutil.which("pi") and not (Path.home() / ".pi").exists():
+        return CheckResult("pi", Status.SKIP, "not detected")
+    from repowire.installers.pi import check_extension_installed
+
+    if check_extension_installed():
+        return CheckResult("pi", Status.OK, "extension installed")
+    return CheckResult(
+        "pi",
+        Status.FAIL,
+        "extension not installed (run `repowire setup`)",
+    )
+
+
+def check_spawn_allowlist(config: Config) -> CheckResult:
+    spawn = config.daemon.spawn
+    if not spawn.allowed_commands and not spawn.allowed_paths:
+        return CheckResult(
+            "Spawn allowlist",
+            Status.SKIP,
+            "not configured (spawn disabled)",
+        )
+
+    children: list[CheckResult] = []
+    for cmd in spawn.allowed_commands:
+        # Allowed commands may have flags ("claude --dangerously-skip-permissions");
+        # resolve the leading binary only.
+        bin_name = cmd.split()[0] if cmd else cmd
+        if shutil.which(bin_name):
+            children.append(CheckResult(f"command: {cmd}", Status.OK))
+        else:
+            children.append(
+                CheckResult(f"command: {cmd}", Status.WARN, f"{bin_name} not on PATH"),
+            )
+    for path_str in spawn.allowed_paths:
+        path = Path(path_str).expanduser()
+        if path.is_dir():
+            children.append(CheckResult(f"path: {path_str}", Status.OK))
+        else:
+            children.append(
+                CheckResult(f"path: {path_str}", Status.WARN, "not an existing directory"),
+            )
+
+    if not children:
+        return CheckResult("Spawn allowlist", Status.SKIP, "empty")
+    worst = _worst(children)
+    summary = (
+        f"{len(spawn.allowed_commands)} command(s), {len(spawn.allowed_paths)} path(s)"
+    )
+    return CheckResult("Spawn allowlist", worst, summary, children=children)
+
+
+def check_auth_token(config: Config) -> CheckResult:
+    if config.daemon.auth_token:
+        return CheckResult(
+            "WebSocket auth token", Status.OK, "set (required for connections)",
+        )
+    return CheckResult(
+        "WebSocket auth token", Status.SKIP, "not set (open access on bind address)",
+    )
+
+
+def check_relay(config: Config, timeout: float = 5.0) -> CheckResult:
+    if not config.relay.enabled:
+        return CheckResult("Relay", Status.SKIP, "not enabled")
+
+    url = config.relay.url
+    api_key = config.relay.api_key
+    if not url:
+        return CheckResult("Relay", Status.FAIL, "enabled but no URL configured")
+
+    relay_http = url.replace("wss://", "https://").replace("ws://", "http://")
+    health_url = f"{relay_http.rstrip('/')}/health"
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(health_url)
+            resp.raise_for_status()
+    except httpx.ConnectError:
+        return CheckResult("Relay", Status.FAIL, f"unreachable: {health_url}")
+    except httpx.HTTPStatusError as exc:
+        return CheckResult("Relay", Status.WARN, f"{health_url}: HTTP {exc.response.status_code}")
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult("Relay", Status.WARN, f"{health_url}: {exc}")
+
+    key_state = "with API key" if api_key else "no API key (anonymous)"
+    return CheckResult("Relay", Status.OK, f"reachable at {url} — {key_state}")
+
+
+def check_channel_transport() -> CheckResult:
+    """Channel transport is opt-in; only inspect if claude-code is detected."""
+    if not shutil.which("claude"):
+        return CheckResult(
+            "Channel transport (experimental)", Status.SKIP, "claude-code not detected",
+        )
+    from repowire.installers.claude_code import check_channel_installed
+
+    if not check_channel_installed():
+        return CheckResult(
+            "Channel transport (experimental)",
+            Status.SKIP,
+            "not configured (default hooks transport)",
+        )
+
+    bun = shutil.which("bun")
+    if not bun:
+        return CheckResult(
+            "Channel transport (experimental)",
+            Status.FAIL,
+            "configured but `bun` not on PATH",
+        )
+    return CheckResult(
+        "Channel transport (experimental)",
+        Status.OK,
+        f"configured, bun at {bun}",
+    )
+
+
+def check_repowire_version() -> CheckResult:
+    return CheckResult("repowire version", Status.OK, __version__)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+_STATUS_RANK = {Status.OK: 0, Status.SKIP: 0, Status.WARN: 1, Status.FAIL: 2}
+
+
+def _worst(results: list[CheckResult]) -> Status:
+    if not results:
+        return Status.OK
+    return max((r.status for r in results), key=lambda s: _STATUS_RANK[s])
+
+
+def run_all(config: Config, daemon_url: str) -> list[CheckResult]:
+    """Run every check in display order and return the list of results."""
+    return [
+        check_repowire_version(),
+        check_python_version(),
+        check_tmux(),
+        check_package_manager(),
+        check_daemon(daemon_url),
+        check_runtimes(),
+        check_spawn_allowlist(config),
+        check_auth_token(config),
+        check_relay(config),
+        check_channel_transport(),
+    ]
+
+
+def exit_code(results: list[CheckResult]) -> int:
+    """1 if any result (including nested) is FAIL, else 0."""
+    def has_fail(r: CheckResult) -> bool:
+        if r.status is Status.FAIL:
+            return True
+        return any(has_fail(c) for c in r.children)
+
+    return 1 if any(has_fail(r) for r in results) else 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,316 @@
+"""Tests for repowire.doctor diagnostic checks."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from repowire.config.models import Config, DaemonConfig, RelayConfig, SpawnSettings
+from repowire.doctor import (
+    CheckResult,
+    Status,
+    _worst,
+    check_auth_token,
+    check_channel_transport,
+    check_daemon,
+    check_package_manager,
+    check_python_version,
+    check_relay,
+    check_repowire_version,
+    check_runtimes,
+    check_spawn_allowlist,
+    check_tmux,
+    exit_code,
+    run_all,
+)
+
+# ---------------------------------------------------------------------------
+# Pure check functions
+# ---------------------------------------------------------------------------
+
+
+class TestPythonVersion:
+    def test_current_passes(self):
+        r = check_python_version()
+        assert r.status is Status.OK
+
+    def test_below_min_fails(self):
+        # Pick a min higher than any plausible runtime
+        r = check_python_version(min_version=(99, 0))
+        assert r.status is Status.FAIL
+
+
+class TestTmux:
+    def test_missing_warns(self):
+        with patch("repowire.doctor.shutil.which", return_value=None):
+            r = check_tmux()
+        assert r.status is Status.WARN
+
+    def test_present_ok(self):
+        fake_proc = MagicMock(stdout="tmux 3.5a\n")
+        with patch("repowire.doctor.shutil.which", return_value="/usr/bin/tmux"), \
+             patch("repowire.doctor.subprocess.run", return_value=fake_proc):
+            r = check_tmux()
+        assert r.status is Status.OK
+        assert "3.5a" in r.detail
+
+
+class TestPackageManager:
+    def test_uv_preferred(self):
+        def which(tool):
+            return "/p/uv" if tool == "uv" else None
+        with patch("repowire.doctor.shutil.which", side_effect=which):
+            r = check_package_manager()
+        assert r.status is Status.OK
+        assert r.detail == "uv"
+
+    def test_none_warns(self):
+        with patch("repowire.doctor.shutil.which", return_value=None):
+            r = check_package_manager()
+        assert r.status is Status.WARN
+
+
+def _mock_client_factory(handler):
+    """Return a Client subclass factory that uses an httpx MockTransport."""
+    transport = httpx.MockTransport(handler)
+
+    class _MockedClient(httpx.Client):
+        def __init__(self, **kwargs):
+            kwargs.pop("transport", None)
+            kwargs.pop("timeout", None)
+            super().__init__(timeout=5.0, transport=transport)
+
+    return _MockedClient
+
+
+class TestDaemon:
+    def test_reachable_ok(self):
+        def handler(_request):
+            return httpx.Response(
+                200, json={"status": "ok", "version": "9.9.9", "relay_mode": False},
+            )
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_daemon("http://localhost:8377")
+        assert r.status is Status.OK
+        assert "9.9.9" in r.detail
+
+    def test_connect_error_fails(self):
+        def handler(_request):
+            raise httpx.ConnectError("nope")
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_daemon("http://localhost:8377")
+        assert r.status is Status.FAIL
+
+
+class TestRuntimes:
+    def test_no_runtimes_warn(self):
+        with patch("repowire.doctor.shutil.which", return_value=None), \
+             patch("repowire.doctor.Path.exists", return_value=False):
+            r = check_runtimes()
+        assert r.status is Status.WARN
+        # All children should be SKIP
+        assert all(c.status is Status.SKIP for c in r.children)
+
+    def test_claude_hooks_missing_fails(self):
+        def which(tool):
+            return "/p/claude" if tool == "claude" else None
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_hooks_installed", return_value=False), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=False), \
+             patch("repowire.installers.claude_code.get_claude_version", return_value=(2, 1, 80)):
+            r = check_runtimes()
+        claude_result = next(c for c in r.children if c.name == "claude-code")
+        assert claude_result.status is Status.FAIL
+        assert r.status is Status.FAIL
+
+    def test_claude_hooks_installed_ok(self):
+        def which(tool):
+            return "/p/claude" if tool == "claude" else None
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_hooks_installed", return_value=True), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=False), \
+             patch("repowire.installers.claude_code.get_claude_version", return_value=(2, 1, 80)):
+            r = check_runtimes()
+        claude_result = next(c for c in r.children if c.name == "claude-code")
+        assert claude_result.status is Status.OK
+
+
+class TestSpawnAllowlist:
+    def test_unconfigured_skip(self):
+        config = Config()
+        r = check_spawn_allowlist(config)
+        assert r.status is Status.SKIP
+
+    def test_resolved_ok(self, tmp_path: Path):
+        config = Config(
+            daemon=DaemonConfig(
+                spawn=SpawnSettings(
+                    allowed_commands=["ls"],
+                    allowed_paths=[str(tmp_path)],
+                ),
+            ),
+        )
+        r = check_spawn_allowlist(config)
+        assert r.status is Status.OK
+
+    def test_unresolved_warns(self):
+        config = Config(
+            daemon=DaemonConfig(
+                spawn=SpawnSettings(
+                    allowed_commands=["definitely-not-a-real-command-xyzzy"],
+                    allowed_paths=["/nonexistent/path/xyzzy"],
+                ),
+            ),
+        )
+        r = check_spawn_allowlist(config)
+        assert r.status is Status.WARN
+
+    def test_command_with_flags(self, tmp_path: Path):
+        config = Config(
+            daemon=DaemonConfig(
+                spawn=SpawnSettings(
+                    allowed_commands=["ls --color"],
+                    allowed_paths=[str(tmp_path)],
+                ),
+            ),
+        )
+        r = check_spawn_allowlist(config)
+        # First token resolves, so OK
+        assert r.status is Status.OK
+
+
+class TestAuthToken:
+    def test_set_ok(self):
+        config = Config(daemon=DaemonConfig(auth_token="secret"))
+        r = check_auth_token(config)
+        assert r.status is Status.OK
+
+    def test_unset_skip(self):
+        r = check_auth_token(Config())
+        assert r.status is Status.SKIP
+
+
+class TestRelay:
+    def test_disabled_skip(self):
+        r = check_relay(Config())
+        assert r.status is Status.SKIP
+
+    def test_reachable_ok(self):
+        config = Config(relay=RelayConfig(enabled=True, url="wss://relay.example", api_key="rw_x"))
+
+        def handler(_request):
+            return httpx.Response(200, json={"status": "ok"})
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_relay(config)
+        assert r.status is Status.OK
+        assert "API key" in r.detail
+
+    def test_unreachable_fails(self):
+        config = Config(relay=RelayConfig(enabled=True, url="wss://relay.example"))
+
+        def handler(_request):
+            raise httpx.ConnectError("down")
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_relay(config)
+        assert r.status is Status.FAIL
+
+
+class TestChannelTransport:
+    def test_no_claude_skip(self):
+        with patch("repowire.doctor.shutil.which", return_value=None):
+            r = check_channel_transport()
+        assert r.status is Status.SKIP
+
+    def test_not_configured_skip(self):
+        def which(tool):
+            return "/p/claude" if tool == "claude" else None
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=False):
+            r = check_channel_transport()
+        assert r.status is Status.SKIP
+
+    def test_configured_no_bun_fails(self):
+        def which(tool):
+            if tool == "claude":
+                return "/p/claude"
+            return None
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=True):
+            r = check_channel_transport()
+        assert r.status is Status.FAIL
+
+    def test_configured_with_bun_ok(self):
+        def which(tool):
+            return f"/p/{tool}" if tool in ("claude", "bun") else None
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=True):
+            r = check_channel_transport()
+        assert r.status is Status.OK
+
+
+# ---------------------------------------------------------------------------
+# Orchestration helpers
+# ---------------------------------------------------------------------------
+
+
+class TestWorstAndExitCode:
+    def test_worst_empty(self):
+        assert _worst([]) is Status.OK
+
+    def test_worst_picks_fail(self):
+        results = [
+            CheckResult("a", Status.OK),
+            CheckResult("b", Status.WARN),
+            CheckResult("c", Status.FAIL),
+        ]
+        assert _worst(results) is Status.FAIL
+
+    def test_worst_picks_warn(self):
+        results = [
+            CheckResult("a", Status.OK),
+            CheckResult("b", Status.WARN),
+            CheckResult("c", Status.SKIP),
+        ]
+        assert _worst(results) is Status.WARN
+
+    def test_exit_code_zero_when_all_pass(self):
+        results = [CheckResult("a", Status.OK), CheckResult("b", Status.WARN)]
+        assert exit_code(results) == 0
+
+    def test_exit_code_one_when_fail(self):
+        results = [CheckResult("a", Status.OK), CheckResult("b", Status.FAIL)]
+        assert exit_code(results) == 1
+
+    def test_exit_code_walks_children(self):
+        results = [
+            CheckResult(
+                "parent",
+                Status.WARN,
+                children=[CheckResult("child", Status.FAIL)],
+            ),
+        ]
+        assert exit_code(results) == 1
+
+
+class TestRunAll:
+    def test_run_all_returns_list(self):
+        config = Config()
+        with patch("repowire.doctor.httpx.Client"):  # daemon will fail, that's fine
+            results = run_all(config, "http://localhost:8377")
+        assert isinstance(results, list)
+        assert len(results) >= 8
+        names = [r.name for r in results]
+        assert "Daemon reachable" in names
+        assert "Agent runtimes" in names
+        assert "Spawn allowlist" in names
+
+
+def test_repowire_version_check():
+    r = check_repowire_version()
+    assert r.status is Status.OK
+    assert r.detail  # should have a version string


### PR DESCRIPTION
Closes #46.

## Summary

Adds `repowire doctor` — a diagnostic subcommand that runs a battery of health checks and prints color-coded results. Exits 0 when everything is green or only warnings/skips; exits 1 if any check fails.

Pure check functions live in `repowire/doctor.py` and return `CheckResult` structs; the CLI layer (`cli.py`) renders them via `rich`. No new dependencies.

## Checks

| Check | OK | WARN | FAIL | SKIP |
| --- | --- | --- | --- | --- |
| `repowire version` | always | — | — | — |
| Python version | ≥ 3.10 | — | < 3.10 | — |
| `tmux` available | found + version | not on PATH | — | — |
| Package manager | `uv`/`pipx`/`pip` on PATH | none found | — | — |
| Daemon reachable | `/health` 200, prints version + relay-mode | — | unreachable / HTTP error | — |
| Agent runtimes (claude-code, codex, gemini, opencode, pi) | hooks/MCP installed | none detected | hooks/MCP missing | runtime CLI absent |
| Spawn allowlist | all commands+paths resolve | unresolved entries | — | not configured |
| WebSocket auth token | set | — | — | unset (open access) |
| Relay | `relay/health` 200 | non-200 HTTP | `enabled` but unreachable / no URL | `relay.enabled=false` |
| Channel transport (experimental) | configured + `bun` on PATH | — | configured but `bun` missing | not configured / no claude-code |

## Example output (live, this dev machine)

```
repowire doctor

✓ repowire version  0.13.4
✓ Python version  3.13 (>= 3.10)
✓ tmux available  tmux 3.5a
✓ Package manager (for updates)  uv
✓ Daemon reachable  http://127.0.0.1:8377 — v0.13.4 (relay mode)
✓ Agent runtimes  5 detected
  ✓ claude-code  v2.1.142 — hooks installed
  ✓ codex  v0.130.0 — hooks + MCP installed
  ✓ gemini  v0.41.2 — hooks + MCP installed
  ✓ opencode  plugin installed
  ✓ pi  extension installed
✓ Spawn allowlist  7 command(s), 2 path(s)
  ✓ command: claude
  ...
· WebSocket auth token  not set (open access on bind address)
✓ Relay  reachable at wss://repowire.io — with API key
· Channel transport (experimental)  not configured (default hooks transport)

22 ok  0 warn  0 fail  2 skip
```

## Other changes

- `daemon/routes/health.py` — `/health` previously hardcoded `"version": "0.1.0"`. Switched to `repowire.__version__` so `doctor` (and external monitors) get the real version.
- README `## CLI Reference` — added `repowire doctor` entry.
- `docs/reference/cli.md` — new `## \`repowire doctor\`` section listing every check.

## Test plan

- [x] `uv run pytest tests/test_doctor.py` — 32 new tests covering each check function (mocked PATH, mocked `httpx`, real `tmp_path`).
- [x] `uv run pytest` — full suite 722 passed.
- [x] `uv run ruff check repowire/doctor.py tests/test_doctor.py repowire/cli.py repowire/daemon/routes/health.py` — clean (pre-existing E501s in `tests/test_opencode_installer.py` unrelated).
- [x] `uv run ty check repowire/` — clean.
- [x] Manual run on dev machine — see output above; exit code 0; rendering matches design.
- [ ] Flip draft → ready when reviewer signs off.