### PR TITLE
feat(peer): git status badge in PeerView header (#185)

### DIFF
--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -25,6 +25,7 @@ from repowire.hooks.utils import (
     ws_hook_pid_path,
 )
 from repowire.hooks.ws_hook_supervisor import spawn_ws_hook
+from repowire.peer_describe import compute_git_status
 from repowire.spawn_hints import consume_hint_full
 
 
@@ -249,7 +250,13 @@ def main(backend: str = "claude-code") -> int:
         # UserPromptSubmit transitions this to "working".
         hint_pending_first_turn = bool(hint and hint.get("pending_first_turn"))
         initial_turn_state = "pending_first_turn" if hint_pending_first_turn else None
-        metadata = {"project": folder_name}
+        metadata: dict = {"project": folder_name}
+        branch = get_git_branch(cwd)
+        if branch:
+            metadata["branch"] = branch
+        git_status = compute_git_status(cwd)
+        if git_status is not None:
+            metadata["git_status"] = git_status
         peer_id, display_name = _register_peer_http(
             cwd,
             circle,

--- a/repowire/peer_describe.py
+++ b/repowire/peer_describe.py
@@ -14,6 +14,7 @@ Resolution rules mirror the daemon's own ambiguity refusal:
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -261,6 +262,67 @@ def build_snapshot(
 # ---------------------------------------------------------------------------
 # Time formatting helpers (pure, testable)
 # ---------------------------------------------------------------------------
+
+
+def _parse_git_status_porcelain(output: str) -> dict[str, int]:
+    """Parse `git status --porcelain=v2 --branch` output into counts.
+
+    Returns dict with ahead/behind/dirty/staged counts. dirty includes
+    unstaged tracked changes plus untracked files. staged counts changes
+    in the index.
+    """
+    ahead = 0
+    behind = 0
+    dirty = 0
+    staged = 0
+    for line in output.splitlines():
+        if line.startswith("# branch.ab "):
+            parts = line.split()
+            # "# branch.ab +1 -2"
+            for tok in parts[2:]:
+                if tok.startswith("+"):
+                    ahead = int(tok[1:])
+                elif tok.startswith("-"):
+                    behind = int(tok[1:])
+        elif line.startswith("1 ") or line.startswith("2 "):
+            # "1 XY ..." for ordinary, "2 XY ..." for rename/copy.
+            # XY are the staged/unstaged status codes; "." means unchanged.
+            xy = line.split(" ", 2)[1]
+            if len(xy) == 2:
+                if xy[0] != ".":
+                    staged += 1
+                if xy[1] != ".":
+                    dirty += 1
+        elif line.startswith("u "):
+            # Unmerged entries count toward both sides.
+            staged += 1
+            dirty += 1
+        elif line.startswith("? "):
+            dirty += 1
+    return {"ahead": ahead, "behind": behind, "dirty": dirty, "staged": staged}
+
+
+def compute_git_status(cwd: str) -> dict[str, int] | None:
+    """Return git status counts for cwd, or None if not a git repo.
+
+    Counts come from `git status --porcelain=v2 --branch`:
+      - ahead / behind: commits relative to upstream (0 if no upstream)
+      - staged: tracked changes in the index
+      - dirty: unstaged tracked changes + untracked files
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain=v2", "--branch"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_git_status_porcelain(result.stdout)
 
 
 def humanize_last_seen(iso: str | None, now: datetime | None = None) -> str:

--- a/tests/test_peer_describe.py
+++ b/tests/test_peer_describe.py
@@ -383,3 +383,186 @@ def test_dataclass_construct_smoke():
         direction="outbound", counterparty="alice", text="hi",
     )
     assert e.event_type == "notification"
+
+
+# ---------------------------------------------------------------------------
+# Git status parsing (compute_git_status integration tests use real repos)
+# ---------------------------------------------------------------------------
+
+
+from repowire.peer_describe import _parse_git_status_porcelain, compute_git_status  # noqa: E402
+
+
+def test_parse_clean_no_upstream():
+    out = "# branch.oid abc123\n# branch.head main\n"
+    assert _parse_git_status_porcelain(out) == {"ahead": 0, "behind": 0, "dirty": 0, "staged": 0}
+
+
+def test_parse_clean_with_upstream():
+    out = (
+        "# branch.oid abc123\n"
+        "# branch.head main\n"
+        "# branch.upstream origin/main\n"
+        "# branch.ab +0 -0\n"
+    )
+    assert _parse_git_status_porcelain(out) == {"ahead": 0, "behind": 0, "dirty": 0, "staged": 0}
+
+
+def test_parse_ahead_only():
+    out = "# branch.ab +3 -0\n"
+    assert _parse_git_status_porcelain(out)["ahead"] == 3
+    assert _parse_git_status_porcelain(out)["behind"] == 0
+
+
+def test_parse_behind_only():
+    out = "# branch.ab +0 -2\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["ahead"] == 0
+    assert res["behind"] == 2
+
+
+def test_parse_ahead_and_behind():
+    out = "# branch.ab +1 -2\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["ahead"] == 1 and res["behind"] == 2
+
+
+def test_parse_dirty_unstaged():
+    out = "1 .M N... 100644 100644 100644 aaa bbb file.txt\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["dirty"] == 1 and res["staged"] == 0
+
+
+def test_parse_staged_only():
+    out = "1 M. N... 100644 100644 100644 aaa bbb file.txt\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["staged"] == 1 and res["dirty"] == 0
+
+
+def test_parse_staged_and_unstaged_same_file():
+    out = "1 MM N... 100644 100644 100644 aaa bbb file.txt\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["staged"] == 1 and res["dirty"] == 1
+
+
+def test_parse_untracked_counts_as_dirty():
+    out = "? newfile.txt\n? other.py\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["dirty"] == 2 and res["staged"] == 0
+
+
+def test_parse_unmerged_counts_both():
+    out = "u UU N... 100644 100644 100644 100644 aaa bbb ccc conflict.txt\n"
+    res = _parse_git_status_porcelain(out)
+    assert res["staged"] == 1 and res["dirty"] == 1
+
+
+def test_parse_combined():
+    out = (
+        "# branch.ab +1 -2\n"
+        "1 M. N... 100644 100644 100644 aaa bbb staged.txt\n"
+        "1 .M N... 100644 100644 100644 aaa bbb dirty.txt\n"
+        "? untracked.txt\n"
+    )
+    assert _parse_git_status_porcelain(out) == {"ahead": 1, "behind": 2, "dirty": 2, "staged": 1}
+
+
+def test_compute_git_status_non_git_dir(tmp_path):
+    assert compute_git_status(str(tmp_path)) is None
+
+
+def _git(cwd, *args):
+    import subprocess
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def test_compute_git_status_clean_repo(tmp_path):
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    _git(tmp_path, "commit", "--allow-empty", "-m", "init")
+    res = compute_git_status(str(tmp_path))
+    assert res == {"ahead": 0, "behind": 0, "dirty": 0, "staged": 0}
+
+
+def test_compute_git_status_dirty_and_untracked(tmp_path):
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "a.txt").write_text("a")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "commit", "-m", "init")
+    (tmp_path / "a.txt").write_text("changed")  # unstaged
+    (tmp_path / "b.txt").write_text("new")       # untracked
+    (tmp_path / "c.txt").write_text("staged")
+    _git(tmp_path, "add", "c.txt")               # staged
+    res = compute_git_status(str(tmp_path))
+    assert res is not None
+    assert res["dirty"] == 2  # a.txt modified + b.txt untracked
+    assert res["staged"] == 1
+
+
+def test_compute_git_status_ahead(tmp_path):
+    import subprocess
+    # Create a bare upstream, clone, commit ahead.
+    upstream = tmp_path / "upstream.git"
+    work = tmp_path / "work"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", "-q", str(upstream), str(work)], check=True, capture_output=True)
+    _git(work, "config", "user.email", "t@t")
+    _git(work, "config", "user.name", "t")
+    _git(work, "commit", "--allow-empty", "-m", "first")
+    _git(work, "push", "-q", "origin", "main")
+    _git(work, "commit", "--allow-empty", "-m", "ahead1")
+    _git(work, "commit", "--allow-empty", "-m", "ahead2")
+    res = compute_git_status(str(work))
+    assert res is not None
+    assert res["ahead"] == 2 and res["behind"] == 0
+
+
+def test_compute_git_status_behind(tmp_path):
+    import subprocess
+    upstream = tmp_path / "upstream.git"
+    work_a = tmp_path / "a"
+    work_b = tmp_path / "b"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True)
+    _git(work_a, "config", "user.email", "t@t")
+    _git(work_a, "config", "user.name", "t")
+    _git(work_a, "commit", "--allow-empty", "-m", "first")
+    _git(work_a, "push", "-q", "origin", "main")
+    subprocess.run(["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True)
+    _git(work_b, "config", "user.email", "t@t")
+    _git(work_b, "config", "user.name", "t")
+    # Now push more from A so B is behind.
+    _git(work_a, "commit", "--allow-empty", "-m", "second")
+    _git(work_a, "push", "-q", "origin", "main")
+    _git(work_b, "fetch", "-q")
+    res = compute_git_status(str(work_b))
+    assert res is not None
+    assert res["behind"] == 1 and res["ahead"] == 0
+
+
+def test_compute_git_status_ahead_and_behind(tmp_path):
+    import subprocess
+    upstream = tmp_path / "upstream.git"
+    work_a = tmp_path / "a"
+    work_b = tmp_path / "b"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
+    subprocess.run(["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True)
+    _git(work_a, "config", "user.email", "t@t")
+    _git(work_a, "config", "user.name", "t")
+    _git(work_a, "commit", "--allow-empty", "-m", "first")
+    _git(work_a, "push", "-q", "origin", "main")
+    subprocess.run(["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True)
+    _git(work_b, "config", "user.email", "t@t")
+    _git(work_b, "config", "user.name", "t")
+    # A pushes ahead by 1.
+    _git(work_a, "commit", "--allow-empty", "-m", "second")
+    _git(work_a, "push", "-q", "origin", "main")
+    # B makes a local commit (ahead 1) then fetches (behind 1 from A's push).
+    _git(work_b, "commit", "--allow-empty", "-m", "local")
+    _git(work_b, "fetch", "-q")
+    res = compute_git_status(str(work_b))
+    assert res is not None
+    assert res["ahead"] == 1 and res["behind"] == 1

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -98,8 +98,10 @@ class TestSessionMain:
         },
     )
     @patch("repowire.hooks.session_handler.subprocess.Popen")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
     def test_session_start_registers(
-        self, mock_popen, mock_tmux, mock_register, mock_fetch, tmp_path,
+        self, mock_branch, mock_status, mock_popen, mock_tmux, mock_register, mock_fetch, tmp_path,
     ):
         with patch("repowire.config.models.CACHE_DIR", tmp_path):
             result = _run_with_input({
@@ -173,7 +175,9 @@ class TestSessionMain:
         self, mock_tmux, mock_register, mock_fetch, tmp_path,
     ):
         """Different cwd in same pane kills old ws-hook and re-registers."""
-        with patch("repowire.config.models.CACHE_DIR", tmp_path):
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler.get_git_branch", return_value=None), \
+             patch("repowire.hooks.session_handler.compute_git_status", return_value=None):
             log_dir = tmp_path / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
             (log_dir / "ws-hook-1.meta.json").write_text(json.dumps({
@@ -226,7 +230,9 @@ class TestSessionMain:
         self, mock_tmux, mock_register, mock_fetch, tmp_path,
     ):
         """Same cwd with a different hook session_id is treated as a fresh takeover."""
-        with patch("repowire.config.models.CACHE_DIR", tmp_path):
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler.get_git_branch", return_value=None), \
+             patch("repowire.hooks.session_handler.compute_git_status", return_value=None):
             log_dir = tmp_path / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
             (log_dir / "ws-hook-1.meta.json").write_text(json.dumps({

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -56,9 +56,12 @@ export function PeerView({
         <span className={cn("h-2.5 w-2.5 rounded-full", statusDot(peer.status))} />
         <div className="min-w-0 flex-1">
           <h1 className="truncate font-headline text-lg font-bold text-on-surface">{peerLabel(peer)}</h1>
-          <div className="mt-1 truncate font-mono text-[11px] text-outline">
-            {peer.backend || "agent"} · {peer.metadata?.branch ? String(peer.metadata.branch) : peer.circle}
-            {peer.path ? <> · {parent}<span className="text-on-surface-variant">{folder}</span></> : null}
+          <div className="mt-1 flex items-center gap-1.5 truncate font-mono text-[11px] text-outline">
+            <span className="truncate">
+              {peer.backend || "agent"} · {peer.metadata?.branch ? String(peer.metadata.branch) : peer.circle}
+              {peer.path ? <> · {parent}<span className="text-on-surface-variant">{folder}</span></> : null}
+            </span>
+            <GitStatusBadge status={peer.metadata?.git_status} />
           </div>
         </div>
         <StatusLabel status={peer.status} />
@@ -446,6 +449,28 @@ function ComposeBar({
         </div>
       )}
     </div>
+  );
+}
+
+function GitStatusBadge({ status }: { status?: { ahead: number; behind: number; dirty: number; staged: number } }) {
+  if (!status) return null;
+  const { ahead, behind, dirty, staged } = status;
+  const hasLocal = dirty > 0 || staged > 0;
+  const hasRemote = ahead > 0 || behind > 0;
+  const color = hasLocal && hasRemote
+    ? "bg-error"
+    : hasRemote
+    ? "bg-orange-500"
+    : hasLocal
+    ? "bg-yellow-500"
+    : "bg-green-500";
+  const tooltip = `git: ${ahead} ahead, ${behind} behind, ${staged} staged, ${dirty} dirty`;
+  return (
+    <span
+      title={tooltip}
+      aria-label={tooltip}
+      className={cn("inline-block h-2 w-2 shrink-0 rounded-full", color)}
+    />
   );
 }
 

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -13,6 +13,12 @@ export interface Peer {
   description?: string;
   metadata?: {
     branch?: string;
+    git_status?: {
+      ahead: number;
+      behind: number;
+      dirty: number;
+      staged: number;
+    };
     [key: string]: unknown;
   };
 }


### PR DESCRIPTION
Closes #185.

## Summary
- `peer_describe.compute_git_status(cwd)` parses `git status --porcelain=v2 --branch` into `{ahead, behind, dirty, staged}`. Returns `None` for non-git dirs (omitted from metadata).
- Session start hook populates `metadata.branch` and `metadata.git_status` at registration.
- PeerView header renders a small colored dot next to the branch chip with hover tooltip showing counts. Colors: green (clean), yellow (local changes), orange (ahead/behind), red (both).
- Untracked files roll into `dirty`; unmerged into both `staged` and `dirty`.

## Test plan
- [x] `_parse_git_status_porcelain` unit tests: clean (with/without upstream), ahead-only, behind-only, ahead+behind, staged, unstaged, untracked, unmerged, combined
- [x] `compute_git_status` integration tests against real `git init` repos: non-git dir, clean repo, dirty + staged + untracked, ahead, behind, ahead+behind
- [x] Existing session_handler tests patched to no-op git probes
- [x] Full suite: 852 passed