### PR TITLE
feat: per-peer MCP config viewer/editor (#183)

### DIFF
--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
+from repowire import peer_mcp
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
@@ -365,6 +366,138 @@ async def get_circle_orchestrator(
         last_seen=orch.last_seen.isoformat() if orch.last_seen else None,
         stale_after_seconds=tolerance,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-peer MCP config (#183) — same-host only in v1
+# ---------------------------------------------------------------------------
+
+
+class McpServerResponse(BaseModel):
+    name: str
+    scope: str = "user"
+    type: str = "stdio"
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    url: str | None = None
+    env_keys: list[str] = Field(default_factory=list)
+
+
+class McpListResponse(BaseModel):
+    servers: list[McpServerResponse]
+
+
+class McpAddRequest(BaseModel):
+    name: str = Field(..., min_length=1, description="Server name (unique per peer)")
+    type: str = Field(default="stdio", description="stdio | http | sse")
+    command: str | None = Field(default=None, description="Command for stdio type")
+    args: list[str] = Field(default_factory=list)
+    url: str | None = Field(default=None, description="URL for http/sse type")
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+async def _resolve_peer_or_404(name: str, circle: str | None) -> Peer:
+    peer_registry = get_peer_registry()
+    peer = await peer_registry.get_peer(name, circle=circle)
+    if not peer:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {name}",
+        )
+    return peer
+
+
+def _enforce_local(peer: Peer) -> None:
+    """Reject cross-host operations until ACP transport is wired (issue #183)."""
+    self_machine = socket.gethostname()
+    if peer.machine and peer.machine != self_machine:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "cross_host",
+                "hint": (
+                    "Per-peer MCP config is same-host only in v1; "
+                    "ACP transport required for remote peers."
+                ),
+                "peer_machine": peer.machine,
+                "self_machine": self_machine,
+            },
+        )
+
+
+def _map_peer_mcp_error(e: peer_mcp.PeerMcpError) -> HTTPException:
+    if isinstance(e, peer_mcp.NotSupportedError):
+        return HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
+    if isinstance(e, peer_mcp.DuplicateServerError):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    if isinstance(e, peer_mcp.ServerNotFoundError):
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    if isinstance(e, peer_mcp.BackendTimeoutError):
+        return HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail=str(e))
+    return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
+
+@router.get("/peers/{name}/mcp", response_model=McpListResponse)
+async def list_peer_mcp(
+    name: str,
+    circle: str | None = Query(None),
+    _: str | None = Depends(require_auth),
+) -> McpListResponse:
+    """List MCP servers configured for the peer's backend.
+
+    Same-host only — returns 409 cross_host for remote peers.
+    """
+    peer = await _resolve_peer_or_404(name, circle)
+    _enforce_local(peer)
+    try:
+        entries = await asyncio.to_thread(peer_mcp.list_servers, peer)
+    except peer_mcp.PeerMcpError as e:
+        raise _map_peer_mcp_error(e) from e
+    return McpListResponse(servers=[McpServerResponse(**e.to_dict()) for e in entries])
+
+
+@router.post("/peers/{name}/mcp", response_model=OkResponse)
+async def add_peer_mcp(
+    name: str,
+    request: McpAddRequest,
+    circle: str | None = Query(None),
+    scope: str = Query("user", description="user | project (claude-code only)"),
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Add an MCP server to the peer's backend config."""
+    peer = await _resolve_peer_or_404(name, circle)
+    _enforce_local(peer)
+    spec = peer_mcp.McpServerSpec(
+        name=request.name,
+        type=request.type,
+        command=request.command,
+        args=list(request.args),
+        url=request.url,
+        env=dict(request.env),
+        scope=scope,
+    )
+    try:
+        await asyncio.to_thread(peer_mcp.add_server, peer, spec)
+    except peer_mcp.PeerMcpError as e:
+        raise _map_peer_mcp_error(e) from e
+    return OkResponse()
+
+
+@router.delete("/peers/{name}/mcp/{server_name}", response_model=OkResponse)
+async def remove_peer_mcp(
+    name: str,
+    server_name: str,
+    circle: str | None = Query(None),
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Remove an MCP server from the peer's backend config."""
+    peer = await _resolve_peer_or_404(name, circle)
+    _enforce_local(peer)
+    try:
+        await asyncio.to_thread(peer_mcp.remove_server, peer, server_name)
+    except peer_mcp.PeerMcpError as e:
+        raise _map_peer_mcp_error(e) from e
+    return OkResponse()
 
 
 # Legacy endpoints for backward compatibility

--- a/repowire/peer_mcp.py
+++ b/repowire/peer_mcp.py
@@ -1,0 +1,461 @@
+"""Per-peer MCP server config: list/add/remove across backends.
+
+Same-host only for v1 — cross-host requires an ACP transport (not yet wired).
+The daemon route layer enforces locality (peer.machine == this host) and circle
+disambiguation; this module is pure backend-dispatch and is safe to call from
+tests with mocked subprocesses or tmp_path-rooted config files.
+
+Each backend exposes:
+
+  list_servers(peer)         -> list[McpServerEntry]
+  add_server(peer, spec)     -> None      (raises DuplicateServerError / NotSupportedError)
+  remove_server(peer, name)  -> None      (raises ServerNotFoundError / NotSupportedError)
+
+Errors are normalized into a small exception hierarchy so the route layer can
+map them to consistent HTTP status codes (404, 409, 501, 504).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from repowire.config.models import AgentType
+from repowire.protocol.peers import Peer
+
+# Subprocess timeout for `claude mcp` calls. Surfaces as 504 in the route.
+SUBPROCESS_TIMEOUT_SECONDS = 10
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class McpServerEntry:
+    """One configured MCP server, normalized across backends."""
+
+    name: str
+    scope: str = "user"  # user | project (claude-code distinguishes)
+    type: str = "stdio"  # stdio | http | sse
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    url: str | None = None
+    env_keys: list[str] = field(default_factory=list)  # keys only, values redacted
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "scope": self.scope,
+            "type": self.type,
+            "command": self.command,
+            "args": list(self.args),
+            "url": self.url,
+            "env_keys": list(self.env_keys),
+        }
+
+
+@dataclass
+class McpServerSpec:
+    """Input shape for add_server. Pass-through, no schema validation."""
+
+    name: str
+    type: str = "stdio"
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    url: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    scope: str = "user"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PeerMcpError(Exception):
+    """Base error for peer MCP operations."""
+
+
+class NotSupportedError(PeerMcpError):
+    """Backend does not support MCP configuration in v1 (e.g. pi)."""
+
+
+class DuplicateServerError(PeerMcpError):
+    """Server with this name already exists."""
+
+
+class ServerNotFoundError(PeerMcpError):
+    """Named server is not configured."""
+
+
+class BackendTimeoutError(PeerMcpError):
+    """Backend CLI call timed out."""
+
+
+class BackendError(PeerMcpError):
+    """Backend CLI returned non-zero or unparseable output."""
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def list_servers(peer: Peer) -> list[McpServerEntry]:
+    backend = peer.backend
+    if backend == AgentType.CLAUDE_CODE:
+        return _claude_list(peer)
+    if backend == AgentType.CODEX:
+        return _codex_list()
+    if backend == AgentType.GEMINI:
+        return _gemini_list()
+    raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+
+
+def add_server(peer: Peer, spec: McpServerSpec) -> None:
+    if not spec.name or not spec.name.strip():
+        raise BackendError("server name is required")
+    existing = {s.name for s in list_servers(peer)}
+    if spec.name in existing:
+        raise DuplicateServerError(f"server {spec.name!r} already exists")
+
+    backend = peer.backend
+    if backend == AgentType.CLAUDE_CODE:
+        _claude_add(peer, spec)
+    elif backend == AgentType.CODEX:
+        _codex_add(spec)
+    elif backend == AgentType.GEMINI:
+        _gemini_add(spec)
+    else:
+        raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+
+
+def remove_server(peer: Peer, name: str) -> None:
+    existing = {s.name for s in list_servers(peer)}
+    if name not in existing:
+        raise ServerNotFoundError(f"server {name!r} not configured")
+
+    backend = peer.backend
+    if backend == AgentType.CLAUDE_CODE:
+        _claude_remove(peer, name)
+    elif backend == AgentType.CODEX:
+        _codex_remove(name)
+    elif backend == AgentType.GEMINI:
+        _gemini_remove(name)
+    else:
+        raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+
+
+# ---------------------------------------------------------------------------
+# claude-code: shells out to the `claude mcp` CLI
+# ---------------------------------------------------------------------------
+
+
+def _claude_cli() -> str:
+    path = shutil.which("claude")
+    if not path:
+        raise NotSupportedError("`claude` CLI not found on PATH")
+    return path
+
+
+def _run_claude(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess:
+    cli = _claude_cli()
+    try:
+        return subprocess.run(
+            [cli, *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise BackendTimeoutError(f"`claude {' '.join(args)}` timed out") from e
+
+
+def _claude_list(peer: Peer) -> list[McpServerEntry]:
+    """Use `claude mcp list` (text output). JSON flag isn't stable across
+    versions, so we parse the human-readable list — one line per server like:
+
+        servername: command arg1 arg2 - ✓ Connected
+        urlname: https://example.com (SSE) - ✓ Connected
+    """
+    result = _run_claude(["mcp", "list"], cwd=peer.path or None)
+    if result.returncode != 0:
+        # CLI exits non-zero when no servers configured on some versions
+        stdout_lower = result.stdout.lower()
+        stderr_lower = result.stderr.lower()
+        if "no mcp servers" in stdout_lower or "no mcp servers" in stderr_lower:
+            return []
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise BackendError(f"claude mcp list failed: {detail}")
+
+    out: list[McpServerEntry] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        # Skip header/footer lines that don't have the "name: detail" shape
+        name, _, rest = line.partition(":")
+        name = name.strip()
+        if not name or " " in name:
+            continue
+        rest = rest.strip()
+        # Strip trailing status decorations like " - ✓ Connected"
+        rest = re.sub(r"\s*-\s*[✓✗].*$", "", rest).strip()
+        if rest.startswith(("http://", "https://")):
+            url = rest.split()[0]
+            entry = McpServerEntry(name=name, type="http", url=url)
+        else:
+            parts = rest.split()
+            command = parts[0] if parts else None
+            args = parts[1:] if len(parts) > 1 else []
+            entry = McpServerEntry(name=name, type="stdio", command=command, args=args)
+        out.append(entry)
+    return out
+
+
+def _claude_add(peer: Peer, spec: McpServerSpec) -> None:
+    scope_flag = ["-s", "project"] if spec.scope == "project" else ["-s", "user"]
+    env_flags: list[str] = []
+    for k, v in spec.env.items():
+        env_flags.extend(["-e", f"{k}={v}"])
+
+    if spec.type in ("http", "sse"):
+        if not spec.url:
+            raise BackendError("url is required for http/sse type")
+        transport = ["--transport", spec.type]
+        args = ["mcp", "add", *scope_flag, *transport, *env_flags, spec.name, spec.url]
+    else:
+        if not spec.command:
+            raise BackendError("command is required for stdio type")
+        args = ["mcp", "add", *scope_flag, *env_flags, spec.name, "--", spec.command, *spec.args]
+
+    cwd = peer.path if spec.scope == "project" else None
+    result = _run_claude(args, cwd=cwd)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise BackendError(f"claude mcp add failed: {detail}")
+
+
+def _claude_remove(peer: Peer, name: str) -> None:
+    result = _run_claude(["mcp", "remove", name], cwd=peer.path or None)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise BackendError(f"claude mcp remove failed: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# codex: edit ~/.codex/config.toml
+# ---------------------------------------------------------------------------
+
+CODEX_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+
+
+_SECTION_RE = re.compile(r"^\[mcp_servers\.([^\]]+)\]\s*$")
+_KV_RE = re.compile(r'^(\w+)\s*=\s*(.+?)\s*$')
+
+
+def _parse_toml_value(raw: str) -> Any:
+    """Minimal TOML value parser: handles strings, lists of strings, inline tables."""
+    raw = raw.strip()
+    if raw.startswith('"') and raw.endswith('"'):
+        return raw[1:-1]
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if not inner:
+            return []
+        items = re.findall(r'"([^"]*)"', inner)
+        return items
+    if raw.startswith("{") and raw.endswith("}"):
+        out: dict[str, str] = {}
+        for pair in re.findall(r'(\w+)\s*=\s*"([^"]*)"', raw):
+            out[pair[0]] = pair[1]
+        return out
+    return raw
+
+
+def _codex_read_sections() -> dict[str, dict[str, Any]]:
+    """Parse only `[mcp_servers.NAME]` sections. Returns name -> {key: parsed_value}."""
+    if not CODEX_CONFIG_PATH.exists():
+        return {}
+    sections: dict[str, dict[str, Any]] = {}
+    current: str | None = None
+    for line in CODEX_CONFIG_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _SECTION_RE.match(stripped)
+        if m:
+            current = m.group(1)
+            sections[current] = {}
+            continue
+        if stripped.startswith("["):
+            current = None  # entered some other section
+            continue
+        if current is None:
+            continue
+        kv = _KV_RE.match(stripped)
+        if kv:
+            sections[current][kv.group(1)] = _parse_toml_value(kv.group(2))
+    return sections
+
+
+def _codex_list() -> list[McpServerEntry]:
+    out: list[McpServerEntry] = []
+    for name, body in _codex_read_sections().items():
+        env = body.get("env", {})
+        env_keys: list[str] = [str(k) for k in env.keys()] if isinstance(env, dict) else []
+        cmd = body.get("command")
+        args = body.get("args", [])
+        if not isinstance(args, list):
+            args = []
+        url = body.get("url")
+        srv_type = "http" if url else "stdio"
+        out.append(
+            McpServerEntry(
+                name=name,
+                scope="user",
+                type=srv_type,
+                command=cmd if isinstance(cmd, str) else None,
+                args=[str(a) for a in args],
+                url=url if isinstance(url, str) else None,
+                env_keys=env_keys,
+            )
+        )
+    return out
+
+
+def _toml_quote(s: str) -> str:
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _codex_render_section(spec: McpServerSpec) -> str:
+    lines = [f"[mcp_servers.{spec.name}]"]
+    if spec.command:
+        lines.append(f"command = {_toml_quote(spec.command)}")
+    if spec.args:
+        rendered_args = ", ".join(_toml_quote(a) for a in spec.args)
+        lines.append(f"args = [{rendered_args}]")
+    if spec.url:
+        lines.append(f"url = {_toml_quote(spec.url)}")
+    if spec.env:
+        rendered_env = ", ".join(f"{k} = {_toml_quote(v)}" for k, v in spec.env.items())
+        lines.append(f"env = {{ {rendered_env} }}")
+    return "\n".join(lines) + "\n"
+
+
+def _codex_add(spec: McpServerSpec) -> None:
+    CODEX_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    section = _codex_render_section(spec)
+    if CODEX_CONFIG_PATH.exists():
+        existing = CODEX_CONFIG_PATH.read_text()
+        sep = "" if existing.endswith("\n\n") else ("\n" if existing.endswith("\n") else "\n\n")
+        CODEX_CONFIG_PATH.write_text(existing + sep + section)
+    else:
+        CODEX_CONFIG_PATH.write_text(section)
+
+
+def _codex_remove(name: str) -> None:
+    if not CODEX_CONFIG_PATH.exists():
+        raise ServerNotFoundError(f"server {name!r} not configured")
+    lines = CODEX_CONFIG_PATH.read_text().splitlines(keepends=True)
+    out: list[str] = []
+    skipping = False
+    target = f"[mcp_servers.{name}]"
+    for line in lines:
+        stripped = line.strip()
+        if stripped == target:
+            skipping = True
+            continue
+        if skipping and stripped.startswith("[") and stripped.endswith("]"):
+            skipping = False
+        if not skipping:
+            out.append(line)
+    CODEX_CONFIG_PATH.write_text("".join(out))
+
+
+# ---------------------------------------------------------------------------
+# gemini: edit ~/.gemini/settings.json mcpServers block
+# ---------------------------------------------------------------------------
+
+GEMINI_SETTINGS_PATH = Path.home() / ".gemini" / "settings.json"
+
+
+def _gemini_load() -> dict[str, Any]:
+    if not GEMINI_SETTINGS_PATH.exists():
+        return {}
+    try:
+        return json.loads(GEMINI_SETTINGS_PATH.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        raise BackendError(f"failed to read gemini settings: {e}") from e
+
+
+def _gemini_save(data: dict[str, Any]) -> None:
+    GEMINI_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = GEMINI_SETTINGS_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.chmod(0o600)
+    tmp.replace(GEMINI_SETTINGS_PATH)
+
+
+def _gemini_list() -> list[McpServerEntry]:
+    data = _gemini_load()
+    servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return []
+    out: list[McpServerEntry] = []
+    for name, body in servers.items():
+        if not isinstance(body, dict):
+            continue
+        env = body.get("env", {})
+        env_keys: list[str] = [str(k) for k in env.keys()] if isinstance(env, dict) else []
+        url = body.get("url") or body.get("httpUrl")
+        srv_type = "http" if url else "stdio"
+        out.append(
+            McpServerEntry(
+                name=name,
+                scope="user",
+                type=srv_type,
+                command=body.get("command") if isinstance(body.get("command"), str) else None,
+                args=list(body.get("args", []) or []),
+                url=url if isinstance(url, str) else None,
+                env_keys=env_keys,
+            )
+        )
+    return out
+
+
+def _gemini_add(spec: McpServerSpec) -> None:
+    data = _gemini_load()
+    servers = data.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        servers = {}
+        data["mcpServers"] = servers
+    entry: dict[str, Any] = {}
+    if spec.command:
+        entry["command"] = spec.command
+    if spec.args:
+        entry["args"] = list(spec.args)
+    if spec.url:
+        entry["url"] = spec.url
+    if spec.env:
+        entry["env"] = dict(spec.env)
+    servers[spec.name] = entry
+    _gemini_save(data)
+
+
+def _gemini_remove(name: str) -> None:
+    data = _gemini_load()
+    servers = data.get("mcpServers", {})
+    if not isinstance(servers, dict) or name not in servers:
+        raise ServerNotFoundError(f"server {name!r} not configured")
+    del servers[name]
+    _gemini_save(data)

--- a/tests/test_peer_mcp_backends.py
+++ b/tests/test_peer_mcp_backends.py
@@ -1,0 +1,246 @@
+"""Unit tests for repowire.peer_mcp backend dispatch.
+
+These tests exercise the pure-function layer: mock subprocess for claude-code,
+redirect codex/gemini config paths into tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from repowire import peer_mcp
+from repowire.config.models import AgentType
+from repowire.protocol.peers import Peer
+
+
+def _peer(backend: AgentType, path: str = "/repo") -> Peer:
+    return Peer(
+        peer_id="repow-test-aaaaaaaa",
+        display_name="test",
+        path=path,
+        machine="thishost",
+        backend=backend,
+    )
+
+
+# ---------------------------------------------------------------------------
+# claude-code
+# ---------------------------------------------------------------------------
+
+
+def _claude_result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+class TestClaudeCode:
+    def test_list_empty(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        empty_result = _claude_result("No MCP servers configured.", returncode=1)
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", return_value=empty_result):
+            assert peer_mcp.list_servers(peer) == []
+
+    def test_list_parses_stdio_and_http(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        stdout = (
+            "filesystem: npx @modelcontextprotocol/server-filesystem /tmp - ✓ Connected\n"
+            "remote: https://example.com/mcp - ✓ Connected\n"
+        )
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", return_value=_claude_result(stdout)):
+            servers = peer_mcp.list_servers(peer)
+        assert len(servers) == 2
+        fs = next(s for s in servers if s.name == "filesystem")
+        assert fs.type == "stdio"
+        assert fs.command == "npx"
+        assert fs.args == ["@modelcontextprotocol/server-filesystem", "/tmp"]
+        remote = next(s for s in servers if s.name == "remote")
+        assert remote.type == "http"
+        assert remote.url == "https://example.com/mcp"
+
+    def test_add_stdio_user_scope(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            calls.append(argv)
+            if "list" in argv:
+                return _claude_result("No MCP servers configured.", returncode=1)
+            return _claude_result("Added.")
+
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", side_effect=fake_run):
+            peer_mcp.add_server(peer, peer_mcp.McpServerSpec(
+                name="mytool", command="mybin", args=["--flag"], scope="user",
+            ))
+
+        add_call = next(c for c in calls if "add" in c)
+        assert "-s" in add_call and "user" in add_call
+        assert "mytool" in add_call
+        assert "mybin" in add_call
+        assert "--flag" in add_call
+
+    def test_add_duplicate_rejected(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        existing = _claude_result("foo: bar - ✓ Connected\n")
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", return_value=existing):
+            with pytest.raises(peer_mcp.DuplicateServerError):
+                peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="foo", command="bar"))
+
+    def test_remove(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            calls.append(argv)
+            if "list" in argv:
+                return _claude_result("foo: bar - ✓ Connected\n")
+            return _claude_result("Removed.")
+
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", side_effect=fake_run):
+            peer_mcp.remove_server(peer, "foo")
+
+        rm_call = next(c for c in calls if "remove" in c)
+        assert "foo" in rm_call
+
+    def test_timeout_surfaces(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        timeout = subprocess.TimeoutExpired(cmd="claude", timeout=10)
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", side_effect=timeout):
+            with pytest.raises(peer_mcp.BackendTimeoutError):
+                peer_mcp.list_servers(peer)
+
+    def test_cli_not_on_path(self):
+        peer = _peer(AgentType.CLAUDE_CODE)
+        with patch("repowire.peer_mcp.shutil.which", return_value=None):
+            with pytest.raises(peer_mcp.NotSupportedError):
+                peer_mcp.list_servers(peer)
+
+
+# ---------------------------------------------------------------------------
+# codex
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def codex_config(tmp_path: Path, monkeypatch):
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr(peer_mcp, "CODEX_CONFIG_PATH", cfg)
+    return cfg
+
+
+class TestCodex:
+    def test_list_empty_no_file(self, codex_config):
+        peer = _peer(AgentType.CODEX)
+        assert peer_mcp.list_servers(peer) == []
+
+    def test_add_list_remove_cycle(self, codex_config):
+        peer = _peer(AgentType.CODEX)
+        peer_mcp.add_server(peer, peer_mcp.McpServerSpec(
+            name="repowire", command="repowire", args=["mcp"], env={"FOO": "bar"},
+        ))
+        assert codex_config.exists()
+        body = codex_config.read_text()
+        assert "[mcp_servers.repowire]" in body
+        assert 'command = "repowire"' in body
+        assert 'args = ["mcp"]' in body
+        assert "FOO" in body
+
+        servers = peer_mcp.list_servers(peer)
+        assert len(servers) == 1
+        assert servers[0].name == "repowire"
+        assert servers[0].command == "repowire"
+        assert servers[0].args == ["mcp"]
+        assert servers[0].env_keys == ["FOO"]
+
+        peer_mcp.remove_server(peer, "repowire")
+        assert "[mcp_servers.repowire]" not in codex_config.read_text()
+
+    def test_add_preserves_existing(self, codex_config):
+        codex_config.write_text("[other]\nkey = \"val\"\n")
+        peer = _peer(AgentType.CODEX)
+        peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="new", command="x"))
+        body = codex_config.read_text()
+        assert "[other]" in body
+        assert "[mcp_servers.new]" in body
+
+    def test_remove_unknown(self, codex_config):
+        codex_config.write_text("")
+        peer = _peer(AgentType.CODEX)
+        with pytest.raises(peer_mcp.ServerNotFoundError):
+            peer_mcp.remove_server(peer, "nope")
+
+
+# ---------------------------------------------------------------------------
+# gemini
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gemini_config(tmp_path: Path, monkeypatch):
+    cfg = tmp_path / "settings.json"
+    monkeypatch.setattr(peer_mcp, "GEMINI_SETTINGS_PATH", cfg)
+    return cfg
+
+
+class TestGemini:
+    def test_list_empty_no_file(self, gemini_config):
+        peer = _peer(AgentType.GEMINI)
+        assert peer_mcp.list_servers(peer) == []
+
+    def test_add_list_remove_cycle(self, gemini_config):
+        peer = _peer(AgentType.GEMINI)
+        peer_mcp.add_server(peer, peer_mcp.McpServerSpec(
+            name="repowire", command="repowire", args=["mcp"], env={"TOKEN": "secret"},
+        ))
+        data = json.loads(gemini_config.read_text())
+        assert "repowire" in data["mcpServers"]
+        assert data["mcpServers"]["repowire"]["command"] == "repowire"
+
+        servers = peer_mcp.list_servers(peer)
+        assert len(servers) == 1
+        assert servers[0].env_keys == ["TOKEN"]
+
+        peer_mcp.remove_server(peer, "repowire")
+        data = json.loads(gemini_config.read_text())
+        assert data.get("mcpServers", {}) == {}
+
+    def test_duplicate_rejected(self, gemini_config):
+        peer = _peer(AgentType.GEMINI)
+        peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="foo", command="x"))
+        with pytest.raises(peer_mcp.DuplicateServerError):
+            peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="foo", command="y"))
+
+    def test_empty_name_rejected(self, gemini_config):
+        peer = _peer(AgentType.GEMINI)
+        with pytest.raises(peer_mcp.BackendError):
+            peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="", command="x"))
+
+
+# ---------------------------------------------------------------------------
+# unsupported backend
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupported:
+    def test_opencode_not_supported(self):
+        peer = _peer(AgentType.OPENCODE)
+        with pytest.raises(peer_mcp.NotSupportedError):
+            peer_mcp.list_servers(peer)
+        with pytest.raises(peer_mcp.NotSupportedError):
+            peer_mcp.add_server(peer, peer_mcp.McpServerSpec(name="x", command="y"))
+
+    def test_pi_not_supported(self):
+        peer = _peer(AgentType.PI)
+        with pytest.raises(peer_mcp.NotSupportedError):
+            peer_mcp.list_servers(peer)

--- a/tests/test_peer_mcp_routes.py
+++ b/tests/test_peer_mcp_routes.py
@@ -1,0 +1,145 @@
+"""HTTP route tests for per-peer MCP config (#183)."""
+
+from __future__ import annotations
+
+import socket
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire import peer_mcp
+from repowire.config.models import AgentType, Config
+from repowire.daemon.deps import cleanup_deps, get_peer_registry, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers as peers_routes
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_test_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=tracker,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+
+    app = FastAPI()
+    app.include_router(peers_routes.router)
+    return app
+
+
+@pytest.fixture
+async def client(tmp_path):
+    app = _make_test_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as c:
+        yield c
+    cleanup_deps()
+
+
+async def _register(client, name="local", backend="codex", machine=None):
+    machine = machine or socket.gethostname()
+    r = await client.post("/peers", json={
+        "name": name,
+        "path": "/tmp/peer",
+        "circle": "default",
+        "backend": backend,
+        "machine": machine,
+    })
+    assert r.status_code == 200, r.text
+    return r.json()["display_name"]
+
+
+class TestMcpRoutes:
+    async def test_list_unknown_peer_404(self, client):
+        r = await client.get("/peers/nonexistent/mcp")
+        assert r.status_code == 404
+
+    async def test_cross_host_rejected_409(self, client):
+        name = await _register(client, name="remote", machine="other-host.example")
+        r = await client.get(f"/peers/{name}/mcp")
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "cross_host"
+
+    async def test_list_add_remove_cycle_codex(self, client, tmp_path, monkeypatch):
+        # Codex backend uses on-disk config; redirect to tmp_path.
+        cfg = tmp_path / "config.toml"
+        monkeypatch.setattr(peer_mcp, "CODEX_CONFIG_PATH", cfg)
+
+        name = await _register(client, name="codexlocal", backend="codex")
+
+        r = await client.get(f"/peers/{name}/mcp")
+        assert r.status_code == 200
+        assert r.json()["servers"] == []
+
+        r = await client.post(f"/peers/{name}/mcp", json={
+            "name": "repowire",
+            "command": "repowire",
+            "args": ["mcp"],
+        })
+        assert r.status_code == 200
+
+        r = await client.get(f"/peers/{name}/mcp")
+        assert r.status_code == 200
+        servers = r.json()["servers"]
+        assert len(servers) == 1
+        assert servers[0]["name"] == "repowire"
+
+        # Duplicate add returns 409
+        r = await client.post(f"/peers/{name}/mcp", json={
+            "name": "repowire", "command": "repowire",
+        })
+        assert r.status_code == 409
+
+        # Remove
+        r = await client.delete(f"/peers/{name}/mcp/repowire")
+        assert r.status_code == 200
+
+        # Remove again -> 404
+        r = await client.delete(f"/peers/{name}/mcp/repowire")
+        assert r.status_code == 404
+
+    async def test_unsupported_backend_returns_501(self, client):
+        name = await _register(client, name="pipeer", backend="claude-code")
+        # Force registry to report opencode
+        registry = get_peer_registry()
+        peer = await registry.get_peer(name)
+        assert peer is not None
+        peer.backend = AgentType.OPENCODE
+
+        r = await client.get(f"/peers/{name}/mcp")
+        assert r.status_code == 501
+
+    async def test_claude_code_timeout_returns_504(self, client):
+        import subprocess as sp
+        name = await _register(client, name="ccpeer", backend="claude-code")
+        timeout = sp.TimeoutExpired(cmd="claude", timeout=10)
+        with patch("repowire.peer_mcp.shutil.which", return_value="/usr/bin/claude"), \
+             patch("repowire.peer_mcp.subprocess.run", side_effect=timeout):
+            r = await client.get(f"/peers/{name}/mcp")
+        assert r.status_code == 504

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -20,6 +20,8 @@ interface PendingAsk {
 const ACK_FRAME_RE = /^\[ack #([^\]\s]+) from @([^\]\s]+)\]\s?([\s\S]*)$/;
 const BARE_ACK_TIMEOUT_MS = 120_000;
 
+type PeerTab = "chat" | "mcp";
+
 export function PeerView({
   peer,
   events,
@@ -34,6 +36,7 @@ export function PeerView({
   onSent: () => void;
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const [activeTab, setActiveTab] = useState<PeerTab>("chat");
   const thread = useMemo(() => {
     const id = peer.peer_id;
     return events
@@ -47,6 +50,11 @@ export function PeerView({
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ block: "end" });
   }, [thread.length]);
+
+  // Reset to chat when switching peers so the tab choice doesn't leak across selections.
+  useEffect(() => {
+    setActiveTab("chat");
+  }, [peer.peer_id]);
 
   const { folder, parent } = peer.path ? shortPath(peer.path) : { folder: "", parent: "" };
 
@@ -81,19 +89,30 @@ export function PeerView({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 px-4 py-4 md:overflow-y-auto md:px-6">
-        {thread.length === 0 ? (
-          <div className="py-10 font-mono text-xs leading-6 text-outline">
-            &gt; no messages with {peerLabel(peer)}.<br />
-            <span>send one to begin a query.</span>
-          </div>
-        ) : (
-          thread.map((event) => <ThreadItem key={event.id} event={event} peer={peer} />)
-        )}
-        <div ref={bottomRef} />
+      <div className="flex shrink-0 gap-0 border-b border-border-faint px-4 md:px-6" role="tablist">
+        <TabButton label="chat" active={activeTab === "chat"} onClick={() => setActiveTab("chat")} />
+        <TabButton label="mcp" active={activeTab === "mcp"} onClick={() => setActiveTab("mcp")} />
       </div>
 
-      <ComposeBar peer={peer} apiBase={apiBase} events={events} onSent={onSent} />
+      {activeTab === "chat" ? (
+        <>
+          <div className="min-h-0 flex-1 px-4 py-4 md:overflow-y-auto md:px-6">
+            {thread.length === 0 ? (
+              <div className="py-10 font-mono text-xs leading-6 text-outline">
+                &gt; no messages with {peerLabel(peer)}.<br />
+                <span>send one to begin a query.</span>
+              </div>
+            ) : (
+              thread.map((event) => <ThreadItem key={event.id} event={event} peer={peer} />)
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          <ComposeBar peer={peer} apiBase={apiBase} events={events} onSent={onSent} />
+        </>
+      ) : (
+        <McpPanel peer={peer} apiBase={apiBase} />
+      )}
     </>
   );
 }
@@ -471,6 +490,341 @@ function GitStatusBadge({ status }: { status?: { ahead: number; behind: number; 
       aria-label={tooltip}
       className={cn("inline-block h-2 w-2 shrink-0 rounded-full", color)}
     />
+  );
+}
+
+function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "border-b-2 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.14em]",
+        active
+          ? "border-primary text-on-surface"
+          : "border-transparent text-outline hover:text-on-surface"
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface McpServerEntry {
+  name: string;
+  scope: string;
+  type: string;
+  command: string | null;
+  args: string[];
+  url: string | null;
+  env_keys: string[];
+}
+
+function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
+  const [servers, setServers] = useState<McpServerEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [crossHost, setCrossHost] = useState(false);
+  const [unsupported, setUnsupported] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setServers(null);
+    setError(null);
+    setCrossHost(false);
+    setUnsupported(false);
+    (async () => {
+      try {
+        const r = await fetch(`${apiBase}/peers/${encodeURIComponent(peer.name)}/mcp`);
+        if (r.status === 409) {
+          const body = await r.json().catch(() => ({}));
+          if (body?.detail?.error === "cross_host") {
+            if (!cancelled) setCrossHost(true);
+            return;
+          }
+        }
+        if (r.status === 501) {
+          if (!cancelled) setUnsupported(true);
+          return;
+        }
+        if (!r.ok) {
+          const text = await r.text();
+          if (!cancelled) setError(text || `HTTP ${r.status}`);
+          return;
+        }
+        const data = await r.json();
+        if (!cancelled) setServers(data.servers || []);
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [peer.name, apiBase, refreshTick]);
+
+  async function handleRemove(name: string) {
+    if (!confirm(`Remove MCP server "${name}"?`)) return;
+    const r = await fetch(
+      `${apiBase}/peers/${encodeURIComponent(peer.name)}/mcp/${encodeURIComponent(name)}`,
+      { method: "DELETE" }
+    );
+    if (!r.ok) {
+      const text = await r.text();
+      setError(text || `HTTP ${r.status}`);
+      return;
+    }
+    setRefreshTick((n) => n + 1);
+  }
+
+  if (crossHost) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-6">
+        <div className="rounded border border-border-faint bg-surface-container-low p-4 font-mono text-xs text-outline">
+          <div className="mb-1 font-semibold text-on-surface-variant">remote host</div>
+          Per-peer MCP config is same-host only in v1. Peer runs on{" "}
+          <span className="text-on-surface">{peer.machine}</span>; ACP transport is required to reach it.
+        </div>
+      </div>
+    );
+  }
+
+  if (unsupported) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-6">
+        <div className="rounded border border-border-faint bg-surface-container-low p-4 font-mono text-xs text-outline">
+          Backend <span className="text-on-surface">{peer.backend}</span> does not support MCP config in v1.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+      {error && (
+        <div className="mb-3 rounded border border-error/30 bg-error/10 px-3 py-2 font-mono text-xs text-on-surface">
+          {error}
+          <button
+            onClick={() => { setError(null); setRefreshTick((n) => n + 1); }}
+            className="ml-2 underline"
+          >
+            retry
+          </button>
+        </div>
+      )}
+
+      {servers === null ? (
+        <div className="font-mono text-xs text-outline">loading...</div>
+      ) : servers.length === 0 ? (
+        <div className="py-6 font-mono text-xs text-outline">
+          no MCP servers configured.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {servers.map((s) => (
+            <li
+              key={s.name}
+              className="flex items-start justify-between gap-3 rounded border border-border-faint bg-surface-container-low px-3 py-2 font-mono text-xs"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-on-surface">{s.name}</span>
+                  <span className="text-[10px] uppercase tracking-wider text-outline">
+                    {s.type}
+                  </span>
+                  {s.scope && s.scope !== "user" && (
+                    <span className="text-[10px] uppercase tracking-wider text-outline">
+                      {s.scope}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-0.5 truncate text-outline">
+                  {s.url || [s.command, ...s.args].filter(Boolean).join(" ")}
+                </div>
+                {s.env_keys.length > 0 && (
+                  <div className="mt-0.5 text-[10px] text-outline">
+                    env: {s.env_keys.join(", ")}
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={() => handleRemove(s.name)}
+                className="shrink-0 border border-border-faint px-2 py-1 text-[10px] uppercase text-outline hover:bg-surface-container-high hover:text-on-surface"
+              >
+                remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-4">
+        {showAdd ? (
+          <AddMcpForm
+            peer={peer}
+            apiBase={apiBase}
+            onCancel={() => setShowAdd(false)}
+            onAdded={() => {
+              setShowAdd(false);
+              setRefreshTick((n) => n + 1);
+            }}
+            onError={(msg) => setError(msg)}
+          />
+        ) : (
+          <button
+            onClick={() => setShowAdd(true)}
+            className="border border-border-faint px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-on-surface hover:bg-surface-container-high"
+          >
+            + add server
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddMcpForm({
+  peer,
+  apiBase,
+  onCancel,
+  onAdded,
+  onError,
+}: {
+  peer: Peer;
+  apiBase: string;
+  onCancel: () => void;
+  onAdded: () => void;
+  onError: (msg: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [type, setType] = useState<"stdio" | "http" | "sse">("stdio");
+  const [command, setCommand] = useState("");
+  const [argsText, setArgsText] = useState("");
+  const [url, setUrl] = useState("");
+  const [envText, setEnvText] = useState("");
+  const [scope, setScope] = useState<"user" | "project">("user");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit() {
+    if (!name.trim()) {
+      onError("server name is required");
+      return;
+    }
+    const env: Record<string, string> = {};
+    for (const line of envText.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1);
+    }
+    setSubmitting(true);
+    try {
+      const r = await fetch(
+        `${apiBase}/peers/${encodeURIComponent(peer.name)}/mcp?scope=${scope}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: name.trim(),
+            type,
+            command: type === "stdio" ? command.trim() : null,
+            args: type === "stdio"
+              ? argsText.split(/\s+/).filter(Boolean)
+              : [],
+            url: type !== "stdio" ? url.trim() : null,
+            env,
+          }),
+        }
+      );
+      if (!r.ok) {
+        const text = await r.text();
+        onError(text || `HTTP ${r.status}`);
+        return;
+      }
+      onAdded();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2 rounded border border-border-faint bg-surface-container-low p-3 font-mono text-xs">
+      <input
+        placeholder="name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full border border-border-faint bg-surface px-2 py-1 text-on-surface"
+      />
+      <div className="flex gap-2">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as typeof type)}
+          className="border border-border-faint bg-surface px-2 py-1 text-on-surface"
+        >
+          <option value="stdio">stdio</option>
+          <option value="http">http</option>
+          <option value="sse">sse</option>
+        </select>
+        {peer.backend === "claude-code" && (
+          <select
+            value={scope}
+            onChange={(e) => setScope(e.target.value as typeof scope)}
+            className="border border-border-faint bg-surface px-2 py-1 text-on-surface"
+          >
+            <option value="user">user scope</option>
+            <option value="project">project scope</option>
+          </select>
+        )}
+      </div>
+      {type === "stdio" ? (
+        <>
+          <input
+            placeholder="command"
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            className="w-full border border-border-faint bg-surface px-2 py-1 text-on-surface"
+          />
+          <input
+            placeholder="args (space separated)"
+            value={argsText}
+            onChange={(e) => setArgsText(e.target.value)}
+            className="w-full border border-border-faint bg-surface px-2 py-1 text-on-surface"
+          />
+        </>
+      ) : (
+        <input
+          placeholder="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="w-full border border-border-faint bg-surface px-2 py-1 text-on-surface"
+        />
+      )}
+      <textarea
+        placeholder="env (one KEY=value per line)"
+        value={envText}
+        onChange={(e) => setEnvText(e.target.value)}
+        rows={3}
+        className="w-full border border-border-faint bg-surface px-2 py-1 text-on-surface"
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={submit}
+          disabled={submitting}
+          className="border border-primary/40 bg-primary/10 px-3 py-1 uppercase tracking-[0.14em] text-on-surface hover:bg-primary/20 disabled:opacity-50"
+        >
+          {submitting ? "adding..." : "add"}
+        </button>
+        <button
+          onClick={onCancel}
+          className="border border-border-faint px-3 py-1 uppercase tracking-[0.14em] text-outline hover:text-on-surface"
+        >
+          cancel
+        </button>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Implements per-peer MCP server config viewer/editor (claudecodeui §4.2 adoption, issue #183).

- New `repowire/peer_mcp.py` module with backend-dispatched `list_servers` / `add_server` / `remove_server`:
  - **claude-code**: shells out to `claude mcp list/add/remove`. `user` scope by default, `project` scope when requested (runs with `cwd=peer.path`). 10s subprocess timeout surfaces as 504.
  - **codex**: read/write `~/.codex/config.toml` `[mcp_servers.NAME]` sections (text-level edit, preserves surrounding content).
  - **gemini**: read/write `~/.gemini/settings.json` `mcpServers` block, atomic tmp-file replace + 0600 perms.
  - **opencode / pi**: returns 501 NotSupported (opencode deferred — needs follow-up issue once its MCP runtime stabilizes).
- New daemon routes in `repowire/daemon/routes/peers.py`:
  - `GET /peers/{name}/mcp` — list servers
  - `POST /peers/{name}/mcp?scope=user|project` — add server
  - `DELETE /peers/{name}/mcp/{server_name}` — remove server
- Same-host enforcement (v1): cross-host returns `409 {error: cross_host, hint, peer_machine, self_machine}`. ACP transport will lift this later.
- Status code mapping: 404 unknown peer / unknown server, 409 duplicate / cross-host, 501 unsupported backend, 504 backend timeout.
- Dashboard MCP tab added inline to `PeerView.tsx` — minimal header strip (no shared `<Tabs>` wrapper, coordinated with sibling #182 transcript tab). Cards show name/type/scope/command-or-url/env-key list, with `+ add server` form supporting stdio/http/sse + env. Cross-host and unsupported backends show explanatory banners.

## Follow-ups (not in this PR)

- opencode MCP backend support (deferred per orchestrator approval).
- Refactor inline tab strip into shared component once #182 (transcript tab) also lands.

## Test plan

- [x] `uv run pytest` — 880 passing (22 new across `test_peer_mcp_backends.py` + `test_peer_mcp_routes.py`)
- [x] `uv run ruff check repowire/ tests/` — clean (2 pre-existing E501s in `test_opencode_installer.py` unrelated)
- [x] `uv run ty check repowire/peer_mcp.py repowire/daemon/routes/peers.py` — clean
- [ ] Live dashboard test: open Peer panel → MCP tab → list/add/remove cycle against local claude-code peer