### PR TITLE
Fix stale peer id reconnect drift

### DIFF
--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -99,6 +99,7 @@ class MessageRouter:
         to_session_id: str,
         to_peer_name: str,
         text: str,
+        intended_recipient_name: str | None = None,
     ) -> None:
         """Send a plain FYI notification (fire-and-forget, no lifecycle).
 
@@ -114,6 +115,15 @@ class MessageRouter:
             "to_peer": to_peer_name,
             "text": text,
         }
+        logger.info(
+            "Notify delivery trace: sender_identity=%s intended_recipient_name=%s "
+            "resolved_peer_id=%s frame.to_peer=%s actual_delivered_pane_id=%s",
+            from_peer,
+            intended_recipient_name or to_peer_name,
+            to_session_id,
+            message["to_peer"],
+            self._transport.get_connection_pane_id(to_session_id),
+        )
         await self._transport.send(to_session_id, message)
         logger.info(f"Notification sent: {from_peer} -> {to_peer_name}")
 
@@ -125,6 +135,7 @@ class MessageRouter:
         correlation_id: str,
         text: str,
         reply_to: str | None = None,
+        intended_recipient_name: str | None = None,
     ) -> None:
         """Send a first-class ask wire message.
 
@@ -150,6 +161,15 @@ class MessageRouter:
         }
         if reply_to is not None:
             message["reply_to"] = reply_to
+        logger.info(
+            "Ask delivery trace: sender_identity=%s intended_recipient_name=%s "
+            "resolved_peer_id=%s frame.to_peer=%s actual_delivered_pane_id=%s",
+            from_peer,
+            intended_recipient_name or to_peer_name,
+            to_session_id,
+            message["to_peer"],
+            self._transport.get_connection_pane_id(to_session_id),
+        )
         await self._transport.send(to_session_id, message)
         logger.info(f"Ask sent: {from_peer} -> {to_peer_name} ({correlation_id[:8]})")
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -491,23 +491,39 @@ class PeerRegistry:
         """
         async with self._lock:
             # Reconnect: if caller provides a peer_id that exists, take over
+            # only when it still describes the same peer identity. Stale pane
+            # metadata can otherwise bind another pane's WebSocket to this id.
             if peer_id and peer_id in self._peers:
                 existing = self._peers[peer_id]
-                old_status = existing.status
-                existing.status = PeerStatus.ONLINE
-                existing.last_seen = datetime.now(timezone.utc)
-                if turn_state is not None:
-                    existing.turn_state = turn_state
-                self._emit_status_change(existing, old_status, PeerStatus.ONLINE)
-                if pane_id:
-                    self._release_pane(pane_id, peer_id)
-                    existing.pane_id = pane_id
-                if tmux_session:
-                    existing.tmux_session = tmux_session
-                if machine != "unknown":
-                    existing.machine = machine
-                logger.info(f"Peer reconnected: {existing.display_name} ({peer_id})")
-                return peer_id, existing.display_name
+                same_backend = existing.backend == backend
+                same_path = not existing.path or not path or existing.path == path
+                if not same_backend or not same_path:
+                    logger.warning(
+                        "Ignoring stale peer_id claim %s: existing=%s backend=%s path=%s "
+                        "claim_backend=%s claim_path=%s",
+                        peer_id,
+                        existing.display_name,
+                        existing.backend.value,
+                        existing.path,
+                        backend.value,
+                        path,
+                    )
+                else:
+                    old_status = existing.status
+                    existing.status = PeerStatus.ONLINE
+                    existing.last_seen = datetime.now(timezone.utc)
+                    if turn_state is not None:
+                        existing.turn_state = turn_state
+                    self._emit_status_change(existing, old_status, PeerStatus.ONLINE)
+                    if pane_id:
+                        self._release_pane(pane_id, peer_id)
+                        existing.pane_id = pane_id
+                    if tmux_session:
+                        existing.tmux_session = tmux_session
+                    if machine != "unknown":
+                        existing.machine = machine
+                    logger.info(f"Peer reconnected: {existing.display_name} ({peer_id})")
+                    return peer_id, existing.display_name
 
             # Fresh registration: daemon owns the name
             assigned_name = self._build_display_name(path or "", circle, backend)
@@ -871,6 +887,7 @@ class PeerRegistry:
             to_session_id=peer_id,
             to_peer_name=peer_name,
             text=text,
+            intended_recipient_name=to_peer,
         )
         return delivery_status
 
@@ -921,6 +938,7 @@ class PeerRegistry:
             correlation_id=correlation_id,
             text=text,
             reply_to=reply_to,
+            intended_recipient_name=to_peer,
         )
 
     async def broadcast(

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -151,7 +151,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         session_id = peer_id
 
         # Register with transport (handles connection + status tracking)
-        await transport.connect(session_id, websocket)
+        await transport.connect(
+            session_id,
+            websocket,
+            pane_id=pane_id,
+            display_name=assigned_name,
+        )
 
         # Send connect response with daemon-assigned name
         await websocket.send_json({

--- a/repowire/daemon/websocket_transport.py
+++ b/repowire/daemon/websocket_transport.py
@@ -24,6 +24,8 @@ class ConnectionInfo:
 
     session_id: str
     websocket: WebSocket
+    pane_id: str | None = None
+    display_name: str | None = None
     connected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
@@ -39,7 +41,13 @@ class WebSocketTransport:
         self._lock = asyncio.Lock()
         self._pong_futures: dict[str, asyncio.Future[dict]] = {}
 
-    async def connect(self, session_id: str, websocket: WebSocket) -> None:
+    async def connect(
+        self,
+        session_id: str,
+        websocket: WebSocket,
+        pane_id: str | None = None,
+        display_name: str | None = None,
+    ) -> None:
         """Register WebSocket connection.
 
         If a connection already exists for this session_id, replace it
@@ -52,6 +60,8 @@ class WebSocketTransport:
             self._connections[session_id] = ConnectionInfo(
                 session_id=session_id,
                 websocket=websocket,
+                pane_id=pane_id,
+                display_name=display_name,
             )
             logger.info(f"Registered connection for {session_id}")
 
@@ -107,6 +117,11 @@ class WebSocketTransport:
     def get_all_sessions(self) -> list[str]:
         """Get all connected session IDs."""
         return list(self._connections.keys())
+
+    def get_connection_pane_id(self, session_id: str) -> str | None:
+        """Return the pane currently bound to a WebSocket session, if known."""
+        conn = self._connections.get(session_id)
+        return conn.pane_id if conn else None
 
     async def ping(self, session_id: str, timeout: float = 5.0) -> dict:
         """Send a ping to a peer and wait for pong.

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1,5 +1,6 @@
 """Tests for MessageRouter — query, notification, and broadcast delivery."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -35,12 +36,32 @@ class TestSendNotification:
         msg = transport.send.call_args[0][1]
         assert msg["type"] == "notify"
         assert msg["from_peer"] == "sender"
+        assert msg["to_peer"] == "recipient"
         assert msg["text"] == "hello"
 
     async def test_transport_error_propagates(self, router, transport):
         transport.send.side_effect = TransportError("disconnected")
         with pytest.raises(TransportError):
             await router.send_notification("sender", "sid-1", "recipient", "hello")
+
+    async def test_logs_delivery_trace(self, router, transport, caplog):
+        caplog.set_level(logging.INFO, logger="repowire.daemon.message_router")
+        transport.get_connection_pane_id.return_value = "%7"
+
+        await router.send_notification(
+            "sender",
+            "sid-1",
+            "recipient",
+            "hello",
+            intended_recipient_name="requested-name",
+        )
+
+        assert "Notify delivery trace" in caplog.text
+        assert "sender_identity=sender" in caplog.text
+        assert "intended_recipient_name=requested-name" in caplog.text
+        assert "resolved_peer_id=sid-1" in caplog.text
+        assert "frame.to_peer=recipient" in caplog.text
+        assert "actual_delivered_pane_id=%7" in caplog.text
 
 
 class TestSendQuery:
@@ -127,6 +148,7 @@ class TestSendAsk:
         assert msg["type"] == "ask"
         assert msg["correlation_id"] == "ask-abc"
         assert msg["from_peer"] == "alice"
+        assert msg["to_peer"] == "bob"
         assert msg["text"].startswith("ping?\n")
         assert '↳ ack("ask-abc")' in msg["text"]
         assert 'ack("ask-abc", "reply")' in msg["text"]

--- a/tests/test_notification_buffer.py
+++ b/tests/test_notification_buffer.py
@@ -57,7 +57,36 @@ class TestNotifyDirectSend:
         )
 
         router.send_notification.assert_awaited_once()
+        kwargs = router.send_notification.await_args.kwargs
+        assert kwargs["to_session_id"] == recipient.peer_id
+        assert kwargs["to_peer_name"] == recipient.display_name
+        assert kwargs["intended_recipient_name"] == recipient.display_name
         assert result == "queued"
+
+    async def test_quick_busy_notifies_keep_frame_target_on_actual_target(
+        self, registry, router,
+    ):
+        sender = _add_peer(registry, "alice", PeerStatus.ONLINE)
+        recipient = _add_peer(registry, "bob", PeerStatus.BUSY)
+
+        first = await registry.notify(
+            from_peer=sender.display_name,
+            to_peer=recipient.display_name,
+            text="first",
+        )
+        second = await registry.notify(
+            from_peer=sender.display_name,
+            to_peer=recipient.peer_id,
+            text="second",
+        )
+        await registry.update_peer_status(recipient.peer_id, PeerStatus.ONLINE)
+
+        assert (first, second) == ("queued", "queued")
+        assert router.send_notification.await_count == 2
+        calls = router.send_notification.await_args_list
+        for call in calls:
+            assert call.kwargs["to_session_id"] == recipient.peer_id
+            assert call.kwargs["to_peer_name"] == recipient.display_name
 
     async def test_notify_to_online_peer_sends_directly(self, registry, router):
         sender = _add_peer(registry, "alice", PeerStatus.ONLINE)

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -176,6 +176,36 @@ async def test_lookup_prefers_pane_owned_peer_when_names_collide(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_stale_peer_id_claim_does_not_steal_existing_peer(tmp_path):
+    """A stale REPOWIRE_PEER_ID must not bind a different pane to an old peer."""
+    registry = _make_registry(tmp_path)
+
+    sse_id, sse_name = await registry.allocate_and_register(
+        circle="dev",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/repowire.feat-sse-improve",
+        pane_id="%1",
+    )
+
+    claimed_id, claimed_name = await registry.allocate_and_register(
+        circle="dev",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/repowire-orchestrator",
+        pane_id="%2",
+        peer_id=sse_id,
+    )
+
+    assert claimed_id != sse_id
+    assert claimed_name != sse_name
+    sse_peer = await registry.get_peer(sse_id)
+    assert sse_peer is not None
+    assert sse_peer.pane_id == "%1"
+    claimed_peer = await registry.get_peer_by_pane("%2")
+    assert claimed_peer is not None
+    assert claimed_peer.peer_id == claimed_id
+
+
+@pytest.mark.asyncio
 async def test_circle_and_description_persist_across_restart(tmp_path):
     """A peer re-registering after restart restores its prior circle + description.
 


### PR DESCRIPTION
## Summary
- reject stale WebSocket peer_id reconnect claims when backend/path do not match the existing peer
- add notify/ask delivery trace logs with intended recipient, resolved peer id, frame to_peer, and bound pane id
- add regressions for BUSY notify frame stamping and stale peer_id claim drift

## Tests
- uv run ruff check repowire/ tests/test_message_router.py tests/test_notification_buffer.py tests/test_session_mapper.py
- uv run ty check repowire/
- uv run pytest