### PR TITLE
fix(spawn): deliver per-spawn seed message to claude-code-family backends

### DIFF
--- a/repowire/installers/post_spawn.py
+++ b/repowire/installers/post_spawn.py
@@ -53,11 +53,15 @@ async def post_spawn_warmup(
         if backend == AgentType.CODEX:
             text = message or DEFAULT_WARMUP_TEMPLATE.format(path=path, circle=circle)
             await _codex_warmup(pane_id, text)
-        else:
-            # claude-code, opencode, gemini: SessionStart (or equivalent) fires
-            # at boot, so no nudge needed. If a future backend needs one, add a
-            # branch here.
-            return
+        elif message:
+            # claude-code, opencode, gemini: SessionStart fires at boot so the
+            # peer self-registers without a nudge, but the per-spawn seed
+            # message was previously dropped on the floor. Deliver it via
+            # tmux send-keys after a short settle delay so the agent has a
+            # prompt to receive into. This closes the
+            # `pending_first_turn` drop where spawn brief silently vanished.
+            await _claude_code_family_seed(pane_id, message)
+        # else: no seed message — registration via SessionStart is enough.
     except Exception as e:
         logger.warning("post_spawn_warmup failed for %s pane %s: %s", backend, pane_id, e)
 
@@ -95,6 +99,29 @@ async def _codex_warmup(pane_id: str, message: str) -> None:
 
     await asyncio.sleep(1)
 
+    await _tmux_send(pane_id, message, literal=True)
+    await asyncio.sleep(0.2)
+    await _tmux_send(pane_id, "C-m")
+
+
+async def _claude_code_family_seed(pane_id: str, message: str) -> None:
+    """Deliver the per-spawn seed message into a claude-code-family pane.
+
+    These backends boot a TUI prompt that's ready to receive input within a
+    few seconds. Sleep for the boot budget, then send the seed text + Enter.
+    Best-effort — failure is logged and swallowed by the caller.
+
+    Sequence:
+      1. Sleep 5s   -- claude-code-family TUI boot budget
+      2. send-keys message + C-m
+    """
+    if not pane_id:
+        return
+    if not shutil.which("tmux"):
+        logger.warning("seed-message: tmux binary not found, skipping")
+        return
+
+    await asyncio.sleep(5)
     await _tmux_send(pane_id, message, literal=True)
     await asyncio.sleep(0.2)
     await _tmux_send(pane_id, "C-m")

--- a/tests/test_post_spawn.py
+++ b/tests/test_post_spawn.py
@@ -9,6 +9,7 @@ import pytest
 from repowire.config.models import AgentType
 from repowire.installers.post_spawn import (
     DEFAULT_WARMUP_TEMPLATE,
+    _claude_code_family_seed,
     _codex_warmup,
     post_spawn_warmup,
 )
@@ -79,6 +80,117 @@ class TestPostSpawnWarmup:
             AgentType.CODEX, "%42",
             path="/tmp/proj", circle="5", message=None,
         )
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._claude_code_family_seed", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_claude_code_with_message_delivers_seed(
+        self, mock_codex: AsyncMock, mock_seed: AsyncMock,
+    ) -> None:
+        """claude-code spawn with a per-spawn seed message must deliver it,
+        not silently drop. This closes the pending_first_turn bug where
+        spawn briefs vanished without reaching the agent.
+        """
+        await post_spawn_warmup(
+            AgentType.CLAUDE_CODE, "%42",
+            path="/tmp/proj", circle="5",
+            message="Task brief from orch",
+        )
+        mock_codex.assert_not_awaited()
+        mock_seed.assert_awaited_once_with("%42", "Task brief from orch")
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._claude_code_family_seed", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_opencode_with_message_delivers_seed(
+        self, mock_codex: AsyncMock, mock_seed: AsyncMock,
+    ) -> None:
+        await post_spawn_warmup(
+            AgentType.OPENCODE, "%42",
+            path="/tmp/proj", circle="5",
+            message="Task brief",
+        )
+        mock_codex.assert_not_awaited()
+        mock_seed.assert_awaited_once_with("%42", "Task brief")
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._claude_code_family_seed", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_gemini_with_message_delivers_seed(
+        self, mock_codex: AsyncMock, mock_seed: AsyncMock,
+    ) -> None:
+        await post_spawn_warmup(
+            AgentType.GEMINI, "%42",
+            path="/tmp/proj", circle="5",
+            message="Task brief",
+        )
+        mock_codex.assert_not_awaited()
+        mock_seed.assert_awaited_once_with("%42", "Task brief")
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._claude_code_family_seed", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn._codex_warmup", new_callable=AsyncMock)
+    async def test_claude_code_without_message_is_still_noop(
+        self, mock_codex: AsyncMock, mock_seed: AsyncMock,
+    ) -> None:
+        """Bare spawns (no message) preserve the prior no-op behavior."""
+        await post_spawn_warmup(
+            AgentType.CLAUDE_CODE, "%42",
+            path="/tmp/proj", circle="5", message=None,
+        )
+        mock_codex.assert_not_awaited()
+        mock_seed.assert_not_awaited()
+
+
+class TestClaudeCodeFamilySeed:
+    """_claude_code_family_seed drives the seed-delivery sequence."""
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.shutil.which", return_value="/usr/bin/tmux")
+    async def test_seed_delivery_sequence(
+        self,
+        _mock_which,
+        mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _claude_code_family_seed("%42", "Task brief from orch")
+
+        # message + C-m submit = 2 sends
+        assert mock_send.await_count == 2
+        calls = mock_send.await_args_list
+        assert calls[0].args == ("%42", "Task brief from orch")
+        assert calls[0].kwargs == {"literal": True}
+        assert calls[1].args == ("%42", "C-m")
+
+        # Sleeps: 5s boot + 0.2s pre-submit
+        sleep_args = [c.args[0] for c in mock_sleep.await_args_list]
+        assert sleep_args == [5, 0.2]
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.shutil.which", return_value=None)
+    async def test_seed_skips_when_tmux_missing(
+        self,
+        _mock_which,
+        _mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _claude_code_family_seed("%42", "Task brief")
+        mock_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("repowire.installers.post_spawn._tmux_send", new_callable=AsyncMock)
+    @patch("repowire.installers.post_spawn.asyncio.sleep", new_callable=AsyncMock)
+    async def test_seed_skips_when_pane_id_empty(
+        self,
+        _mock_sleep: AsyncMock,
+        mock_send: AsyncMock,
+    ) -> None:
+        await _claude_code_family_seed("", "Task brief")
+        mock_send.assert_not_awaited()
 
 
 class TestCodexWarmup:


### PR DESCRIPTION
## Summary

Bug discovered during the v0.13.x train: every spawn_peer call with a message for a claude-code/opencode/gemini backend left the peer in pending_first_turn state. The seed brief was passed through the API but post_spawn_warmup silently dropped it — only codex received the message because codex was the only backend with a tmux send-keys path. Orchestrators had to manually notify_peer with the same brief as a workaround on every spawn.

## Fix

post_spawn_warmup now delivers the per-spawn seed message via tmux send-keys for claude-code, opencode, and gemini when a message is present. The existing no-op behavior for bare spawns (no message) is preserved.

Sequence:
1. Sleep 5s — TUI boot budget
2. tmux send-keys -l <message>
3. tmux send-keys C-m — submit

Best-effort, swallows tmux failures so a stalled send doesn't block /spawn or anything else.

## Tests

tests/test_post_spawn.py adds regression coverage:
- test_claude_code_with_message_delivers_seed — primary regression test for the dropped-brief bug
- test_opencode_with_message_delivers_seed
- test_gemini_with_message_delivers_seed
- test_claude_code_without_message_is_still_noop — preserves prior no-op for bare spawns
- TestClaudeCodeFamilySeed class covering the new _claude_code_family_seed helper: send sequence, sleep budget, tmux-missing skip, empty-pane-id skip

17/17 pass in tests/test_post_spawn.py. Ruff + ty clean on touched files.

(There are 6 unrelated pre-existing failures in tests/test_routes.py::TestHealth and tests/test_event_bus.py from a pydantic-version-validation issue that surfaces locally; not from this change.)