### PR TITLE
feat(cli): add 'repowire peer describe' command (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ repowire serve --relay            # Run daemon with relay connection
 repowire peer new PATH            # Spawn new peer in tmux
 repowire peer new . --circle dev  # Spawn with custom circle
 repowire peer list                # List peers and their status (god-view, includes offline)
+repowire peer describe NAME       # Show full state for one peer (open asks, last seen, recent activity)
+repowire peer describe NAME --circle 5    # Disambiguate when name exists in multiple circles
 repowire peer prune               # Remove offline peers
 
 repowire telegram start           # Run Telegram bot (config or env vars)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,10 +55,13 @@ Exits 0 if all checks pass (or only warn/skip). Exits 1 if any check fails — s
 ```bash
 repowire peer new PATH [--circle CIRCLE]   # spawn a new peer in tmux
 repowire peer list                          # god-view list (all circles, includes caller)
+repowire peer describe NAME_OR_ID [--circle C]  # full state for one peer
 repowire peer prune                         # remove offline peers from the registry
 ```
 
 `peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP [`list_peers`](mcp-tools.md#list_peers) tool defaults to a peer-facing view (online only, caller hidden).
+
+`peer describe` accepts either a display name (`clitcoin-claude-code`) or a peer id (`repow-5-abd4d21e`). Pass `--circle` when a display name is ambiguous across circles — without it, the command refuses to guess and prints the same misroute-style refusal the daemon emits internally. Output includes identity (project, circle, role, backend), liveness (status, path, machine, last-seen), open ask threads in both directions, and the last few communication events involving the peer. Reads `GET /peers`, `GET /peers/{id}`, `GET /asks/pending?direction=both`, and `GET /events` — no new daemon endpoints.
 
 ## `repowire build-ui`
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1358,6 +1358,119 @@ def peer_list(show_offline: bool) -> None:
     console.print(table)
 
 
+@peer.command(name="describe")
+@click.argument("identifier")
+@click.option(
+    "--circle", "-c", default=None,
+    help="Circle to scope lookup when a display_name is ambiguous across circles.",
+)
+def peer_describe(identifier: str, circle: str | None) -> None:
+    """Show all known state for one peer.
+
+    IDENTIFIER may be a display_name (e.g. 'clitcoin-claude-code') or a
+    peer_id (e.g. 'repow-5-abd4d21e'). When a display_name matches multiple
+    peers across circles, pass --circle to disambiguate.
+    """
+    import sys
+
+    import httpx
+
+    from repowire.peer_describe import (
+        ResolveAmbiguous,
+        ResolveNotFound,
+        ambiguity_message,
+        build_snapshot,
+        fetch_all_peers,
+        resolve_peer,
+    )
+
+    daemon_url = _get_daemon_url()
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            peers = fetch_all_peers(client, daemon_url)
+            outcome = resolve_peer(peers, identifier, circle=circle)
+            if isinstance(outcome, ResolveNotFound):
+                console.print(f"[red]Peer not found:[/] {identifier}")
+                console.print("[dim]Run `repowire peer list` to see available names.[/]")
+                sys.exit(1)
+            if isinstance(outcome, ResolveAmbiguous):
+                console.print(f"[red]{ambiguity_message(outcome)}[/]")
+                sys.exit(1)
+            snapshot = build_snapshot(client, daemon_url, outcome)
+    except httpx.ConnectError:
+        console.print(
+            f"[red]Cannot connect to daemon at {daemon_url}.[/] "
+            "Run 'repowire serve' first.",
+        )
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Daemon error: {e}[/]")
+        sys.exit(1)
+
+    _render_peer_snapshot(snapshot)
+
+
+def _render_peer_snapshot(snapshot: object) -> None:
+    """Render a PeerSnapshot to the console."""
+    from repowire.peer_describe import PeerSnapshot, humanize_last_seen
+
+    assert isinstance(snapshot, PeerSnapshot)
+    p = snapshot.peer
+    status = p.get("status", "?")
+    status_color = {"online": "green", "busy": "yellow", "offline": "red"}.get(status, "white")
+
+    rows: list[tuple[str, str]] = [
+        ("Peer", f"[cyan]{p.get('display_name', '?')}[/]  [dim]({p.get('peer_id', '?')})[/]"),
+        ("Project", p.get("metadata", {}).get("project") or "[dim]-[/]"),
+        ("Circle", f"[magenta]{p.get('circle', 'global')}[/]"),
+        ("Role", p.get("role", "agent")),
+        ("Backend", p.get("backend", "?")),
+        ("Status", f"[{status_color}]{status}[/]"),
+        ("Path", p.get("path") or "[dim]-[/]"),
+        ("Machine", p.get("machine") or "[dim]-[/]"),
+        ("Last seen", humanize_last_seen(p.get("last_seen"))),
+        ("Turn state", p.get("turn_state") or "[dim]-[/]"),
+        ("Description", p.get("description") or "[dim]-[/]"),
+    ]
+
+    for label, value in rows:
+        console.print(f"[bold]{label + ':':14}[/] {value}")
+
+    console.print("")
+    n_in = len(snapshot.inbound_asks)
+    n_out = len(snapshot.outbound_asks)
+    console.print(f"[bold]Open asks:[/]    {n_in} inbound, {n_out} outbound")
+    for a in snapshot.inbound_asks:
+        when = humanize_last_seen(a.created_at)
+        snippet = a.text if len(a.text) <= 60 else a.text[:57] + "..."
+        console.print(
+            f"  [green]inbound[/]   {a.correlation_id}  from [cyan]@{a.from_peer}[/]  "
+            f"{when}  [dim]\"{snippet}\"[/]",
+        )
+    for a in snapshot.outbound_asks:
+        when = humanize_last_seen(a.created_at)
+        snippet = a.text if len(a.text) <= 60 else a.text[:57] + "..."
+        console.print(
+            f"  [yellow]outbound[/]  {a.correlation_id}  to [cyan]@{a.to_peer}[/]  "
+            f"{when}  [dim]\"{snippet}\"[/]",
+        )
+
+    console.print("")
+    console.print(f"[bold]Recent activity:[/]  (last {len(snapshot.recent_activity)} events)")
+    if not snapshot.recent_activity:
+        console.print("  [dim]no recent events[/]")
+        return
+    for ev in snapshot.recent_activity:
+        ts = ev.timestamp[11:16] if len(ev.timestamp) >= 16 else ev.timestamp
+        arrow = {"inbound": "←", "outbound": "→", "self": "·"}.get(ev.direction, " ")
+        cp = f"@{ev.counterparty}" if ev.counterparty else ""
+        snippet = ev.text if len(ev.text) <= 60 else ev.text[:57] + "..."
+        line = f"  [dim]{ts}[/]  {arrow} [cyan]{ev.event_type}[/] {cp}"
+        if snippet:
+            line += f"  [dim]\"{snippet}\"[/]"
+        console.print(line)
+
+
 @peer.command(name="new")
 @click.argument("path", type=click.Path(exists=True), default=".")
 @click.option(

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -115,18 +115,33 @@ class AskTracker:
         self,
         peer_id: str,
         max_results: int = 10,
+        direction: str = "inbound",
     ) -> list[Ask]:
-        """Return open asks targeting this peer, newest first, capped at max_results.
+        """Return open asks for this peer, newest first, capped at max_results.
+
+        direction:
+          - "inbound"  (default): asks targeting this peer (to_peer_id == peer_id)
+          - "outbound": asks this peer opened (from_peer_id == peer_id)
+          - "both":    union of the two
 
         Lazy-repair: opportunistically evicts TTL-expired asks at most once
         per _EVICTION_INTERVAL_SECONDS. Stop hooks call this on each response,
         so the dict gets swept regularly without a background timer.
         """
+        if direction not in ("inbound", "outbound", "both"):
+            raise ValueError(f"invalid direction: {direction!r}")
         await self._maybe_evict_expired()
         async with self._lock:
+            def matches(ask: Ask) -> bool:
+                if direction == "inbound":
+                    return ask.to_peer_id == peer_id
+                if direction == "outbound":
+                    return ask.from_peer_id == peer_id
+                return ask.to_peer_id == peer_id or ask.from_peer_id == peer_id
+
             candidates = [
                 ask for ask in self._asks.values()
-                if ask.to_peer_id == peer_id and not ask.closed
+                if matches(ask) and not ask.closed
             ]
             candidates.sort(key=lambda a: a.created_at, reverse=True)
             return candidates[:max_results]

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -75,8 +75,10 @@ class _NoOpRequest(BaseModel):
 class PendingAsk(BaseModel):
     correlation_id: str
     from_peer: str
+    to_peer: str
     text: str
     created_at: str
+    direction: str  # "inbound" or "outbound"
 
 
 class PendingAsksResponse(BaseModel):
@@ -261,19 +263,32 @@ async def mark_reminded(
 async def pending_asks(
     pane_id: str | None = None,
     peer_id: str | None = None,
+    direction: str = "inbound",
     _: str | None = Depends(require_auth),
 ) -> PendingAsksResponse:
-    """Return all open asks targeting this peer, newest first.
+    """Return open asks for this peer, newest first.
 
     Lookup is by either `pane_id` (tmux-pane-keyed transports: Claude Code,
     Codex, Gemini Stop hooks) or `peer_id` (transports that own multiple
     peers per process, like the pi extension which runs N sessions sharing
     one tmux pane). Exactly one is required.
+
+    `direction` selects which side of the ask thread to return:
+      - "inbound"  (default) — asks targeting this peer (Stop-hook reminders)
+      - "outbound" — asks this peer opened (used by `repowire peer describe`)
+      - "both"    — union of the two
+
+    The default is `inbound` to preserve back-compat with Stop-hook polls.
     """
     if not pane_id and not peer_id:
         raise HTTPException(status_code=400, detail="Must provide pane_id or peer_id")
     if pane_id and peer_id:
         raise HTTPException(status_code=400, detail="Provide only one of pane_id or peer_id")
+    if direction not in ("inbound", "outbound", "both"):
+        raise HTTPException(
+            status_code=400,
+            detail="direction must be one of: inbound, outbound, both",
+        )
 
     peer_registry = get_peer_registry()
     state = get_app_state()
@@ -291,15 +306,24 @@ async def pending_asks(
             raise HTTPException(status_code=404, detail=f"No peer with id: {peer_id}")
         resolved_peer_id = peer.peer_id
 
-    pending = await ask_tracker.pending_for_peer(resolved_peer_id)
+    pending = await ask_tracker.pending_for_peer(resolved_peer_id, direction=direction)
+
+    def _direction_for(ask: object) -> str:
+        # Inbound if the ask targets this peer, outbound if from this peer.
+        # With direction="both" the same ask can only be one of the two.
+        from repowire.daemon.ask_tracker import Ask  # local to avoid cycle in tests
+        assert isinstance(ask, Ask)
+        return "inbound" if ask.to_peer_id == resolved_peer_id else "outbound"
 
     return PendingAsksResponse(
         asks=[
             PendingAsk(
                 correlation_id=ask.correlation_id,
                 from_peer=ask.from_peer_name,
+                to_peer=ask.to_peer_name,
                 text=ask.text,
                 created_at=ask.created_at.isoformat(),
+                direction=_direction_for(ask),
             )
             for ask in pending
         ],

--- a/repowire/peer_describe.py
+++ b/repowire/peer_describe.py
@@ -1,0 +1,289 @@
+"""Snapshot one peer's full state for `repowire peer describe`.
+
+Pure functions: each takes an httpx.Client + daemon_url and returns plain
+data. The CLI layer (cli.py) handles rendering and exit codes. Tests mock
+the httpx transport — no live daemon required.
+
+Resolution rules mirror the daemon's own ambiguity refusal:
+
+  - Accept either display_name or peer_id.
+  - If `circle=` is supplied, filter to that circle.
+  - If 2+ matches survive and no circle is supplied, refuse with the same
+    message format the daemon emits (issue #136).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+
+@dataclass
+class PendingAsk:
+    """One open ask thread (either direction)."""
+
+    correlation_id: str
+    direction: str  # "inbound" | "outbound"
+    from_peer: str
+    to_peer: str
+    text: str
+    created_at: str
+
+
+@dataclass
+class ActivityEvent:
+    """One recent communication event involving this peer."""
+
+    event_type: str  # "notification" | "query" | "response" | "chat_turn" | ...
+    timestamp: str  # ISO
+    direction: str  # "inbound" | "outbound" | "self"
+    counterparty: str  # display_name of the other side, or "" for chat_turn
+    text: str
+
+
+@dataclass
+class PeerSnapshot:
+    """Everything known about one peer."""
+
+    peer: dict[str, Any]
+    inbound_asks: list[PendingAsk] = field(default_factory=list)
+    outbound_asks: list[PendingAsk] = field(default_factory=list)
+    recent_activity: list[ActivityEvent] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResolveNotFound:
+    identifier: str
+    known_names: list[str]
+
+
+@dataclass
+class ResolveAmbiguous:
+    identifier: str
+    circles: list[str]
+
+
+def resolve_peer(
+    peers: list[dict[str, Any]],
+    identifier: str,
+    circle: str | None = None,
+) -> dict[str, Any] | ResolveNotFound | ResolveAmbiguous:
+    """Resolve identifier to a single peer dict, or report failure.
+
+    Tries peer_id first (always unique), then display_name. When
+    display_name yields multiple matches:
+      - filter by circle if supplied
+      - if still ambiguous, return ResolveAmbiguous so the caller can show
+        the same refusal format the daemon emits internally
+    """
+    by_id = [p for p in peers if p.get("peer_id") == identifier]
+    if by_id:
+        return by_id[0]
+
+    by_name = [p for p in peers if p.get("display_name") == identifier]
+    if not by_name:
+        return ResolveNotFound(
+            identifier=identifier,
+            known_names=sorted({p.get("display_name", "") for p in peers if p.get("display_name")}),
+        )
+
+    if circle is not None:
+        by_name = [p for p in by_name if p.get("circle") == circle]
+        if not by_name:
+            return ResolveNotFound(
+                identifier=identifier,
+                known_names=sorted(
+                    {p.get("display_name", "") for p in peers if p.get("display_name")},
+                ),
+            )
+
+    if len(by_name) == 1:
+        return by_name[0]
+
+    return ResolveAmbiguous(
+        identifier=identifier,
+        circles=sorted({p.get("circle", "global") for p in by_name}),
+    )
+
+
+def ambiguity_message(amb: ResolveAmbiguous) -> str:
+    """Match the daemon's refusal format (peer_registry._lookup_peer_unlocked)."""
+    return (
+        f"Ambiguous peer name {amb.identifier!r}: matches in circles "
+        f"{amb.circles}. Specify --circle= or pass a peer_id."
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP fetchers
+# ---------------------------------------------------------------------------
+
+
+def fetch_all_peers(client: httpx.Client, daemon_url: str) -> list[dict[str, Any]]:
+    """GET /peers — return all peers (online + offline)."""
+    resp = client.get(f"{daemon_url}/peers")
+    resp.raise_for_status()
+    return resp.json().get("peers", [])
+
+
+def fetch_pending_asks(
+    client: httpx.Client,
+    daemon_url: str,
+    peer_id: str,
+    direction: str = "both",
+) -> list[PendingAsk]:
+    """GET /asks/pending?peer_id=...&direction=... — open asks for one peer.
+
+    Returns [] if the daemon doesn't recognize the peer_id (e.g. just
+    pruned) rather than raising — describe is a read-only inspection and
+    a stale id shouldn't break the render.
+    """
+    resp = client.get(
+        f"{daemon_url}/asks/pending",
+        params={"peer_id": peer_id, "direction": direction},
+    )
+    if resp.status_code == 404:
+        return []
+    resp.raise_for_status()
+    items = resp.json().get("asks", [])
+    return [
+        PendingAsk(
+            correlation_id=a["correlation_id"],
+            direction=a.get("direction", "inbound"),
+            from_peer=a.get("from_peer", ""),
+            to_peer=a.get("to_peer", ""),
+            text=a.get("text", ""),
+            created_at=a.get("created_at", ""),
+        )
+        for a in items
+    ]
+
+
+def fetch_recent_activity(
+    client: httpx.Client,
+    daemon_url: str,
+    peer_id: str,
+    peer_name: str,
+    limit: int = 5,
+) -> list[ActivityEvent]:
+    """GET /events, filter to this peer, newest first, cap at limit."""
+    resp = client.get(f"{daemon_url}/events")
+    resp.raise_for_status()
+    events = resp.json()
+    if not isinstance(events, list):
+        return []
+
+    out: list[ActivityEvent] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        from_id = ev.get("from_peer_id")
+        to_id = ev.get("to_peer_id")
+        from_name = ev.get("from") or ev.get("peer") or ""
+        to_name = ev.get("to") or ""
+
+        # Match by peer_id (precise) or display_name (events from older
+        # versions or chat_turn events that only carry the name).
+        is_from = from_id == peer_id or from_name == peer_name
+        is_to = to_id == peer_id or to_name == peer_name
+        if not (is_from or is_to):
+            continue
+
+        if is_from and is_to:
+            direction = "self"
+            counterparty = ""
+        elif is_from:
+            direction = "outbound"
+            counterparty = to_name
+        else:
+            direction = "inbound"
+            counterparty = from_name
+
+        out.append(
+            ActivityEvent(
+                event_type=ev.get("type", "?"),
+                timestamp=ev.get("timestamp", ""),
+                direction=direction,
+                counterparty=counterparty,
+                text=str(ev.get("text", ""))[:120],
+            ),
+        )
+
+    # Events are stored append-order (oldest first). Reverse for newest-first.
+    out.reverse()
+    return out[:limit]
+
+
+def build_snapshot(
+    client: httpx.Client,
+    daemon_url: str,
+    peer: dict[str, Any],
+) -> PeerSnapshot:
+    """Build the full snapshot for an already-resolved peer."""
+    peer_id = peer["peer_id"]
+    peer_name = peer.get("display_name") or peer.get("name") or peer_id
+
+    inbound: list[PendingAsk] = []
+    outbound: list[PendingAsk] = []
+    try:
+        all_asks = fetch_pending_asks(client, daemon_url, peer_id, direction="both")
+        for a in all_asks:
+            (inbound if a.direction == "inbound" else outbound).append(a)
+    except httpx.HTTPError:
+        # Older daemon without direction= support — fall back to inbound only.
+        try:
+            inbound = fetch_pending_asks(client, daemon_url, peer_id, direction="inbound")
+        except httpx.HTTPError:
+            pass
+
+    activity: list[ActivityEvent] = []
+    try:
+        activity = fetch_recent_activity(client, daemon_url, peer_id, peer_name)
+    except httpx.HTTPError:
+        pass
+
+    return PeerSnapshot(
+        peer=peer,
+        inbound_asks=inbound,
+        outbound_asks=outbound,
+        recent_activity=activity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Time formatting helpers (pure, testable)
+# ---------------------------------------------------------------------------
+
+
+def humanize_last_seen(iso: str | None, now: datetime | None = None) -> str:
+    """'2m ago (14:55 UTC)' style. Empty string if iso is None/empty."""
+    if not iso:
+        return "never"
+    try:
+        ts = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return iso
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    delta = current - ts
+    secs = int(delta.total_seconds())
+    if secs < 0:
+        rel = "in the future"
+    elif secs < 60:
+        rel = f"{secs}s ago"
+    elif secs < 3600:
+        rel = f"{secs // 60}m ago"
+    elif secs < 86400:
+        rel = f"{secs // 3600}h ago"
+    else:
+        rel = f"{secs // 86400}d ago"
+    return f"{rel} ({ts.strftime('%H:%M %Z') or ts.strftime('%H:%M UTC')})"

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -324,6 +324,47 @@ class TestPendingAsks:
         r = await client.get("/asks/pending?peer_id=does-not-exist")
         assert r.status_code == 404
 
+    async def test_direction_outbound_returns_asks_this_peer_opened(self, env):
+        """direction=outbound returns asks where this peer is the sender."""
+        client, _, _, _ = env
+        alice = await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        # Use the actual assigned display_name so from_peer_id resolves
+        # to alice's peer_id (and not the literal "alice" string fallback).
+        r = await client.post("/ask", json={
+            "from_peer": alice, "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+
+        # Default direction (inbound): alice has no inbound asks
+        r = await client.get(f"/asks/pending?peer_id={alice}")
+        assert r.status_code == 200
+        assert r.json()["asks"] == []
+
+        # direction=outbound: alice has one outbound ask
+        r = await client.get(f"/asks/pending?peer_id={alice}&direction=outbound")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["asks"]) == 1
+        assert body["asks"][0]["correlation_id"] == cid
+        assert body["asks"][0]["direction"] == "outbound"
+        assert body["asks"][0]["to_peer"] == bob
+
+        # direction=both: union (alice still has only the outbound)
+        r = await client.get(f"/asks/pending?peer_id={alice}&direction=both")
+        assert len(r.json()["asks"]) == 1
+
+        # Bob's inbound view is unchanged by default
+        r = await client.get(f"/asks/pending?peer_id={bob}")
+        assert len(r.json()["asks"]) == 1
+        assert r.json()["asks"][0]["direction"] == "inbound"
+
+    async def test_direction_invalid_returns_400(self, env):
+        client, _, _, _ = env
+        bob = await _register_peer(client, "bob")
+        r = await client.get(f"/asks/pending?peer_id={bob}&direction=sideways")
+        assert r.status_code == 400
+
 
 class TestDeprecatedNoOps:
     """Compat: legacy transports may still POST these. Should return 200 silently."""

--- a/tests/test_peer_describe.py
+++ b/tests/test_peer_describe.py
@@ -1,0 +1,385 @@
+"""Tests for repowire.peer_describe (pure-function module + resolver)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from repowire.peer_describe import (
+    ActivityEvent,
+    PendingAsk,
+    ResolveAmbiguous,
+    ResolveNotFound,
+    ambiguity_message,
+    build_snapshot,
+    fetch_all_peers,
+    fetch_pending_asks,
+    fetch_recent_activity,
+    humanize_last_seen,
+    resolve_peer,
+)
+
+
+def _peer(
+    peer_id: str,
+    name: str,
+    circle: str = "global",
+    status: str = "online",
+    **extra: object,
+) -> dict:
+    p: dict = {
+        "peer_id": peer_id,
+        "name": name,
+        "display_name": name,
+        "circle": circle,
+        "status": status,
+        "backend": "claude-code",
+        "role": "agent",
+        "path": "/tmp/x",
+        "machine": "host",
+        "last_seen": "2026-05-15T14:55:00+00:00",
+        "turn_state": "idle",
+        "description": "",
+        "metadata": {},
+    }
+    p.update(extra)
+    return p
+
+
+def _client(handler):
+    """Build an httpx.Client backed by a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport, base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# resolve_peer
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePeer:
+    def test_single_match_by_name(self):
+        peers = [_peer("p-1", "alice")]
+        r = resolve_peer(peers, "alice")
+        assert isinstance(r, dict)
+        assert r["peer_id"] == "p-1"
+
+    def test_single_match_by_peer_id(self):
+        peers = [_peer("p-1", "alice")]
+        r = resolve_peer(peers, "p-1")
+        assert isinstance(r, dict)
+        assert r["peer_id"] == "p-1"
+
+    def test_not_found(self):
+        peers = [_peer("p-1", "alice"), _peer("p-2", "bob")]
+        r = resolve_peer(peers, "carol")
+        assert isinstance(r, ResolveNotFound)
+        assert r.identifier == "carol"
+        assert "alice" in r.known_names
+        assert "bob" in r.known_names
+
+    def test_ambiguous_across_circles(self):
+        peers = [
+            _peer("p-1", "alice", circle="5"),
+            _peer("p-2", "alice", circle="default"),
+        ]
+        r = resolve_peer(peers, "alice")
+        assert isinstance(r, ResolveAmbiguous)
+        assert sorted(r.circles) == ["5", "default"]
+
+    def test_ambiguous_resolved_by_circle(self):
+        peers = [
+            _peer("p-1", "alice", circle="5"),
+            _peer("p-2", "alice", circle="default"),
+        ]
+        r = resolve_peer(peers, "alice", circle="5")
+        assert isinstance(r, dict)
+        assert r["peer_id"] == "p-1"
+
+    def test_circle_filter_yields_not_found(self):
+        peers = [_peer("p-1", "alice", circle="5")]
+        r = resolve_peer(peers, "alice", circle="default")
+        assert isinstance(r, ResolveNotFound)
+
+    def test_peer_id_wins_over_display_name_match(self):
+        peers = [
+            _peer("p-1", "alice", circle="5"),
+            _peer("alice", "carol", circle="default"),  # peer_id == "alice"
+        ]
+        r = resolve_peer(peers, "alice")
+        assert isinstance(r, dict)
+        assert r["peer_id"] == "alice"
+
+    def test_ambiguity_message_format(self):
+        amb = ResolveAmbiguous(identifier="alice", circles=["5", "default"])
+        msg = ambiguity_message(amb)
+        assert "Ambiguous peer name 'alice'" in msg
+        assert "['5', 'default']" in msg
+        assert "--circle=" in msg
+
+
+# ---------------------------------------------------------------------------
+# fetch_all_peers
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAllPeers:
+    def test_returns_list(self):
+        def handler(request):
+            assert request.url.path == "/peers"
+            return httpx.Response(200, json={"peers": [_peer("p-1", "alice")]})
+
+        with _client(handler) as client:
+            peers = fetch_all_peers(client, "http://test")
+        assert len(peers) == 1
+        assert peers[0]["display_name"] == "alice"
+
+    def test_empty_peers(self):
+        def handler(_request):
+            return httpx.Response(200, json={"peers": []})
+
+        with _client(handler) as client:
+            peers = fetch_all_peers(client, "http://test")
+        assert peers == []
+
+    def test_http_error_raises(self):
+        def handler(_request):
+            return httpx.Response(500, json={"detail": "boom"})
+
+        with _client(handler) as client, pytest.raises(httpx.HTTPError):
+            fetch_all_peers(client, "http://test")
+
+
+# ---------------------------------------------------------------------------
+# fetch_pending_asks
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPendingAsks:
+    def test_returns_both_directions(self):
+        def handler(request):
+            assert request.url.path == "/asks/pending"
+            assert request.url.params["peer_id"] == "p-1"
+            assert request.url.params["direction"] == "both"
+            return httpx.Response(200, json={
+                "asks": [
+                    {
+                        "correlation_id": "ask-a",
+                        "from_peer": "alice", "to_peer": "bob",
+                        "text": "hello", "created_at": "2026-05-15T14:53:00+00:00",
+                        "direction": "inbound",
+                    },
+                    {
+                        "correlation_id": "ask-b",
+                        "from_peer": "bob", "to_peer": "carol",
+                        "text": "out", "created_at": "2026-05-15T14:54:00+00:00",
+                        "direction": "outbound",
+                    },
+                ],
+            })
+
+        with _client(handler) as client:
+            asks = fetch_pending_asks(client, "http://test", "p-1")
+        assert len(asks) == 2
+        assert asks[0].direction == "inbound"
+        assert asks[1].direction == "outbound"
+
+    def test_404_returns_empty(self):
+        def handler(_request):
+            return httpx.Response(404, json={"detail": "no peer"})
+
+        with _client(handler) as client:
+            asks = fetch_pending_asks(client, "http://test", "p-missing")
+        assert asks == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_recent_activity
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRecentActivity:
+    def test_filters_by_peer_id_or_name(self):
+        def handler(_request):
+            return httpx.Response(200, json=[
+                # Inbound (notification to p-1)
+                {
+                    "id": "1", "type": "notification",
+                    "timestamp": "2026-05-15T14:50:00+00:00",
+                    "from": "alice", "to": "bob",
+                    "from_peer_id": "p-a", "to_peer_id": "p-1",
+                    "text": "hi bob",
+                },
+                # Outbound (p-1 -> someone)
+                {
+                    "id": "2", "type": "notification",
+                    "timestamp": "2026-05-15T14:51:00+00:00",
+                    "from": "bob", "to": "carol",
+                    "from_peer_id": "p-1", "to_peer_id": "p-c",
+                    "text": "bye carol",
+                },
+                # Irrelevant
+                {
+                    "id": "3", "type": "notification",
+                    "timestamp": "2026-05-15T14:52:00+00:00",
+                    "from": "alice", "to": "carol",
+                    "from_peer_id": "p-a", "to_peer_id": "p-c",
+                    "text": "nope",
+                },
+            ])
+
+        with _client(handler) as client:
+            events = fetch_recent_activity(client, "http://test", "p-1", "bob")
+
+        assert len(events) == 2
+        # Newest first
+        assert events[0].timestamp == "2026-05-15T14:51:00+00:00"
+        assert events[0].direction == "outbound"
+        assert events[0].counterparty == "carol"
+        assert events[1].direction == "inbound"
+
+    def test_handles_non_list_response(self):
+        def handler(_request):
+            return httpx.Response(200, json={"oops": "not a list"})
+
+        with _client(handler) as client:
+            events = fetch_recent_activity(client, "http://test", "p-1", "bob")
+        assert events == []
+
+    def test_limit_caps_results(self):
+        def handler(_request):
+            return httpx.Response(200, json=[
+                {
+                    "id": str(i), "type": "notification",
+                    "timestamp": f"2026-05-15T14:{50 + i:02d}:00+00:00",
+                    "from": "alice", "to": "bob",
+                    "from_peer_id": "p-a", "to_peer_id": "p-1",
+                    "text": f"msg {i}",
+                }
+                for i in range(10)
+            ])
+
+        with _client(handler) as client:
+            events = fetch_recent_activity(client, "http://test", "p-1", "bob", limit=3)
+        assert len(events) == 3
+
+
+# ---------------------------------------------------------------------------
+# build_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshot:
+    def test_online_peer_full_snapshot(self):
+        peer = _peer("p-1", "bob")
+
+        def handler(request):
+            path = request.url.path
+            if path == "/asks/pending":
+                return httpx.Response(200, json={
+                    "asks": [
+                        {
+                            "correlation_id": "ask-in",
+                            "from_peer": "alice", "to_peer": "bob",
+                            "text": "?", "created_at": "2026-05-15T14:53:00+00:00",
+                            "direction": "inbound",
+                        },
+                    ],
+                })
+            if path == "/events":
+                return httpx.Response(200, json=[
+                    {
+                        "id": "1", "type": "notification",
+                        "timestamp": "2026-05-15T14:54:00+00:00",
+                        "from": "alice", "to": "bob",
+                        "from_peer_id": "p-a", "to_peer_id": "p-1",
+                        "text": "hi",
+                    },
+                ])
+            return httpx.Response(404)
+
+        with _client(handler) as client:
+            snap = build_snapshot(client, "http://test", peer)
+
+        assert snap.peer["peer_id"] == "p-1"
+        assert len(snap.inbound_asks) == 1
+        assert snap.inbound_asks[0].correlation_id == "ask-in"
+        assert snap.outbound_asks == []
+        assert len(snap.recent_activity) == 1
+
+    def test_offline_peer_still_renders_with_no_asks(self):
+        peer = _peer("p-1", "bob", status="offline")
+
+        def handler(request):
+            if request.url.path == "/asks/pending":
+                # Daemon may have evicted; return 404 to mimic forget_peer cleanup
+                return httpx.Response(404, json={"detail": "no peer"})
+            if request.url.path == "/events":
+                return httpx.Response(200, json=[])
+            return httpx.Response(404)
+
+        with _client(handler) as client:
+            snap = build_snapshot(client, "http://test", peer)
+
+        assert snap.peer["status"] == "offline"
+        assert snap.inbound_asks == []
+        assert snap.outbound_asks == []
+        assert snap.recent_activity == []
+
+
+# ---------------------------------------------------------------------------
+# humanize_last_seen
+# ---------------------------------------------------------------------------
+
+
+class TestHumanizeLastSeen:
+    def test_empty_returns_never(self):
+        assert humanize_last_seen(None) == "never"
+        assert humanize_last_seen("") == "never"
+
+    def test_seconds_ago(self):
+        now = datetime(2026, 5, 15, 15, 0, 0, tzinfo=timezone.utc)
+        iso = (now - timedelta(seconds=30)).isoformat()
+        s = humanize_last_seen(iso, now=now)
+        assert "30s ago" in s
+
+    def test_minutes_ago(self):
+        now = datetime(2026, 5, 15, 15, 0, 0, tzinfo=timezone.utc)
+        iso = (now - timedelta(minutes=5)).isoformat()
+        s = humanize_last_seen(iso, now=now)
+        assert "5m ago" in s
+
+    def test_hours_ago(self):
+        now = datetime(2026, 5, 15, 15, 0, 0, tzinfo=timezone.utc)
+        iso = (now - timedelta(hours=3)).isoformat()
+        s = humanize_last_seen(iso, now=now)
+        assert "3h ago" in s
+
+    def test_days_ago(self):
+        now = datetime(2026, 5, 15, 15, 0, 0, tzinfo=timezone.utc)
+        iso = (now - timedelta(days=2)).isoformat()
+        s = humanize_last_seen(iso, now=now)
+        assert "2d ago" in s
+
+    def test_malformed_returns_input(self):
+        assert humanize_last_seen("garbage") == "garbage"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass smoke checks
+# ---------------------------------------------------------------------------
+
+
+def test_dataclass_construct_smoke():
+    a = PendingAsk(
+        correlation_id="ask-1", direction="inbound",
+        from_peer="alice", to_peer="bob", text="?", created_at="now",
+    )
+    assert a.direction == "inbound"
+
+    e = ActivityEvent(
+        event_type="notification", timestamp="now",
+        direction="outbound", counterparty="alice", text="hi",
+    )
+    assert e.event_type == "notification"


### PR DESCRIPTION
Closes #43.

## Summary

`repowire peer describe <name_or_id>` prints all known state for one peer in a single rich-rendered block: identity (project/circle/role/backend), liveness (status/path/machine/last-seen/turn-state), open ask threads (inbound + outbound), and the last 5 communication events involving the peer.

```
$ repowire peer describe clitcoin-claude-code
Peer:          clitcoin-claude-code  (repow-5-abd4d21e)
Project:       clitcoin
Circle:        5
Role:          agent
Backend:       claude-code
Status:        online
Path:          /Users/prass/development/projects/clitcoin
Machine:       Prasannas-MacBook-Pro.local
Last seen:     10h ago (04:39 UTC)
...
Open asks:    0 inbound, 0 outbound

Recent activity:  (last 5 events)
  04:38  → chat_turn   "..."
  04:38  → chat_turn   "..."
  04:37  ← notification @.repowire-orchestrator-claude-code  "..."
```

Accepts either display_name (`clitcoin-claude-code`) or peer_id (`repow-5-abd4d21e`). `--circle` disambiguates when the same display_name lives in multiple circles; without it the command refuses with the daemon's misroute-style message format (issue #136). Not-found exits 1 with a hint to run `repowire peer list`.

## Daemon API change (additive, back-compat)

`GET /asks/pending` gains an optional `direction=inbound|outbound|both` query param.

- Default remains `inbound`. Every existing caller (`ws-hook`, channel server, pi extension, `repowire/client.py`) passes no `direction`, so behaviour is unchanged.
- `outbound` returns asks this peer opened; `both` is the union.
- `PendingAsk` response now also carries `to_peer` and `direction` fields so consumers can distinguish the two.

The brief was "Don't introduce new daemon endpoints." We took the option-(b) reading: same route, sharper filter, no new resource surface. The alternative (scraping `GET /events`) loses correlation-id detail and produces data that's stale by render time.

## What's in the diff

- `repowire/peer_describe.py` — pure functions (`resolve_peer`, `fetch_all_peers`, `fetch_pending_asks`, `fetch_recent_activity`, `build_snapshot`, `humanize_last_seen`) plus three dataclasses (`PeerSnapshot`, `PendingAsk`, `ActivityEvent`). Mirrors `doctor.py` shape.
- `repowire/cli.py` — `repowire peer describe` Click subcommand + rich render in `_render_peer_snapshot`.
- `repowire/daemon/ask_tracker.py` — `pending_for_peer` gains `direction=` (default `"inbound"`).
- `repowire/daemon/routes/asks.py` — route accepts `direction=`, validates input, returns enriched `PendingAsk`.
- `tests/test_peer_describe.py` — 25 tests covering resolver, fetchers, snapshot builder, time formatter, with `httpx.MockTransport`.
- `tests/test_ask_routes.py` — 2 new tests for the `direction=` param.
- README CLI Reference + `docs/reference/cli.md` updated.

## Test plan

- [x] `uv run pytest` — 751 passed
- [x] `uvx ruff check repowire/` — clean
- [x] `uv run ty check repowire/` — clean
- [x] Manual: `repowire peer describe nudge-claude-code` (online), `repowire peer describe repow-5-abd4d21e` (peer_id), `repowire peer describe nonexistent` (exit 1 with hint).
- [ ] Ambiguous-name case not constructible in current mesh; covered in unit tests (`test_ambiguous_across_circles`, `test_ambiguity_message_format`).
- [ ] Reviewer: confirm option-(b) reading on the daemon-API constraint is acceptable; happy to revert to inbound-only + events scrape if not.