### PR TITLE
Reject stale ws-hook respawn metadata

### DIFF
--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -55,7 +56,7 @@ def main(backend: str = "claude-code") -> int:
     # Lazy-repair: if the ws-hook process for this pane died (OOM, SIGKILL,
     # unhandled exception), Stop is the cheapest place to notice and relaunch.
     # No new polling -- this piggy-backs on traffic that already runs every turn.
-    maybe_respawn(pane_id)
+    maybe_respawn(pane_id, backend=backend, cwd=input_data.get("cwd") or os.getcwd())
 
     # Get response text: adapter extracts from agent-specific fields,
     # fall back to transcript parsing for Claude Code

--- a/repowire/hooks/ws_hook_supervisor.py
+++ b/repowire/hooks/ws_hook_supervisor.py
@@ -15,6 +15,7 @@ the persisted pane metadata. No new polling.
 from __future__ import annotations
 
 import fcntl
+import logging
 import os
 import subprocess
 import sys
@@ -27,6 +28,8 @@ from repowire.hooks.utils import (
     ws_hook_lock_path,
     ws_hook_pid_path,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def spawn_ws_hook(
@@ -89,7 +92,12 @@ def _pid_alive(pid: int) -> bool:
         return True
 
 
-def maybe_respawn(pane_id: str | None) -> bool:
+def maybe_respawn(
+    pane_id: str | None,
+    *,
+    backend: str | None = None,
+    cwd: str | None = None,
+) -> bool:
     """Restart the ws-hook for `pane_id` iff its prior process is dead.
 
     Lazy-repair path triggered from the Stop hook. Returns True when a fresh
@@ -132,11 +140,11 @@ def maybe_respawn(pane_id: str | None) -> bool:
                 return False
 
             metadata = read_pane_runtime_metadata(pane_id)
-            cwd = metadata.get("cwd")
+            metadata_cwd = metadata.get("cwd")
             display_name = metadata.get("display_name")
-            backend = metadata.get("backend") or "claude-code"
+            metadata_backend = metadata.get("backend") or "claude-code"
             peer_id = metadata.get("peer_id")
-            if not cwd or not display_name:
+            if not metadata_cwd or not display_name:
                 # Without these we can't recreate the prior connect state.
                 # Drop the stale pid file so a future SessionStart isn't
                 # confused, but don't spawn blindly.
@@ -145,13 +153,35 @@ def maybe_respawn(pane_id: str | None) -> bool:
                 except OSError:
                     pass
                 return False
+            if not backend or not cwd:
+                logger.warning(
+                    "ws-hook respawn rejected: metadata claims backend=%s cwd=%s "
+                    "but current hook reports backend=%s cwd=%s (pane %s)",
+                    metadata_backend,
+                    metadata_cwd,
+                    backend,
+                    cwd,
+                    pane_id,
+                )
+                return False
+            if metadata_backend != backend or metadata_cwd != cwd:
+                logger.warning(
+                    "ws-hook respawn rejected: metadata claims backend=%s cwd=%s "
+                    "but current hook reports backend=%s cwd=%s (pane %s)",
+                    metadata_backend,
+                    metadata_cwd,
+                    backend,
+                    cwd,
+                    pane_id,
+                )
+                return False
 
             new_pid = spawn_ws_hook(
                 pane_id=pane_id,
                 peer_id=peer_id,
                 display_name=display_name,
-                backend=backend,
-                cwd=cwd,
+                backend=metadata_backend,
+                cwd=metadata_cwd,
                 lock_fd=lock_fd,
             )
             return new_pid is not None

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -206,6 +206,39 @@ async def test_stale_peer_id_claim_does_not_steal_existing_peer(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_stale_peer_id_claim_same_path_different_backend_does_not_steal_peer(tmp_path):
+    """Same-cwd sibling agents must not be allowed to rebind each other's peer_id."""
+    registry = _make_registry(tmp_path)
+    shared_path = "/tmp/repowire-research-acp-claude"
+
+    gemini_id, gemini_name = await registry.allocate_and_register(
+        circle="dev",
+        backend=AgentType.GEMINI,
+        path=shared_path,
+        pane_id="%1",
+    )
+
+    claimed_id, claimed_name = await registry.allocate_and_register(
+        circle="dev",
+        backend=AgentType.CLAUDE_CODE,
+        path=shared_path,
+        pane_id="%2",
+        peer_id=gemini_id,
+    )
+
+    assert claimed_id != gemini_id
+    assert claimed_name != gemini_name
+    gemini_peer = await registry.get_peer(gemini_id)
+    assert gemini_peer is not None
+    assert gemini_peer.backend == AgentType.GEMINI
+    assert gemini_peer.pane_id == "%1"
+    claimed_peer = await registry.get_peer_by_pane("%2")
+    assert claimed_peer is not None
+    assert claimed_peer.peer_id == claimed_id
+    assert claimed_peer.backend == AgentType.CLAUDE_CODE
+
+
+@pytest.mark.asyncio
 async def test_circle_and_description_persist_across_restart(tmp_path):
     """A peer re-registering after restart restores its prior circle + description.
 

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -44,6 +44,26 @@ class TestStopHandler:
             })
             assert result == 0
 
+    @patch("repowire.hooks.stop_handler.maybe_respawn")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    def test_respawn_receives_current_backend_and_cwd(
+        self, mock_pane, mock_status, mock_respawn,
+    ):
+        with patch("sys.stdin") as stdin:
+            stdin.read.return_value = json.dumps({
+                "hook_event_name": "AfterAgent",
+                "cwd": "/tmp/current",
+                "session_id": "gemini123-rest",
+                "final_response": "done",
+            })
+            result = main("gemini")
+
+        assert result == 0
+        mock_respawn.assert_called_once_with(
+            "%42", backend="gemini", cwd="/tmp/current",
+        )
+
     @patch("repowire.hooks.stop_handler.daemon_post")
     @patch("repowire.hooks.stop_handler.update_status", return_value=True)
     @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
@@ -293,4 +313,3 @@ class TestReminderStopOutput:
         parsed = json.loads(buf.getvalue().strip())
         assert parsed["decision"] == "deny"
         assert "ask-x" in parsed["reason"]
-

--- a/tests/test_ws_hook_supervisor.py
+++ b/tests/test_ws_hook_supervisor.py
@@ -24,11 +24,11 @@ def cache_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _write_meta(pane_id: str, cwd: str) -> None:
+def _write_meta(pane_id: str, cwd: str, backend: str = "claude-code") -> None:
     write_pane_runtime_metadata(
         pane_id,
         {
-            "backend": "claude-code",
+            "backend": backend,
             "cwd": cwd,
             "display_name": "respawn-test",
             "hook_session_id": "sess-1",
@@ -67,7 +67,9 @@ class TestMaybeRespawn:
         with patch.object(
             ws_hook_supervisor, "spawn_ws_hook", return_value=12345,
         ) as mock_spawn:
-            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is True
+            assert ws_hook_supervisor.maybe_respawn(
+                PANE_ID, backend="claude-code", cwd=str(cache_dir),
+            ) is True
             mock_spawn.assert_called_once()
             kwargs = mock_spawn.call_args.kwargs
             assert kwargs["pane_id"] == PANE_ID
@@ -75,6 +77,53 @@ class TestMaybeRespawn:
             assert kwargs["backend"] == "claude-code"
             assert kwargs["peer_id"] == "repow-default-deadbeef"
             assert kwargs["cwd"] == str(cache_dir)
+
+    def test_rejects_respawn_without_current_context(self, cache_dir, caplog):
+        ws_hook_pid_path(PANE_ID).write_text("99999999")
+        _write_meta(PANE_ID, str(cache_dir))
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(PANE_ID) is False
+            mock_spawn.assert_not_called()
+
+        assert "ws-hook respawn rejected" in caplog.text
+        assert "metadata claims backend=claude-code" in caplog.text
+        assert f"cwd={cache_dir}" in caplog.text
+        assert f"(pane {PANE_ID})" in caplog.text
+
+    def test_rejects_respawn_when_backend_mismatches(self, cache_dir, caplog):
+        ws_hook_pid_path(PANE_ID).write_text("99999999")
+        _write_meta(PANE_ID, str(cache_dir), backend="gemini")
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(
+                PANE_ID, backend="claude-code", cwd=str(cache_dir),
+            ) is False
+            mock_spawn.assert_not_called()
+
+        assert (
+            "ws-hook respawn rejected: metadata claims backend=gemini "
+            f"cwd={cache_dir} but current hook reports backend=claude-code "
+            f"cwd={cache_dir} (pane {PANE_ID})"
+        ) in caplog.text
+
+    def test_rejects_respawn_when_cwd_mismatches(self, cache_dir, tmp_path, caplog):
+        ws_hook_pid_path(PANE_ID).write_text("99999999")
+        metadata_cwd = str(cache_dir / "old")
+        current_cwd = str(tmp_path / "current")
+        _write_meta(PANE_ID, metadata_cwd)
+
+        with patch.object(ws_hook_supervisor, "spawn_ws_hook") as mock_spawn:
+            assert ws_hook_supervisor.maybe_respawn(
+                PANE_ID, backend="claude-code", cwd=current_cwd,
+            ) is False
+            mock_spawn.assert_not_called()
+
+        assert (
+            "ws-hook respawn rejected: metadata claims backend=claude-code "
+            f"cwd={metadata_cwd} but current hook reports backend=claude-code "
+            f"cwd={current_cwd} (pane {PANE_ID})"
+        ) in caplog.text
 
     def test_does_not_respawn_when_lock_contested(self, cache_dir):
         ws_hook_pid_path(PANE_ID).write_text("99999999")


### PR DESCRIPTION
## Bug

Bug 1 from the mesh hotfix slice: asks addressed to one same-path sibling backend could be answered by another sibling. Live evidence was an ask to `repowire-research-acp-claude-gemini` answered by `repowire-research-acp-claude-claude-code`, with both peers registered at the same project path and distinct peer IDs.

## Root cause

The daemon registry guard is correct when reconnect metadata is correct: a same-path/different-backend stale `peer_id` claim is rejected. The upstream issue was Stop-hook lazy ws-hook respawn. `stop_handler.py` called `maybe_respawn(pane_id)` without current backend/cwd context, and `ws_hook_supervisor.py` trusted persisted pane metadata to relaunch a dead ws-hook. If stale metadata belonged to a sibling backend in the same cwd, respawn could fabricate a WebSocket claim using the sibling's `peer_id`/backend for the current pane.

## Fix

- Pass current hook `backend` and `cwd` into `maybe_respawn()` from the Stop hook.
- Add optional `backend=` and `cwd=` kwargs to `maybe_respawn()` without breaking existing callers.
- Reject respawn when current context is missing or when persisted metadata backend/cwd differs from the current hook.
- Log a loud mismatch with both sides: metadata backend/cwd and current hook backend/cwd plus pane ID.
- Leave stale metadata intact on mismatch for diagnostics/recovery.

## Tests

- Added same-path/different-backend `allocate_and_register` characterization test showing the registry guard already rejects correct input.
- Added ws-hook supervisor tests for missing current context, backend mismatch, and cwd mismatch.
- Added Stop hook test proving current backend/cwd are passed to respawn.
- `uv run pytest tests/test_session_mapper.py -k same_path_different_backend`
- `uv run pytest tests/test_ws_hook_supervisor.py tests/test_stop_handler.py`
- `uv run pytest` (`848 passed`)
- `uv run ruff check repowire/ tests/test_session_mapper.py tests/test_ws_hook_supervisor.py tests/test_stop_handler.py`
- `uv run ty check repowire/`

Note: `bd dolt push` was attempted but this worktree's Beads database has no Dolt remote configured (`remote origin not found`).