### PR TITLE
feat(sse): event-driven server push + client reconnection with gap recovery (#55)

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -105,6 +105,9 @@ class PeerRegistry:
         self._load_events()
         self._last_repair: float = 0.0
         self._repair_lock = asyncio.Lock()
+        # Per-subscriber wakeup events for SSE streamers. add_event() sets
+        # all of them; each streamer clears and waits on its own.
+        self._event_subscribers: set[asyncio.Event] = set()
 
     # ------------------------------------------------------------------
     # Mapping persistence
@@ -199,7 +202,32 @@ class PeerRegistry:
             }
         )
         self._events_dirty = True
+        for sub in self._event_subscribers:
+            sub.set()
         return event_id
+
+    def subscribe_events(self) -> asyncio.Event:
+        """Register a wakeup Event fired on each add_event call.
+
+        Caller must pair with unsubscribe_events on cleanup.
+        """
+        evt = asyncio.Event()
+        self._event_subscribers.add(evt)
+        return evt
+
+    def unsubscribe_events(self, evt: asyncio.Event) -> None:
+        """Remove a subscriber Event registered via subscribe_events."""
+        self._event_subscribers.discard(evt)
+
+    def events_since(self, event_id: str | None) -> list[dict[str, Any]]:
+        """Return events after the given id. If id is None or evicted, return all."""
+        events = list(self._events)
+        if event_id is None:
+            return events
+        for i, event in enumerate(events):
+            if event["id"] == event_id:
+                return events[i + 1 :]
+        return events
 
     def _update_event(self, event_id: str, updates: dict[str, Any]) -> bool:
         """Update an existing event by ID."""

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -328,11 +328,24 @@ async def ingest_chat_turn(
 
 @router.get("/events")
 async def get_events(
+    since: str | None = Query(None, description="Return events after this event id"),
     _: str | None = Depends(require_auth),
 ) -> list[dict]:
-    """Get the last 100 communication events."""
+    """Get communication events.
+
+    Without ``since``: returns the full buffered window (last 500).
+    With ``since``: returns events after the given id, or the full window if
+    the id has been evicted from the buffer (gap-recovery fallback).
+    """
     peer_registry = get_peer_registry()
-    return peer_registry.get_events()
+    if since is None:
+        return peer_registry.get_events()
+    return peer_registry.events_since(since)
+
+
+# Heartbeat interval for SSE keep-alives. Long enough that idle connections
+# aren't chatty, short enough that proxies/clients notice a dead socket.
+SSE_HEARTBEAT_SECS = 15.0
 
 
 @router.get("/events/stream")
@@ -341,46 +354,41 @@ async def stream_events(
 ) -> StreamingResponse:
     """Stream events via Server-Sent Events (SSE).
 
-    Clients connect once and receive events as they occur.
+    Event-driven: blocks on an asyncio.Event set by ``add_event``, with a
+    periodic comment-frame heartbeat so both ends detect dead connections.
     """
     peer_registry = get_peer_registry()
 
     async def event_generator():
+        # Subscribe before the initial flush so events added concurrently
+        # with the flush still wake us on the next loop iteration.
+        wakeup = peer_registry.subscribe_events()
         last_event_id: str | None = None
-        while True:
-            events = peer_registry.get_events()
+        try:
+            initial = peer_registry.get_events()
+            for event in initial:
+                yield f"data: {json.dumps(event)}\n\n"
+            if initial:
+                last_event_id = initial[-1]["id"]
+            # Clear any signals raised during the initial flush; we've already
+            # delivered everything currently buffered.
+            wakeup.clear()
 
-            # Find new events since last seen ID
-            if not events:
-                await asyncio.sleep(0.5)
-                continue
+            while True:
+                try:
+                    await asyncio.wait_for(wakeup.wait(), timeout=SSE_HEARTBEAT_SECS)
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+                    continue
+                wakeup.clear()
 
-            if last_event_id is None:
-                # First poll: send all current events
-                for event in events:
-                    yield f"data: {json.dumps(event)}\n\n"
-                last_event_id = events[-1]["id"]
-            else:
-                # Find index after last seen event
-                new_events = []
-                seen = False
-                for event in events:
-                    if seen:
-                        new_events.append(event)
-                    elif event["id"] == last_event_id:
-                        seen = True
-
-                if not seen:
-                    # last_event_id was evicted from deque; send all
-                    new_events = events
-
+                new_events = peer_registry.events_since(last_event_id)
                 for event in new_events:
                     yield f"data: {json.dumps(event)}\n\n"
-
                 if new_events:
                     last_event_id = new_events[-1]["id"]
-
-            await asyncio.sleep(0.5)
+        finally:
+            peer_registry.unsubscribe_events(wakeup)
 
     return StreamingResponse(
         event_generator(),

--- a/tests/test_sse_stream.py
+++ b/tests/test_sse_stream.py
@@ -1,0 +1,156 @@
+"""SSE event-driven push tests.
+
+Validates the event-driven path replacing the old 0.5s poll loop:
+  - add_event() wakes a subscribed waiter within ~10ms
+  - every subscriber is woken (no single-consumer race)
+  - GET /events?since=<id> returns the gap-recovery slice
+
+The streaming endpoint itself is exercised via the registry primitives
+(subscribe_events / events_since) rather than the HTTP stream, because
+httpx's ASGITransport does not reliably surface intermediate SSE chunks
+to the client before the generator completes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon.deps import init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import messages
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_registry(tmp_path: Path) -> PeerRegistry:
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    return registry
+
+
+def _make_app(tmp_path: Path) -> tuple[FastAPI, PeerRegistry]:
+    registry = _make_registry(tmp_path)
+    cfg = registry._config
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=registry._transport,
+        query_tracker=registry._query_tracker,
+        message_router=registry._router,
+        peer_registry=registry,
+        relay_mode=cfg.relay.enabled,
+    )
+    init_deps(cfg, registry, app_state)
+    app = FastAPI()
+    app.include_router(messages.router)
+    return app, registry
+
+
+@pytest.mark.asyncio
+async def test_add_event_wakes_subscriber_within_10ms(tmp_path):
+    """add_event() must wake a subscribed Event within ~10ms (not the old 500ms)."""
+    registry = _make_registry(tmp_path)
+    wakeup = registry.subscribe_events()
+    try:
+        loop = asyncio.get_event_loop()
+
+        async def fire():
+            await asyncio.sleep(0.005)
+            registry.add_event("wake_test", {"payload": "ping"})
+
+        fire_task = asyncio.create_task(fire())
+        start = loop.time()
+        await asyncio.wait_for(wakeup.wait(), timeout=1.0)
+        elapsed = loop.time() - start
+        await fire_task
+
+        # Old behavior bound was 500ms; event-driven should be < 50ms.
+        assert elapsed < 0.05, f"wake took {elapsed:.4f}s — slower than event-driven"
+
+        new = registry.events_since(None)
+        assert new and new[-1]["type"] == "wake_test"
+    finally:
+        registry.unsubscribe_events(wakeup)
+
+
+@pytest.mark.asyncio
+async def test_add_event_fans_out_to_all_subscribers(tmp_path):
+    """Every subscriber gets woken — confirms no single-consumer race."""
+    registry = _make_registry(tmp_path)
+    a = registry.subscribe_events()
+    b = registry.subscribe_events()
+    c = registry.subscribe_events()
+    try:
+        registry.add_event("fanout", {})
+        # All three should be set without blocking.
+        await asyncio.wait_for(asyncio.gather(a.wait(), b.wait(), c.wait()), timeout=0.5)
+        assert a.is_set() and b.is_set() and c.is_set()
+    finally:
+        registry.unsubscribe_events(a)
+        registry.unsubscribe_events(b)
+        registry.unsubscribe_events(c)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_wakeups(tmp_path):
+    """After unsubscribe, add_event does not set the (detached) Event."""
+    registry = _make_registry(tmp_path)
+    wakeup = registry.subscribe_events()
+    registry.unsubscribe_events(wakeup)
+
+    registry.add_event("post_unsub", {})
+    assert not wakeup.is_set()
+
+
+@pytest.mark.asyncio
+async def test_events_since_slice(tmp_path):
+    """events_since returns the correct slice and falls back on unknown id."""
+    registry = _make_registry(tmp_path)
+    id_a = registry.add_event("a", {})
+    id_b = registry.add_event("b", {})
+    id_c = registry.add_event("c", {})
+
+    assert [e["id"] for e in registry.events_since(id_a)] == [id_b, id_c]
+    assert registry.events_since(id_c) == []
+    # Unknown id → return full buffer (gap-recovery)
+    full = [e["id"] for e in registry.events_since("missing")]
+    assert full == [id_a, id_b, id_c]
+    # None → full buffer
+    assert [e["id"] for e in registry.events_since(None)] == [id_a, id_b, id_c]
+
+
+@pytest.mark.asyncio
+async def test_get_events_since_query_param(tmp_path):
+    """GET /events?since=<id> exposes events_since over HTTP."""
+    app, registry = _make_app(tmp_path)
+    id_a = registry.add_event("a", {})
+    id_b = registry.add_event("b", {})
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/events?since={id_a}")
+        assert resp.status_code == 200
+        assert [e["id"] for e in resp.json()] == [id_b]
+
+        resp = await client.get("/events?since=does-not-exist")
+        assert [e["id"] for e in resp.json()] == [id_a, id_b]
+
+        resp = await client.get("/events")
+        assert [e["id"] for e in resp.json()] == [id_a, id_b]

--- a/web/app/dashboard/components/TopBar.tsx
+++ b/web/app/dashboard/components/TopBar.tsx
@@ -1,22 +1,24 @@
 import Image from "next/image";
 import { Plus, RefreshCw, Settings } from "lucide-react";
 import { cn } from "../lib/utils";
+import type { ConnectionState } from "../lib/useEventStream";
 
 export function TopBar({
   counts,
-  isConnected,
+  connection,
   isRefreshing,
   onRefresh,
   onSpawn,
   onSettings,
 }: {
   counts: Record<"online" | "busy" | "offline", number>;
-  isConnected: boolean;
+  connection: ConnectionState;
   isRefreshing: boolean;
   onRefresh: () => void;
   onSpawn: () => void;
   onSettings: () => void;
 }) {
+  const badge = connectionBadge(connection);
   return (
     <header className="sticky top-0 z-30 col-span-full flex min-h-[calc(48px+env(safe-area-inset-top))] items-center gap-3 border-b border-border-faint bg-surface-dim px-3 pt-[env(safe-area-inset-top)] md:static md:h-[52px] md:min-h-0 md:px-5 md:pt-0">
       <div className="flex min-w-0 items-center gap-3 md:w-[397px]">
@@ -35,14 +37,13 @@ export function TopBar({
       <div
         className={cn(
           "ml-auto flex items-center gap-2 border px-2.5 py-1 font-mono text-[10px] font-semibold tracking-[0.16em] md:ml-0",
-          isConnected
-            ? "border-secondary/25 bg-secondary/10 text-secondary"
-            : "border-error/25 bg-error/10 text-error"
+          badge.className,
         )}
+        title={badge.title}
       >
-        <span className={cn("h-2 w-2 rounded-full", isConnected ? "bg-secondary pulse-online" : "bg-error")} />
-        <span className="hidden sm:inline">{isConnected ? "MESH CONNECTED" : "DISCONNECTED"}</span>
-        <span className="sm:hidden">{isConnected ? "LIVE" : "DOWN"}</span>
+        <span className={cn("h-2 w-2 rounded-full", badge.dot)} />
+        <span className="hidden sm:inline">{badge.long}</span>
+        <span className="sm:hidden">{badge.short}</span>
       </div>
 
       <button
@@ -68,6 +69,42 @@ export function TopBar({
       </button>
     </header>
   );
+}
+
+interface BadgeSpec {
+  className: string;
+  dot: string;
+  long: string;
+  short: string;
+  title: string;
+}
+
+function connectionBadge(state: ConnectionState): BadgeSpec {
+  if (state.status === "live") {
+    return {
+      className: "border-secondary/25 bg-secondary/10 text-secondary",
+      dot: "bg-secondary pulse-online",
+      long: "MESH CONNECTED",
+      short: "LIVE",
+      title: "Connected to daemon event stream",
+    };
+  }
+  if (state.status === "reconnecting") {
+    return {
+      className: "border-tertiary-fixed-dim/30 bg-tertiary-fixed-dim/10 text-tertiary-fixed-dim",
+      dot: "bg-tertiary-fixed-dim glow-busy",
+      long: `RECONNECTING ${state.retryInSec}s`,
+      short: `${state.retryInSec}s`,
+      title: `Connection dropped. Retrying in ${state.retryInSec}s.`,
+    };
+  }
+  return {
+    className: "border-error/25 bg-error/10 text-error",
+    dot: "bg-error",
+    long: "DISCONNECTED",
+    short: "DOWN",
+    title: "Not connected to daemon event stream",
+  };
 }
 
 function CountPill({ label, value, tone }: { label: string; value: number; tone: "online" | "busy" | "offline" }) {

--- a/web/app/dashboard/lib/useEventStream.ts
+++ b/web/app/dashboard/lib/useEventStream.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Event } from "../types";
+
+/**
+ * Connection state for the SSE event stream.
+ *
+ *   live          - EventSource is open
+ *   reconnecting  - dropped; waiting `retryInSec` before next attempt
+ *   disconnected  - initial state, or never connected
+ */
+export type ConnectionState =
+  | { status: "live" }
+  | { status: "reconnecting"; retryInSec: number }
+  | { status: "disconnected" };
+
+interface UseEventStreamOptions {
+  apiBase: string;
+  /** Called for every newly-seen event (already deduped by id). */
+  onEvent: (event: Event) => void;
+  /** Called after a successful reconnect once gap recovery completes. */
+  onReconnected?: () => void;
+  /** Last-seen event id getter (a ref-like accessor, so the manager always reads fresh). */
+  getLastSeenId: () => string | null;
+}
+
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+const JITTER_RATIO = 0.2;
+
+function nextBackoff(prev: number): number {
+  const grown = Math.min(prev * 2, MAX_BACKOFF_MS);
+  const jitter = grown * JITTER_RATIO * (Math.random() * 2 - 1);
+  return Math.max(500, grown + jitter);
+}
+
+function isValidEvent(value: unknown): value is Event {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "string" &&
+    typeof v.type === "string" &&
+    typeof v.timestamp === "string"
+  );
+}
+
+/**
+ * Subscribe to /events/stream with exponential backoff reconnection and
+ * gap recovery via /events?since=<last_seen_id> on each reconnect.
+ *
+ * Returns the current connection state for UI rendering.
+ */
+export function useEventStream({
+  apiBase,
+  onEvent,
+  onReconnected,
+  getLastSeenId,
+}: UseEventStreamOptions): ConnectionState {
+  const [state, setState] = useState<ConnectionState>({ status: "disconnected" });
+  const onEventRef = useRef(onEvent);
+  const onReconnectedRef = useRef(onReconnected);
+  const getLastSeenIdRef = useRef(getLastSeenId);
+
+  // Keep callback refs current without re-running the effect (which would
+  // close and re-open the SSE connection on every render).
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+  useEffect(() => {
+    onReconnectedRef.current = onReconnected;
+  }, [onReconnected]);
+  useEffect(() => {
+    getLastSeenIdRef.current = getLastSeenId;
+  }, [getLastSeenId]);
+
+  useEffect(() => {
+    let disposed = false;
+    let source: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let countdownTimer: ReturnType<typeof setInterval> | null = null;
+    let backoffMs = INITIAL_BACKOFF_MS;
+    let hasConnected = false;
+
+    const clearTimers = () => {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (countdownTimer) {
+        clearInterval(countdownTimer);
+        countdownTimer = null;
+      }
+    };
+
+    const recoverGap = async () => {
+      const lastSeen = getLastSeenIdRef.current();
+      if (!lastSeen) return;
+      try {
+        const res = await fetch(`${apiBase}/events?since=${encodeURIComponent(lastSeen)}`);
+        if (!res.ok) return;
+        const missed: unknown = await res.json();
+        if (!Array.isArray(missed)) return;
+        for (const item of missed) {
+          if (isValidEvent(item)) onEventRef.current(item);
+        }
+      } catch {
+        // Network errors during gap fetch are non-fatal — the live stream
+        // will resume; we just miss whatever happened during the outage.
+      }
+    };
+
+    const connect = () => {
+      if (disposed) return;
+      clearTimers();
+      source = new EventSource(`${apiBase}/events/stream`);
+
+      source.onopen = () => {
+        backoffMs = INITIAL_BACKOFF_MS;
+        setState({ status: "live" });
+        if (hasConnected) {
+          void recoverGap().then(() => onReconnectedRef.current?.());
+        }
+        hasConnected = true;
+      };
+
+      source.onmessage = (e) => {
+        try {
+          const parsed: unknown = JSON.parse(e.data);
+          if (isValidEvent(parsed)) onEventRef.current(parsed);
+        } catch (err) {
+          console.error("Failed to parse SSE event:", err);
+        }
+      };
+
+      source.onerror = () => {
+        if (disposed) return;
+        source?.close();
+        source = null;
+
+        const delay = backoffMs;
+        backoffMs = nextBackoff(backoffMs);
+
+        const startedAt = Date.now();
+        const tick = () => {
+          const remaining = Math.max(0, delay - (Date.now() - startedAt));
+          setState({ status: "reconnecting", retryInSec: Math.ceil(remaining / 1000) });
+        };
+        tick();
+        countdownTimer = setInterval(tick, 500);
+        reconnectTimer = setTimeout(() => {
+          clearTimers();
+          connect();
+        }, delay);
+      };
+    };
+
+    connect();
+
+    return () => {
+      disposed = true;
+      clearTimers();
+      source?.close();
+    };
+  }, [apiBase]);
+
+  return state;
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "./lib/utils";
+import { useEventStream } from "./lib/useEventStream";
 import { SettingsDialog, SpawnDialog } from "./components/DashboardDialogs";
 import { MeshFeed } from "./components/MeshFeed";
 import { MobileTabs, type MobileTab } from "./components/MobileTabs";
@@ -34,7 +35,6 @@ function DashboardInner() {
   const [peers, setPeers] = useState<Peer[]>([]);
   const [events, setEvents] = useState<Event[]>([]);
   const [orchestrators, setOrchestrators] = useState<OrchestratorStatus[]>([]);
-  const [isConnected, setIsConnected] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [selectedPeerId, setSelectedPeerId] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
@@ -42,6 +42,7 @@ function DashboardInner() {
   const [showSpawn, setShowSpawn] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const eventIdsRef = useRef<Set<string>>(new Set());
+  const lastSeenIdRef = useRef<string | null>(null);
   const peersRef = useRef<Peer[]>([]);
 
   const fetchOrchestrators = useCallback(async (nextPeers?: Peer[]) => {
@@ -108,12 +109,33 @@ function DashboardInner() {
       if (res.ok) {
         const data: Event[] = await res.json();
         eventIdsRef.current = new Set(data.map((event) => event.id));
+        if (data.length > 0) lastSeenIdRef.current = data[data.length - 1].id;
         setEvents(data);
       }
     } catch (error) {
       console.error("Failed to fetch events:", error);
     }
   }, []);
+
+  const ingestEvent = useCallback(
+    (event: Event) => {
+      if (eventIdsRef.current.has(event.id)) return;
+      eventIdsRef.current.add(event.id);
+      lastSeenIdRef.current = event.id;
+      setEvents((prev) => {
+        const next = [...prev, event];
+        return next.length > 500 ? next.slice(-500) : next;
+      });
+      if (event.type === "status_change") void fetchPeers();
+    },
+    [fetchPeers],
+  );
+
+  const connection = useEventStream({
+    apiBase: API_BASE,
+    onEvent: ingestEvent,
+    getLastSeenId: useCallback(() => lastSeenIdRef.current, []),
+  });
 
   const refreshData = useCallback(async () => {
     setIsRefreshing(true);
@@ -122,42 +144,7 @@ function DashboardInner() {
   }, [fetchEvents, fetchPeers]);
 
   useEffect(() => {
-    const loadInitialData = async () => {
-      await Promise.all([fetchPeers(), fetchEvents()]);
-    };
-    void loadInitialData();
-
-    const eventSource = new EventSource(`${API_BASE}/events/stream`);
-    eventSource.onopen = () => setIsConnected(true);
-    eventSource.onmessage = (e) => {
-      try {
-        const parsed: unknown = JSON.parse(e.data);
-        if (
-          typeof parsed === "object" &&
-          parsed !== null &&
-          "id" in parsed &&
-          "type" in parsed &&
-          "timestamp" in parsed &&
-          typeof (parsed as Record<string, unknown>).id === "string" &&
-          typeof (parsed as Record<string, unknown>).type === "string" &&
-          typeof (parsed as Record<string, unknown>).timestamp === "string"
-        ) {
-          const event = parsed as Event;
-          if (eventIdsRef.current.has(event.id)) return;
-          eventIdsRef.current.add(event.id);
-          setEvents((prev) => {
-            const next = [...prev, event];
-            return next.length > 500 ? next.slice(-500) : next;
-          });
-          if (event.type === "status_change") fetchPeers();
-        }
-      } catch (error) {
-        console.error("Failed to parse SSE event:", error);
-      }
-    };
-    eventSource.onerror = () => setIsConnected(false);
-
-    return () => eventSource.close();
+    void Promise.all([fetchPeers(), fetchEvents()]);
   }, [fetchEvents, fetchPeers]);
 
   const selectedPeer = useMemo(
@@ -223,7 +210,7 @@ function DashboardInner() {
       <div className="flex min-h-dvh flex-col md:grid md:h-full md:min-h-0 md:grid-cols-[420px_1fr] md:grid-rows-[52px_auto_1fr]">
         <TopBar
           counts={counts}
-          isConnected={isConnected}
+          connection={connection}
           isRefreshing={isRefreshing}
           onRefresh={refreshData}
           onSpawn={() => setShowSpawn(true)}
@@ -292,7 +279,7 @@ function DashboardInner() {
       {showSettings && (
         <SettingsDialog
           apiBase={API_BASE}
-          isConnected={isConnected}
+          isConnected={connection.status === "live"}
           peers={peers}
           onClose={() => setShowSettings(false)}
         />


### PR DESCRIPTION
## Summary

Closes #55. Replaces the dashboard SSE polling loop with event-driven push and adds resilient client-side reconnection with gap recovery.

**Server (`repowire/daemon/`)**
- `PeerRegistry.add_event()` now fans out to per-subscriber `asyncio.Event`s via new `subscribe_events()` / `unsubscribe_events()`. No more 0.5s poll in the SSE generator.
- `stream_events` awaits its wakeup Event with a 15s timeout; on timeout emits a `: keepalive` comment frame so dead connections are detected by both ends. `finally` block guarantees subscriber cleanup on `CancelledError` (client disconnect).
- `GET /events` gains optional `?since=<id>` query param. Returns events strictly after the id, or the full buffer if the id has been evicted (gap-recovery fallback).
- Wire format is unchanged. Old clients that just read `/events/stream` continue to work, just without backoff or gap recovery.

**Client (`web/app/dashboard/`)**
- New `useEventStream` hook wraps `EventSource` with exponential backoff (1s → 30s, ±20% jitter), per-event dedupe via id, and `/events?since=<last_seen_id>` fetch on each successful reconnect.
- `TopBar` connection chip now renders three states: `MESH CONNECTED` (live, green), `RECONNECTING Ns` (amber countdown), `DISCONNECTED` (red).
- `page.tsx` tracks `lastSeenIdRef` updated on every ingested event so gap recovery has a stable cursor.

## Test plan

- [x] `pytest -q` — 836 passed
- [x] `ruff check repowire/` clean
- [x] `uv run ty check repowire/` clean
- [x] `npm run build` clean from `web/`
- [x] New `tests/test_sse_stream.py`:
  - `add_event` wakes a subscribed waiter within <50ms (proves no 500ms poll)
  - fan-out to multiple subscribers (regression guard against single-consumer race)
  - `unsubscribe_events` detaches cleanly
  - `events_since` returns correct slice; unknown id falls back to full buffer
  - `GET /events?since=<id>` returns the slice over HTTP
- [ ] Live smoke against running daemon (verify keepalive frames every 15s + reconnect badge on simulated `daemon stop/start`) — deferred to review iteration

## Notes for review

- The httpx `ASGITransport` doesn't reliably surface intermediate SSE chunks before the streaming generator completes, so the wake-latency property is exercised at the registry primitive level (`subscribe_events` + `add_event`). This still proves the relevant property: no polling, sub-50ms wake.
- Heartbeat interval is 15s, matching what the brief suggested. Tunable via `SSE_HEARTBEAT_SECS` in `repowire/daemon/routes/messages.py`.