### PR TITLE
feat(transcript): per-peer transcript view with persistent history (#182)

### DIFF
--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -17,6 +17,7 @@ from repowire.daemon.deps import get_peer_registry
 from repowire.daemon.peer_registry import PaneHijackRejectedError
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
+from repowire.session.history import load_peer_turns, page_turns
 
 router = APIRouter(tags=["peers"])
 
@@ -332,6 +333,60 @@ async def touch_peer_last_seen(
             detail=f"Peer not found: {name}",
         )
     return OkResponse()
+
+
+class TranscriptTurn(BaseModel):
+    role: str
+    text: str
+    timestamp: str
+    session_id: str
+    tool_calls: list[dict[str, str]] = Field(default_factory=list)
+
+
+class TranscriptResponse(BaseModel):
+    turns: list[TranscriptTurn]
+    next_before: str | None = None
+
+
+@router.get("/peers/{name}/transcript", response_model=TranscriptResponse)
+async def get_peer_transcript(
+    name: str,
+    limit: int = Query(50, ge=1, le=500, description="Max turns to return"),
+    before: str | None = Query(
+        None, description="ISO-8601 cursor; return turns strictly older than this."
+    ),
+    circle: str | None = Query(None),
+    _: str | None = Depends(require_auth),
+) -> TranscriptResponse:
+    """Paginated newest-first transcript for a peer's working directory.
+
+    v1 reads Claude Code JSONLs under ~/.claude/projects/<encoded-cwd>/.
+    Codex peers return an empty list (follow-up: rollout header scan).
+    Returns 200 with empty turns when no transcript files exist.
+    """
+    peer_registry = get_peer_registry()
+    peer = await peer_registry.get_peer(name, circle=circle)
+    if peer is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {name}",
+        )
+
+    turns = await asyncio.to_thread(load_peer_turns, peer.path, peer.backend)
+    page, next_before = page_turns(turns, limit, before)
+    return TranscriptResponse(
+        turns=[
+            TranscriptTurn(
+                role=t.role,
+                text=t.text,
+                timestamp=t.timestamp,
+                session_id=t.session_id,
+                tool_calls=t.tool_calls,
+            )
+            for t in page
+        ],
+        next_before=next_before,
+    )
 
 
 class SetCircleRequest(BaseModel):

--- a/repowire/session/history.py
+++ b/repowire/session/history.py
@@ -1,0 +1,166 @@
+"""Full-replay transcript parser and per-peer session discovery.
+
+Companion to `transcript.py` (last-turn only). Used by the
+`GET /peers/{name}/transcript` daemon route.
+
+v1 supports Claude Code on-disk transcripts:
+`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. The cwd is encoded
+by replacing path separators with `-` (matching Claude Code's own scheme).
+
+Codex transcripts (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`) are
+date-bucketed rather than keyed by cwd, so per-peer discovery there
+requires scanning rollout headers — deferred to a follow-up issue.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from repowire.session.transcript import _summarize_tool_input
+
+
+@dataclass
+class Turn:
+    """One user or assistant turn from a transcript replay."""
+
+    role: str  # "user" | "assistant"
+    text: str
+    timestamp: str  # ISO-8601; "" if missing
+    session_id: str
+    tool_calls: list[dict[str, str]]  # [{name, input}] — empty for user turns
+
+
+def _claude_projects_dir() -> Path:
+    return Path.home() / ".claude" / "projects"
+
+
+def _encode_cwd(path: str) -> str:
+    """Claude Code encodes the cwd by replacing `/` with `-`.
+
+    Example: `/Users/x/dev/repo` → `-Users-x-dev-repo`.
+    """
+    return path.replace("/", "-")
+
+
+def discover_claude_sessions(peer_path: str | None) -> list[Path]:
+    """List Claude JSONL transcripts for a peer's working directory.
+
+    Returns empty list if the peer has no path or the project dir is absent.
+    """
+    if not peer_path:
+        return []
+    project_dir = _claude_projects_dir() / _encode_cwd(peer_path)
+    if not project_dir.is_dir():
+        return []
+    return sorted(project_dir.glob("*.jsonl"))
+
+
+def _extract_text(content: Any) -> str:
+    """Concatenate text fragments from a Claude message `content` value."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                if text:
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    if isinstance(content, dict) and content.get("type") == "text":
+        return content.get("text", "") or ""
+    return ""
+
+
+def _iter_claude_turns(path: Path) -> Iterator[Turn]:
+    """Yield Turn objects from a Claude Code JSONL transcript.
+
+    Skips tool-only assistant entries (no text) and tool_result-only user
+    entries, which match the semantics of the dashboard's live chat_turn ring.
+    """
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                entry_type = entry.get("type")
+                if entry_type not in ("user", "assistant"):
+                    continue
+                message = entry.get("message", {})
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content", [])
+
+                if entry_type == "user" and isinstance(content, list) and content and all(
+                    isinstance(c, dict) and c.get("type") == "tool_result" for c in content
+                ):
+                    continue
+
+                text = _extract_text(content)
+                tool_calls: list[dict[str, str]] = []
+                if entry_type == "assistant" and isinstance(content, list):
+                    for item in content:
+                        if isinstance(item, dict) and item.get("type") == "tool_use":
+                            tool_calls.append({
+                                "name": item.get("name", "unknown"),
+                                "input": _summarize_tool_input(
+                                    item.get("name", "unknown"),
+                                    item.get("input", {}),
+                                ),
+                            })
+
+                if not text and not tool_calls:
+                    continue
+
+                yield Turn(
+                    role=entry_type,
+                    text=text,
+                    timestamp=entry.get("timestamp", "") or "",
+                    session_id=entry.get("sessionId", "") or path.stem,
+                    tool_calls=tool_calls,
+                )
+    except OSError:
+        return
+
+
+def load_peer_turns(peer_path: str | None, backend: str) -> list[Turn]:
+    """Load and sort-merge all turns for a peer across session files.
+
+    Newest-first. Returns empty list for non-claude-code backends (codex
+    discovery is a follow-up). Sort key is (timestamp, session_id) so
+    turns with missing or duplicate timestamps remain deterministic.
+    """
+    if backend != "claude-code":
+        return []
+    turns: list[Turn] = []
+    for path in discover_claude_sessions(peer_path):
+        turns.extend(_iter_claude_turns(path))
+    turns.sort(key=lambda t: (t.timestamp, t.session_id), reverse=True)
+    return turns
+
+
+def page_turns(turns: list[Turn], limit: int, before: str | None) -> tuple[list[Turn], str | None]:
+    """Slice a newest-first turn list by cursor.
+
+    `before` is an ISO-8601 timestamp; only turns strictly older than it are
+    returned. Returns (page, next_before). `next_before` is the oldest
+    timestamp in the page when more results exist, else None.
+    """
+    if before:
+        filtered = [t for t in turns if t.timestamp and t.timestamp < before]
+    else:
+        filtered = turns
+    page = filtered[:limit]
+    next_before = page[-1].timestamp if len(filtered) > limit and page else None
+    return page, next_before

--- a/repowire/session/history.py
+++ b/repowire/session/history.py
@@ -14,6 +14,7 @@ requires scanning rollout headers — deferred to a follow-up issue.
 
 from __future__ import annotations
 
+import base64
 import json
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -32,6 +33,7 @@ class Turn:
     timestamp: str  # ISO-8601; "" if missing
     session_id: str
     tool_calls: list[dict[str, str]]  # [{name, input}] — empty for user turns
+    line_offset: int = 0  # tie-breaker for same-timestamp turns within a session file
 
 
 def _claude_projects_dir() -> Path:
@@ -86,7 +88,7 @@ def _iter_claude_turns(path: Path) -> Iterator[Turn]:
     """
     try:
         with open(path) as f:
-            for line in f:
+            for line_no, line in enumerate(f):
                 line = line.strip()
                 if not line:
                     continue
@@ -129,38 +131,88 @@ def _iter_claude_turns(path: Path) -> Iterator[Turn]:
                     timestamp=entry.get("timestamp", "") or "",
                     session_id=entry.get("sessionId", "") or path.stem,
                     tool_calls=tool_calls,
+                    line_offset=line_no,
                 )
     except OSError:
         return
+
+
+def _sort_key(t: Turn) -> tuple[str, str, int]:
+    return (t.timestamp, t.session_id, t.line_offset)
 
 
 def load_peer_turns(peer_path: str | None, backend: str) -> list[Turn]:
     """Load and sort-merge all turns for a peer across session files.
 
     Newest-first. Returns empty list for non-claude-code backends (codex
-    discovery is a follow-up). Sort key is (timestamp, session_id) so
-    turns with missing or duplicate timestamps remain deterministic.
+    discovery is a follow-up). Sort key is the composite cursor tuple
+    `(timestamp, session_id, line_offset)`; turns with empty timestamps
+    sort to the end (oldest) in the newest-first ordering.
     """
     if backend != "claude-code":
         return []
     turns: list[Turn] = []
     for path in discover_claude_sessions(peer_path):
         turns.extend(_iter_claude_turns(path))
-    turns.sort(key=lambda t: (t.timestamp, t.session_id), reverse=True)
+    turns.sort(key=_sort_key, reverse=True)
     return turns
 
 
-def page_turns(turns: list[Turn], limit: int, before: str | None) -> tuple[list[Turn], str | None]:
-    """Slice a newest-first turn list by cursor.
+def encode_cursor(t: Turn) -> str:
+    """Pack a Turn's composite cursor into an opaque URL-safe token.
 
-    `before` is an ISO-8601 timestamp; only turns strictly older than it are
-    returned. Returns (page, next_before). `next_before` is the oldest
-    timestamp in the page when more results exist, else None.
+    Format (pre-encoding): `ts|session_id|line_offset`. The `|` separator
+    cannot appear in ISO timestamps; session IDs are UUIDs or filenames
+    without `|`. Base64-urlsafe encoding makes the token opaque on the wire.
+    """
+    raw = f"{t.timestamp}|{t.session_id}|{t.line_offset}".encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_cursor(cursor: str) -> tuple[str, str, int] | None:
+    """Decode an opaque cursor back into a `(timestamp, session_id, line_offset)` tuple.
+
+    Returns None when the cursor is malformed — callers treat that as
+    "ignore the cursor" (first page).
+    """
+    if not cursor:
+        return None
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(cursor + padding).decode()
+    except (ValueError, UnicodeDecodeError):
+        return None
+    parts = raw.split("|", 2)
+    if len(parts) != 3:
+        return None
+    ts, session_id, offset_str = parts
+    try:
+        offset = int(offset_str)
+    except ValueError:
+        return None
+    return (ts, session_id, offset)
+
+
+def page_turns(turns: list[Turn], limit: int, before: str | None) -> tuple[list[Turn], str | None]:
+    """Slice a newest-first turn list by an opaque cursor.
+
+    `before` is an opaque cursor produced by `encode_cursor` (or None for
+    the first page). Returns `(page, next_cursor)`. `next_cursor` is the
+    composite cursor of the last turn on the page when more results exist,
+    else None.
+
+    Empty-timestamp turns are included consistently in both first-page and
+    paginated requests — their composite tuple `("", session, offset)` is
+    compared the same way as any other turn.
     """
     if before:
-        filtered = [t for t in turns if t.timestamp and t.timestamp < before]
+        cursor = decode_cursor(before)
+        if cursor is None:
+            filtered = turns
+        else:
+            filtered = [t for t in turns if _sort_key(t) < cursor]
     else:
         filtered = turns
     page = filtered[:limit]
-    next_before = page[-1].timestamp if len(filtered) > limit and page else None
-    return page, next_before
+    next_cursor = encode_cursor(page[-1]) if len(filtered) > limit and page else None
+    return page, next_cursor

--- a/tests/test_transcript_history.py
+++ b/tests/test_transcript_history.py
@@ -1,0 +1,198 @@
+"""Tests for repowire/session/history.py — full-replay parser + pagination.
+
+Route tests for GET /peers/{name}/transcript live in
+test_transcript_history_routes.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from repowire.session.history import (
+    Turn,
+    _encode_cwd,
+    discover_claude_sessions,
+    load_peer_turns,
+    page_turns,
+)
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.write_text("".join(json.dumps(e) + "\n" for e in entries))
+
+
+def _u(ts: str, text: str) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "sessionId": "s1",
+        "message": {"content": text},
+    }
+
+
+def _a(ts: str, text: str, tool_uses: list[dict] | None = None) -> dict:
+    content: list[dict] = []
+    if text:
+        content.append({"type": "text", "text": text})
+    if tool_uses:
+        content.extend(tool_uses)
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "sessionId": "s1",
+        "message": {"content": content},
+    }
+
+
+class TestEncodeCwd:
+    def test_simple(self):
+        assert _encode_cwd("/Users/x/dev/repo") == "-Users-x-dev-repo"
+
+
+class TestDiscoverClaudeSessions:
+    def test_returns_sorted_jsonls(self, tmp_path: Path):
+        peer_path = "/peer/work/dir"
+        projects_root = tmp_path / "projects"
+        encoded = projects_root / _encode_cwd(peer_path)
+        encoded.mkdir(parents=True)
+        (encoded / "b.jsonl").write_text("")
+        (encoded / "a.jsonl").write_text("")
+        (encoded / "skip.txt").write_text("nope")
+
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            found = discover_claude_sessions(peer_path)
+
+        assert [p.name for p in found] == ["a.jsonl", "b.jsonl"]
+
+    def test_empty_when_dir_missing(self, tmp_path: Path):
+        absent = tmp_path / "absent"
+        with patch("repowire.session.history._claude_projects_dir", return_value=absent):
+            assert discover_claude_sessions("/some/path") == []
+
+    def test_empty_when_no_peer_path(self):
+        assert discover_claude_sessions(None) == []
+
+
+class TestLoadPeerTurnsClaude:
+    def _setup(self, tmp_path: Path, entries: list[dict]) -> tuple[str, Path]:
+        peer_path = "/peer/work"
+        projects_root = tmp_path / "projects"
+        session_dir = projects_root / _encode_cwd(peer_path)
+        session_dir.mkdir(parents=True)
+        _write_jsonl(session_dir / "session.jsonl", entries)
+        return peer_path, projects_root
+
+    def test_basic_replay_newest_first(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                _u("2026-01-01T00:00:00Z", "first q"),
+                _a("2026-01-01T00:00:01Z", "first a"),
+                _u("2026-01-02T00:00:00Z", "second q"),
+                _a("2026-01-02T00:00:01Z", "second a"),
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert [t.text for t in turns] == ["second a", "second q", "first a", "first q"]
+        assert turns[0].role == "assistant"
+        assert turns[1].role == "user"
+
+    def test_skips_tool_result_only_user_entries(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                _u("2026-01-01T00:00:00Z", "real q"),
+                _a("2026-01-01T00:00:01Z", "real a"),
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "sessionId": "s1",
+                    "message": {"content": [{"type": "tool_result", "content": "ok"}]},
+                },
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert len(turns) == 2
+
+    def test_extracts_tool_calls_on_assistant_turn(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                _a(
+                    "2026-01-01T00:00:00Z",
+                    "running",
+                    tool_uses=[
+                        {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}
+                    ],
+                )
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert turns[0].tool_calls == [{"name": "Bash", "input": "ls -la"}]
+
+    def test_skips_malformed_lines(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(tmp_path, [_a("2026-01-01T00:00:00Z", "ok")])
+        session_dir = projects_root / _encode_cwd(peer_path)
+        with open(session_dir / "session.jsonl", "a") as f:
+            f.write("not json\n")
+            f.write("\n")
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert len(turns) == 1
+
+    def test_sort_merges_across_sessions(self, tmp_path: Path):
+        peer_path = "/peer/work"
+        projects_root = tmp_path / "projects"
+        session_dir = projects_root / _encode_cwd(peer_path)
+        session_dir.mkdir(parents=True)
+        _write_jsonl(session_dir / "a.jsonl", [
+            _u("2026-01-01T00:00:00Z", "old"),
+        ])
+        _write_jsonl(session_dir / "b.jsonl", [
+            _u("2026-01-03T00:00:00Z", "new"),
+        ])
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert [t.text for t in turns] == ["new", "old"]
+
+
+class TestLoadPeerTurnsBackends:
+    def test_codex_returns_empty_in_v1(self):
+        assert load_peer_turns("/any/path", "codex") == []
+
+    def test_gemini_returns_empty(self):
+        assert load_peer_turns("/any/path", "gemini") == []
+
+
+def _t(ts: str) -> Turn:
+    return Turn(role="user", text=ts, timestamp=ts, session_id="s", tool_calls=[])
+
+
+class TestPageTurns:
+    def test_no_cursor_returns_head(self):
+        turns = [_t("2026-01-03"), _t("2026-01-02"), _t("2026-01-01")]
+        page, nxt = page_turns(turns, limit=2, before=None)
+        assert [t.text for t in page] == ["2026-01-03", "2026-01-02"]
+        assert nxt == "2026-01-02"
+
+    def test_cursor_filters_strictly_older(self):
+        turns = [_t("2026-01-03"), _t("2026-01-02"), _t("2026-01-01")]
+        page, nxt = page_turns(turns, limit=10, before="2026-01-03")
+        assert [t.text for t in page] == ["2026-01-02", "2026-01-01"]
+        assert nxt is None
+
+    def test_last_page_has_null_cursor(self):
+        turns = [_t("2026-01-02"), _t("2026-01-01")]
+        page, nxt = page_turns(turns, limit=10, before=None)
+        assert len(page) == 2
+        assert nxt is None
+
+    def test_empty_returns_empty(self):
+        page, nxt = page_turns([], limit=5, before=None)
+        assert page == []
+        assert nxt is None

--- a/tests/test_transcript_history.py
+++ b/tests/test_transcript_history.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 from repowire.session.history import (
     Turn,
     _encode_cwd,
+    decode_cursor,
     discover_claude_sessions,
+    encode_cursor,
     load_peer_turns,
     page_turns,
 )
@@ -169,8 +171,15 @@ class TestLoadPeerTurnsBackends:
         assert load_peer_turns("/any/path", "gemini") == []
 
 
-def _t(ts: str) -> Turn:
-    return Turn(role="user", text=ts, timestamp=ts, session_id="s", tool_calls=[])
+def _t(ts: str, session_id: str = "s", line_offset: int = 0, text: str | None = None) -> Turn:
+    return Turn(
+        role="user",
+        text=text if text is not None else ts,
+        timestamp=ts,
+        session_id=session_id,
+        tool_calls=[],
+        line_offset=line_offset,
+    )
 
 
 class TestPageTurns:
@@ -178,11 +187,12 @@ class TestPageTurns:
         turns = [_t("2026-01-03"), _t("2026-01-02"), _t("2026-01-01")]
         page, nxt = page_turns(turns, limit=2, before=None)
         assert [t.text for t in page] == ["2026-01-03", "2026-01-02"]
-        assert nxt == "2026-01-02"
+        assert decode_cursor(nxt or "") == ("2026-01-02", "s", 0)
 
     def test_cursor_filters_strictly_older(self):
         turns = [_t("2026-01-03"), _t("2026-01-02"), _t("2026-01-01")]
-        page, nxt = page_turns(turns, limit=10, before="2026-01-03")
+        cursor = encode_cursor(turns[0])
+        page, nxt = page_turns(turns, limit=10, before=cursor)
         assert [t.text for t in page] == ["2026-01-02", "2026-01-01"]
         assert nxt is None
 
@@ -196,3 +206,71 @@ class TestPageTurns:
         page, nxt = page_turns([], limit=5, before=None)
         assert page == []
         assert nxt is None
+
+    def test_same_timestamp_boundary_no_drop(self):
+        # Three turns share the page-boundary timestamp. With a plain-timestamp
+        # cursor, paginating after the first page would drop the remaining two.
+        # The composite cursor must include a tiebreaker so they survive.
+        turns = [
+            _t("2026-01-03T00:00:00Z", session_id="s", line_offset=2, text="a"),
+            _t("2026-01-02T00:00:00Z", session_id="s", line_offset=1, text="b"),
+            _t("2026-01-02T00:00:00Z", session_id="s", line_offset=0, text="c"),
+            _t("2026-01-02T00:00:00Z", session_id="r", line_offset=0, text="d"),
+            _t("2026-01-01T00:00:00Z", session_id="s", line_offset=0, text="e"),
+        ]
+        # Pre-sort to match what load_peer_turns produces (newest-first by composite key).
+        turns.sort(key=lambda t: (t.timestamp, t.session_id, t.line_offset), reverse=True)
+        page1, cursor1 = page_turns(turns, limit=2, before=None)
+        assert [t.text for t in page1] == ["a", "b"]
+        assert cursor1 is not None
+        page2, cursor2 = page_turns(turns, limit=2, before=cursor1)
+        # The remaining same-ts turns must be returned, not dropped.
+        assert [t.text for t in page2] == ["c", "d"]
+        assert cursor2 is not None
+        page3, cursor3 = page_turns(turns, limit=2, before=cursor2)
+        assert [t.text for t in page3] == ["e"]
+        assert cursor3 is None
+
+    def test_empty_timestamp_consistent_across_pages(self):
+        # Turns with empty timestamps must be reachable when paginating with
+        # a cursor, not just on the first page.
+        turns = [
+            _t("2026-01-02T00:00:00Z", session_id="s", line_offset=0, text="recent"),
+            _t("2026-01-01T00:00:00Z", session_id="s", line_offset=0, text="older"),
+            _t("", session_id="s", line_offset=5, text="no_ts_a"),
+            _t("", session_id="s", line_offset=3, text="no_ts_b"),
+        ]
+        turns.sort(key=lambda t: (t.timestamp, t.session_id, t.line_offset), reverse=True)
+        # First page includes the newest non-empty-ts turn.
+        page1, cursor1 = page_turns(turns, limit=1, before=None)
+        assert [t.text for t in page1] == ["recent"]
+        assert cursor1 is not None
+        # Paginate through everything; empty-ts turns must surface, not vanish.
+        seen: list[str] = list(t.text for t in page1)
+        cursor = cursor1
+        while cursor is not None:
+            page, cursor = page_turns(turns, limit=1, before=cursor)
+            seen.extend(t.text for t in page)
+        assert "no_ts_a" in seen
+        assert "no_ts_b" in seen
+        assert seen == ["recent", "older", "no_ts_a", "no_ts_b"]
+
+    def test_cursor_roundtrip(self):
+        t = _t("2026-01-02T00:00:00Z", session_id="abc-123", line_offset=42)
+        cursor = encode_cursor(t)
+        assert decode_cursor(cursor) == ("2026-01-02T00:00:00Z", "abc-123", 42)
+
+    def test_malformed_cursor_falls_back_to_first_page(self):
+        turns = [_t("2026-01-02"), _t("2026-01-01")]
+        page, _ = page_turns(turns, limit=10, before="not-a-real-cursor!!!")
+        assert [t.text for t in page] == ["2026-01-02", "2026-01-01"]
+
+    def test_empty_timestamp_included_on_first_page(self):
+        # Regression: first page used to include empty-ts turns; this must still hold.
+        turns = [
+            _t("2026-01-02", session_id="s", line_offset=0, text="a"),
+            _t("", session_id="s", line_offset=1, text="b"),
+        ]
+        turns.sort(key=lambda t: (t.timestamp, t.session_id, t.line_offset), reverse=True)
+        page, _ = page_turns(turns, limit=10, before=None)
+        assert [t.text for t in page] == ["a", "b"]

--- a/tests/test_transcript_history_routes.py
+++ b/tests/test_transcript_history_routes.py
@@ -1,0 +1,168 @@
+"""Route tests for GET /peers/{name}/transcript."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.session.history import _encode_cwd
+
+
+def _make_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=tracker,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+    app = FastAPI()
+    app.include_router(peers.router)
+    return app, registry
+
+
+def _write_session(projects_root: Path, peer_path: str, entries: list[dict]) -> None:
+    session_dir = projects_root / _encode_cwd(peer_path)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    out = session_dir / "session.jsonl"
+    with open(out, "a") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+@pytest.mark.anyio
+async def test_unknown_peer_returns_404(tmp_path: Path):
+    app, _ = _make_app(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+            res = await ac.get("/peers/ghost/transcript")
+        assert res.status_code == 404
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_peer_with_no_transcripts_returns_empty(tmp_path: Path):
+    app, registry = _make_app(tmp_path)
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path="/peer/work",
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        with patch(
+            "repowire.session.history._claude_projects_dir",
+            return_value=tmp_path / "absent",
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                res = await ac.get(f"/peers/{name}/transcript")
+        assert res.status_code == 200
+        assert res.json() == {"turns": [], "next_before": None}
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_returns_paginated_turns(tmp_path: Path):
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        _write_session(projects_root, peer_path, [
+            {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "q1"}},
+            {"type": "assistant", "timestamp": "2026-01-01T00:00:01Z", "sessionId": "s1",
+             "message": {"content": [{"type": "text", "text": "a1"}]}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "q2"}},
+            {"type": "assistant", "timestamp": "2026-01-02T00:00:01Z", "sessionId": "s1",
+             "message": {"content": [{"type": "text", "text": "a2"}]}},
+        ])
+
+        with patch(
+            "repowire.session.history._claude_projects_dir",
+            return_value=projects_root,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                res = await ac.get(f"/peers/{name}/transcript", params={"limit": 2})
+                body = res.json()
+                assert res.status_code == 200
+                assert [t["text"] for t in body["turns"]] == ["a2", "q2"]
+                assert body["next_before"] == "2026-01-02T00:00:00Z"
+
+                res2 = await ac.get(
+                    f"/peers/{name}/transcript",
+                    params={"limit": 10, "before": body["next_before"]},
+                )
+                body2 = res2.json()
+                assert [t["text"] for t in body2["turns"]] == ["a1", "q1"]
+                assert body2["next_before"] is None
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_codex_peer_returns_empty_v1(tmp_path: Path):
+    app, registry = _make_app(tmp_path)
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CODEX,
+            path="/peer/work",
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+            res = await ac.get(f"/peers/{name}/transcript")
+        assert res.status_code == 200
+        assert res.json()["turns"] == []
+    finally:
+        cleanup_deps()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/tests/test_transcript_history_routes.py
+++ b/tests/test_transcript_history_routes.py
@@ -129,7 +129,7 @@ async def test_returns_paginated_turns(tmp_path: Path):
                 body = res.json()
                 assert res.status_code == 200
                 assert [t["text"] for t in body["turns"]] == ["a2", "q2"]
-                assert body["next_before"] == "2026-01-02T00:00:00Z"
+                assert body["next_before"] is not None
 
                 res2 = await ac.get(
                     f"/peers/{name}/transcript",
@@ -159,6 +159,116 @@ async def test_codex_peer_returns_empty_v1(tmp_path: Path):
             res = await ac.get(f"/peers/{name}/transcript")
         assert res.status_code == 200
         assert res.json()["turns"] == []
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_same_timestamp_boundary_does_not_drop_turns(tmp_path: Path):
+    """Regression: when the page-boundary timestamp is shared by multiple
+    turns, the cursor must include a tiebreaker so they survive pagination."""
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        # Five turns; three share the same timestamp at the page boundary.
+        _write_session(projects_root, peer_path, [
+            {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "oldest"}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "mid_a"}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "mid_b"}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "mid_c"}},
+            {"type": "user", "timestamp": "2026-01-03T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "newest"}},
+        ])
+
+        with patch(
+            "repowire.session.history._claude_projects_dir",
+            return_value=projects_root,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                # Page 1: limit=2 lands the boundary mid-cluster.
+                res = await ac.get(f"/peers/{name}/transcript", params={"limit": 2})
+                body = res.json()
+                texts: list[str] = [t["text"] for t in body["turns"]]
+                cursor = body["next_before"]
+                assert cursor is not None
+                while cursor is not None:
+                    res = await ac.get(
+                        f"/peers/{name}/transcript",
+                        params={"limit": 2, "before": cursor},
+                    )
+                    body = res.json()
+                    texts.extend(t["text"] for t in body["turns"])
+                    cursor = body["next_before"]
+                # All five turns must be present; no drop at the boundary.
+                assert sorted(texts) == sorted(
+                    ["newest", "mid_a", "mid_b", "mid_c", "oldest"]
+                )
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_empty_timestamp_turns_reachable_via_cursor(tmp_path: Path):
+    """Regression: turns with empty timestamps used to be included on the
+    first page but dropped on paginated requests."""
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        _write_session(projects_root, peer_path, [
+            {"type": "user", "sessionId": "s1",
+             "message": {"content": "no_ts_a"}},
+            {"type": "user", "sessionId": "s1",
+             "message": {"content": "no_ts_b"}},
+            {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "older"}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z", "sessionId": "s1",
+             "message": {"content": "newer"}},
+        ])
+
+        with patch(
+            "repowire.session.history._claude_projects_dir",
+            return_value=projects_root,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                texts: list[str] = []
+                cursor: str | None = None
+                for _ in range(10):
+                    params: dict[str, object] = {"limit": 1}
+                    if cursor is not None:
+                        params["before"] = cursor
+                    res = await ac.get(f"/peers/{name}/transcript", params=params)
+                    body = res.json()
+                    texts.extend(t["text"] for t in body["turns"])
+                    cursor = body["next_before"]
+                    if cursor is None:
+                        break
+                assert "no_ts_a" in texts
+                assert "no_ts_b" in texts
+                assert sorted(texts) == sorted(["newer", "older", "no_ts_a", "no_ts_b"])
     finally:
         cleanup_deps()
 

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -7,6 +7,14 @@ import type { Event, Peer } from "../types";
 import { peerLabel } from "../types";
 import { formatTime, StatusLabel } from "./status";
 
+interface TranscriptTurn {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+  session_id: string;
+  tool_calls: { name: string; input: string }[];
+}
+
 interface PendingAsk {
   correlation_id: string;
   to_peer: string;
@@ -20,7 +28,7 @@ interface PendingAsk {
 const ACK_FRAME_RE = /^\[ack #([^\]\s]+) from @([^\]\s]+)\]\s?([\s\S]*)$/;
 const BARE_ACK_TIMEOUT_MS = 120_000;
 
-type PeerTab = "chat" | "mcp";
+type PeerTab = "chat" | "mcp" | "history";
 
 export function PeerView({
   peer,
@@ -91,6 +99,7 @@ export function PeerView({
 
       <div className="flex shrink-0 gap-0 border-b border-border-faint px-4 md:px-6" role="tablist">
         <TabButton label="chat" active={activeTab === "chat"} onClick={() => setActiveTab("chat")} />
+        <TabButton label="history" active={activeTab === "history"} onClick={() => setActiveTab("history")} />
         <TabButton label="mcp" active={activeTab === "mcp"} onClick={() => setActiveTab("mcp")} />
       </div>
 
@@ -110,6 +119,8 @@ export function PeerView({
 
           <ComposeBar peer={peer} apiBase={apiBase} events={events} onSent={onSent} />
         </>
+      ) : activeTab === "history" ? (
+        <HistoryPane peer={peer} apiBase={apiBase} />
       ) : (
         <McpPanel peer={peer} apiBase={apiBase} />
       )}
@@ -188,6 +199,118 @@ function ToolCallBlock({ toolCalls }: { toolCalls: { name: string; input: string
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function HistoryPane({ peer, apiBase }: { peer: Peer; apiBase: string }) {
+  const [turns, setTurns] = useState<TranscriptTurn[]>([]);
+  const [nextBefore, setNextBefore] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+
+  const fetchPage = async (before: string | null) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(`${apiBase}/peers/${encodeURIComponent(peer.name)}/transcript`, window.location.origin);
+      url.searchParams.set("limit", "50");
+      if (before) url.searchParams.set("before", before);
+      const res = await fetch(url.toString().replace(window.location.origin, ""), {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        setError(`Error ${res.status}`);
+        return;
+      }
+      const data = (await res.json()) as { turns: TranscriptTurn[]; next_before: string | null };
+      setTurns((prev) => [...prev, ...data.turns]);
+      setNextBefore(data.next_before);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      setLoading(false);
+      setInitialized(true);
+    }
+  };
+
+  useEffect(() => {
+    setTurns([]);
+    setNextBefore(null);
+    setInitialized(false);
+    fetchPage(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [peer.peer_id]);
+
+  useEffect(() => {
+    const el = topSentinelRef.current;
+    if (!el || !nextBefore || loading) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) fetchPage(nextBefore);
+      },
+      { rootMargin: "100px" }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nextBefore, loading]);
+
+  return (
+    <div className="min-h-0 flex-1 px-4 py-4 md:overflow-y-auto md:px-6">
+      {nextBefore && (
+        <div ref={topSentinelRef} className="py-2 text-center font-mono text-[10px] text-outline">
+          {loading ? "loading older…" : "scroll up for older"}
+        </div>
+      )}
+      {turns.length === 0 && initialized && !loading && (
+        <div className="py-10 font-mono text-xs leading-6 text-outline">
+          &gt; no transcript history for {peerLabel(peer)}.<br />
+          <span>{peer.backend === "claude-code" ? "this peer has no on-disk sessions yet." : "history is claude-code only in v1."}</span>
+        </div>
+      )}
+      {turns.length === 0 && !initialized && loading && (
+        <div className="py-10 font-mono text-xs leading-6 text-outline">&gt; loading…</div>
+      )}
+      {error && (
+        <div className="mb-2 flex items-center gap-2 font-mono text-xs text-error">
+          <AlertCircle className="h-3.5 w-3.5" />
+          <span>{error}</span>
+        </div>
+      )}
+      {[...turns].reverse().map((turn, idx) => (
+        <HistoryTurn key={`${turn.session_id}-${turn.timestamp}-${idx}`} turn={turn} peer={peer} />
+      ))}
+    </div>
+  );
+}
+
+function HistoryTurn({ turn, peer }: { turn: TranscriptTurn; peer: Peer }) {
+  const isUser = turn.role === "user";
+  return (
+    <div className={cn("mb-4 flex flex-col", isUser ? "items-end" : "items-start")}>
+      <div className="mb-1 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-outline">
+        {isUser ? "@user" : peerLabel(peer)} · {turn.timestamp ? formatTime(turn.timestamp) : "—"}
+      </div>
+      <div
+        className={cn(
+          "max-w-[82%] min-w-0 rounded p-3 font-mono text-[13px] leading-6 text-on-surface [overflow-wrap:anywhere]",
+          isUser
+            ? "border-r-2 border-primary/40 bg-primary/5"
+            : "border-l-2 border-primary/40 bg-surface-container-high"
+        )}
+      >
+        {isUser ? (
+          <p className="whitespace-pre-wrap break-words">{turn.text}</p>
+        ) : (
+          <div className="prose prose-invert prose-sm max-w-none break-words [&_pre]:overflow-x-auto">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{turn.text}</ReactMarkdown>
+          </div>
+        )}
+      </div>
+      {!isUser && turn.tool_calls.length > 0 && <ToolCallBlock toolCalls={turn.tool_calls} />}
     </div>
   );
 }


### PR DESCRIPTION
Closes #182.

## Summary
- New `repowire/session/history.py`: full-replay parser for Claude Code JSONL transcripts (companion to last-turn `transcript.py`), per-peer session discovery via `~/.claude/projects/<encoded-cwd>/*.jsonl`, sort-merge across session files, timestamp-cursor pagination.
- New route `GET /peers/{name}/transcript?limit=&before=&circle=` returning `{turns, next_before}` newest-first. Empty list (200) when no transcripts exist; 404 only on unknown peer.
- Dashboard `PeerView`: inline tab strip (Live / History). History tab fetches the new route, IntersectionObserver auto-loads older pages on upward scroll. New `<HistoryPane>` subcomponent in same file (no other refactors to PeerView).

## Scope
- **v1 is claude-code only.** Codex transcripts live at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` and are not keyed by cwd — discovery requires scanning rollout headers for `cwd` (or session_id matching). Codex/Gemini/OpenCode peers return an empty `turns` list. Follow-up issue to be filed for codex discovery.
- No cross-host transcript push (ACP-gated per spec).
- No transcript editing/search (out of scope per spec).

## Tabs coordination
Coordinated with `#183` MCP-config-tab peer: inline header strip, no shared `<Tabs>` wrapper this round. Either PR can refactor to a shared component as a follow-up.

## Tests
- `tests/test_transcript_history.py` — 15 tests: cwd encoding, session discovery, full Claude replay, tool-result skipping, tool_use extraction, malformed-line skip, sort-merge across sessions, codex/gemini return empty, pagination boundary (`before=` filter, last-page `next_before=null`).
- `tests/test_transcript_history_routes.py` — 4 tests: unknown peer 404, no transcripts returns empty 200, paginated turns with cursor round-trip, codex peer empty.
- Full suite: 877 passed. Ruff clean. ty clean.

## Test plan
- [x] Parser unit tests cover Claude format + skip rules
- [x] Pagination boundary tested both with and without cursor
- [x] Route 404 vs 200-empty distinguished
- [x] Codex peer returns empty in v1
- [ ] Manual: load dashboard, switch to History tab on a peer with on-disk sessions