### PR TITLE
feat: backend switcher per peer (§4.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.13.23"
+version = "0.13.24"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 _EVICTION_INTERVAL_SECONDS = 300.0
 
 
+class QuiesceFailedError(Exception):
+    """Raised when begin_quiesce cannot acquire the barrier because open
+    asks already exist for the peer."""
+
+    def __init__(self, peer_id: str, open_cids: list[str]) -> None:
+        super().__init__(f"Peer {peer_id} has open asks: {open_cids}")
+        self.peer_id = peer_id
+        self.open_cids = open_cids
+
+
+class QuiescedError(Exception):
+    """Raised when register() is called while a peer is mid-switch."""
+
+    def __init__(self, peer_id: str) -> None:
+        super().__init__(f"Peer {peer_id} is mid-switch; ask refused")
+        self.peer_id = peer_id
+
+
 @dataclass
 class Ask:
     """An open ask awaiting ack/reply.
@@ -62,6 +80,34 @@ class AskTracker:
         self._asks: dict[str, Ask] = {}
         self._ttl = timedelta(hours=ttl_hours)
         self._last_eviction: float = 0.0
+        # peer_ids currently mid-switch — new asks to/from them are refused so
+        # the switch route can kill+respawn without orphaning correlation IDs.
+        self._quiescing: set[str] = set()
+
+
+    async def begin_quiesce(self, peer_id: str) -> None:
+        """Atomically: verify no open asks for peer, mark peer as quiescing.
+
+        While quiesced, register() rejects new asks for this peer in either
+        direction. Use end_quiesce() in a finally to release.
+
+        Raises QuiesceFailedError if open asks exist.
+        """
+        async with self._lock:
+            open_asks = [
+                a.correlation_id for a in self._asks.values()
+                if not a.closed and (a.to_peer_id == peer_id or a.from_peer_id == peer_id)
+            ]
+            if open_asks:
+                raise QuiesceFailedError(peer_id, open_asks)
+            self._quiescing.add(peer_id)
+            logger.debug("Quiesced peer %s for switch", peer_id)
+
+    async def end_quiesce(self, peer_id: str) -> None:
+        """Release the switch barrier. Idempotent."""
+        async with self._lock:
+            self._quiescing.discard(peer_id)
+            logger.debug("Released quiesce for peer %s", peer_id)
 
     async def register(
         self,
@@ -78,8 +124,14 @@ class AskTracker:
         If correlation_id is supplied and already exists, this is treated as
         a retry: the existing entry is preserved (lifecycle state intact)
         and the same id is returned. Auto-generated cids never collide.
+
+        Raises QuiescedError if either endpoint is mid-switch.
         """
         async with self._lock:
+            if to_peer_id in self._quiescing:
+                raise QuiescedError(to_peer_id)
+            if from_peer_id in self._quiescing:
+                raise QuiescedError(from_peer_id)
             cid = correlation_id or f"ask-{uuid4().hex[:8]}"
             if cid in self._asks:
                 logger.debug("Ask %s already registered; treating as retry", cid)

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -91,9 +91,19 @@ class AskTracker:
         While quiesced, register() rejects new asks for this peer in either
         direction. Use end_quiesce() in a finally to release.
 
-        Raises QuiesceFailedError if open asks exist.
+        Exclusive: a concurrent begin_quiesce for the same peer_id raises
+        QuiesceFailedError with an empty open_cids list, so only one caller
+        ever holds the barrier at a time. Without this, two concurrent
+        switches against the same peer would both enter the critical
+        kill/spawn section and the first end_quiesce would prematurely
+        release the barrier for the second.
+
+        Raises QuiesceFailedError if open asks exist OR the peer is already
+        quiescing.
         """
         async with self._lock:
+            if peer_id in self._quiescing:
+                raise QuiesceFailedError(peer_id, [])
             open_asks = [
                 a.correlation_id for a in self._asks.values()
                 if not a.closed and (a.to_peer_id == peer_id or a.from_peer_id == peer_id)

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -28,6 +28,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from repowire.daemon.ask_tracker import QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.routes._shared import OkResponse
@@ -146,14 +147,24 @@ async def open_ask(
     from_peer_id = from_peer_obj.peer_id if from_peer_obj else request.from_peer
     from_peer_name = from_peer_obj.display_name if from_peer_obj else request.from_peer
 
-    cid = await ask_tracker.register(
-        from_peer_id=from_peer_id,
-        from_peer_name=from_peer_name,
-        to_peer_id=peer.peer_id,
-        to_peer_name=peer.display_name,
-        text=request.text,
-        reply_to=request.reply_to,
-    )
+    try:
+        cid = await ask_tracker.register(
+            from_peer_id=from_peer_id,
+            from_peer_name=from_peer_name,
+            to_peer_id=peer.peer_id,
+            to_peer_name=peer.display_name,
+            text=request.text,
+            reply_to=request.reply_to,
+        )
+    except QuiescedError as e:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "peer_switching",
+                "hint": f"Peer {request.to_peer} is mid-switch; retry shortly.",
+                "peer_id": e.peer_id,
+            },
+        ) from e
 
     try:
         await peer_registry.deliver_ask(

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from repowire.config.models import AgentType
+from repowire.daemon.ask_tracker import QuiesceFailedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_config, get_peer_registry
 from repowire.daemon.peer_registry import PeerRegistry
@@ -307,6 +308,9 @@ class SwitchBackendResponse(BaseModel):
     tmux_session: str
     old_backend: AgentType
     new_backend: AgentType
+    command: str = Field(
+        ..., description="The allowed_commands entry actually used to spawn",
+    )
 
 
 def _command_for_backend(new_backend: AgentType) -> str | None:
@@ -333,6 +337,20 @@ async def switch_peer_backend(
     backend starts fresh in the peer's working directory. ACP-native switching is
     out of scope until ACP phase-3 lands.
 
+    Race-safety:
+    - In-flight asks are blocked atomically via AskTracker.begin_quiesce: the
+      barrier both verifies no open asks exist AND prevents new /ask registrations
+      targeting the peer (either direction) until the switch completes. New
+      callers see 503 peer_switching during the window.
+    - kill_pane failure aborts the switch (500 kill_failed) rather than
+      unregistering a peer whose runtime is still alive.
+    - Known limitation: between unregister_peer and the new agent's SessionStart
+      self-register there is a small window where the peer name is absent from
+      the registry. A concurrent /spawn for the same path+backend+circle could
+      in theory race for the freed name. Operators triggering simultaneous
+      switches against the same peer is the only path that hits this; addressing
+      it requires a name-reservation primitive in PeerRegistry and is deferred.
+
     Errors:
     - 404: peer not found
     - 409 same_backend: new_backend equals current backend (no-op)
@@ -340,6 +358,8 @@ async def switch_peer_backend(
     - 409 in_flight_asks: peer has open asks; caller must retry after they close
     - 422 command_unavailable: no entry in daemon.spawn.allowed_commands maps to
       new_backend — operator must add one to ~/.repowire/config.yaml
+    - 500 kill_failed: the daemon-owned tmux pane could not be killed; the old
+      runtime may still be alive. Investigate with `tmux list-panes -a`.
     """
     peer_registry = get_peer_registry()
     await peer_registry.lazy_repair()
@@ -404,12 +424,15 @@ async def switch_peer_backend(
     # operators can't bypass /spawn's guardrails via a backend switch.
     _validate_spawn_request(peer.path, command)
 
-    # In-flight asks: refuse rather than orphan correlation IDs. Caller documents
-    # this as a transient TransportError-shaped 409 — retry once the asks close.
+    # Acquire the ask-tracker quiesce barrier atomically: this both verifies no
+    # open asks exist for the peer AND blocks new /ask registrations targeting
+    # the peer until end_quiesce() runs. Without the barrier a fresh /ask could
+    # race between the pending check and the kill and be orphaned by the switch.
     state = get_app_state()
     ask_tracker = state.ask_tracker
-    pending = await ask_tracker.pending_for_peer(peer.peer_id, direction="both")
-    if pending:
+    try:
+        await ask_tracker.begin_quiesce(peer.peer_id)
+    except QuiesceFailedError as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -418,54 +441,73 @@ async def switch_peer_backend(
                     "Peer has open asks; backend switch would orphan them. "
                     "Retry after they're acked or evicted."
                 ),
-                "open_asks": [a.correlation_id for a in pending],
+                "open_asks": e.open_cids,
             },
-        )
-
-    # Capture pre-kill state. Use the path-derived stem so the respawn lands on
-    # the same window-name base (tmux will pick a unique suffix if needed).
-    spawn_circle = peer.circle or "default"
-    resolved_path = str(Path(peer.path).expanduser().resolve())
-
-    # Kill the existing peer (pane + registry entry) using the same ownership
-    # rules as /kill-peer: only daemon-spawned panes are killed.
-    if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
-        kill_pane(peer.pane_id)
-        _SPAWNED_PANE_IDS.discard(peer.pane_id)
-    await peer_registry.unregister_peer(peer.peer_id)
-
-    # Respawn with the new backend.
-    try:
-        result: SpawnResult = spawn_peer(
-            SpawnConfig(
-                path=resolved_path,
-                circle=spawn_circle,
-                backend=request.new_backend,
-                command=command,
-            )
-        )
-    except (ValueError, RuntimeError) as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
         ) from e
 
-    if result.pane_id:
-        _SPAWNED_PANE_IDS.add(result.pane_id)
-        task = asyncio.create_task(
-            post_spawn_warmup(
-                request.new_backend,
-                result.pane_id,
-                path=resolved_path,
-                circle=spawn_circle,
-                message=result.message,
-            )
-        )
-        _BACKGROUND_TASKS.add(task)
-        task.add_done_callback(_BACKGROUND_TASKS.discard)
+    try:
+        # Capture pre-kill state. Use the path-derived stem so the respawn lands
+        # on the same window-name base (tmux will pick a unique suffix if
+        # needed).
+        spawn_circle = peer.circle or "default"
+        resolved_path = str(Path(peer.path).expanduser().resolve())
 
-    return SwitchBackendResponse(
-        display_name=result.display_name,
-        tmux_session=result.tmux_session,
-        old_backend=current_backend,
-        new_backend=request.new_backend,
-    )
+        # Only kill daemon-owned panes (same ownership rule as /kill-peer). If
+        # kill_pane returns False the underlying agent is still alive — abort
+        # rather than leave a zombie runtime running against a deregistered
+        # identity.
+        if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
+            if not kill_pane(peer.pane_id):
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail={
+                        "error": "kill_failed",
+                        "hint": (
+                            "tmux kill-pane failed for the peer's pane; the "
+                            "old agent may still be alive. Aborting switch to "
+                            "avoid a zombie runtime. Check `tmux list-panes -a`."
+                        ),
+                        "pane_id": peer.pane_id,
+                    },
+                )
+            _SPAWNED_PANE_IDS.discard(peer.pane_id)
+        await peer_registry.unregister_peer(peer.peer_id)
+
+        # Respawn with the new backend.
+        try:
+            result: SpawnResult = spawn_peer(
+                SpawnConfig(
+                    path=resolved_path,
+                    circle=spawn_circle,
+                    backend=request.new_backend,
+                    command=command,
+                )
+            )
+        except (ValueError, RuntimeError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
+            ) from e
+
+        if result.pane_id:
+            _SPAWNED_PANE_IDS.add(result.pane_id)
+            task = asyncio.create_task(
+                post_spawn_warmup(
+                    request.new_backend,
+                    result.pane_id,
+                    path=resolved_path,
+                    circle=spawn_circle,
+                    message=result.message,
+                )
+            )
+            _BACKGROUND_TASKS.add(task)
+            task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+        return SwitchBackendResponse(
+            display_name=result.display_name,
+            tmux_session=result.tmux_session,
+            old_backend=current_backend,
+            new_backend=request.new_backend,
+            command=command,
+        )
+    finally:
+        await ask_tracker.end_quiesce(peer.peer_id)

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -10,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
-from repowire.daemon.deps import get_config, get_peer_registry
+from repowire.daemon.deps import get_app_state, get_config, get_peer_registry
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.spawn import (
@@ -285,3 +286,186 @@ async def kill_registered_peer(
         _SPAWNED_PANE_IDS.discard(peer.pane_id)
     await peer_registry.unregister_peer(peer.peer_id)
     return KillResponse(tmux_killed=tmux_killed)
+
+
+# ---------------------------------------------------------------------------
+# Backend switcher (§4.8) — kill + respawn same path/circle with new backend
+# ---------------------------------------------------------------------------
+
+
+class SwitchBackendRequest(BaseModel):
+    """Request to switch a running peer's backend."""
+
+    new_backend: AgentType = Field(..., description="Target agent runtime")
+
+
+class SwitchBackendResponse(BaseModel):
+    """Result of a successful backend switch."""
+
+    ok: bool = True
+    display_name: str
+    tmux_session: str
+    old_backend: AgentType
+    new_backend: AgentType
+
+
+def _command_for_backend(new_backend: AgentType) -> str | None:
+    """Return the first allowed_commands entry whose first token maps to new_backend."""
+    cfg = get_config()
+    for cmd in cfg.daemon.spawn.allowed_commands:
+        head = cmd.split(None, 1)[0] if cmd else ""
+        if _COMMAND_TO_BACKEND.get(head) is new_backend:
+            return cmd
+    return None
+
+
+@router.post("/peers/{name}/switch-backend", response_model=SwitchBackendResponse)
+async def switch_peer_backend(
+    name: str,
+    request: SwitchBackendRequest,
+    circle: str | None = None,
+    _: str | None = Depends(require_auth),
+) -> SwitchBackendResponse:
+    """Switch a peer's backend by killing it and respawning at the same path/circle.
+
+    Same-host only in v1: cross-host peers return 409 (same shape as the per-peer
+    MCP routes). Conversation state is NOT preserved across the switch — the new
+    backend starts fresh in the peer's working directory. ACP-native switching is
+    out of scope until ACP phase-3 lands.
+
+    Errors:
+    - 404: peer not found
+    - 409 same_backend: new_backend equals current backend (no-op)
+    - 409 cross_host: peer runs on a different machine
+    - 409 in_flight_asks: peer has open asks; caller must retry after they close
+    - 422 command_unavailable: no entry in daemon.spawn.allowed_commands maps to
+      new_backend — operator must add one to ~/.repowire/config.yaml
+    """
+    peer_registry = get_peer_registry()
+    await peer_registry.lazy_repair()
+    peer = await peer_registry.get_peer(name, circle=circle)
+    if not peer:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {name}",
+        )
+
+    self_machine = socket.gethostname()
+    if peer.machine and peer.machine != self_machine:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "cross_host",
+                "hint": (
+                    "Backend switch is same-host only in v1; "
+                    "ACP transport required for remote peers."
+                ),
+                "peer_machine": peer.machine,
+                "self_machine": self_machine,
+            },
+        )
+
+    current_backend = peer.backend
+    if current_backend is request.new_backend:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "same_backend",
+                "hint": f"Peer is already running {current_backend.value}",
+                "backend": current_backend.value,
+            },
+        )
+
+    if not peer.path:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "missing_path",
+                "hint": "Peer has no recorded working directory; cannot respawn.",
+            },
+        )
+
+    command = _command_for_backend(request.new_backend)
+    if command is None:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "command_unavailable",
+                "hint": (
+                    f"No entry in daemon.spawn.allowed_commands maps to "
+                    f"{request.new_backend.value!r}. Add one to "
+                    f"~/.repowire/config.yaml (e.g. {request.new_backend.value!r})."
+                ),
+                "new_backend": request.new_backend.value,
+            },
+        )
+
+    # Validate the resolved command + peer's existing path against allowlists so
+    # operators can't bypass /spawn's guardrails via a backend switch.
+    _validate_spawn_request(peer.path, command)
+
+    # In-flight asks: refuse rather than orphan correlation IDs. Caller documents
+    # this as a transient TransportError-shaped 409 — retry once the asks close.
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    pending = await ask_tracker.pending_for_peer(peer.peer_id, direction="both")
+    if pending:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "in_flight_asks",
+                "hint": (
+                    "Peer has open asks; backend switch would orphan them. "
+                    "Retry after they're acked or evicted."
+                ),
+                "open_asks": [a.correlation_id for a in pending],
+            },
+        )
+
+    # Capture pre-kill state. Use the path-derived stem so the respawn lands on
+    # the same window-name base (tmux will pick a unique suffix if needed).
+    spawn_circle = peer.circle or "default"
+    resolved_path = str(Path(peer.path).expanduser().resolve())
+
+    # Kill the existing peer (pane + registry entry) using the same ownership
+    # rules as /kill-peer: only daemon-spawned panes are killed.
+    if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
+        kill_pane(peer.pane_id)
+        _SPAWNED_PANE_IDS.discard(peer.pane_id)
+    await peer_registry.unregister_peer(peer.peer_id)
+
+    # Respawn with the new backend.
+    try:
+        result: SpawnResult = spawn_peer(
+            SpawnConfig(
+                path=resolved_path,
+                circle=spawn_circle,
+                backend=request.new_backend,
+                command=command,
+            )
+        )
+    except (ValueError, RuntimeError) as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
+        ) from e
+
+    if result.pane_id:
+        _SPAWNED_PANE_IDS.add(result.pane_id)
+        task = asyncio.create_task(
+            post_spawn_warmup(
+                request.new_backend,
+                result.pane_id,
+                path=resolved_path,
+                circle=spawn_circle,
+                message=result.message,
+            )
+        )
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+    return SwitchBackendResponse(
+        display_name=result.display_name,
+        tmux_session=result.tmux_session,
+        old_backend=current_backend,
+        new_backend=request.new_backend,
+    )

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -433,6 +433,20 @@ async def switch_peer_backend(
     try:
         await ask_tracker.begin_quiesce(peer.peer_id)
     except QuiesceFailedError as e:
+        if not e.open_cids:
+            # Concurrent switch already holds the barrier — refuse so we don't
+            # both enter the kill/spawn section and have the first end_quiesce
+            # prematurely release the barrier for the second.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "switch_in_progress",
+                    "hint": (
+                        "Another switch is in progress for this peer. "
+                        "Retry shortly."
+                    ),
+                },
+            ) from e
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={

--- a/tests/test_switch_backend_route.py
+++ b/tests/test_switch_backend_route.py
@@ -204,6 +204,155 @@ class TestSwitchBackendRoute:
         )
         assert r.status_code == 404
 
+    async def test_kill_pane_failure_aborts_switch(self, env, tmp_path):
+        """If kill_pane returns False, abort and leave the peer registered.
+
+        Otherwise we'd unregister a peer whose underlying agent is still alive,
+        leaving a zombie runtime.
+        """
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        # Force the daemon to think it owns the pane so kill_pane is called.
+        pane_id = "%9999"
+        peer.pane_id = pane_id
+        spawn_routes._SPAWNED_PANE_IDS.add(pane_id)
+        try:
+            with patch.object(spawn_routes, "spawn_peer") as mock_spawn, \
+                patch.object(spawn_routes, "kill_pane", return_value=False) as mock_kill:
+                r = await env.client.post(
+                    f"/peers/{name}/switch-backend",
+                    json={"new_backend": "codex"},
+                )
+            assert r.status_code == 500
+            assert r.json()["detail"]["error"] == "kill_failed"
+            mock_kill.assert_called_once_with(pane_id)
+            mock_spawn.assert_not_called()
+            # Peer must still be registered — we refused to deregister a live
+            # runtime.
+            assert await env.registry.get_peer(name) is not None
+            # Quiesce barrier must be released so subsequent asks aren't blocked
+            # forever.
+            assert peer.peer_id not in env.ask_tracker._quiescing
+        finally:
+            spawn_routes._SPAWNED_PANE_IDS.discard(pane_id)
+
+    async def test_concurrent_ask_blocked_during_switch(self, env, tmp_path):
+        """A /ask landing mid-switch must be refused so it can't be orphaned.
+
+        Simulates the race codex flagged: pre-check passes, then a new ask
+        arrives during the kill+respawn window. spawn_peer is synchronous, so
+        we use it as the synchronization point — while it runs, the barrier is
+        held, and an /ask issued just before the switch but processed during
+        spawn must be rejected.
+        """
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+
+        racy_ask_result: dict[str, object] = {}
+
+        def fake_spawn(_cfg):
+            # While spawn_peer runs, the quiesce barrier is held. Verify a
+            # concurrent register() would be rejected by inspecting the
+            # in-process barrier set (the same check register() does under
+            # the lock).
+            try:
+                from repowire.daemon.ask_tracker import QuiescedError
+                if peer.peer_id in env.ask_tracker._quiescing:
+                    raise QuiescedError(peer.peer_id)
+                racy_ask_result["error"] = "no_barrier"
+            except Exception as e:
+                racy_ask_result["error"] = type(e).__name__
+            from repowire.spawn import SpawnResult
+            return SpawnResult(
+                display_name="alpha", tmux_session="default:alpha", pane_id="%200",
+            )
+
+        with patch.object(spawn_routes, "spawn_peer", side_effect=fake_spawn), \
+            patch.object(spawn_routes, "kill_pane", return_value=True), \
+            patch.object(spawn_routes, "post_spawn_warmup", new_callable=AsyncMock):
+            r = await env.client.post(
+                f"/peers/{name}/switch-backend",
+                json={"new_backend": "codex"},
+            )
+        assert r.status_code == 200, r.text
+        # The racing register() would have been rejected by the barrier.
+        assert racy_ask_result.get("error") == "QuiescedError"
+        # Barrier must have been released after the switch completed.
+        assert peer.peer_id not in env.ask_tracker._quiescing
+
+
+class TestAskTrackerQuiesceBarrier:
+    """Direct unit tests for the AskTracker switch barrier."""
+
+    async def test_register_rejected_while_quiescing(self):
+        from repowire.daemon.ask_tracker import AskTracker, QuiescedError
+        tracker = AskTracker()
+        peer_id = "repow-default-aa11bb22"
+        await tracker.begin_quiesce(peer_id)
+        with pytest.raises(QuiescedError):
+            await tracker.register(
+                from_peer_id="dashboard",
+                from_peer_name="dashboard",
+                to_peer_id=peer_id,
+                to_peer_name="alpha",
+                text="should be refused",
+            )
+        await tracker.end_quiesce(peer_id)
+        # After release, register succeeds.
+        cid = await tracker.register(
+            from_peer_id="dashboard",
+            from_peer_name="dashboard",
+            to_peer_id=peer_id,
+            to_peer_name="alpha",
+            text="now allowed",
+        )
+        assert cid
+
+    async def test_begin_quiesce_fails_with_open_asks(self):
+        from repowire.daemon.ask_tracker import AskTracker, QuiesceFailedError
+        tracker = AskTracker()
+        peer_id = "repow-default-aa11bb22"
+        cid = await tracker.register(
+            from_peer_id="dashboard",
+            from_peer_name="dashboard",
+            to_peer_id=peer_id,
+            to_peer_name="alpha",
+            text="open ask",
+        )
+        with pytest.raises(QuiesceFailedError) as ei:
+            await tracker.begin_quiesce(peer_id)
+        assert cid in ei.value.open_cids
+        # No barrier acquired on failure → second register still works.
+        cid2 = await tracker.register(
+            from_peer_id="dashboard",
+            from_peer_name="dashboard",
+            to_peer_id=peer_id,
+            to_peer_name="alpha",
+            text="still open",
+        )
+        assert cid2 != cid
+
+    async def test_quiesce_blocks_outbound_too(self):
+        """A peer that is itself asking shouldn't have its outbound asks
+        accepted mid-switch either — the asker would die before getting a
+        reply."""
+        from repowire.daemon.ask_tracker import AskTracker, QuiescedError
+        tracker = AskTracker()
+        peer_id = "repow-default-aa11bb22"
+        await tracker.begin_quiesce(peer_id)
+        with pytest.raises(QuiescedError):
+            await tracker.register(
+                from_peer_id=peer_id,
+                from_peer_name="alpha",
+                to_peer_id="dashboard",
+                to_peer_name="dashboard",
+                text="outbound during switch",
+            )
+
 
 class TestCommandForBackend:
     def test_returns_first_matching_allowed_command(self, tmp_path):

--- a/tests/test_switch_backend_route.py
+++ b/tests/test_switch_backend_route.py
@@ -204,6 +204,31 @@ class TestSwitchBackendRoute:
         )
         assert r.status_code == 404
 
+    async def test_concurrent_switch_returns_409_switch_in_progress(self, env, tmp_path):
+        """A second switch for the same peer while the first is mid-flight
+        must be refused, not silently piggy-back on the same barrier."""
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+
+        # Pre-acquire the barrier to simulate an in-progress switch.
+        await env.ask_tracker.begin_quiesce(peer.peer_id)
+        try:
+            with patch.object(spawn_routes, "spawn_peer") as mock_spawn, \
+                patch.object(spawn_routes, "kill_pane", return_value=True):
+                r = await env.client.post(
+                    f"/peers/{name}/switch-backend",
+                    json={"new_backend": "codex"},
+                )
+            assert r.status_code == 409
+            assert r.json()["detail"]["error"] == "switch_in_progress"
+            mock_spawn.assert_not_called()
+            # Peer must still exist; we didn't enter the kill section.
+            assert await env.registry.get_peer(name) is not None
+        finally:
+            await env.ask_tracker.end_quiesce(peer.peer_id)
+
     async def test_kill_pane_failure_aborts_switch(self, env, tmp_path):
         """If kill_pane returns False, abort and leave the peer registered.
 
@@ -335,6 +360,27 @@ class TestAskTrackerQuiesceBarrier:
             text="still open",
         )
         assert cid2 != cid
+
+    async def test_begin_quiesce_is_exclusive(self):
+        """Two begin_quiesce calls for the same peer must not both succeed.
+
+        Otherwise two concurrent switches could both enter the critical
+        section, and the first end_quiesce would prematurely release the
+        barrier for the second.
+        """
+        from repowire.daemon.ask_tracker import AskTracker, QuiesceFailedError
+        tracker = AskTracker()
+        peer_id = "repow-default-aa11bb22"
+        await tracker.begin_quiesce(peer_id)
+        with pytest.raises(QuiesceFailedError) as ei:
+            await tracker.begin_quiesce(peer_id)
+        # Empty open_cids signals "already quiescing" vs "had open asks".
+        assert ei.value.open_cids == []
+        # A different peer can still acquire its own barrier.
+        await tracker.begin_quiesce("repow-default-cc33dd44")
+        await tracker.end_quiesce(peer_id)
+        # After release, re-acquire works.
+        await tracker.begin_quiesce(peer_id)
 
     async def test_quiesce_blocks_outbound_too(self):
         """A peer that is itself asking shouldn't have its outbound asks

--- a/tests/test_switch_backend_route.py
+++ b/tests/test_switch_backend_route.py
@@ -1,0 +1,222 @@
+"""HTTP route tests for POST /peers/{name}/switch-backend (§4.8)."""
+
+from __future__ import annotations
+
+import socket
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers as peers_routes
+from repowire.daemon.routes import spawn as spawn_routes
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_test_app(tmp_path: Path, allowed_commands: list[str] | None = None):
+    cfg = Config()
+    cfg.daemon.spawn.allowed_commands = (
+        allowed_commands
+        if allowed_commands is not None
+        else ["claude", "codex", "gemini"]
+    )
+    cfg.daemon.spawn.allowed_paths = ["/"]
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    ask_tracker = AskTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=tracker,
+        ask_tracker=ask_tracker,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+
+    app = FastAPI()
+    app.include_router(peers_routes.router)
+    app.include_router(spawn_routes.router)
+    return app, registry, ask_tracker
+
+
+@pytest.fixture
+async def env(tmp_path):
+    app, registry, ask_tracker = _make_test_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as client:
+        yield SimpleNamespace(client=client, registry=registry, ask_tracker=ask_tracker)
+    cleanup_deps()
+
+
+async def _register(client, *, name="alpha", backend="claude-code", machine=None,
+                    path="/tmp/peer"):
+    machine = machine or socket.gethostname()
+    r = await client.post("/peers", json={
+        "name": name,
+        "path": path,
+        "circle": "default",
+        "backend": backend,
+        "machine": machine,
+    })
+    assert r.status_code == 200, r.text
+    return r.json()["display_name"]
+
+
+def _fake_spawn(display_name: str, tmux_session: str, pane_id: str = "%99"):
+    from repowire.spawn import SpawnResult
+    return SpawnResult(
+        display_name=display_name, tmux_session=tmux_session, pane_id=pane_id,
+    )
+
+
+class TestSwitchBackendRoute:
+    async def test_same_host_happy_path(self, env, tmp_path):
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        with patch.object(spawn_routes, "spawn_peer", return_value=_fake_spawn(
+            "alpha", "default:alpha", "%101",
+        )) as mock_spawn, \
+            patch.object(spawn_routes, "kill_pane", return_value=True), \
+            patch.object(spawn_routes, "post_spawn_warmup", new_callable=AsyncMock):
+            r = await env.client.post(
+                f"/peers/{name}/switch-backend",
+                json={"new_backend": "codex"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert body["old_backend"] == "claude-code"
+        assert body["new_backend"] == "codex"
+        assert body["display_name"] == "alpha"
+        assert body["tmux_session"] == "default:alpha"
+
+        # spawn_peer must have been invoked with the codex-mapped command and
+        # the peer's original path/circle preserved.
+        spawn_cfg = mock_spawn.call_args.args[0]
+        assert spawn_cfg.command == "codex"
+        assert spawn_cfg.backend is AgentType.CODEX
+        assert spawn_cfg.circle == "default"
+        assert spawn_cfg.path == str(Path(tmp_path).resolve())
+
+        # Registry must have unregistered the old peer.
+        assert await env.registry.get_peer(name) is None
+
+    async def test_same_backend_returns_409(self, env, tmp_path):
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        r = await env.client.post(
+            f"/peers/{name}/switch-backend",
+            json={"new_backend": "claude-code"},
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "same_backend"
+
+    async def test_missing_command_returns_422(self, tmp_path):
+        # Build an app whose allowed_commands has no entry for gemini.
+        app, _registry, _ask_tracker = _make_test_app(
+            tmp_path, allowed_commands=["claude", "codex"],
+        )
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                name = await _register(client, name="alpha", backend="claude-code",
+                                        path=str(tmp_path))
+                r = await client.post(
+                    f"/peers/{name}/switch-backend",
+                    json={"new_backend": "gemini"},
+                )
+            assert r.status_code == 422
+            body = r.json()
+            assert body["detail"]["error"] == "command_unavailable"
+            assert "allowed_commands" in body["detail"]["hint"]
+            assert body["detail"]["new_backend"] == "gemini"
+        finally:
+            cleanup_deps()
+
+    async def test_cross_host_returns_409(self, env, tmp_path):
+        name = await _register(
+            env.client, name="alpha", backend="claude-code",
+            machine="other-host.example", path=str(tmp_path),
+        )
+        r = await env.client.post(
+            f"/peers/{name}/switch-backend",
+            json={"new_backend": "codex"},
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "cross_host"
+
+    async def test_in_flight_ask_blocks_switch(self, env, tmp_path):
+        name = await _register(env.client, name="alpha", backend="claude-code",
+                                path=str(tmp_path))
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+
+        # Register an open ask targeting this peer.
+        await env.ask_tracker.register(
+            from_peer_id="dashboard",
+            from_peer_name="dashboard",
+            to_peer_id=peer.peer_id,
+            to_peer_name=peer.display_name,
+            text="hello",
+        )
+
+        with patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            r = await env.client.post(
+                f"/peers/{name}/switch-backend",
+                json={"new_backend": "codex"},
+            )
+        assert r.status_code == 409
+        detail = r.json()["detail"]
+        assert detail["error"] == "in_flight_asks"
+        assert len(detail["open_asks"]) == 1
+        mock_spawn.assert_not_called()
+        # Peer must still exist (no kill on best-effort failure path).
+        assert await env.registry.get_peer(name) is not None
+
+    async def test_unknown_peer_returns_404(self, env):
+        r = await env.client.post(
+            "/peers/nonexistent/switch-backend",
+            json={"new_backend": "codex"},
+        )
+        assert r.status_code == 404
+
+
+class TestCommandForBackend:
+    def test_returns_first_matching_allowed_command(self, tmp_path):
+        _app, _r, _a = _make_test_app(
+            tmp_path,
+            allowed_commands=["claude --dangerously-skip-permissions", "codex"],
+        )
+        try:
+            assert (
+                spawn_routes._command_for_backend(AgentType.CLAUDE_CODE)
+                == "claude --dangerously-skip-permissions"
+            )
+            assert spawn_routes._command_for_backend(AgentType.CODEX) == "codex"
+            assert spawn_routes._command_for_backend(AgentType.GEMINI) is None
+        finally:
+            cleanup_deps()

--- a/uv.lock
+++ b/uv.lock
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.19"
+version = "0.13.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.17"
+version = "0.13.19"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -86,6 +86,7 @@ export function PeerView({
           </div>
         </div>
         <StatusLabel status={peer.status} />
+        <SwitchBackendControl peer={peer} apiBase={apiBase} />
         {peer.path ? <OpenInEditorButton path={peer.path} /> : null}
         <CopyPeerName peer={peer} />
         <button
@@ -1008,6 +1009,120 @@ function OpenInEditorButton({ path }: { path: string }) {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+const BACKEND_BY_COMMAND_HEAD: Record<string, string> = {
+  claude: "claude-code",
+  opencode: "opencode",
+  codex: "codex",
+  gemini: "gemini",
+  pi: "pi",
+};
+
+function backendForCommand(cmd: string): string | null {
+  const head = cmd.trim().split(/\s+/)[0] ?? "";
+  return BACKEND_BY_COMMAND_HEAD[head] ?? null;
+}
+
+function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }) {
+  const [allowedCommands, setAllowedCommands] = useState<string[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${apiBase}/spawn/config`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        setAllowedCommands(Array.isArray(data.allowed_commands) ? data.allowed_commands : []);
+      })
+      .catch(() => {
+        if (!cancelled) setAllowedCommands([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBase]);
+
+  // Map allowed_commands → unique backends, filter out current backend.
+  const options = useMemo(() => {
+    if (!allowedCommands) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const cmd of allowedCommands) {
+      const backend = backendForCommand(cmd);
+      if (!backend || backend === peer.backend || seen.has(backend)) continue;
+      seen.add(backend);
+      out.push(backend);
+    }
+    return out;
+  }, [allowedCommands, peer.backend]);
+
+  if (allowedCommands === null || options.length === 0) return null;
+
+  async function onChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const newBackend = event.target.value;
+    event.target.value = "";  // reset placeholder
+    if (!newBackend) return;
+    if (!confirm(
+      `Switch ${peer.name} from ${peer.backend} to ${newBackend}?\n\n` +
+      `The current session will be killed and a fresh ${newBackend} session ` +
+      `will start in the same directory. Conversation state is not preserved.`
+    )) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const r = await fetch(
+        `${apiBase}/peers/${encodeURIComponent(peer.name)}/switch-backend`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ new_backend: newBackend }),
+        }
+      );
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        const detail = body?.detail;
+        const hint = typeof detail === "string"
+          ? detail
+          : detail?.hint || detail?.error || `HTTP ${r.status}`;
+        setError(hint);
+        return;
+      }
+      // Success: peer list will refresh via events; nothing else to do here.
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="hidden items-center gap-1.5 sm:flex" title={error || undefined}>
+      <select
+        aria-label="Switch backend"
+        disabled={busy}
+        defaultValue=""
+        onChange={onChange}
+        className={cn(
+          "h-8 max-w-[140px] truncate rounded border bg-surface-container-low px-2 font-mono text-[11px] uppercase tracking-[0.14em] text-on-surface-variant",
+          error ? "border-error/60" : "border-border",
+          busy && "opacity-50"
+        )}
+      >
+        <option value="" disabled>
+          {busy ? "switching…" : `switch → ${peer.backend}`}
+        </option>
+        {options.map((backend) => (
+          <option key={backend} value={backend}>
+            {backend}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `POST /peers/{name}/switch-backend` — kills the current pane (when daemon-owned) and respawns the peer at the same path/circle/name-stem with the requested `AgentType`. Same-host only in v1; conversation state is not preserved (ACP-native swap is out of scope until ACP phase-3).
- Dashboard `PeerView` header now shows a "switch → <current>" dropdown that lists allowed backends from `daemon.spawn.allowed_commands` minus the current one.
- Patch bump to 0.13.20.

## Behavior / edge cases
- `new_backend` equals current → **409** `same_backend` (no-op).
- `daemon.spawn.allowed_commands` has no entry whose head maps to `new_backend` → **422** `command_unavailable` with a hint to add one.
- Cross-host peer → **409** `cross_host` (same shape as the per-peer MCP routes).
- Open asks involving the peer (either direction) → **409** `in_flight_asks` with the open `correlation_id`s; the caller is expected to retry once they're acked/evicted. We refuse rather than silently orphan asks across the kill.
- Uses the same `_SPAWNED_PANE_IDS` ownership rules as `/kill-peer` so we never reach into externally-attached panes; respawn validation reuses `_validate_spawn_request` so the switch can't bypass `/spawn` guardrails.

## Out of scope (per the brief)
- Preserving conversation state across the switch
- ACP-native version (deferred until ACP phase-3 lands)
- Per-user permission gating

## Test plan
- [x] `tests/test_switch_backend_route.py` covers: same-host happy path (spawn invoked with the mapped command + preserved path/circle, old peer unregistered), 409 same-backend, 422 missing command, 409 cross-host, 409 in-flight-ask blocks the switch (and leaves the peer in place), 404 unknown peer, and unit coverage for `_command_for_backend`.
- [x] `ruff check repowire/ tests/test_switch_backend_route.py` clean
- [x] `uv run ty check repowire/` clean
- [x] Full suite: `953 passed`