### PR TITLE
fix(telegram): use valid 👍 reaction emoji

### DIFF
--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -680,12 +680,7 @@ class TelegramPeer:
             )
             if r.status_code == 200:
                 if message_id:
-                    try:
-                        delivery_status = r.json().get("status", "sent")
-                    except Exception:
-                        delivery_status = "sent"
-                    emoji = "⏳" if delivery_status == "queued" else "✓"
-                    await self._tg_react(message_id, emoji=emoji)
+                    await self._tg_react(message_id, emoji="👍")
                 # No text reply on success — reaction is the confirmation
             else:
                 detail = r.json().get("detail", r.text)


### PR DESCRIPTION
## Summary
- ⏳/✓ aren't in Telegram's free reaction set, so `setMessageReaction` silently failed
- Daemon `/notify` doesn't actually queue (status is label-only), so the queued/sent branching was meaningless
- Always send 👍 on HTTP 200 — single confirmation reaction that actually renders

## Test plan
- [ ] Send a message via Telegram, confirm 👍 reaction appears on the source message