### PR TITLE
feat(landing): Navbar dashboard link → relay.repowire.io/dashboard (#151)

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -13,7 +13,19 @@ import type { Event, OrchestratorStatus, Peer } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8377";
 
+const RELAY_DASHBOARD_URL = "https://relay.repowire.io/dashboard";
+
 export default function Dashboard() {
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.location.hostname === "repowire.io") {
+      window.location.replace(RELAY_DASHBOARD_URL);
+    }
+  }, []);
+
+  return <DashboardInner />;
+}
+
+function DashboardInner() {
   const [peers, setPeers] = useState<Peer[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
   const [orchestrators, setOrchestrators] = useState<OrchestratorStatus[]>([]);

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -16,12 +16,17 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8377";
 const RELAY_DASHBOARD_URL = "https://relay.repowire.io/dashboard";
 
 export default function Dashboard() {
+  const [redirecting] = useState(
+    () => typeof window !== "undefined" && window.location.hostname === "repowire.io",
+  );
+
   useEffect(() => {
-    if (typeof window !== "undefined" && window.location.hostname === "repowire.io") {
+    if (redirecting) {
       window.location.replace(RELAY_DASHBOARD_URL);
     }
-  }, []);
+  }, [redirecting]);
 
+  if (redirecting) return null;
   return <DashboardInner />;
 }
 

--- a/web/components/Navbar.tsx
+++ b/web/components/Navbar.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { Github } from "lucide-react";
+import { Github, LogIn } from "lucide-react";
+
+const DASHBOARD_URL = "https://relay.repowire.io/dashboard";
 
 export default function Navbar() {
   return (
@@ -20,12 +22,6 @@ export default function Navbar() {
             Docs
           </Link>
           <Link
-            href="/dashboard"
-            className="hidden font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-outline transition-colors hover:text-primary-fixed sm:inline"
-          >
-            Dashboard
-          </Link>
-          <Link
             href="https://github.com/prassanna-ravishankar/repowire"
             target="_blank"
             rel="noopener noreferrer"
@@ -33,6 +29,14 @@ export default function Navbar() {
           >
             <span className="sr-only">GitHub</span>
             <Github className="h-5 w-5" />
+          </Link>
+          <Link
+            href={DASHBOARD_URL}
+            className="inline-flex items-center gap-1.5 rounded border border-primary/40 bg-primary/10 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-primary-fixed transition-[filter,transform,background] hover:bg-primary/20 hover:brightness-110 active:scale-[0.98]"
+          >
+            <LogIn className="h-3 w-3" />
+            <span className="hidden sm:inline">Sign in</span>
+            <span className="sm:hidden">Dash</span>
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Replace the plain "Dashboard" text link in the marketing Navbar with a distinct "Sign in" CTA (border + tinted background, icon, responsive label) pointing directly at `https://relay.repowire.io/dashboard`. Sits next to the GitHub icon so it reads as an account-affordance, not just another nav item.
- Fix the broken `repowire.io/dashboard` shell that ships in the static export (PR #149 landed it on apex with no daemon backing it). When the dashboard page mounts and `window.location.hostname === "repowire.io"`, it `replace()`s to `https://relay.repowire.io/dashboard`. The same bundle still renders normally when served by the daemon (`localhost:8377/dashboard`) or the relay (`relay.repowire.io/dashboard`).

## Decision on /dashboard at apex

Went with the redirect path (option a from the brief) instead of stripping `web/app/dashboard/` from the export. Reasons:

1. **Same bundle, three hosts.** `web/out/dashboard.html` is also served verbatim by the daemon (`repowire/daemon/app.py:253`) and by the relay (`repowire/relay/server.py:445`). Deleting the route would force a separate build pipeline or special-casing in those servers. Host-aware redirect is a one-liner that leaves the bundle untouched.
2. **Static export ignores `next.config.ts` `redirects()`.** With `output: "export"`, redirects in the Next config are no-ops — they only work on a running Next server. A client redirect inside the page is the only static-export-friendly option short of a meta-refresh HTML override.
3. **Bookmarks keep working.** Anyone who has `repowire.io/dashboard` saved lands on the real dashboard.

The redirect is gated on hostname so the daemon and relay paths are unaffected.

## Before / after

Before — apex serves the dashboard shell with no daemon, DISCONNECTED banner, "no peers", "no mesh events":

\`\`\`
$ curl -s --resolve repowire.io:443:104.21.93.182 https://repowire.io/dashboard -o /tmp/dash.html -w "HTTP %{http_code}\n"
HTTP 200
$ grep -o "DISCONNECTED\|no peers match\|no mesh events" /tmp/dash.html
DISCONNECTED
no peers match
no mesh events
\`\`\`

After (once deployed): same HTML still 200s, but on first render the client effect calls `window.location.replace("https://relay.repowire.io/dashboard")` so the user lands on the working, gated relay dashboard.

## Test plan

- [x] `npm run build` — clean, 11/11 static pages
- [x] `out/index.html` contains the new "Sign in" CTA + `relay.repowire.io/dashboard` href
- [x] `out/_next/static/chunks/*.js` bundles the redirect URL into the dashboard page
- [ ] Smoke after deploy: confirm `https://repowire.io/dashboard` 30x-equivalent (client replace) lands on relay
- [ ] Smoke `localhost:8377/dashboard` still renders the dashboard SPA (daemon path unaffected)
- [ ] Smoke `https://relay.repowire.io/dashboard` still renders the dashboard SPA (relay path unaffected)