### PR TITLE
feat(daemon): attachment directory quota (#34)

### DIFF
--- a/repowire/daemon/routes/attachments.py
+++ b/repowire/daemon/routes/attachments.py
@@ -19,6 +19,7 @@ router = APIRouter(tags=["attachments"])
 ATTACHMENTS_DIR = Path.home() / ".repowire" / "attachments"
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 MAX_AGE_HOURS = 24
+MAX_DIR_SIZE = 200 * 1024 * 1024  # 200MB total cap; 507 when exceeded
 
 
 def _ensure_dir() -> Path:
@@ -39,6 +40,19 @@ def _cleanup_expired() -> None:
             pass
 
 
+def _dir_size() -> int:
+    """Total bytes used by the attachments directory. Best-effort."""
+    if not ATTACHMENTS_DIR.exists():
+        return 0
+    total = 0
+    for f in ATTACHMENTS_DIR.iterdir():
+        try:
+            total += f.stat().st_size
+        except OSError:
+            pass
+    return total
+
+
 @router.post("/attachments")
 async def upload_attachment(
     file: UploadFile,
@@ -49,6 +63,21 @@ async def upload_attachment(
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"File too large (max {MAX_FILE_SIZE // 1024 // 1024}MB)",
+        )
+
+    # Sweep TTL'd files first so a stale-but-expired dir doesn't deny a legitimate upload.
+    _cleanup_expired()
+
+    used = _dir_size()
+    if used >= MAX_DIR_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_507_INSUFFICIENT_STORAGE,
+            detail=(
+                f"Attachments directory full "
+                f"({used // 1024 // 1024}MB used, "
+                f"{MAX_DIR_SIZE // 1024 // 1024}MB cap). "
+                f"Wait for the {MAX_AGE_HOURS}h TTL to clear older files."
+            ),
         )
 
     ext = Path(file.filename or "file").suffix or ".bin"
@@ -65,12 +94,19 @@ async def upload_attachment(
                     status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                     detail=f"File too large (max {MAX_FILE_SIZE // 1024 // 1024}MB)",
                 )
+            if used + size > MAX_DIR_SIZE:
+                dest.unlink(missing_ok=True)
+                raise HTTPException(
+                    status_code=status.HTTP_507_INSUFFICIENT_STORAGE,
+                    detail=(
+                        f"Attachments directory would exceed cap "
+                        f"({MAX_DIR_SIZE // 1024 // 1024}MB). "
+                        f"Wait for the {MAX_AGE_HOURS}h TTL to clear older files."
+                    ),
+                )
             out.write(chunk)
 
     logger.info("Attachment saved: %s (%d bytes)", dest.name, size)
-
-    # Opportunistic cleanup
-    _cleanup_expired()
 
     return {
         "id": attachment_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -174,6 +175,48 @@ async def test_upload_and_download_attachment(client: AsyncRepowireClient, tmp_p
 
         downloaded = await client.download_attachment(uploaded.id)
         assert downloaded == b"hello attachment"
+
+
+async def test_attachment_quota_rejects_when_dir_full(
+    client: AsyncRepowireClient, tmp_path
+):
+    """When the attachments dir already exceeds MAX_DIR_SIZE, upload returns 507."""
+    attachment_dir = tmp_path / "attachments"
+    attachment_dir.mkdir(parents=True)
+    # Pre-fill the dir with one file at the cap so a fresh upload tips it over.
+    fat = attachment_dir / "pre-existing.bin"
+    fat.write_bytes(b"\x00" * (attachments.MAX_DIR_SIZE))
+
+    with (
+        patch.object(attachments, "ATTACHMENTS_DIR", attachment_dir),
+        patch.object(attachments, "MAX_AGE_HOURS", 999_999),  # block TTL cleanup
+    ):
+        with pytest.raises(DaemonHTTPError) as exc_info:
+            await client.upload_attachment(
+                b"new content", filename="new.txt", content_type="text/plain"
+            )
+        assert exc_info.value.status == 507
+        assert "full" in str(exc_info.value).lower() or "cap" in str(exc_info.value).lower()
+
+
+async def test_attachment_quota_allows_after_ttl_sweep(
+    client: AsyncRepowireClient, tmp_path
+):
+    """If pre-existing files are expired, the upload handler sweeps them and the upload succeeds."""
+    attachment_dir = tmp_path / "attachments"
+    attachment_dir.mkdir(parents=True)
+    stale = attachment_dir / "stale.bin"
+    stale.write_bytes(b"\x00" * attachments.MAX_DIR_SIZE)
+    # Force the file's mtime to look expired.
+    old = time.time() - (attachments.MAX_AGE_HOURS + 1) * 3600
+    os.utime(stale, (old, old))
+
+    with patch.object(attachments, "ATTACHMENTS_DIR", attachment_dir):
+        uploaded = await client.upload_attachment(
+            b"fresh upload", filename="fresh.txt", content_type="text/plain"
+        )
+        assert uploaded.size == len(b"fresh upload")
+    assert not stale.exists()
 
 
 async def test_auth_token_is_sent(tmp_path):


### PR DESCRIPTION
Closes #34.

POST /attachments enforces a configurable total-directory cap (200MB default). Before each upload: sweep TTL-expired files; if dir is at/over cap return **507**; also enforce cap mid-stream so a single oversized upload can't tip past the limit. 507 detail surfaces current usage + cap + TTL window.

Tests: existing flow unchanged; new test pre-fills at cap → 507; new test pre-fills with expired files → upload succeeds after TTL sweep. 742 pass total. ruff + ty clean.

Severity per the issue: low (requires local or authed-relay access).