### PR TITLE
fix(config): validate logging level (#41)

### DIFF
--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 DEFAULT_QUERY_TIMEOUT: float = 300.0
 """Default timeout in seconds for peer-to-peer queries (5 minutes)."""
@@ -149,11 +149,25 @@ class DaemonConfig(BaseModel):
     spawn: SpawnSettings = Field(default_factory=SpawnSettings)
 
 
+_VALID_LOG_LEVELS = frozenset({"debug", "info", "warning", "error", "critical"})
+
+
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
     level: str = Field(default="info", description="Log level")
     file: str | None = Field(None, description="Log file path")
+
+    @field_validator("level")
+    @classmethod
+    def _validate_level(cls, v: str) -> str:
+        normalized = v.lower()
+        if normalized not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"Invalid log level '{v}'. Must be one of: "
+                f"{', '.join(sorted(_VALID_LOG_LEVELS))}"
+            )
+        return normalized
 
 
 class TelegramConfig(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,14 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+from pydantic import ValidationError
+
 from repowire.config.models import (
     AgentType,
     Config,
     DaemonConfig,
+    LoggingConfig,
     PeerConfig,
     RelayConfig,
     SpawnSettings,
@@ -129,3 +133,30 @@ class TestPeerConfigEffective:
     def test_effective_peer_id_legacy(self):
         peer = PeerConfig(name="test", tmux_session="0:test")
         assert peer.effective_peer_id == "legacy-0:test"
+
+
+class TestLoggingConfig:
+    def test_default_level(self):
+        assert LoggingConfig().level == "info"
+
+    @pytest.mark.parametrize("level", ["debug", "info", "warning", "error", "critical"])
+    def test_valid_levels(self, level: str):
+        assert LoggingConfig(level=level).level == level
+
+    @pytest.mark.parametrize("level", ["DEBUG", "Info", "WARNING", "Error", "CRITICAL"])
+    def test_case_insensitive_normalized_to_lower(self, level: str):
+        assert LoggingConfig(level=level).level == level.lower()
+
+    @pytest.mark.parametrize("level", ["trace", "verbose", "", "warn", "fatal", "info "])
+    def test_invalid_level_raises(self, level: str):
+        with pytest.raises(ValidationError) as exc:
+            LoggingConfig(level=level)
+        # Pydantic wraps the ValueError; check the message surfaces the user's input
+        assert level in str(exc.value) or repr(level) in str(exc.value)
+
+    def test_invalid_level_message_lists_valid_options(self):
+        with pytest.raises(ValidationError) as exc:
+            LoggingConfig(level="loud")
+        msg = str(exc.value)
+        for valid in ["debug", "info", "warning", "error", "critical"]:
+            assert valid in msg


### PR DESCRIPTION
Closes #41.

## Change

Adds a Pydantic `field_validator` to `LoggingConfig.level`. Accepts `debug` / `info` / `warning` / `error` / `critical` case-insensitively, normalizes to lowercase, raises `ValidationError` with a clear message listing valid options on anything else.

## Tests

17 new `TestLoggingConfig` cases:
- Default "info"
- All 5 valid levels accepted
- Case-insensitive normalization (DEBUG → debug, Info → info, etc.)
- Common typos rejected (`trace`, `verbose`, `warn`, `fatal`, `info ` with trailing space, empty string)
- Error message lists all valid options so the user knows what to use

Full suite: 740 passed (up from 722). ruff + ty clean.