### PR TITLE
Log inbound notify injection drops

### DIFF
--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -54,6 +54,10 @@ class NotifyResponse(BaseModel):
     ``status`` reflects the recipient's state at send-time: ``sent`` means
     ONLINE (immediate paste), ``queued`` means BUSY (ws-hook holds the paste
     until the current turn ends). Wire format otherwise unchanged.
+
+    Notify is fire-and-forget: daemon-side success means the frame was handed
+    to the recipient WebSocket, not that the agent received or processed it.
+    Use ask/ack when confirmed delivery matters.
     """
 
     ok: bool = True

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -303,7 +303,15 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
     # Safety: verify agent is still running in the pane before injecting text
     needs_safety = msg_type in ("query", "ask", "notify", "broadcast")
     if needs_safety and not await asyncio.to_thread(_is_pane_safe, pane_id):
-        logger.warning(f"Pane {pane_id} not safe for injection, dropping {msg_type}")
+        logger.error(
+            "Inbound delivery dropped: pane %s not safe for %s injection "
+            "(from=%s to=%s correlation_id=%s)",
+            pane_id,
+            msg_type,
+            data.get("from_peer", "unknown"),
+            data.get("to_peer", ""),
+            data.get("correlation_id", ""),
+        )
         if msg_type in ("query", "ask") and websocket:
             correlation_id = data.get("correlation_id", "")
             try:
@@ -394,8 +402,23 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
                 _tmux_send_keys, pane_id, f"@{from_peer}{to_label}: {text}",
             ):
                 logger.info(f"Injected notification from {from_peer}")
+            else:
+                logger.error(
+                    "Inbound notification dropped: tmux send-keys failed "
+                    "(pane=%s from=%s to=%s)",
+                    pane_id,
+                    from_peer,
+                    to_peer,
+                )
         except Exception as e:
-            logger.error(f"Failed to inject notification: {e}")
+            logger.exception(
+                "Inbound notification dropped: injection error "
+                "(pane=%s from=%s to=%s): %s",
+                pane_id,
+                data.get("from_peer", "unknown"),
+                data.get("to_peer", ""),
+                e,
+            )
 
     elif msg_type == "broadcast":
         try:

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -524,6 +524,8 @@ def create_mcp_server() -> FastMCP:
         Use for status updates, announcements, or replying to notifications.
         Special peers: 'telegram' sends to user's phone.
         The dashboard sees your responses automatically via chat turns - no need to notify it.
+        Fire-and-forget means daemon-side success does NOT guarantee agent receipt.
+        Use ask() when confirmed delivery matters.
 
         Do NOT use SendMessage to reach repowire peers. SendMessage is a Claude
         Code harness tool for same-session teammates only.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -55,6 +55,51 @@ class TestHandleAskAndNotify:
         mock_send.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_notify_tmux_failure_logs_drop_without_daemon_error(self, caplog):
+        websocket = AsyncMock()
+        with (
+            patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=True),
+            patch("repowire.hooks.websocket_hook._tmux_send_keys", return_value=False),
+        ):
+            await websocket_hook.handle_message(
+                {
+                    "type": "notify",
+                    "from_peer": "alice",
+                    "to_peer": "bob",
+                    "text": "fyi",
+                },
+                "%5",
+                websocket,
+            )
+
+        websocket.send.assert_not_called()
+        assert "Inbound notification dropped: tmux send-keys failed" in caplog.text
+        assert "pane=%5" in caplog.text
+        assert "from=alice" in caplog.text
+        assert "to=bob" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_notify_pane_safety_drop_has_no_daemon_error_frame(self, caplog):
+        websocket = AsyncMock()
+        with patch("repowire.hooks.websocket_hook._is_pane_safe", return_value=False):
+            with pytest.raises(websocket_hook.PaneUnsafeError):
+                await websocket_hook.handle_message(
+                    {
+                        "type": "notify",
+                        "from_peer": "alice",
+                        "to_peer": "bob",
+                        "text": "fyi",
+                    },
+                    "%5",
+                    websocket,
+                )
+
+        websocket.send.assert_not_called()
+        assert "Inbound delivery dropped: pane %5 not safe for notify injection" in caplog.text
+        assert "from=alice" in caplog.text
+        assert "to=bob" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_notify_injection_includes_recipient_when_provided(self):
         """When the daemon includes `to_peer`, the injected frame labels the
         recipient so the receiver can spot misroutes at a glance (issue #136).


### PR DESCRIPTION
## Bug

Bug 2 from the mesh hotfix slice: `notify_peer()` could return success after the daemon handed a notify frame to the recipient WebSocket, while the recipient ws-hook later failed to inject it into the agent terminal. This is fire-and-forget by design, but the local hook-side drop was too quiet.

## Root cause

`repowire/hooks/websocket_hook.py` treated notify as a plain FYI with no lifecycle. If pane safety failed, only a generic warning was logged. If tmux `send-keys` returned false for notify, no explicit drop log was emitted. Since notify has no hook-to-daemon ack frame, these failures are invisible to the daemon/caller.

## Fix

- Log inbound delivery drops at error level when pane safety rejects injection, including message type, sender, recipient, correlation id, and pane.
- Log inbound notification drops at error level when tmux `send-keys` fails or the notify handler raises.
- Clarify `/notify` and MCP `notify_peer()` docs: fire-and-forget success does not guarantee agent receipt; use `ask()`/ask-ack when confirmed delivery matters.
- Filed protocol follow-up issue: https://github.com/prassanna-ravishankar/repowire/issues/179

## Tests

- Added hook characterization tests proving notify injection failures do not send a daemon/caller error frame and are only visible through hook logs.
- `uv run pytest tests/test_hooks.py`
- `uv run pytest` (`850 passed`)
- `uv run ruff check repowire/ tests/test_hooks.py`
- `uv run ty check repowire/`

Note: `bd dolt push` was attempted but this worktree's Beads database has no Dolt remote configured (`remote origin not found`).