### PR TITLE
test: add installer module tests (codex, gemini, claude_code) (#39)

### DIFF
--- a/tests/test_claude_code_installer.py
+++ b/tests/test_claude_code_installer.py
@@ -1,0 +1,318 @@
+"""Filesystem install/uninstall tests for the Claude Code installer.
+
+Claude Code stores hooks in ~/.claude/settings.json (JSON) and the
+experimental channel MCP server in ~/.claude.json (JSON).
+
+Unlike codex/gemini, install_hooks replaces the whole event entry —
+it does not dedupe a list of repowire+user entries for the same event.
+We test the documented behavior, not a hypothetical one.
+
+install_channel is gated by bun + version + server file presence — those
+are monkeypatched to keep tests hermetic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repowire.installers import claude_code as cc_mod
+
+
+def _retarget(tmp_path, monkeypatch):
+    settings = tmp_path / ".claude" / "settings.json"
+    claude_json = tmp_path / ".claude.json"
+    monkeypatch.setattr(cc_mod, "CLAUDE_SETTINGS", settings)
+    monkeypatch.setattr(cc_mod, "CLAUDE_JSON", claude_json)
+    return settings, claude_json
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+# -- install_hooks ----------------------------------------------------------
+
+
+def test_install_hooks_on_empty_writes_all_events(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+
+    assert cc_mod.install_hooks() is True
+    data = _read(settings)
+
+    assert set(data["hooks"]) == {
+        "Stop", "SessionStart", "SessionEnd", "UserPromptSubmit", "Notification",
+    }
+    # All point at the repowire CLI.
+    assert "repowire hook stop" in data["hooks"]["Stop"][0]["hooks"][0]["command"]
+    assert "repowire hook session" in data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    assert "repowire hook prompt" in data["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    # Notification carries the idle_prompt matcher.
+    assert data["hooks"]["Notification"][0]["matcher"] == "idle_prompt"
+
+
+def test_install_hooks_channel_mode_only_writes_stop(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    assert cc_mod.install_hooks(channel_mode=True) is True
+    data = _read(settings)
+    assert set(data["hooks"]) == {"Stop"}
+
+
+def test_install_hooks_preserves_top_level_keys(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({"theme": "dark", "permissions": {"allow": ["Bash"]}}))
+
+    cc_mod.install_hooks()
+    data = _read(settings)
+    assert data["theme"] == "dark"
+    assert data["permissions"] == {"allow": ["Bash"]}
+    assert "Stop" in data["hooks"]
+
+
+def test_install_hooks_is_idempotent(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    cc_mod.install_hooks()
+    first = settings.read_text()
+    cc_mod.install_hooks()
+    second = settings.read_text()
+    assert first == second
+    # And each event has exactly one entry.
+    data = json.loads(second)
+    for event in cc_mod.HOOK_EVENTS:
+        assert len(data["hooks"][event]) == 1
+
+
+def test_install_hooks_replaces_existing_repowire_entry_for_same_event(tmp_path, monkeypatch):
+    """Documented behavior: install_hooks unconditionally sets each event,
+    so a stale repowire entry from an earlier version gets refreshed."""
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    settings.parent.mkdir(parents=True)
+    pre = {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "old-repowire-hook"}]}]}}
+    settings.write_text(json.dumps(pre))
+
+    cc_mod.install_hooks()
+    data = _read(settings)
+    stop_cmds = [e["hooks"][0]["command"] for e in data["hooks"]["Stop"]]
+    assert stop_cmds == ["repowire hook stop"]
+
+
+# -- uninstall_hooks --------------------------------------------------------
+
+
+def test_uninstall_hooks_after_install_clears_all(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    cc_mod.install_hooks()
+    assert cc_mod.uninstall_hooks() is True
+    data = _read(settings)
+    assert "hooks" not in data
+
+
+def test_uninstall_hooks_preserves_other_top_level_keys(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({"theme": "dark"}))
+    cc_mod.install_hooks()
+
+    cc_mod.uninstall_hooks()
+    data = _read(settings)
+    assert data == {"theme": "dark"}
+
+
+def test_uninstall_hooks_keeps_non_repowire_event_keys(tmp_path, monkeypatch):
+    """uninstall_hooks only drops events in HOOK_EVENTS; unrelated event
+    names left by the user must survive."""
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    cc_mod.install_hooks()
+    data = _read(settings)
+    custom = [{"hooks": [{"type": "command", "command": "custom"}]}]
+    data["hooks"]["CustomEvent"] = custom
+    settings.write_text(json.dumps(data))
+
+    cc_mod.uninstall_hooks()
+    after = _read(settings)
+    assert after["hooks"] == {"CustomEvent": custom}
+
+
+def test_uninstall_hooks_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert cc_mod.uninstall_hooks() is False
+
+
+def test_uninstall_hooks_noop_when_no_hooks_key(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps({"theme": "dark"}))
+    assert cc_mod.uninstall_hooks() is False
+
+
+# -- check_hooks_installed --------------------------------------------------
+
+
+def test_check_hooks_installed_requires_full_event_set(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert cc_mod.check_hooks_installed() is False
+    cc_mod.install_hooks()
+    assert cc_mod.check_hooks_installed() is True
+    # Channel mode installs only Stop -> not a "full" install per the check.
+    cc_mod.uninstall_hooks()
+    cc_mod.install_hooks(channel_mode=True)
+    assert cc_mod.check_hooks_installed() is False
+
+
+# -- install_channel (MCP path for Claude Code) -----------------------------
+
+
+def _stub_channel_prereqs(monkeypatch, tmp_path):
+    """Make install_channel believe bun, version, and server.ts all exist."""
+    monkeypatch.setattr(cc_mod, "_has_bun", lambda: True)
+    monkeypatch.setattr(cc_mod, "supports_channels", lambda: True)
+    fake_server = tmp_path / "fake_pkg" / "channel" / "server.ts"
+    fake_server.parent.mkdir(parents=True)
+    fake_server.write_text("// stub")
+    monkeypatch.setattr(cc_mod, "_find_channel_server", lambda: fake_server)
+    # bun install runs in cwd of server.ts; stub it out.
+    import subprocess
+    def fake_run(*_args, **_kwargs):
+        class R:
+            returncode = 0
+            stderr = b""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return fake_server
+
+
+def test_install_channel_on_empty_writes_mcp_entry(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    server = _stub_channel_prereqs(monkeypatch, tmp_path)
+
+    ok, msg = cc_mod.install_channel()
+    assert ok is True
+    assert "Channel transport installed" in msg
+
+    data = _read(claude_json)
+    assert data["mcpServers"]["repowire-channel"] == {
+        "command": "bun",
+        "args": [str(server)],
+    }
+
+
+def test_install_channel_preserves_existing_mcp_servers(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    claude_json.write_text(json.dumps({
+        "theme": "dark",
+        "mcpServers": {"other": {"command": "other"}},
+    }))
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+
+    ok, _msg = cc_mod.install_channel()
+    assert ok is True
+    data = _read(claude_json)
+    assert data["theme"] == "dark"
+    assert data["mcpServers"]["other"] == {"command": "other"}
+    assert "repowire-channel" in data["mcpServers"]
+
+
+def test_install_channel_is_idempotent(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+
+    cc_mod.install_channel()
+    first = claude_json.read_text()
+    cc_mod.install_channel()
+    second = claude_json.read_text()
+    assert first == second
+    data = json.loads(second)
+    # Exactly one repowire-channel entry.
+    assert list(data["mcpServers"].keys()).count("repowire-channel") == 1
+
+
+def test_install_channel_bails_without_bun(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    monkeypatch.setattr(cc_mod, "_has_bun", lambda: False)
+    ok, msg = cc_mod.install_channel()
+    assert ok is False
+    assert "bun" in msg.lower()
+
+
+def test_install_channel_bails_on_unsupported_version(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    monkeypatch.setattr(cc_mod, "_has_bun", lambda: True)
+    monkeypatch.setattr(cc_mod, "supports_channels", lambda: False)
+    monkeypatch.setattr(cc_mod, "get_claude_version", lambda: (2, 0, 0))
+    ok, msg = cc_mod.install_channel()
+    assert ok is False
+    assert "channels" in msg.lower()
+
+
+# -- uninstall_channel ------------------------------------------------------
+
+
+def test_uninstall_channel_removes_entry(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+    cc_mod.install_channel()
+
+    assert cc_mod.uninstall_channel() is True
+    # mcpServers had only repowire-channel -> dropped entirely.
+    data = _read(claude_json)
+    assert "mcpServers" not in data
+
+
+def test_uninstall_channel_keeps_other_servers(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    claude_json.write_text(json.dumps({"mcpServers": {"other": {"command": "other"}}}))
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+    cc_mod.install_channel()
+
+    assert cc_mod.uninstall_channel() is True
+    data = _read(claude_json)
+    assert data["mcpServers"] == {"other": {"command": "other"}}
+
+
+def test_uninstall_channel_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert cc_mod.uninstall_channel() is False
+
+
+def test_uninstall_channel_noop_when_not_installed(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    claude_json.write_text(json.dumps({"mcpServers": {"other": {"command": "other"}}}))
+    assert cc_mod.uninstall_channel() is False
+
+
+def test_check_channel_installed_reflects_state(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+    assert cc_mod.check_channel_installed() is False
+    cc_mod.install_channel()
+    assert cc_mod.check_channel_installed() is True
+    cc_mod.uninstall_channel()
+    assert cc_mod.check_channel_installed() is False
+
+
+# -- Round-trip -------------------------------------------------------------
+
+
+def test_hooks_roundtrip_restores_user_settings(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch)
+    settings.parent.mkdir(parents=True)
+    original = {"theme": "dark", "permissions": {"allow": ["Bash"]}}
+    settings.write_text(json.dumps(original))
+
+    cc_mod.install_hooks()
+    cc_mod.uninstall_hooks()
+
+    assert _read(settings) == original
+
+
+def test_channel_roundtrip_restores_user_settings(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    original = {"theme": "dark", "mcpServers": {"other": {"command": "other"}}}
+    claude_json.write_text(json.dumps(original))
+    _stub_channel_prereqs(monkeypatch, tmp_path)
+
+    cc_mod.install_channel()
+    cc_mod.uninstall_channel()
+
+    assert _read(claude_json) == original

--- a/tests/test_codex_installer.py
+++ b/tests/test_codex_installer.py
@@ -1,0 +1,272 @@
+"""Filesystem install/uninstall tests for the Codex installer.
+
+Codex stores hooks in ~/.codex/hooks.json (JSON) and the MCP server +
+`[features] hooks = true` flag in ~/.codex/config.toml (string-edited).
+
+Tests rebind the module-level path constants to a tmp_path so the real
+filesystem is never touched. install_hooks / install_mcp must preserve
+user content, be idempotent, and round-trip cleanly via the matching
+uninstall.
+"""
+
+from __future__ import annotations
+
+import json
+
+from repowire.installers import codex as codex_mod
+
+
+def _retarget(tmp_path, monkeypatch):
+    """Point codex module's path constants at tmp_path."""
+    home = tmp_path / ".codex"
+    monkeypatch.setattr(codex_mod, "CODEX_HOME", home)
+    monkeypatch.setattr(codex_mod, "HOOKS_PATH", home / "hooks.json")
+    monkeypatch.setattr(codex_mod, "CONFIG_PATH", home / "config.toml")
+    return home
+
+
+# -- install_hooks ----------------------------------------------------------
+
+
+def test_install_hooks_on_empty_writes_all_events(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    assert codex_mod.install_hooks() is True
+
+    data = json.loads((home / "hooks.json").read_text())
+    assert set(data["hooks"]) == {"SessionStart", "Stop", "UserPromptSubmit"}
+    # Each event has exactly one repowire entry.
+    for event in ("SessionStart", "Stop", "UserPromptSubmit"):
+        entries = data["hooks"][event]
+        assert len(entries) == 1
+        assert "repowire" in entries[0]["hooks"][0]["command"]
+    # SessionStart carries the documented matcher.
+    assert data["hooks"]["SessionStart"][0]["matcher"] == "startup|resume|clear"
+
+
+def test_install_hooks_preserves_user_entries(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    user_entry = {"hooks": [{"type": "command", "command": "/usr/local/bin/my-script"}]}
+    pre = {"hooks": {"Stop": [user_entry], "OtherEvent": [user_entry]}, "user_key": "keep me"}
+    (home / "hooks.json").write_text(json.dumps(pre))
+
+    codex_mod.install_hooks()
+    data = json.loads((home / "hooks.json").read_text())
+
+    # User's Stop entry survives alongside the repowire one.
+    stop = data["hooks"]["Stop"]
+    assert user_entry in stop
+    assert any("repowire" in e["hooks"][0]["command"] for e in stop)
+    # Unrelated event is untouched.
+    assert data["hooks"]["OtherEvent"] == [user_entry]
+    # Top-level user keys preserved.
+    assert data["user_key"] == "keep me"
+
+
+def test_install_hooks_is_idempotent(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    codex_mod.install_hooks()
+    first = (home / "hooks.json").read_text()
+    codex_mod.install_hooks()
+    second = (home / "hooks.json").read_text()
+
+    assert first == second
+    data = json.loads(second)
+    for event in ("SessionStart", "Stop", "UserPromptSubmit"):
+        repowire_entries = [
+            e for e in data["hooks"][event]
+            if "repowire" in e["hooks"][0]["command"]
+        ]
+        assert len(repowire_entries) == 1, f"duplicate repowire hook in {event}"
+
+
+# -- uninstall_hooks --------------------------------------------------------
+
+
+def test_uninstall_hooks_after_install_clears_repowire(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    codex_mod.install_hooks()
+    assert codex_mod.uninstall_hooks() is True
+
+    data = json.loads((home / "hooks.json").read_text())
+    # The whole top-level "hooks" key is dropped when nothing remains.
+    assert "hooks" not in data
+
+
+def test_uninstall_hooks_keeps_user_entries(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    codex_mod.install_hooks()
+    # Append a user entry to an existing event.
+    data = json.loads((home / "hooks.json").read_text())
+    user_entry = {"hooks": [{"type": "command", "command": "/usr/local/bin/my-script"}]}
+    data["hooks"]["Stop"].append(user_entry)
+    (home / "hooks.json").write_text(json.dumps(data))
+
+    assert codex_mod.uninstall_hooks() is True
+    after = json.loads((home / "hooks.json").read_text())
+    assert after["hooks"]["Stop"] == [user_entry]
+    # SessionStart and UserPromptSubmit had only repowire entries -> gone.
+    assert "SessionStart" not in after["hooks"]
+    assert "UserPromptSubmit" not in after["hooks"]
+
+
+def test_uninstall_hooks_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    # No file at all.
+    assert codex_mod.uninstall_hooks() is False
+
+
+def test_uninstall_hooks_noop_when_only_user_entries(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    user_only = {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}
+    (home / "hooks.json").write_text(json.dumps(user_only))
+
+    assert codex_mod.uninstall_hooks() is False
+    assert json.loads((home / "hooks.json").read_text()) == user_only
+
+
+# -- install_mcp / config.toml ----------------------------------------------
+
+
+def test_install_mcp_on_empty_writes_section_and_feature_flag(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    assert codex_mod.install_mcp() is True
+    content = (home / "config.toml").read_text()
+
+    assert "[mcp_servers.repowire]" in content
+    assert 'command = "repowire"' in content
+    assert 'args = ["mcp"]' in content
+    assert "[features]" in content
+    assert "hooks = true" in content
+
+
+def test_install_mcp_preserves_existing_config(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    pre = (
+        "model = \"gpt-5\"\n"
+        "\n"
+        "[mcp_servers.other]\n"
+        "command = \"other-tool\"\n"
+        "args = [\"serve\"]\n"
+    )
+    (home / "config.toml").write_text(pre)
+
+    codex_mod.install_mcp()
+    content = (home / "config.toml").read_text()
+
+    # Existing content survives verbatim.
+    assert "model = \"gpt-5\"" in content
+    assert "[mcp_servers.other]" in content
+    assert "command = \"other-tool\"" in content
+    # And ours is appended.
+    assert "[mcp_servers.repowire]" in content
+
+
+def test_install_mcp_is_idempotent(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    codex_mod.install_mcp()
+    first = (home / "config.toml").read_text()
+    codex_mod.install_mcp()
+    second = (home / "config.toml").read_text()
+
+    assert first == second
+    assert second.count("[mcp_servers.repowire]") == 1
+    assert second.count("hooks = true") == 1
+
+
+def test_install_mcp_respects_existing_features_block(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    (home / "config.toml").write_text("[features]\nhooks = false\n")
+
+    codex_mod.install_mcp()
+    content = (home / "config.toml").read_text()
+    # Existing hooks flag respected (not overwritten).
+    assert "hooks = false" in content
+    assert "hooks = true" not in content
+
+
+def test_install_mcp_injects_into_existing_features_block(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    (home / "config.toml").write_text("[features]\nother = true\n")
+
+    codex_mod.install_mcp()
+    content = (home / "config.toml").read_text()
+    assert "hooks = true" in content
+    assert "other = true" in content
+    # Only one [features] header.
+    assert content.count("[features]") == 1
+
+
+# -- uninstall_mcp ----------------------------------------------------------
+
+
+def test_uninstall_mcp_removes_section(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    codex_mod.install_mcp()
+    assert codex_mod.uninstall_mcp() is True
+    content = (home / "config.toml").read_text()
+    assert "[mcp_servers.repowire]" not in content
+    assert "command = \"repowire\"" not in content
+
+
+def test_uninstall_mcp_keeps_other_sections(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    pre = (
+        "model = \"gpt-5\"\n"
+        "\n"
+        "[mcp_servers.other]\n"
+        "command = \"other-tool\"\n"
+    )
+    (home / "config.toml").write_text(pre)
+    codex_mod.install_mcp()
+
+    codex_mod.uninstall_mcp()
+    content = (home / "config.toml").read_text()
+    assert "[mcp_servers.other]" in content
+    assert "command = \"other-tool\"" in content
+    assert "model = \"gpt-5\"" in content
+
+
+def test_uninstall_mcp_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    # No config.toml at all.
+    assert codex_mod.uninstall_mcp() is False
+
+
+def test_uninstall_mcp_noop_when_section_missing(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    (home / "config.toml").write_text("model = \"gpt-5\"\n")
+    assert codex_mod.uninstall_mcp() is False
+
+
+# -- check_* ----------------------------------------------------------------
+
+
+def test_check_hooks_installed_reflects_state(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert codex_mod.check_hooks_installed() is False
+    codex_mod.install_hooks()
+    assert codex_mod.check_hooks_installed() is True
+    codex_mod.uninstall_hooks()
+    assert codex_mod.check_hooks_installed() is False
+
+
+def test_check_mcp_installed_reflects_state(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert codex_mod.check_mcp_installed() is False
+    codex_mod.install_mcp()
+    assert codex_mod.check_mcp_installed() is True
+    codex_mod.uninstall_mcp()
+    assert codex_mod.check_mcp_installed() is False

--- a/tests/test_gemini_installer.py
+++ b/tests/test_gemini_installer.py
@@ -1,0 +1,244 @@
+"""Filesystem install/uninstall tests for the Gemini installer.
+
+Gemini stores hooks and MCP servers together in ~/.gemini/settings.json
+(JSON). Writes go through an atomic .tmp + chmod 600 + replace dance.
+
+Tests rebind GEMINI_HOME / SETTINGS_PATH to tmp_path so the real
+filesystem is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+
+from repowire.installers import gemini as gemini_mod
+
+
+def _retarget(tmp_path, monkeypatch):
+    home = tmp_path / ".gemini"
+    monkeypatch.setattr(gemini_mod, "GEMINI_HOME", home)
+    monkeypatch.setattr(gemini_mod, "SETTINGS_PATH", home / "settings.json")
+    return home
+
+
+def _read(home):
+    return json.loads((home / "settings.json").read_text())
+
+
+# -- install_hooks ----------------------------------------------------------
+
+
+def test_install_hooks_on_empty_writes_all_events(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+
+    assert gemini_mod.install_hooks() is True
+    data = _read(home)
+
+    assert set(data["hooks"]) == {"SessionStart", "BeforeAgent", "AfterAgent"}
+    for event in ("SessionStart", "BeforeAgent", "AfterAgent"):
+        entries = data["hooks"][event]
+        assert len(entries) == 1
+        assert "repowire" in entries[0]["hooks"][0]["command"]
+        assert "--backend=gemini" in entries[0]["hooks"][0]["command"]
+    assert data["hooks"]["SessionStart"][0]["matcher"] == "startup"
+
+
+def test_install_hooks_writes_with_600_perms(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_hooks()
+    # Atomic write should leave the file at 0o600.
+    mode = (home / "settings.json").stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_install_hooks_preserves_user_entries_and_top_level_keys(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    user_entry = {"hooks": [{"type": "command", "command": "/usr/local/bin/my-hook"}]}
+    pre = {
+        "theme": "dark",
+        "hooks": {"AfterAgent": [user_entry], "CustomEvent": [user_entry]},
+    }
+    (home / "settings.json").write_text(json.dumps(pre))
+
+    gemini_mod.install_hooks()
+    data = _read(home)
+
+    assert data["theme"] == "dark"
+    after = data["hooks"]["AfterAgent"]
+    assert user_entry in after
+    assert any("repowire" in e["hooks"][0]["command"] for e in after)
+    assert data["hooks"]["CustomEvent"] == [user_entry]
+
+
+def test_install_hooks_is_idempotent(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_hooks()
+    first = (home / "settings.json").read_text()
+    gemini_mod.install_hooks()
+    second = (home / "settings.json").read_text()
+
+    assert first == second
+    data = json.loads(second)
+    for event in ("SessionStart", "BeforeAgent", "AfterAgent"):
+        repowire_entries = [
+            e for e in data["hooks"][event]
+            if "repowire" in e["hooks"][0]["command"]
+        ]
+        assert len(repowire_entries) == 1
+
+
+# -- uninstall_hooks --------------------------------------------------------
+
+
+def test_uninstall_hooks_after_install_drops_hooks_key(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_hooks()
+    assert gemini_mod.uninstall_hooks() is True
+    data = _read(home)
+    assert "hooks" not in data
+
+
+def test_uninstall_hooks_keeps_user_entries(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_hooks()
+    data = _read(home)
+    user_entry = {"hooks": [{"type": "command", "command": "echo hi"}]}
+    data["hooks"]["AfterAgent"].append(user_entry)
+    (home / "settings.json").write_text(json.dumps(data))
+
+    assert gemini_mod.uninstall_hooks() is True
+    after = _read(home)
+    assert after["hooks"]["AfterAgent"] == [user_entry]
+    assert "SessionStart" not in after["hooks"]
+
+
+def test_uninstall_hooks_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert gemini_mod.uninstall_hooks() is False
+
+
+def test_uninstall_hooks_noop_when_only_user_entries(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    user_only = {"hooks": {"AfterAgent": [{"hooks": [{"type": "command", "command": "x"}]}]}}
+    (home / "settings.json").write_text(json.dumps(user_only))
+    assert gemini_mod.uninstall_hooks() is False
+    assert _read(home) == user_only
+
+
+# -- install_mcp ------------------------------------------------------------
+
+
+def test_install_mcp_on_empty(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    assert gemini_mod.install_mcp() is True
+    data = _read(home)
+    assert data["mcpServers"]["repowire"] == {"command": "repowire", "args": ["mcp"]}
+
+
+def test_install_mcp_preserves_other_servers_and_keys(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    pre = {
+        "theme": "dark",
+        "mcpServers": {"other": {"command": "other", "args": []}},
+    }
+    (home / "settings.json").write_text(json.dumps(pre))
+
+    gemini_mod.install_mcp()
+    data = _read(home)
+    assert data["theme"] == "dark"
+    assert data["mcpServers"]["other"] == {"command": "other", "args": []}
+    assert "repowire" in data["mcpServers"]
+
+
+def test_install_mcp_is_idempotent(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_mcp()
+    first = (home / "settings.json").read_text()
+    gemini_mod.install_mcp()
+    second = (home / "settings.json").read_text()
+    assert first == second
+
+
+# -- uninstall_mcp ----------------------------------------------------------
+
+
+def test_uninstall_mcp_after_install(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    gemini_mod.install_mcp()
+    assert gemini_mod.uninstall_mcp() is True
+    data = _read(home)
+    assert "mcpServers" not in data
+
+
+def test_uninstall_mcp_keeps_other_servers(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    pre = {"mcpServers": {"other": {"command": "other"}}}
+    (home / "settings.json").write_text(json.dumps(pre))
+    gemini_mod.install_mcp()
+
+    assert gemini_mod.uninstall_mcp() is True
+    data = _read(home)
+    assert data["mcpServers"] == {"other": {"command": "other"}}
+
+
+def test_uninstall_mcp_noop_when_absent(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert gemini_mod.uninstall_mcp() is False
+
+
+def test_uninstall_mcp_noop_when_no_repowire_entry(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    pre = {"mcpServers": {"other": {"command": "other"}}}
+    (home / "settings.json").write_text(json.dumps(pre))
+    assert gemini_mod.uninstall_mcp() is False
+
+
+# -- Round-trip -------------------------------------------------------------
+
+
+def test_full_roundtrip_restores_user_config(tmp_path, monkeypatch):
+    home = _retarget(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    user_entry = {"hooks": [{"type": "command", "command": "/usr/local/bin/my-hook"}]}
+    original = {
+        "theme": "dark",
+        "hooks": {"AfterAgent": [user_entry]},
+        "mcpServers": {"other": {"command": "other"}},
+    }
+    (home / "settings.json").write_text(json.dumps(original))
+
+    gemini_mod.install_hooks()
+    gemini_mod.install_mcp()
+    gemini_mod.uninstall_hooks()
+    gemini_mod.uninstall_mcp()
+
+    data = _read(home)
+    assert data["theme"] == "dark"
+    assert data["hooks"]["AfterAgent"] == [user_entry]
+    assert data["mcpServers"] == {"other": {"command": "other"}}
+
+
+# -- check_* ----------------------------------------------------------------
+
+
+def test_check_hooks_installed_reflects_state(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert gemini_mod.check_hooks_installed() is False
+    gemini_mod.install_hooks()
+    assert gemini_mod.check_hooks_installed() is True
+    gemini_mod.uninstall_hooks()
+    assert gemini_mod.check_hooks_installed() is False
+
+
+def test_check_mcp_installed_reflects_state(tmp_path, monkeypatch):
+    _retarget(tmp_path, monkeypatch)
+    assert gemini_mod.check_mcp_installed() is False
+    gemini_mod.install_mcp()
+    assert gemini_mod.check_mcp_installed() is True
+    gemini_mod.uninstall_mcp()
+    assert gemini_mod.check_mcp_installed() is False


### PR DESCRIPTION
Closes #39.

Adds filesystem install/uninstall tests for the three installer modules that previously had no coverage. Follows the `tests/test_pi_installer.py` pattern: `tmp_path` + `monkeypatch.setattr` to rebind module-level path constants, then drive the real read/write code paths.

## Per-module test counts

- **`tests/test_codex_installer.py` — 18 tests**
  Covers `install_hooks` / `uninstall_hooks` on `~/.codex/hooks.json` and `install_mcp` / `uninstall_mcp` on `~/.codex/config.toml` (which is string-edited, not parsed). Cases: empty-config install, user-entry preservation (top-level keys, user hooks on shared and unrelated events, other `[mcp_servers.*]` sections), idempotency (install twice → byte-identical, no duplicate entries), uninstall round-trip (drops empty `hooks` key entirely), uninstall no-op when absent / only-user-entries, `[features] hooks = true` flag (added to bare config, injected into existing `[features]`, respected when user already set it false), `check_hooks_installed` / `check_mcp_installed` state transitions.

- **`tests/test_gemini_installer.py` — 18 tests**
  Covers `install_hooks` / `uninstall_hooks` / `install_mcp` / `uninstall_mcp` on `~/.gemini/settings.json` (single combined file). Cases: empty-config install (correct hook events `SessionStart` / `BeforeAgent` / `AfterAgent` with `--backend=gemini`), file written at `0o600` (atomic `.tmp + chmod + replace`), preservation of unrelated top-level keys and other `mcpServers` entries, idempotency (byte-identical re-run, single repowire entry per event), uninstall no-op variants, full install→install→uninstall→uninstall round-trip restoring the original user config.

- **`tests/test_claude_code_installer.py` — 23 tests**
  Covers `install_hooks` / `uninstall_hooks` on `~/.claude/settings.json` and `install_channel` / `uninstall_channel` on `~/.claude.json` (Claude Code's MCP path — there is no `install_mcp` helper; the channel installer is the MCP install). Cases: full hook set on empty config, `channel_mode=True` writes only Stop, preservation of unrelated top-level keys (theme, permissions) and unrelated event names, idempotency, replacement of stale repowire entries, full-vs-partial install distinction in `check_hooks_installed`. For `install_channel`: bun and version prerequisites are monkeypatched (`_has_bun`, `supports_channels`, `_find_channel_server`, `subprocess.run` for `bun install`) so tests are hermetic. Covers empty install, preservation of other MCP servers, idempotency, graceful failure when bun missing or version too old, and round-trip restoration.

## Test plan
- [x] `uv run pytest tests/test_codex_installer.py tests/test_gemini_installer.py tests/test_claude_code_installer.py` — 59 new tests pass
- [x] `uv run pytest` — full suite passes (826 tests)
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [ ] CI green