### PR TITLE
feat(daemon): TTL-based peer description auto-clear (#162)

### DIFF
--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -145,6 +145,17 @@ class DaemonConfig(BaseModel):
         default=24, description="Remove session mappings and offline peers older than this",
     )
 
+    # Peer description TTL — clears stale task descriptions on read.
+    # Peers tend to forget to clear their set_description after a task ends;
+    # this caps the staleness window without requiring a background sweep.
+    description_ttl_seconds: float = Field(
+        default=900,
+        description=(
+            "Seconds before a peer's task description is auto-cleared on read. "
+            "Set to 0 to disable."
+        ),
+    )
+
     # Spawn settings
     spawn: SpawnSettings = Field(default_factory=SpawnSettings)
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -109,6 +109,11 @@ class PeerRegistry:
         # all of them; each streamer clears and waits on its own.
         self._event_subscribers: set[asyncio.Event] = set()
 
+        # When each peer's current description was set. Used for clear-on-read
+        # TTL — see config.daemon.description_ttl_seconds. Registry-internal
+        # so the wire-facing Peer schema stays untouched.
+        self._description_set_at: dict[str, datetime] = {}
+
     # ------------------------------------------------------------------
     # Mapping persistence
     # ------------------------------------------------------------------
@@ -635,7 +640,10 @@ class PeerRegistry:
     async def get_peer(self, identifier: str, circle: str | None = None) -> Peer | None:
         """Get a peer by session_id or display_name."""
         async with self._lock:
-            return self._lookup_peer_unlocked(identifier, circle=circle)
+            peer = self._lookup_peer_unlocked(identifier, circle=circle)
+            if peer:
+                self._apply_description_ttl(peer)
+            return peer
 
     async def resolve_peer_strict(
         self, identifier: str, circle: str | None = None
@@ -655,13 +663,17 @@ class PeerRegistry:
             in_circle = lambda p: circle is None or p.circle == circle  # noqa: E731
             by_id = [p for p in self._peers.values() if p.peer_id == identifier and in_circle(p)]
             if by_id:
+                self._apply_description_ttl(by_id[0])
                 return by_id[0]
             by_name = [
                 p for p in self._peers.values()
                 if p.display_name == identifier and in_circle(p)
             ]
             if len(by_name) == 1:
+                self._apply_description_ttl(by_name[0])
                 return by_name[0]
+            for p in by_name:
+                self._apply_description_ttl(p)
             return by_name
 
     async def get_peer_by_pane(self, pane_id: str) -> Peer | None:
@@ -669,18 +681,25 @@ class PeerRegistry:
         async with self._lock:
             for peer in self._peers.values():
                 if peer.pane_id == pane_id:
+                    self._apply_description_ttl(peer)
                     return peer
             return None
 
     async def get_peers_by_circle(self, circle: str) -> list[Peer]:
         """Get all peers in a given circle."""
         async with self._lock:
-            return [p for p in self._peers.values() if p.circle == circle]
+            peers = [p for p in self._peers.values() if p.circle == circle]
+            for p in peers:
+                self._apply_description_ttl(p)
+            return peers
 
     async def get_all_peers(self) -> list[Peer]:
         """Get all registered peers."""
         async with self._lock:
-            return list(self._peers.values())
+            peers = list(self._peers.values())
+            for p in peers:
+                self._apply_description_ttl(p)
+            return peers
 
     def heartbeat_tolerance(self) -> int:
         """Seconds a peer's last_seen may lag before it's considered dead.
@@ -1065,12 +1084,44 @@ class PeerRegistry:
                 return False
             peer.description = description
             peer.last_seen = datetime.now(timezone.utc)
+            if description:
+                self._description_set_at[peer.peer_id] = datetime.now(timezone.utc)
+            else:
+                self._description_set_at.pop(peer.peer_id, None)
             mapping = self._mappings.get(peer.peer_id)
             if mapping and mapping.description != description:
                 mapping.description = description
                 mapping.updated_at = datetime.now(timezone.utc).isoformat()
                 self._mappings_dirty = True
             return True
+
+    def _apply_description_ttl(self, peer: Peer) -> None:
+        """Clear peer.description if it's older than the configured TTL.
+
+        Mutates in place so list_peers / get_peer reflect cleared state on the
+        next read without waiting for a sweep. TTL <= 0 disables the check.
+        """
+        if not peer.description:
+            return
+        ttl = self._config.daemon.description_ttl_seconds
+        if ttl <= 0:
+            return
+        set_at = self._description_set_at.get(peer.peer_id)
+        if set_at is None:
+            # Description was set before TTL tracking started (e.g. restored
+            # from a persisted mapping). Stamp now so the TTL window is
+            # well-defined, rather than clearing a description we cannot age.
+            self._description_set_at[peer.peer_id] = datetime.now(timezone.utc)
+            return
+        if (datetime.now(timezone.utc) - set_at).total_seconds() < ttl:
+            return
+        peer.description = ""
+        self._description_set_at.pop(peer.peer_id, None)
+        mapping = self._mappings.get(peer.peer_id)
+        if mapping and mapping.description:
+            mapping.description = ""
+            mapping.updated_at = datetime.now(timezone.utc).isoformat()
+            self._mappings_dirty = True
 
     async def set_peer_circle(self, identifier: str, circle: str) -> None:
         """Update peer's circle (both in-memory Peer AND persistent mapping)."""

--- a/tests/test_description_ttl.py
+++ b/tests/test_description_ttl.py
@@ -1,0 +1,136 @@
+"""Tests for peer description TTL (clear-on-read).
+
+Issue #162: peer descriptions never auto-clear after a task completes.
+Daemon-side TTL with clear-on-read semantics — no background sweep, so the
+cleared state surfaces on the very next list_peers / get_peer call.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repowire.config.models import Config
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+@pytest.fixture
+def mock_router():
+    router = MagicMock(spec=MessageRouter)
+    router.send_query = AsyncMock(return_value="ok")
+    router.send_notification = AsyncMock()
+    router.broadcast = AsyncMock(return_value=[])
+    return router
+
+
+def _make_config(ttl_seconds: float) -> Config:
+    cfg = Config()
+    cfg.daemon.description_ttl_seconds = ttl_seconds
+    return cfg
+
+
+def _make_peer(name: str = "dev") -> Peer:
+    return Peer(
+        peer_id=f"repow-test-{name}",
+        display_name=name,
+        path="/app",
+        machine="laptop",
+        status=PeerStatus.ONLINE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_description_set_then_read_within_ttl_preserved(mock_router):
+    """Set description → read within TTL → description survives."""
+    registry = PeerRegistry(config=_make_config(60), message_router=mock_router)
+    await registry.register_peer(_make_peer())
+
+    await registry.update_description("dev", "fixing auth bug")
+
+    peer = await registry.get_peer("dev")
+    assert peer is not None
+    assert peer.description == "fixing auth bug"
+
+    all_peers = await registry.get_all_peers()
+    assert all_peers[0].description == "fixing auth bug"
+
+
+@pytest.mark.asyncio
+async def test_description_clears_on_read_after_ttl(mock_router):
+    """Set description → wind set_at past TTL → next read returns empty."""
+    registry = PeerRegistry(config=_make_config(60), message_router=mock_router)
+    await registry.register_peer(_make_peer())
+
+    await registry.update_description("dev", "working on #162")
+
+    # Wind the internal set_at back beyond the TTL window so the next read
+    # trips clear-on-read without sleeping.
+    peer_id = "repow-test-dev"
+    registry._description_set_at[peer_id] = (
+        datetime.now(timezone.utc) - timedelta(seconds=120)
+    )
+
+    peer = await registry.get_peer("dev")
+    assert peer is not None
+    assert peer.description == ""
+    # Internal timestamp store is cleaned up so we don't leak entries.
+    assert peer_id not in registry._description_set_at
+
+    # list_peers / get_all_peers reflects the cleared state immediately —
+    # no sweep needed.
+    all_peers = await registry.get_all_peers()
+    assert all_peers[0].description == ""
+
+
+@pytest.mark.asyncio
+async def test_ttl_zero_disables_clearing(mock_router):
+    """description_ttl_seconds=0 disables the TTL entirely."""
+    registry = PeerRegistry(config=_make_config(0), message_router=mock_router)
+    await registry.register_peer(_make_peer())
+
+    await registry.update_description("dev", "long-running task")
+
+    # Even a wildly old set_at must not trigger clearing when TTL is 0.
+    registry._description_set_at["repow-test-dev"] = (
+        datetime.now(timezone.utc) - timedelta(hours=24)
+    )
+
+    peer = await registry.get_peer("dev")
+    assert peer is not None
+    assert peer.description == "long-running task"
+
+
+@pytest.mark.asyncio
+async def test_update_description_resets_ttl_window(mock_router):
+    """Updating the description re-stamps set_at, sliding the TTL window."""
+    registry = PeerRegistry(config=_make_config(60), message_router=mock_router)
+    await registry.register_peer(_make_peer())
+
+    await registry.update_description("dev", "task A")
+    # Age it past the TTL.
+    registry._description_set_at["repow-test-dev"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=120)
+    )
+    # New description should win, with a fresh set_at, and survive read.
+    await registry.update_description("dev", "task B")
+
+    peer = await registry.get_peer("dev")
+    assert peer is not None
+    assert peer.description == "task B"
+
+
+@pytest.mark.asyncio
+async def test_clearing_description_drops_set_at(mock_router):
+    """Setting the description to '' (explicit clear) removes the timestamp."""
+    registry = PeerRegistry(config=_make_config(60), message_router=mock_router)
+    await registry.register_peer(_make_peer())
+
+    await registry.update_description("dev", "task")
+    assert "repow-test-dev" in registry._description_set_at
+
+    await registry.update_description("dev", "")
+    assert "repow-test-dev" not in registry._description_set_at

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #162. Peer task descriptions (set via `set_description` MCP tool) tend to linger past task completion because peers forget to clear them. This adds a daemon-side TTL with **clear-on-read** semantics so stale descriptions surface as empty on the next `list_peers` / `get_peer` call — no background sweep, no polling.

## Design

- `DaemonConfig.description_ttl_seconds` (default `900`, i.e. 15 min). Set to `0` to disable.
- Registry stores `_description_set_at: dict[peer_id, datetime]` — kept off the wire-facing `Peer` schema to avoid churning the protocol. Internal only.
- `update_description()` stamps `set_at` on a non-empty description, removes the entry when set to `""`.
- New `_apply_description_ttl(peer)` helper clears `peer.description` (and the persisted SessionMapping) in place when read past TTL. Applied at every read path: `get_peer`, `get_peer_by_pane`, `get_peers_by_circle`, `get_all_peers`, `resolve_peer_strict`.
- Descriptions restored from a persisted SessionMapping (e.g. after daemon restart) get their `set_at` stamped on first read — gives a well-defined TTL window rather than instant clearing.

Chose option (1) TTL with configurable threshold over (2) sentinel / (3) activity-tied. TTL matches user intent (cap staleness), is dead simple, and clear-on-read lets `list_peers` reflect cleared state immediately without a sweep — matches the lazy-repair philosophy in `CLAUDE.md`.

## Acceptance criteria

- [x] description carries internal set_at timestamp
- [x] after N minutes, daemon clears it
- [x] threshold configurable (`daemon.description_ttl_seconds`)
- [x] list_peers reflects cleared state immediately (clear-on-read, no sweep)

## Test plan

- [x] `tests/test_description_ttl.py` — 5 cases:
  - set → read within TTL → preserved
  - set → wind set_at past TTL → next `get_peer` and `get_all_peers` both return `""`
  - `ttl=0` disables clearing (even 24h-old descriptions survive)
  - re-setting the description slides the TTL window
  - explicit clear (`update_description(peer, "")`) drops the timestamp entry
- [x] `pytest -q` — 844 passed
- [x] `ruff check repowire/` clean
- [x] `uv run ty check repowire/` clean