### PR TITLE
feat(notify): differentiate sent vs queued in bot acks (#92)

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -18,7 +18,7 @@ from collections import deque
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT, AgentType, Config
@@ -800,13 +800,18 @@ class PeerRegistry:
         text: str,
         bypass_circle: bool = False,
         circle: str | None = None,
-    ) -> None:
+    ) -> Literal["sent", "queued"]:
         """Send a notification to a peer (fire-and-forget).
 
         Direct wire send via the router. No daemon-side queueing: BUSY peers
         have a live WS and ws-hook buffers the tmux paste through the busy
         turn, so direct send is sufficient. Offline peers raise TransportError
         so callers can retry or escalate.
+
+        Returns:
+            "sent" if recipient was ONLINE at send-time (immediate delivery),
+            "queued" if recipient was BUSY (ws-hook holds the paste until the
+            current turn ends).
 
         Raises:
             ValueError: peer not found / circle boundary violated.
@@ -820,12 +825,16 @@ class PeerRegistry:
             peer_id = peer.peer_id
             peer_name = peer.display_name
             from_peer_id = from_obj.peer_id if from_obj else None
+            delivery_status: Literal["sent", "queued"] = (
+                "queued" if peer.status == PeerStatus.BUSY else "sent"
+            )
 
         self.add_event(
             "notification",
             {
                 "from": from_peer, "to": to_peer, "text": text,
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
+                "delivery_status": delivery_status,
             },
         )
 
@@ -835,6 +844,7 @@ class PeerRegistry:
             to_peer_name=peer_name,
             text=text,
         )
+        return delivery_status
 
     async def deliver_ask(
         self,

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -48,6 +48,18 @@ class NotifyRequest(BaseModel):
     circle: str | None = Field(None, description="Circle to scope target peer lookup")
 
 
+class NotifyResponse(BaseModel):
+    """Response from /notify.
+
+    ``status`` reflects the recipient's state at send-time: ``sent`` means
+    ONLINE (immediate paste), ``queued`` means BUSY (ws-hook holds the paste
+    until the current turn ends). Wire format otherwise unchanged.
+    """
+
+    ok: bool = True
+    status: Literal["sent", "queued"] = "sent"
+
+
 class BroadcastRequest(BaseModel):
     """Request to broadcast a message."""
 
@@ -133,15 +145,17 @@ async def query_peer(
         return QueryResponse(error=f"Query failed: {e}")
 
 
-@router.post("/notify", response_model=OkResponse)
+@router.post("/notify", response_model=NotifyResponse)
 async def notify_peer(
     request: NotifyRequest,
     _: str | None = Depends(require_auth),
-) -> OkResponse:
+) -> NotifyResponse:
     """Send a notification to a peer (fire-and-forget).
 
     Direct WS send. 503 if the recipient has no live connection so the
-    caller knows to retry later.
+    caller knows to retry later. Returns ``status=sent`` when the recipient
+    was ONLINE at send-time, ``status=queued`` when the recipient was BUSY
+    (ws-hook holds the paste until the agent's current turn ends).
     """
     from repowire.daemon.websocket_transport import TransportError
 
@@ -149,14 +163,14 @@ async def notify_peer(
     await peer_registry.lazy_repair()
 
     try:
-        await peer_registry.notify(
+        delivery_status = await peer_registry.notify(
             from_peer=request.from_peer,
             to_peer=request.to_peer,
             text=request.text,
             bypass_circle=request.bypass_circle,
             circle=request.circle,
         )
-        return OkResponse()
+        return NotifyResponse(status=delivery_status)
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/repowire/slack/bot.py
+++ b/repowire/slack/bot.py
@@ -376,7 +376,16 @@ class SlackPeer:
                 },
             )
             if r.status_code == 200:
-                await self._slack_send(f":white_check_mark: → *@{_esc(peer)}*")
+                try:
+                    delivery_status = r.json().get("status", "sent")
+                except Exception:
+                    delivery_status = "sent"
+                icon = (
+                    ":hourglass_flowing_sand:"
+                    if delivery_status == "queued"
+                    else ":white_check_mark:"
+                )
+                await self._slack_send(f"{icon} → *@{_esc(peer)}*")
             else:
                 try:
                     detail = r.json().get("detail", r.text)

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -680,7 +680,12 @@ class TelegramPeer:
             )
             if r.status_code == 200:
                 if message_id:
-                    await self._tg_react(message_id)
+                    try:
+                        delivery_status = r.json().get("status", "sent")
+                    except Exception:
+                        delivery_status = "sent"
+                    emoji = "⏳" if delivery_status == "queued" else "✓"
+                    await self._tg_react(message_id, emoji=emoji)
                 # No text reply on success — reaction is the confirmation
             else:
                 detail = r.json().get("detail", r.text)

--- a/tests/test_notification_buffer.py
+++ b/tests/test_notification_buffer.py
@@ -50,25 +50,27 @@ class TestNotifyDirectSend:
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
         recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
 
-        await registry.notify(
+        result = await registry.notify(
             from_peer=sender.display_name,
             to_peer=recipient.display_name,
         text="hi",
         )
 
         router.send_notification.assert_awaited_once()
+        assert result == "queued"
 
     async def test_notify_to_online_peer_sends_directly(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
         recipient = _add_peer(registry, "bob", PeerStatus.ONLINE)
 
-        await registry.notify(
+        result = await registry.notify(
             from_peer=sender.display_name,
             to_peer=recipient.display_name,
             text="hi",
         )
 
         router.send_notification.assert_awaited_once()
+        assert result == "sent"
 
     async def test_notify_propagates_transport_error(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -638,6 +638,69 @@ class TestNotify:
         })
         assert r.status_code == 404
 
+    async def test_notify_online_recipient_returns_sent(self, client, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from repowire.protocol.peers import PeerStatus
+
+        registry = get_peer_registry()
+        _sender_id, sender_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/sender",
+        )
+        recipient_id, recipient_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/recipient",
+        )
+        # Recipient is ONLINE (default from allocate_and_register)
+        registry._peers[recipient_id].status = PeerStatus.ONLINE
+        monkeypatch.setattr(
+            registry._router, "send_notification", AsyncMock(return_value=None),
+        )
+
+        r = await client.post("/notify", json={
+            "from_peer": sender_name,
+            "to_peer": recipient_name,
+            "text": "hello",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is True
+        assert body["status"] == "sent"
+
+    async def test_notify_busy_recipient_returns_queued(self, client, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from repowire.protocol.peers import PeerStatus
+
+        registry = get_peer_registry()
+        _sender_id, sender_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/sender2",
+        )
+        recipient_id, recipient_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/recipient2",
+        )
+        registry._peers[recipient_id].status = PeerStatus.BUSY
+        monkeypatch.setattr(
+            registry._router, "send_notification", AsyncMock(return_value=None),
+        )
+
+        r = await client.post("/notify", json={
+            "from_peer": sender_name,
+            "to_peer": recipient_name,
+            "text": "hello",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is True
+        assert body["status"] == "queued"
+
 
 # -- Broadcast --
 


### PR DESCRIPTION
## Summary

- `/notify` now returns `{ok: true, status: "sent" | "queued"}`. `status` reflects the recipient's state at send-time: `sent` when ONLINE (immediate paste), `queued` when BUSY (ws-hook holds the paste until the agent's current turn ends).
- Telegram bot reacts ✓ on `sent`, ⏳ on `queued`.
- Slack bot replies `:white_check_mark: → @peer` on `sent`, `:hourglass_flowing_sand: → @peer` on `queued`.
- `status` defaults to `"sent"` on the response model for back-compat with any existing 200 consumers that ignored the field.

Closes #92.

## Notes

PR #91 originally introduced a daemon-side BUSY queue but it was reverted in #104 ("Rip ask BUSY queue + turn-counter grace + once-only reminders"). Today the daemon already direct-sends to BUSY peers and ws-hook buffers the tmux paste through the busy turn — so "queued" here means "delivered to ws-hook while recipient was mid-turn; will land at turn end." That's the user-facing distinction the bot ack reflects.

## Test plan

- [x] `tests/test_notification_buffer.py` — registry-level: notify to ONLINE returns `"sent"`, notify to BUSY returns `"queued"`.
- [x] `tests/test_routes.py::TestNotify` — route-level: `/notify` returns `status="sent"` for ONLINE recipient, `status="queued"` for BUSY recipient. Existing 404 unchanged.
- [x] `uv run ruff check repowire/` clean.
- [x] `uv run ty check repowire/` clean.
- [x] Full suite: 769 passed.
- [ ] Manual sanity: mock a BUSY peer via `/session/update` and POST `/notify` to confirm `status=queued` end-to-end.