### PR TITLE
Return 410 for closed ask replies

### DIFF
--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from repowire.daemon.auth import require_auth
@@ -158,15 +158,19 @@ async def ack_ask(
 
     Bare ack: close the ask, return 200.
 
+    Bare re-ack of an already-closed ask is idempotent and returns 200.
+
     Ack-with-message: deliver the reply first; only close on successful
-    delivery. If the asker has no live WS the ask stays open and 503 is
-    returned so the recipient can retry (or drop the message and bare-ack
-    if they give up). This avoids closing the thread while silently dropping
-    the reply under the new fail-loud / no-queue contract.
+    delivery. If the ask is already closed, the reply cannot be delivered and
+    410 is returned. If the asker has no live WS the ask stays open and 503 is
+    returned so the recipient can retry (or drop the message and bare-ack if
+    they give up). This avoids closing the thread while silently dropping the
+    reply under the new fail-loud / no-queue contract.
 
     Returns:
-        200 on success, 200 on idempotent re-ack (already closed), 404 if
-        unknown corr_id, 503 if reply delivery failed.
+        200 on success, 200 on idempotent bare re-ack, 404 if unknown corr_id,
+        410 if an ack-with-message targets an already-closed ask, 503 if reply
+        delivery failed.
     """
     peer_registry = get_peer_registry()
     state = get_app_state()
@@ -178,8 +182,16 @@ async def ack_ask(
             status_code=404,
             detail=f"No open ask with correlation_id: {request.correlation_id}",
         )
+    if existing.closed and request.message:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=(
+                f"Ask {request.correlation_id} is already closed; "
+                "reply message was not delivered."
+            ),
+        )
     if existing.closed:
-        # Idempotent re-ack: already closed, nothing to do.
+        # Idempotent bare re-ack: already closed, nothing to do.
         return OkResponse()
 
     if request.message:

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -249,6 +249,26 @@ class TestAck:
         })
         assert r2.status_code == 200
 
+    async def test_ack_with_msg_on_closed_ask_returns_410(self, env):
+        client, _, _, msg_router = env
+        await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": bob, "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+        await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob,
+        })
+
+        r2 = await client.post("/ack", json={
+            "correlation_id": cid, "from_peer": bob, "message": "late reply",
+        })
+
+        assert r2.status_code == 410
+        assert "already closed" in r2.json()["detail"]
+        assert msg_router.send_notification.await_count == 0
+
 
 class TestPendingAsks:
     async def test_returns_open_asks(self, env):


### PR DESCRIPTION
## Bug

Bug 3 from the mesh hotfix slice: `ack(corr_id, message)` on an already-closed ask returned 200 OK even though the reply message could not be delivered. That made late replies look successful while silently dropping the message.

## Root cause

`repowire/daemon/routes/asks.py` treated every closed ask as an idempotent re-ack before checking whether the caller supplied a reply message. Bare re-ack should stay idempotent, but ack-with-message has delivery semantics and cannot succeed after the ask is closed.

## Fix

- Return `410 Gone` when `ack(corr_id, message)` targets an already-closed ask.
- Keep bare re-ack of a closed ask at `200 OK`.
- Update the `/ack` route docstring to document the split behavior.

## Tests

- Added `test_ack_with_msg_on_closed_ask_returns_410` in `tests/test_ask_routes.py`.
- `uv run pytest tests/test_ask_routes.py`
- `uv run pytest` (`841 passed`)
- `uv run ruff check repowire/ tests/test_ask_routes.py`
- `uv run ty check repowire/`

Note: `bd dolt push` was attempted but this worktree's Beads database has no Dolt remote configured (`remote origin not found`).