### PR TITLE
Reap stale offline WebSocket peers

### DIFF
--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -155,6 +155,13 @@ class DaemonConfig(BaseModel):
             "Set to 0 to disable."
         ),
     )
+    peer_reap_ttl_seconds: float = Field(
+        default=600,
+        description=(
+            "Seconds an OFFLINE peer may remain in the registry before lazy repair "
+            "reaps it. Set to 0 to disable."
+        ),
+    )
 
     # Spawn settings
     spawn: SpawnSettings = Field(default_factory=SpawnSettings)

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -1320,6 +1320,7 @@ class PeerRegistry:
             self._last_repair = time.monotonic()
             await self._demote_disconnected_peers()
             await self._demote_unsafe_connected_peers()
+            await self._reap_dangling_peers()
             await self._evict_stale_peers()
             self._save_events()
             self._persist_mappings()
@@ -1380,6 +1381,59 @@ class PeerRegistry:
         if count:
             logger.info("demoted %d unsafe connected peers", count)
         return count
+
+    async def _reap_dangling_peers(self) -> int:
+        """Remove OFFLINE peers whose liveness TTL has expired.
+
+        Lazy-repair only: no background polling. ONLINE/BUSY peers are first
+        demoted by the WebSocket liveness checks above; this pass removes peers
+        that stayed offline past the configured grace window.
+        """
+        ttl = self._config.daemon.peer_reap_ttl_seconds
+        if ttl <= 0:
+            return 0
+
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=ttl)
+        async with self._lock:
+            stale = [
+                p for p in self._peers.values()
+                if p.status == PeerStatus.OFFLINE
+                and p.last_seen is not None
+                and p.last_seen < cutoff
+            ]
+            for peer in stale:
+                self._peers.pop(peer.peer_id, None)
+                self._mappings.pop(peer.peer_id, None)
+                self._description_set_at.pop(peer.peer_id, None)
+                self._mappings_dirty = True
+
+        for peer in stale:
+            if self._transport is not None:
+                try:
+                    await self._transport.disconnect(peer.peer_id)
+                except Exception as e:
+                    logger.warning(
+                        "reaper: failed to disconnect %s transport: %s",
+                        peer.peer_id,
+                        e,
+                    )
+            if self._ask_tracker is not None:
+                await self._ask_tracker.forget_peer(peer.peer_id)
+            self.add_event(
+                "peer_reaped",
+                {
+                    "peer_id": peer.peer_id,
+                    "display_name": peer.display_name,
+                    "backend": peer.backend.value,
+                    "path": peer.path,
+                    "pane_id": peer.pane_id,
+                    "reason": "offline_ttl",
+                },
+            )
+
+        if stale:
+            logger.info("reaped %d dangling offline peers", len(stale))
+        return len(stale)
 
     async def _evict_stale_peers(self) -> int:
         """Evict long-offline peers from both _peers and _mappings.

--- a/tests/test_lazy_repair.py
+++ b/tests/test_lazy_repair.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from repowire.config.models import AgentType, Config
-from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.peer_registry import PeerRegistry, SessionMapping
 from repowire.daemon.websocket_transport import WebSocketTransport
 from repowire.protocol.peers import Peer, PeerStatus
 
@@ -22,6 +22,7 @@ def _make_peer(
     backend: AgentType = AgentType.CLAUDE_CODE,
     pane_id: str | None = None,
     circle: str = "dev",
+    last_seen: datetime | None = None,
 ) -> Peer:
     return Peer(
         peer_id=peer_id,
@@ -32,21 +33,30 @@ def _make_peer(
         circle=circle,
         status=status,
         pane_id=pane_id,
+        last_seen=last_seen or datetime.now(timezone.utc),
     )
 
 
 def _make_manager(
     transport: WebSocketTransport | None = None,
     query_tracker: MagicMock | None = None,
+    ask_tracker: MagicMock | None = None,
+    *,
+    peer_reap_ttl_seconds: float | None = None,
 ) -> PeerRegistry:
     config = Config()
+    if peer_reap_ttl_seconds is not None:
+        config.daemon.peer_reap_ttl_seconds = peer_reap_ttl_seconds
     router = MagicMock()
-    return PeerRegistry(
+    registry = PeerRegistry(
         config=config,
         message_router=router,
         query_tracker=query_tracker,
         transport=transport,
+        ask_tracker=ask_tracker,
     )
+    registry._events.clear()
+    return registry
 
 
 # -- get_peer_by_pane --
@@ -147,6 +157,83 @@ class TestLazyRepairDebounce:
         result = await manager.get_peer(peer.peer_id)
         assert result.status == PeerStatus.OFFLINE
         transport.ping.assert_awaited_once_with(peer.peer_id, timeout=1.0)
+
+
+class TestLazyRepairReaper:
+    async def test_reaps_offline_peer_after_ttl(self):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.disconnect = AsyncMock(return_value=True)
+        ask_tracker = MagicMock()
+        ask_tracker.forget_peer = AsyncMock(return_value=1)
+        manager = _make_manager(
+            transport=transport,
+            ask_tracker=ask_tracker,
+            peer_reap_ttl_seconds=600,
+        )
+        stale_seen = datetime.now(timezone.utc) - timedelta(seconds=601)
+        peer = _make_peer(
+            status=PeerStatus.OFFLINE,
+            pane_id="%5",
+            last_seen=stale_seen,
+        )
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = stale_seen
+            manager._mappings[peer.peer_id] = SessionMapping(
+                session_id=peer.peer_id,
+                display_name=peer.display_name,
+                circle=peer.circle,
+                backend=peer.backend,
+                path=peer.path,
+            )
+
+        await manager.lazy_repair()
+
+        assert await manager.get_peer(peer.peer_id) is None
+        assert peer.peer_id not in manager._mappings
+        transport.disconnect.assert_awaited_once_with(peer.peer_id)
+        ask_tracker.forget_peer.assert_awaited_once_with(peer.peer_id)
+        events = manager.get_events()
+        assert len(events) == 1
+        assert events[0]["type"] == "peer_reaped"
+        assert events[0]["peer_id"] == peer.peer_id
+        assert events[0]["display_name"] == peer.display_name
+        assert events[0]["backend"] == peer.backend.value
+        assert events[0]["pane_id"] == "%5"
+        assert events[0]["reason"] == "offline_ttl"
+
+    async def test_does_not_reap_offline_peer_younger_than_ttl(self):
+        manager = _make_manager(peer_reap_ttl_seconds=600)
+        recent_seen = datetime.now(timezone.utc) - timedelta(seconds=599)
+        peer = _make_peer(status=PeerStatus.OFFLINE, last_seen=recent_seen)
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = recent_seen
+
+        await manager.lazy_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result is not None
+        assert result.status == PeerStatus.OFFLINE
+
+    async def test_reaper_disabled_with_zero_ttl(self):
+        manager = _make_manager(peer_reap_ttl_seconds=0)
+        stale_seen = datetime.now(timezone.utc) - timedelta(hours=1)
+        peer = _make_peer(status=PeerStatus.OFFLINE, last_seen=stale_seen)
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = stale_seen
+
+        await manager.lazy_repair()
+
+        assert await manager.get_peer(peer.peer_id) is not None
+        assert manager.get_events() == []
 
 
 # -- active_repair liveness checks --


### PR DESCRIPTION
## Issue

Closes #171. Stale WebSocket-backed peers can remain registered after their pane/ws-hook dies, leaving name/peer_id bindings around for peers that can no longer receive payload-bearing delivery. This complements the recent reconnect identity fixes by cleaning up dead bindings after liveness has already failed.

## Root cause

`PeerRegistry.lazy_repair()` already demotes peers with missing/unsafe WebSocket connections, but removal was tied to `prune_max_age_hours` (24h by default). That left dead peers visible and addressable long after delivery had become impossible.

## Fix

- Add `daemon.peer_reap_ttl_seconds` with a 600 second default and `0` to disable.
- Extend debounced `lazy_repair()` with a reaper pass for `OFFLINE` peers older than the reap TTL. No daemon polling loop is added.
- Reaping removes the peer and mapping, clears description TTL state, best-effort disconnects transport, forgets related asks, logs the reap, and emits a `peer_reaped` event.
- `peer_reaped` uses the existing event buffer/SSE path: `add_event()` already wakes `/events/stream` subscribers, so orchestrator/dashboard consumers should see it without extra wiring.

## Notes

- The reaper uses the existing WebSocket/pane_alive lazy-repair path as the liveness source. It does not add direct pane PID probing.
- The 503→410 semantic for the currently-known-but-WS-dead delivery window is left out of scope as requested. After reaping, subsequent sends fail loudly because the peer is gone from the registry.

## Tests

- Added lazy-repair coverage for reaping stale offline peers.
- Added coverage that fresh offline peers are retained and TTL=0 disables reaping.
- Added assertions for `peer_reaped` event payload, transport disconnect, mapping removal, and ask cleanup.
- `uv run pytest tests/test_lazy_repair.py`
- `uv run pytest` (`858 passed`)
- `uv run ruff check repowire/ tests/test_lazy_repair.py`
- `uv run ty check repowire/`

Note: `bd dolt push` was attempted but this worktree's Beads database has no Dolt remote configured (`remote origin not found`).