### PR TITLE
Revive offline peers on MCP touch

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -1042,19 +1042,24 @@ class PeerRegistry:
     async def touch_last_seen(
         self, identifier: str, circle: str | None = None,
     ) -> bool:
-        """Refresh a peer's last_seen without changing status.
+        """Refresh a peer's last_seen and revive OFFLINE peers.
 
         Outbound MCP traffic from a peer is a liveness signal even when the
         peer's ws-hook has dropped (inbound is broken, but the agent is alive
-        and acting). Lets `is_orchestrator_present` and other last_seen-keyed
-        checks count that activity instead of going stale on the new wrinkle
-        introduced by the liveness slice.
+        and acting). If the registry still marks that peer OFFLINE, the
+        observed activity is stronger evidence than the stale status, so revive
+        it to ONLINE while preserving BUSY/ONLINE peers as-is.
         """
         async with self._lock:
             peer = self._lookup_peer_unlocked(identifier, circle=circle)
             if not peer:
                 return False
+            old_status = peer.status
+            if peer.status == PeerStatus.OFFLINE:
+                peer.status = PeerStatus.ONLINE
             peer.last_seen = datetime.now(timezone.utc)
+            if old_status != peer.status:
+                self._emit_status_change(peer, old_status, peer.status)
             return True
 
     async def update_description(

--- a/tests/test_orchestrator_liveness.py
+++ b/tests/test_orchestrator_liveness.py
@@ -274,14 +274,23 @@ class TestTouchLastSeen:
 
         assert await registry.is_orchestrator_present("team") is True
 
-    async def test_touch_does_not_change_status(self, tmp_path):
+    async def test_touch_revives_offline_peer(self, tmp_path):
         registry = _make_registry(tmp_path)
         await _register_orch(
             registry, circle="team", status=PeerStatus.OFFLINE,
         )
         await registry.touch_last_seen("repow-team-orch1")
         async with registry._lock:
-            assert registry._peers["repow-team-orch1"].status == PeerStatus.OFFLINE
+            assert registry._peers["repow-team-orch1"].status == PeerStatus.ONLINE
+
+    async def test_touch_preserves_busy_status(self, tmp_path):
+        registry = _make_registry(tmp_path)
+        await _register_orch(
+            registry, circle="team", status=PeerStatus.BUSY,
+        )
+        await registry.touch_last_seen("repow-team-orch1")
+        async with registry._lock:
+            assert registry._peers["repow-team-orch1"].status == PeerStatus.BUSY
 
     async def test_touch_returns_false_for_unknown_peer(self, tmp_path):
         registry = _make_registry(tmp_path)
@@ -308,3 +317,19 @@ class TestTouchLastSeen:
         body = r.json()
         assert body["present"] is True
         assert body["peer_id"] == "orch-1"
+
+    async def test_touch_route_revives_offline_peer(self, app_and_registry):
+        client, registry = app_and_registry
+        await _register_orch(
+            registry,
+            circle="team",
+            name="orch",
+            peer_id="orch-1",
+            status=PeerStatus.OFFLINE,
+        )
+
+        r = await client.post("/peers/orch-1/touch")
+        assert r.status_code == 200
+
+        async with registry._lock:
+            assert registry._peers["orch-1"].status == PeerStatus.ONLINE


### PR DESCRIPTION
## Bug

Bug 4 from the mesh hotfix slice: peers could remain `offline` in `list_peers` while actively responding through MCP. Today's evidence showed an MCP-active peer with fresh activity/ack behavior but stale offline status.

## Root cause

`PeerRegistry.touch_last_seen()` refreshed `last_seen` but intentionally preserved `status`. MCP tool entry calls `/peers/{name}/touch`, so outbound activity proved the agent was alive but did not promote an `OFFLINE` registry entry back to `ONLINE`.

## Fix

- `touch_last_seen()` now revives `OFFLINE` peers to `ONLINE` when activity is observed.
- Existing `ONLINE` and `BUSY` statuses are preserved.
- A status-change event is emitted when touch revives an offline peer.

## Tests

- Added/updated orchestrator liveness coverage for direct registry touch and route touch.
- Added coverage that `BUSY` is preserved.
- `uv run pytest tests/test_orchestrator_liveness.py`
- `uv run pytest` (`843 passed`)
- `uv run ruff check repowire/ tests/test_orchestrator_liveness.py`
- `uv run ty check repowire/`

Note: `bd dolt push` was attempted but this worktree's Beads database has no Dolt remote configured (`remote origin not found`).