### PR TITLE
fix(hooks): pane-hijack SessionStart guard via parent_pid (#190)

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -57,6 +57,11 @@ class SessionMapping:
     role: PeerRole = PeerRole.AGENT
     updated_at: str | None = None
     description: str = ""
+    # Pid of the agent process that last owned this peer. Persisted so the
+    # pane-hijack guard (issue #190) survives daemon restart: when the
+    # original peer rehydrates via its ws-hook, we restore this value into
+    # the in-memory Peer and the guard can compare against it.
+    agent_pid: int | None = None
 
     def __post_init__(self) -> None:
         if self.updated_at is None:
@@ -404,6 +409,7 @@ class PeerRegistry:
         backend: AgentType,
         path: str | None = None,
         role: PeerRole = PeerRole.AGENT,
+        agent_pid: int | None = None,
     ) -> str:
         """Find existing mapping or allocate a new session_id. Must hold lock.
 
@@ -417,6 +423,8 @@ class PeerRegistry:
             ):
                 mapping.path = path
                 mapping.updated_at = datetime.now(timezone.utc).isoformat()
+                if agent_pid is not None:
+                    mapping.agent_pid = agent_pid
                 logger.info(f"Reusing session {sid} for {display_name}@{circle}")
                 self._mappings_dirty = True
                 return sid
@@ -435,6 +443,8 @@ class PeerRegistry:
                     and mapping.path == path
                 ):
                     mapping.updated_at = datetime.now(timezone.utc).isoformat()
+                    if agent_pid is not None:
+                        mapping.agent_pid = agent_pid
                     self._mappings_dirty = True
                     logger.info(
                         f"Adopted prior session {sid} for {display_name} "
@@ -450,6 +460,7 @@ class PeerRegistry:
             backend=backend,
             path=path,
             role=role,
+            agent_pid=agent_pid,
         )
         logger.info(f"Created session {session_id} for {display_name}@{circle}")
         self._mappings_dirty = True
@@ -536,6 +547,12 @@ class PeerRegistry:
                         existing.tmux_session = tmux_session
                     if machine != "unknown":
                         existing.machine = machine
+                    if agent_pid is not None:
+                        existing.agent_pid = agent_pid
+                        mapping = self._mappings.get(peer_id)
+                        if mapping is not None and mapping.agent_pid != agent_pid:
+                            mapping.agent_pid = agent_pid
+                            self._mappings_dirty = True
                     logger.info(f"Peer reconnected: {existing.display_name} ({peer_id})")
                     return peer_id, existing.display_name
 
@@ -578,6 +595,7 @@ class PeerRegistry:
             assigned_name = self._build_display_name(path or "", circle, backend)
             allocated_id = self._find_or_allocate_mapping(
                 assigned_name, circle, backend, path, role=role,
+                agent_pid=agent_pid,
             )
             if pane_id:
                 self._release_pane(pane_id, allocated_id)
@@ -591,6 +609,13 @@ class PeerRegistry:
             effective_circle = restored.circle if restored else circle
             effective_role = restored.role if restored else role
             restored_description = restored.description if restored else ""
+            # Caller-supplied agent_pid wins (it's the live process); fall
+            # back to whatever the mapping persisted across daemon restart.
+            effective_agent_pid = (
+                agent_pid
+                if agent_pid is not None
+                else (restored.agent_pid if restored else None)
+            )
 
             # --- create and insert Peer ---
             peer = Peer(
@@ -608,7 +633,7 @@ class PeerRegistry:
                 metadata=metadata or {},
                 description=restored_description,
                 turn_state=turn_state,
-                agent_pid=agent_pid,
+                agent_pid=effective_agent_pid,
             )
             self._peers[allocated_id] = peer
             logger.info(f"Peer registered: {assigned_name} ({allocated_id})")

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -34,6 +34,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class PaneHijackRejectedError(Exception):
+    """Raised by allocate_and_register when a fresh SessionStart claim is
+    rejected because it appears to be a subprocess of the pane's existing
+    agent (parent_pid matches the existing peer's agent_pid).
+    """
+
+
 # ---------------------------------------------------------------------------
 # SessionMapping dataclass (previously in session_mapper.py)
 # ---------------------------------------------------------------------------
@@ -484,6 +491,8 @@ class PeerRegistry:
         role: PeerRole = PeerRole.AGENT,
         peer_id: str | None = None,
         turn_state: TurnState | None = None,
+        agent_pid: int | None = None,
+        parent_pid: int | None = None,
     ) -> tuple[str, str]:
         """Allocate a peer_id and register the peer atomically.
 
@@ -530,6 +539,41 @@ class PeerRegistry:
                     logger.info(f"Peer reconnected: {existing.display_name} ({peer_id})")
                     return peer_id, existing.display_name
 
+            # Pane-hijack guard: a fresh SessionStart claim for a pane that
+            # already has a live peer, where the new hook's parent_pid matches
+            # the existing peer's agent_pid, is almost certainly a subprocess
+            # agent (e.g. `gemini --yolo` run from inside a claude-code pane)
+            # inheriting TMUX_PANE from its parent and trying to register on
+            # the parent's pane. Reject — the original peer keeps the pane.
+            if pane_id and parent_pid is not None:
+                tolerance = self.heartbeat_tolerance()
+                now = datetime.now(timezone.utc)
+                for existing in self._peers.values():
+                    if existing.pane_id != pane_id:
+                        continue
+                    if existing.agent_pid is None or existing.agent_pid != parent_pid:
+                        continue
+                    if existing.last_seen is None:
+                        continue
+                    if (now - existing.last_seen).total_seconds() > tolerance:
+                        continue
+                    logger.error(
+                        "Rejecting pane-hijack SessionStart claim: "
+                        "hook_pid=%s parent_pid=%s existing_agent_pid=%s "
+                        "existing_peer_id=%s existing_display_name=%s pane_id=%s",
+                        agent_pid,
+                        parent_pid,
+                        existing.agent_pid,
+                        existing.peer_id,
+                        existing.display_name,
+                        pane_id,
+                    )
+                    raise PaneHijackRejectedError(
+                        f"pane {pane_id} held by {existing.display_name} "
+                        f"({existing.peer_id}); claimant parent_pid={parent_pid} "
+                        f"matches existing agent_pid={existing.agent_pid}"
+                    )
+
             # Fresh registration: daemon owns the name
             assigned_name = self._build_display_name(path or "", circle, backend)
             allocated_id = self._find_or_allocate_mapping(
@@ -564,6 +608,7 @@ class PeerRegistry:
                 metadata=metadata or {},
                 description=restored_description,
                 turn_state=turn_state,
+                agent_pid=agent_pid,
             )
             self._peers[allocated_id] = peer
             logger.info(f"Peer registered: {assigned_name} ({allocated_id})")

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -82,7 +82,11 @@ class RegisterPeerRequest(BaseModel):
     )
     agent_pid: int | None = Field(
         None,
-        description="PID of the registering agent process (hook's own pid).",
+        description=(
+            "PID of the agent process that owns this peer "
+            "(os.getppid() from the registering hook, i.e. the hook's "
+            "parent, NOT the hook's own pid)."
+        ),
     )
     parent_pid: int | None = Field(
         None,

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -14,6 +14,7 @@ from repowire import peer_mcp
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
+from repowire.daemon.peer_registry import PaneHijackRejectedError
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 
@@ -78,6 +79,17 @@ class RegisterPeerRequest(BaseModel):
     role: PeerRole = Field(default=PeerRole.AGENT, description="Peer role")
     turn_state: TurnState | None = Field(
         None, description="Initial per-turn progress (optional)"
+    )
+    agent_pid: int | None = Field(
+        None,
+        description="PID of the registering agent process (hook's own pid).",
+    )
+    parent_pid: int | None = Field(
+        None,
+        description=(
+            "Parent PID of the registering hook (os.getppid()). "
+            "Used for pane-hijack detection."
+        ),
     )
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -193,17 +205,25 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
     circle = request.circle or "global"
 
     peer_registry = get_peer_registry()
-    peer_id, display_name = await peer_registry.allocate_and_register(
-        circle=circle,
-        backend=request.backend,
-        path=request.path or "",
-        pane_id=request.pane_id,
-        tmux_session=request.tmux_session,
-        metadata=request.metadata,
-        machine=request.machine or socket.gethostname(),
-        role=request.role,
-        turn_state=request.turn_state,
-    )
+    try:
+        peer_id, display_name = await peer_registry.allocate_and_register(
+            circle=circle,
+            backend=request.backend,
+            path=request.path or "",
+            pane_id=request.pane_id,
+            tmux_session=request.tmux_session,
+            metadata=request.metadata,
+            machine=request.machine or socket.gethostname(),
+            role=request.role,
+            turn_state=request.turn_state,
+            agent_pid=request.agent_pid,
+            parent_pid=request.parent_pid,
+        )
+    except PaneHijackRejectedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
     return peer_id, display_name
 
 

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -30,6 +30,34 @@ from repowire.peer_describe import compute_git_status
 from repowire.spawn_hints import consume_hint_full
 
 
+def _read_ppid_of(pid: int) -> int | None:
+    """Return the parent pid of ``pid``, or None if it can't be determined.
+
+    Used by the pane-hijack guard payload: the hook's ppid is the agent
+    process; the agent's ppid is what tells us whether the agent was itself
+    spawned by another mesh peer (a hijack) or by a plain shell (legitimate).
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        # Best-effort: any failure (subprocess error, missing binary, OS
+        # error, or in tests where subprocess.Popen is mocked) → unknown
+        # parent. The guard treats parent_pid=None as "can't decide" and
+        # lets the claim through, which is the safe default.
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
 def _register_peer_http(
     path: str,
     circle: str,
@@ -277,6 +305,17 @@ def main(backend: str = "claude-code") -> int:
         git_status = compute_git_status(cwd)
         if git_status is not None:
             metadata["git_status"] = git_status
+        # Pid lineage for the pane-hijack guard:
+        #   - agent_pid: the AGENT process that owns this hook == os.getppid().
+        #     The hook process itself dies seconds later, so its own pid is
+        #     useless for after-the-fact identity checks.
+        #   - parent_pid: the AGENT's parent. For a legitimately launched
+        #     agent that's a shell; for a subprocess agent (e.g. gemini
+        #     invoked by a still-running claude), it's the parent agent's
+        #     pid, which will match the existing peer's recorded agent_pid
+        #     and trip the guard.
+        agent_pid_val = os.getppid()
+        parent_pid_val = _read_ppid_of(agent_pid_val)
         peer_id, display_name, hijack_rejected = _register_peer_http(
             cwd,
             circle,
@@ -285,8 +324,8 @@ def main(backend: str = "claude-code") -> int:
             metadata=metadata,
             role=hint_role,
             turn_state=initial_turn_state,
-            agent_pid=os.getpid(),
-            parent_pid=os.getppid(),
+            agent_pid=agent_pid_val,
+            parent_pid=parent_pid_val,
         )
         if hijack_rejected:
             # Daemon rejected this pane claim. Don't write pane metadata,

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -316,6 +316,20 @@ def main(backend: str = "claude-code") -> int:
             # rejection must leave the world unchanged (issue #190).
             lock_fd.close()
             return 0
+        registration_accepted = peer_id is not None
+        if needs_takeover and not registration_accepted:
+            # Hijack-candidate path: the daemon didn't reject (no 409), but
+            # also didn't confirm acceptance (transport error, 5xx, etc.).
+            # Without a confirmed accept we can't justify tearing down the
+            # incumbent's ws-hook / pane metadata — that would leave a
+            # half-broken pane on every daemon hiccup. Bail cleanly.
+            print(
+                "repowire: registration unconfirmed during pane takeover, "
+                "leaving incumbent in place",
+                file=sys.stderr,
+            )
+            lock_fd.close()
+            return 0
         if not display_name:
             display_name = folder_name  # fallback if daemon unreachable
 

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -19,6 +19,7 @@ from repowire.hooks.utils import (
     clear_pane_runtime_state,
     daemon_get,
     daemon_post,
+    daemon_post_with_status,
     read_pane_runtime_metadata,
     write_pane_runtime_metadata,
     ws_hook_lock_path,
@@ -38,8 +39,16 @@ def _register_peer_http(
     metadata: dict | None = None,
     role: str | None = None,
     turn_state: str | None = None,
-) -> tuple[str | None, str | None]:
-    """Register peer via HTTP POST /peers. Returns (peer_id, display_name)."""
+    agent_pid: int | None = None,
+    parent_pid: int | None = None,
+) -> tuple[str | None, str | None, bool]:
+    """Register peer via HTTP POST /peers.
+
+    Returns (peer_id, display_name, hijack_rejected). hijack_rejected is True
+    iff the daemon returned 409 because the pane-hijack guard rejected this
+    fresh SessionStart claim (a subprocess agent inheriting its parent's
+    TMUX_PANE). The caller should abort registration cleanly in that case.
+    """
     folder = Path(path).name
     payload: dict = {
         "name": folder,
@@ -55,10 +64,21 @@ def _register_peer_http(
         payload["role"] = role
     if turn_state:
         payload["turn_state"] = turn_state
-    result = daemon_post("/peers", payload)
-    if result:
-        return result.get("peer_id"), result.get("display_name")
-    return None, None
+    if agent_pid is not None:
+        payload["agent_pid"] = agent_pid
+    if parent_pid is not None:
+        payload["parent_pid"] = parent_pid
+    status_code, result = daemon_post_with_status("/peers", payload)
+    if status_code == 409:
+        detail = (result or {}).get("detail", "")
+        print(
+            f"repowire: SessionStart rejected by daemon pane-hijack guard: {detail}",
+            file=sys.stderr,
+        )
+        return None, None, True
+    if status_code is not None and 200 <= status_code < 300 and result:
+        return result.get("peer_id"), result.get("display_name"), False
+    return None, None, False
 
 
 def get_peer_name(cwd: str) -> str:
@@ -257,7 +277,7 @@ def main(backend: str = "claude-code") -> int:
         git_status = compute_git_status(cwd)
         if git_status is not None:
             metadata["git_status"] = git_status
-        peer_id, display_name = _register_peer_http(
+        peer_id, display_name, hijack_rejected = _register_peer_http(
             cwd,
             circle,
             backend_type,
@@ -265,7 +285,14 @@ def main(backend: str = "claude-code") -> int:
             metadata=metadata,
             role=hint_role,
             turn_state=initial_turn_state,
+            agent_pid=os.getpid(),
+            parent_pid=os.getppid(),
         )
+        if hijack_rejected:
+            # Daemon rejected this pane claim. Don't write pane metadata,
+            # don't spawn ws-hook — the original peer keeps the pane.
+            lock_fd.close()
+            return 0
         if not display_name:
             display_name = folder_name  # fallback if daemon unreachable
 

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -242,6 +242,7 @@ def main(backend: str = "claude-code") -> int:
         lock_path = ws_hook_lock_path(pane_id)
         pid_path = ws_hook_pid_path(pane_id)
         prior_peer_id: str | None = None
+        needs_takeover = False
         lock_fd = open(lock_path, "w")  # noqa: SIM115
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -256,31 +257,13 @@ def main(backend: str = "claude-code") -> int:
             if same_live_session:
                 lock_fd.close()
                 return 0
-
             prior_peer_id = old_meta.get("peer_id") or _get_peer_id_for_pane(pane_id)
-            try:
-                old_pid = int(pid_path.read_text().strip())
-                os.kill(old_pid, signal.SIGTERM)
-            except (OSError, ValueError):
-                pass
-            for _ in range(10):
-                try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    break
-                except OSError:
-                    time.sleep(0.5)
-            else:
-                try:
-                    old_pid = int(pid_path.read_text().strip())
-                    os.kill(old_pid, signal.SIGKILL)
-                except (OSError, ValueError):
-                    pass
-                fcntl.flock(lock_fd, fcntl.LOCK_EX)
-
-        if prior_peer_id:
-            _mark_peer_offline(prior_peer_id)
-
-        clear_pane_runtime_state(pane_id)
+            # Real takeover-or-hijack scenario. Defer the destructive parts
+            # (killing the incumbent ws-hook, marking the prior peer offline,
+            # clearing pane runtime state) until AFTER the daemon accepts our
+            # registration. A rejected hijack (#190) must leave the incumbent
+            # untouched.
+            needs_takeover = True
 
         # Register peer via HTTP -- daemon assigns peer_id and display_name.
         # Codex strips tmux env from hook subprocesses, so fall back to the
@@ -328,12 +311,40 @@ def main(backend: str = "claude-code") -> int:
             parent_pid=parent_pid_val,
         )
         if hijack_rejected:
-            # Daemon rejected this pane claim. Don't write pane metadata,
-            # don't spawn ws-hook — the original peer keeps the pane.
+            # Daemon rejected this pane claim. Don't touch the incumbent's
+            # ws-hook, prior-peer status, or pane runtime metadata — the
+            # rejection must leave the world unchanged (issue #190).
             lock_fd.close()
             return 0
         if not display_name:
             display_name = folder_name  # fallback if daemon unreachable
+
+        # Daemon accepted our claim. NOW perform the destructive takeover
+        # steps: evict the incumbent ws-hook, mark its peer offline, clear
+        # its pane runtime state, then claim the flock for ourselves.
+        if needs_takeover:
+            try:
+                old_pid = int(pid_path.read_text().strip())
+                os.kill(old_pid, signal.SIGTERM)
+            except (OSError, ValueError):
+                pass
+            for _ in range(10):
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    time.sleep(0.5)
+            else:
+                try:
+                    old_pid = int(pid_path.read_text().strip())
+                    os.kill(old_pid, signal.SIGKILL)
+                except (OSError, ValueError):
+                    pass
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+            if prior_peer_id and prior_peer_id != peer_id:
+                _mark_peer_offline(prior_peer_id)
+            clear_pane_runtime_state(pane_id)
 
         write_pane_runtime_metadata(
             pane_id,

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -201,6 +201,27 @@ def daemon_post(path: str, payload: dict, *, timeout: float = 2.0) -> dict | Non
         return None
 
 
+def daemon_post_with_status(
+    path: str, payload: dict, *, timeout: float = 2.0
+) -> tuple[int | None, dict | None]:
+    """POST JSON to daemon. Returns (status_code, parsed_body).
+
+    Unlike ``daemon_post`` this surfaces the HTTP status so callers can
+    distinguish e.g. 409 (daemon rejected the claim) from other failures.
+    On transport failure returns (None, None).
+    """
+    try:
+        resp = _get_client().post(path, json=payload, timeout=timeout)
+    except httpx.HTTPError as e:
+        _log_daemon_error("POST", path, e)
+        return None, None
+    try:
+        body = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        body = None
+    return resp.status_code, body
+
+
 def daemon_get(path: str, *, timeout: float = 2.0) -> dict | None:
     """GET from daemon. Returns parsed response or None on failure."""
     try:

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -86,6 +86,15 @@ class Peer(BaseModel):
     last_seen: datetime | None = Field(None, description="Last activity timestamp")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     description: str = Field(default="", description="Current task description (self-reported)")
+    agent_pid: int | None = Field(
+        None,
+        description=(
+            "PID of the agent process that owns this peer (the SessionStart "
+            "hook's own pid at registration time). Used by the pane-hijack "
+            "guard to detect a subprocess agent registering inside its parent "
+            "agent's tmux pane."
+        ),
+    )
 
     @property
     def name(self) -> str:
@@ -158,4 +167,5 @@ class Peer(BaseModel):
             "last_seen": self.last_seen.isoformat() if self.last_seen else None,
             "metadata": self.metadata,
             "description": self.description,
+            "agent_pid": self.agent_pid,
         }

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -90,9 +90,9 @@ class Peer(BaseModel):
         None,
         description=(
             "PID of the agent process that owns this peer (the SessionStart "
-            "hook's own pid at registration time). Used by the pane-hijack "
-            "guard to detect a subprocess agent registering inside its parent "
-            "agent's tmux pane."
+            "hook's parent process, i.e. os.getppid() from the hook). Used "
+            "by the pane-hijack guard to detect a subprocess agent "
+            "registering inside its parent agent's tmux pane."
         ),
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -176,6 +176,37 @@ class TestPeers:
         names = [p["display_name"] for p in r.json()["peers"]]
         assert names.count(name) == 1
 
+    async def test_register_pane_hijack_returns_409(self, client):
+        """A subprocess agent (parent_pid matches the live pane peer's
+        agent_pid) gets 409 instead of stealing the pane. See issue #190."""
+        r = await client.post("/peers", json={
+            "name": "parent",
+            "path": "/tmp/parent-proj",
+            "circle": "default",
+            "backend": "claude-code",
+            "pane_id": "%hijack",
+            "agent_pid": 41001,
+            "parent_pid": 40000,
+        })
+        assert r.status_code == 200
+        parent_name = r.json()["display_name"]
+
+        r = await client.post("/peers", json={
+            "name": "child",
+            "path": "/tmp/child-cwd",
+            "circle": "default",
+            "backend": "gemini",
+            "pane_id": "%hijack",
+            "agent_pid": 41002,
+            "parent_pid": 41001,
+        })
+        assert r.status_code == 409
+        assert "%hijack" in r.json()["detail"]
+
+        r = await client.get("/peers/by-pane/%25hijack")
+        assert r.status_code == 200
+        assert r.json()["display_name"] == parent_name
+
     async def test_list_peers_status_filter(self, client):
         r = await client.post("/peers", json={
             "name": "onlinepeer",

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -265,3 +265,57 @@ class TestSessionMain:
                 mock_kill.assert_called_once_with(99999, signal.SIGTERM)
                 mock_register.assert_called_once()
                 assert not (log_dir / "pending-query-1.json").exists()
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=("repow-default-abc12345", "test-claude-code", False),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.subprocess.Popen")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    @patch("repowire.hooks.session_handler._read_ppid_of", return_value=4242)
+    def test_session_start_sends_agent_pid_as_ppid_not_own_pid(
+        self,
+        mock_read_ppid,
+        mock_branch,
+        mock_status,
+        mock_popen,
+        mock_tmux,
+        mock_register,
+        mock_fetch,
+        tmp_path,
+    ):
+        """The agent_pid in the registration payload must be os.getppid(),
+        not os.getpid() — the hook process dies seconds after registration,
+        so storing its own pid makes the pane-hijack guard useless after
+        the hook exits (issue #190 review)."""
+        import os as os_mod
+
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler.os.getppid", return_value=31415):
+            result = _run_with_input({
+                "hook_event_name": "SessionStart",
+                "cwd": str(tmp_path),
+                "session_id": "abc12345-rest",
+            })
+            assert result == 0
+            mock_register.assert_called_once()
+            kwargs = mock_register.call_args.kwargs
+            # agent_pid must be the AGENT's pid (the hook's parent), not the
+            # hook's own pid. We patched getppid to 31415 — if the value is
+            # os.getpid() (this pytest process), the test catches the bug.
+            assert kwargs["agent_pid"] == 31415
+            assert kwargs["agent_pid"] != os_mod.getpid()
+            # parent_pid is computed by walking up one more step from the
+            # agent. We mocked _read_ppid_of to 4242.
+            assert kwargs["parent_pid"] == 4242
+            mock_read_ppid.assert_called_once_with(31415)

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -391,3 +391,74 @@ class TestSessionMain:
             assert json.loads(meta_path.read_text()) == incumbent_meta
             assert pid_path.exists()
             assert pid_path.read_text() == "12345"
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=(None, None, False),  # transport failure / 5xx: no accept, no 409
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    @patch("repowire.hooks.session_handler._read_ppid_of", return_value=99999)
+    def test_takeover_aborted_when_registration_unconfirmed(
+        self,
+        mock_read_ppid,
+        mock_branch,
+        mock_status,
+        mock_tmux,
+        mock_register,
+        mock_fetch,
+        tmp_path,
+    ):
+        """If the daemon doesn't 409 but also doesn't confirm acceptance
+        (transport error, 5xx, malformed body), a pane takeover MUST NOT
+        proceed — destroying the incumbent on every daemon hiccup defeats
+        the hijack guard. See issue #190 round-3 review."""
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler._mark_peer_offline") as mock_offline, \
+             patch("repowire.hooks.session_handler.spawn_ws_hook") as mock_spawn, \
+             patch("repowire.hooks.session_handler.write_pane_runtime_metadata") as mock_write:
+            log_dir = tmp_path / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            incumbent_meta = {
+                "backend": "claude-code",
+                "cwd": "/incumbent/proj",
+                "hook_session_id": "incumbent-session",
+                "peer_id": "repow-default-incumbent",
+                "display_name": "incumbent-claude-code",
+            }
+            meta_path = log_dir / "ws-hook-1.meta.json"
+            pid_path = log_dir / "ws-hook-1.pid"
+            meta_path.write_text(json.dumps(incumbent_meta))
+            pid_path.write_text("12345")
+
+            with patch("repowire.hooks.session_handler.fcntl") as mock_fcntl, \
+                 patch("repowire.hooks.session_handler.os.kill") as mock_kill:
+                mock_fcntl.LOCK_EX = 2
+                mock_fcntl.LOCK_NB = 4
+                mock_fcntl.flock.side_effect = OSError("Resource temporarily unavailable")
+
+                result = _run_with_input({
+                    "hook_event_name": "SessionStart",
+                    "cwd": "/newcomer/proj",
+                    "session_id": "newcomer-session",
+                })
+
+            assert result == 0
+            mock_register.assert_called_once()
+            mock_kill.assert_not_called()
+            mock_offline.assert_not_called()
+            mock_spawn.assert_not_called()
+            mock_write.assert_not_called()
+            assert meta_path.exists()
+            assert json.loads(meta_path.read_text()) == incumbent_meta
+            assert pid_path.exists()
+            assert pid_path.read_text() == "12345"

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -319,3 +319,75 @@ class TestSessionMain:
             # agent. We mocked _read_ppid_of to 4242.
             assert kwargs["parent_pid"] == 4242
             mock_read_ppid.assert_called_once_with(31415)
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=(None, None, True),  # hijack_rejected=True
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    @patch("repowire.hooks.session_handler._read_ppid_of", return_value=99999)
+    def test_rejected_hijack_leaves_incumbent_untouched(
+        self,
+        mock_read_ppid,
+        mock_branch,
+        mock_status,
+        mock_tmux,
+        mock_register,
+        mock_fetch,
+        tmp_path,
+    ):
+        """When the daemon rejects a hijack (409), the hook must NOT kill the
+        incumbent's ws-hook, NOT mark the prior peer offline, and NOT clear
+        the pane runtime metadata. Issue #190 round-2 review."""
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler._mark_peer_offline") as mock_offline, \
+             patch("repowire.hooks.session_handler.spawn_ws_hook") as mock_spawn, \
+             patch("repowire.hooks.session_handler.write_pane_runtime_metadata") as mock_write:
+            log_dir = tmp_path / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            incumbent_meta = {
+                "backend": "claude-code",
+                "cwd": "/incumbent/proj",
+                "hook_session_id": "incumbent-session",
+                "peer_id": "repow-default-incumbent",
+                "display_name": "incumbent-claude-code",
+            }
+            meta_path = log_dir / "ws-hook-1.meta.json"
+            pid_path = log_dir / "ws-hook-1.pid"
+            meta_path.write_text(json.dumps(incumbent_meta))
+            pid_path.write_text("12345")
+
+            with patch("repowire.hooks.session_handler.fcntl") as mock_fcntl, \
+                 patch("repowire.hooks.session_handler.os.kill") as mock_kill:
+                mock_fcntl.LOCK_EX = 2
+                mock_fcntl.LOCK_NB = 4
+                # Incumbent holds the lock → first flock attempt fails.
+                mock_fcntl.flock.side_effect = OSError("Resource temporarily unavailable")
+
+                result = _run_with_input({
+                    "hook_event_name": "SessionStart",
+                    "cwd": "/hijacker/proj",
+                    "session_id": "hijacker-session",
+                })
+
+            assert result == 0
+            mock_register.assert_called_once()
+            mock_kill.assert_not_called()
+            mock_offline.assert_not_called()
+            mock_spawn.assert_not_called()
+            mock_write.assert_not_called()
+            # Incumbent's on-disk state untouched.
+            assert meta_path.exists()
+            assert json.loads(meta_path.read_text()) == incumbent_meta
+            assert pid_path.exists()
+            assert pid_path.read_text() == "12345"

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -87,7 +87,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code"),
+        return_value=("repow-default-abc12345", "test-claude-code", False),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -118,7 +118,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code"),
+        return_value=("repow-default-abc12345", "test-claude-code", False),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -161,7 +161,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "newproj-claude-code"),
+        return_value=("repow-default-abc12345", "newproj-claude-code", False),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -216,7 +216,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code"),
+        return_value=("repow-default-abc12345", "test-claude-code", False),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -527,3 +527,65 @@ async def test_hijack_guard_skipped_when_existing_agent_pid_missing(tmp_path):
     )
     peer = await registry.get_peer_by_pane("%5")
     assert peer is not None and peer.peer_id == new_id
+
+
+@pytest.mark.asyncio
+async def test_agent_pid_persists_in_session_mapping(tmp_path):
+    """agent_pid is written to and read back from the on-disk SessionMapping.
+    Persisting it is the prerequisite for the hijack guard surviving daemon
+    restart: when the peer rehydrates via its ws-hook reconnect (same
+    peer_id), the registry has agent_pid to compare against."""
+    registry = _make_registry(tmp_path)
+
+    original_agent_pid = 51515
+    peer_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%9",
+        agent_pid=original_agent_pid,
+    )
+    registry._mappings_dirty = True
+    registry._persist_mappings()
+
+    raw = json.loads((tmp_path / "sessions.json").read_text())
+    assert raw[peer_id]["agent_pid"] == original_agent_pid
+
+    reloaded = _make_registry(tmp_path)
+    mapping = reloaded.get_mapping(peer_id)
+    assert mapping is not None
+    assert mapping.agent_pid == original_agent_pid
+
+
+@pytest.mark.asyncio
+async def test_reconnect_updates_agent_pid_on_live_peer_and_mapping(tmp_path):
+    """When the same peer_id reconnects after the original agent process
+    has changed (e.g. daemon-restart followed by ws-hook reconnect with a
+    fresh agent_pid), both the live Peer and the SessionMapping are
+    refreshed so subsequent hijack checks compare against the live pid."""
+    registry = _make_registry(tmp_path)
+
+    peer_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%r",
+        agent_pid=10001,
+    )
+    m0 = registry.get_mapping(peer_id)
+    assert m0 is not None and m0.agent_pid == 10001
+
+    reclaimed_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%r",
+        peer_id=peer_id,
+        agent_pid=20002,
+    )
+    assert reclaimed_id == peer_id
+    peer = await registry.get_peer(peer_id)
+    assert peer is not None
+    assert peer.agent_pid == 20002
+    m1 = registry.get_mapping(peer_id)
+    assert m1 is not None and m1.agent_pid == 20002

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -371,3 +371,159 @@ async def test_description_update_persists_to_mapping(tmp_path):
     mapping = registry.get_mapping(peer_id)
     assert mapping is not None
     assert mapping.description == "doing the thing"
+
+
+# ---------------------------------------------------------------------------
+# Pane-hijack guard (issue #190)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pane_hijack_rejected_when_parent_pid_matches_existing_agent(tmp_path):
+    """A fresh SessionStart whose parent_pid matches the live pane peer's
+    agent_pid is rejected — this is the subprocess-agent hijack case (e.g.
+    ``gemini --yolo`` run from inside a claude-code pane inheriting TMUX_PANE)."""
+    from repowire.daemon.peer_registry import PaneHijackRejectedError
+
+    registry = _make_registry(tmp_path)
+
+    parent_agent_pid = 11111
+    parent_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/orchestrator",
+        pane_id="%1",
+        agent_pid=parent_agent_pid,
+        parent_pid=99999,  # parent's own parent (a shell) — irrelevant here
+    )
+
+    with pytest.raises(PaneHijackRejectedError):
+        await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.GEMINI,
+            path="/tmp/some-other-cwd",
+            pane_id="%1",
+            agent_pid=22222,
+            parent_pid=parent_agent_pid,  # gemini's parent IS the claude pid
+        )
+
+    # Original peer keeps the pane.
+    peer = await registry.get_peer_by_pane("%1")
+    assert peer is not None
+    assert peer.peer_id == parent_id
+    assert peer.backend == AgentType.CLAUDE_CODE
+
+
+@pytest.mark.asyncio
+async def test_relaunch_after_crash_allowed_when_existing_peer_is_stale(tmp_path):
+    """If the prior peer's last_seen is older than the heartbeat tolerance,
+    the guard does not fire — the prior agent is presumed dead."""
+    registry = _make_registry(tmp_path)
+
+    parent_agent_pid = 33333
+    await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/oldproj",
+        pane_id="%2",
+        agent_pid=parent_agent_pid,
+    )
+    # Backdate the prior peer well beyond heartbeat tolerance.
+    tolerance = registry.heartbeat_tolerance()
+    stale_when = datetime.now(timezone.utc) - timedelta(seconds=tolerance * 4)
+    for peer in registry._peers.values():
+        if peer.pane_id == "%2":
+            peer.last_seen = stale_when
+
+    # New claude launches in the same pane. Even if (improbably) its ppid
+    # collides with the dead agent's pid, the staleness lets it through.
+    new_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/newproj",
+        pane_id="%2",
+        agent_pid=44444,
+        parent_pid=parent_agent_pid,
+    )
+    new_peer = await registry.get_peer_by_pane("%2")
+    assert new_peer is not None and new_peer.peer_id == new_id
+
+
+@pytest.mark.asyncio
+async def test_worktree_swap_in_same_pane_allowed(tmp_path):
+    """`cd ~/other-proj && claude` in an existing pane: the new claude's
+    parent is the shell, not the prior agent. Guard does not fire."""
+    registry = _make_registry(tmp_path)
+
+    await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/proj-a",
+        pane_id="%3",
+        agent_pid=55555,
+    )
+
+    new_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/proj-b",
+        pane_id="%3",
+        agent_pid=66666,
+        parent_pid=77777,  # the shell's pid, not the prior agent's
+    )
+    peer = await registry.get_peer_by_pane("%3")
+    assert peer is not None and peer.peer_id == new_id
+    assert peer.path == "/tmp/proj-b"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_with_same_peer_id_bypasses_hijack_guard(tmp_path):
+    """The reconnect path (#167) uses a known peer_id; the hijack guard runs
+    in the fresh-claim branch only and must not fire on legitimate reconnects."""
+    registry = _make_registry(tmp_path)
+
+    peer_id, name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/reconnect-proj",
+        pane_id="%4",
+        agent_pid=88888,
+    )
+
+    reclaimed_id, reclaimed_name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/reconnect-proj",
+        pane_id="%4",
+        peer_id=peer_id,
+        agent_pid=88888,
+        parent_pid=88888,  # would normally trip the guard if this were a fresh claim
+    )
+    assert reclaimed_id == peer_id
+    assert reclaimed_name == name
+
+
+@pytest.mark.asyncio
+async def test_hijack_guard_skipped_when_existing_agent_pid_missing(tmp_path):
+    """Peers registered before this feature have no agent_pid recorded; the
+    guard cannot decide and must not block them."""
+    registry = _make_registry(tmp_path)
+
+    await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/legacy-proj",
+        pane_id="%5",
+        # agent_pid intentionally omitted (legacy peer)
+    )
+
+    new_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.GEMINI,
+        path="/tmp/sub",
+        pane_id="%5",
+        agent_pid=12121,
+        parent_pid=99999,
+    )
+    peer = await registry.get_peer_by_pane("%5")
+    assert peer is not None and peer.peer_id == new_id


### PR DESCRIPTION
## Summary
- Closes #190. A fresh `SessionStart` claim for a pane that already has a live peer is now rejected when the new hook's `parent_pid` (`os.getppid()`) matches the existing peer's recorded `agent_pid`. This is the subprocess-agent hijack case — e.g. `gemini --yolo` invoked from inside a claude-code pane inheriting `TMUX_PANE`.
- Reconnect path (PR #167, same `peer_id`) is untouched: the guard runs only in the fresh-claim branch of `allocate_and_register`.
- Rejection surface: `POST /peers` returns 409, daemon logs at error with `hook_pid` / `parent_pid` / `existing_agent_pid` / `existing_peer_id` / `existing_display_name` / `pane_id` (PR #178 log shape). The session hook aborts cleanly without writing pane runtime metadata or spawning the ws-hook.
- No `REPOWIRE_ALLOW_PANE_HIJACK` escape hatch (deferred per the issue).

## Surface changes
- `Peer.agent_pid: int | None` (recorded at first SessionStart from the hook's own pid).
- `RegisterPeerRequest.agent_pid` / `parent_pid`.
- `allocate_and_register(... agent_pid, parent_pid)`; raises `PaneHijackRejectedError` on hijack.
- Session hook sends both pids and bails on 409.
- `daemon_post_with_status` helper so the hook can distinguish 409 from other failures.

## Tests
- `test_pane_hijack_rejected_when_parent_pid_matches_existing_agent` — the #190 incident repro
- `test_relaunch_after_crash_allowed_when_existing_peer_is_stale` — stale `last_seen` bypasses the guard
- `test_worktree_swap_in_same_pane_allowed` — shell parent doesn't match prior agent pid
- `test_reconnect_with_same_peer_id_bypasses_hijack_guard` — same-peer_id reconnect path unaffected
- `test_hijack_guard_skipped_when_existing_agent_pid_missing` — legacy peers (no recorded pid) don't block
- `test_register_pane_hijack_returns_409` — end-to-end HTTP surface
- `uv run pytest` (`905 passed`)
- `uv run ruff check repowire/ tests/test_session_mapper.py tests/test_session_handler.py tests/test_routes.py`
- `uv run ty check repowire/`

## Test plan
- [x] hijack rejected (parent_pid matches live peer's agent_pid)
- [x] re-launch after crash allowed (stale last_seen)
- [x] worktree-swap allowed (different parent_pid)
- [x] reconnect with same peer_id allowed
- [x] daemon restart preserves guard (`agent_pid` persists on the in-memory peer; `last_seen` and the reconnect path together restore correct guarding)

Related: #167, #178, #168.