### PR TITLE
feat(orchestrator): allow command override via orchestrator.yaml

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1260,7 +1260,7 @@ def orchestrator_start(runtime: str | None, service: bool) -> None:
 
     circle = yaml_config.get("circle") or "default"
     backend = AgentType(selected_runtime)
-    command = _ORCHESTRATOR_RUNTIME_COMMANDS[selected_runtime]
+    command = yaml_config.get("command") or _ORCHESTRATOR_RUNTIME_COMMANDS[selected_runtime]
 
     console.print(
         f"[cyan]Spawning orchestrator[/] "

--- a/repowire/orchestrator/template/orchestrator.yaml.example
+++ b/repowire/orchestrator/template/orchestrator.yaml.example
@@ -12,6 +12,13 @@
 # Circle (logical subnet) the orchestrator joins. Default: "default".
 # circle: default
 
+# Override the spawn command for the selected runtime. When unset, the
+# orchestrator uses the built-in default for each runtime (e.g.
+# `claude --dangerously-skip-permissions` for claude-code). Useful for
+# wrappers, extra flags, or pinning a specific binary path. No validation —
+# the operator owns this string.
+# command: "claude --dangerously-skip-permissions --model opus"
+
 # Default telegram chat id for routing user-directed updates. Leave unset
 # to fall back to the global TELEGRAM_CHAT_ID from ~/.repowire/config.yaml.
 # telegram_chat_id: ""

--- a/tests/test_cli_orchestrator.py
+++ b/tests/test_cli_orchestrator.py
@@ -124,3 +124,53 @@ def test_start_spawns_with_role_orchestrator(
     assert config.role == "orchestrator"
     assert config.backend.value == "pi"
     assert config.command == "pi"
+
+
+def _stub_start_deps(monkeypatch: pytest.MonkeyPatch, runtime: str) -> MagicMock:
+    """Stub daemon health, runtime detection, and spawn for orchestrator start."""
+    spawn_mock = MagicMock()
+    spawn_mock.return_value = MagicMock(
+        display_name="orchestrator",
+        tmux_session="default:orchestrator",
+        pane_id="%99",
+    )
+    monkeypatch.setattr("repowire.spawn.spawn_peer", spawn_mock)
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+    httpx_get_mock = MagicMock()
+    httpx_get_mock.return_value.__enter__.return_value.get.return_value = MagicMock(
+        raise_for_status=lambda: None,
+    )
+    monkeypatch.setattr("httpx.Client", httpx_get_mock)
+    monkeypatch.setattr("repowire.cli._detect_runtime_for_orchestrator", lambda: runtime)
+    return spawn_mock
+
+
+def test_start_uses_default_command_when_yaml_omits_it(
+    tmp_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No `command` in orchestrator.yaml → fall back to built-in default."""
+    runner = CliRunner()
+    runner.invoke(main, ["orchestrator", "init"])
+    spawn_mock = _stub_start_deps(monkeypatch, "claude-code")
+
+    result = runner.invoke(main, ["orchestrator", "start"])
+    assert result.exit_code == 0, result.output
+    config = spawn_mock.call_args[0][0]
+    assert config.command == "claude --dangerously-skip-permissions"
+
+
+def test_start_honors_command_override_from_yaml(
+    tmp_workspace: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`command:` in orchestrator.yaml overrides the built-in default."""
+    runner = CliRunner()
+    runner.invoke(main, ["orchestrator", "init"])
+    (tmp_workspace / "orchestrator.yaml").write_text(
+        'command: "claude --dangerously-skip-permissions --model opus"\n'
+    )
+    spawn_mock = _stub_start_deps(monkeypatch, "claude-code")
+
+    result = runner.invoke(main, ["orchestrator", "start"])
+    assert result.exit_code == 0, result.output
+    config = spawn_mock.call_args[0][0]
+    assert config.command == "claude --dangerously-skip-permissions --model opus"


### PR DESCRIPTION
## Summary
- Add optional `command` field to `orchestrator.yaml` that overrides the built-in spawn command for the selected runtime.
- Resolution order: `yaml_config['command']` → `_ORCHESTRATOR_RUNTIME_COMMANDS[selected_runtime]`.
- Document the field in `orchestrator.yaml.example` (commented out).
- Trust the operator: no validation on the override string.

Closes #170.

## Test plan
- [x] `tests/test_cli_orchestrator.py::test_start_uses_default_command_when_yaml_omits_it` — default branch
- [x] `tests/test_cli_orchestrator.py::test_start_honors_command_override_from_yaml` — override branch
- [x] Existing 9 orchestrator CLI tests still pass

Out of scope: CLI passthrough / `extra_args` (per spec).