### PR TITLE
feat: block-level chat_turn_delta streaming (§4.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.13.26"
+version = "0.13.27"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -211,6 +211,10 @@ class ExperimentsConfig(BaseModel):
 
         experiments:
           acp_broker_client: true
+          chat_turn_streaming: true
+
+    Promote to a stable surface or remove once an experiment concludes —
+    don't let entries linger.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -221,6 +225,15 @@ class ExperimentsConfig(BaseModel):
             "Route asks to ACP-marked peers through a broker-side ACP client "
             "(initialize / session/new / session/prompt) instead of the WS path. "
             "Phase-3: codex-acp only."
+        ),
+    )
+
+    chat_turn_streaming: bool = Field(
+        default=False,
+        description=(
+            "Stream block-level chat_turn_delta events as the assistant turn "
+            "is written to the transcript JSONL, in addition to the final "
+            "chat_turn at Stop. Claude Code transports only."
         ),
     )
 

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -313,8 +313,41 @@ class ChatTurnRequest(BaseModel):
     role: Literal["user", "assistant"]
     text: str
     tool_calls: list[ToolCallInfo] | None = None
+    turn_id: str | None = Field(
+        None,
+        description=(
+            "Assistant message uuid. When present, lets the dashboard reconcile "
+            "streaming chat_turn_delta bubbles to this final turn deterministically "
+            "and lets the daemon reject post-final late deltas."
+        ),
+    )
     peer_id: str | None = Field(None, description="Peer ID (if known)")
     pane_id: str | None = Field(None, description="Tmux pane ID (resolves peer_id server-side)")
+
+
+# Bounded set of turn_ids that have already received their final chat_turn.
+# Late chat_turn_delta posts for these ids are dropped — the dashboard would
+# render them as orphan streaming bubbles otherwise.
+#
+# Capacity caps memory growth; FIFO eviction means very old turns may shadow
+# new collisions but turn_ids are message-uuids so collisions don't occur in
+# practice. Process-local (deltas/finals always pass through the same daemon).
+_FINALIZED_TURN_IDS_CAPACITY: int = 4096
+_finalized_turn_ids: dict[str, None] = {}
+
+
+def _mark_turn_finalized(turn_id: str) -> None:
+    if turn_id in _finalized_turn_ids:
+        # Refresh recency so a finalized id stays in the set as long as deltas
+        # might still trickle in.
+        del _finalized_turn_ids[turn_id]
+    _finalized_turn_ids[turn_id] = None
+    while len(_finalized_turn_ids) > _FINALIZED_TURN_IDS_CAPACITY:
+        _finalized_turn_ids.pop(next(iter(_finalized_turn_ids)))
+
+
+def _is_turn_finalized(turn_id: str) -> bool:
+    return turn_id in _finalized_turn_ids
 
 
 @router.post("/events/chat", response_model=OkResponse)
@@ -332,7 +365,59 @@ async def ingest_chat_turn(
             data["peer_id"] = peer.peer_id
             data["peer"] = peer.display_name  # canonicalize to registered name
 
+    if request.turn_id and request.role == "assistant":
+        _mark_turn_finalized(request.turn_id)
+
     peer_registry.add_event("chat_turn", data)
+    return OkResponse()
+
+
+class ChatTurnDeltaRequest(BaseModel):
+    """Request to ingest a partial chat-turn block while it streams.
+
+    Block-level rather than token-level: each request carries one completed
+    assistant text block or tool_use, as written to the transcript JSONL.
+    The final ``chat_turn`` event remains authoritative for end-of-turn —
+    deltas are additive, clients that ignore them keep working.
+    """
+
+    peer: str
+    role: Literal["assistant"] = "assistant"
+    turn_id: str = Field(..., description="Stable id for the assistant turn (deltas group by this)")
+    chunk_index: int = Field(..., ge=0, description="Monotonic 0-based index within the turn")
+    kind: Literal["text", "tool_use"] = Field(default="text", description="Block kind")
+    text: str = Field("", description="Block content (full text block, or tool_use summary)")
+    tool_call: ToolCallInfo | None = Field(None, description="Set when kind=tool_use")
+    is_final: bool = Field(default=False, description="Hint: last delta in this turn")
+    peer_id: str | None = Field(None, description="Peer ID (if known)")
+    pane_id: str | None = Field(None, description="Tmux pane ID (resolves peer_id server-side)")
+
+
+@router.post("/events/chat_delta", response_model=OkResponse)
+async def ingest_chat_turn_delta(
+    request: ChatTurnDeltaRequest,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Ingest a streaming chat-turn delta from the per-pane transcript tailer.
+
+    Drops deltas whose ``turn_id`` has already received its final ``chat_turn``
+    — those would render as orphan streaming bubbles on the dashboard. Returns
+    200 on drop so the streamer's best-effort post doesn't retry into a
+    failure loop.
+    """
+    if _is_turn_finalized(request.turn_id):
+        return OkResponse()
+
+    peer_registry = get_peer_registry()
+    data = request.model_dump(exclude={"pane_id"})
+
+    if not request.peer_id and request.pane_id:
+        peer = await peer_registry.get_peer_by_pane(request.pane_id)
+        if peer:
+            data["peer_id"] = peer.peer_id
+            data["peer"] = peer.display_name
+
+    peer_registry.add_event("chat_turn_delta", data)
     return OkResponse()
 
 

--- a/repowire/hooks/chat_delta_streamer.py
+++ b/repowire/hooks/chat_delta_streamer.py
@@ -1,0 +1,355 @@
+"""Block-level chat_turn_delta streamer.
+
+Spawned by the prompt hook at turn start (when ``experiments.chat_turn_streaming``
+is on). Tails the Claude Code transcript JSONL appended during the active turn
+and posts a ``/events/chat_delta`` for every new assistant text / tool_use
+block. Exits when the Stop hook clears the pidfile, when the transcript stops
+growing past an idle window, or when a hard wall-clock cap is hit.
+
+Why polling here is acceptable: this is a transient per-turn helper, not a
+daemon-side loop. The lazy-repair doctrine targets the daemon and long-lived
+processes; a short-lived 200ms tail bound to one turn is the simplest viable
+shape until ACP ``chat/update`` gives us a push channel.
+
+Block-level, not token-level: Claude Code writes one *completed* content
+block per JSONL line. claudecodeui gets token frames because it spawns
+``claude`` as a child and reads stdout JSON — a path the hook model never
+sees. Block-level still delivers the §4.3 UX win (long turns render
+progressively instead of one big landing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from repowire.hooks.utils import daemon_post, pane_logs_dir
+from repowire.session.transcript import _summarize_tool_input
+
+POLL_INTERVAL_S = 0.2
+"""How often to re-stat the transcript. 200ms keeps perceived latency low
+without burning CPU on a quiet file."""
+
+IDLE_EXIT_AFTER_S = 90.0
+"""Exit after this many seconds with no new bytes. Stop hook normally clears
+the pidfile first; this is a fallback for missed Stops."""
+
+WALL_CLOCK_CAP_S = 1800.0
+"""Hard cap (30 min). A streamer this old means something went wrong."""
+
+
+def _sanitize_pane(pane_id: str) -> str:
+    return pane_id.replace("%", "").replace("/", "").replace("\\", "") or "unknown"
+
+
+def streamer_pid_path(pane_id: str) -> Path:
+    """Pidfile for the streamer attached to a pane. Stop handler reads/deletes."""
+    return pane_logs_dir() / f"chat-delta-streamer-{_sanitize_pane(pane_id)}.pid"
+
+
+def streamer_lock_path(pane_id: str) -> Path:
+    """Lockfile guarding the single-owner streamer for a pane.
+
+    Held under flock for the streamer's whole lifetime. A second streamer
+    spawning for the same pane fails the non-blocking lock and exits cleanly
+    rather than racing on the transcript.
+    """
+    return pane_logs_dir() / f"chat-delta-streamer-{_sanitize_pane(pane_id)}.lock"
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` exists. EPERM counts as alive (foreign owner)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def terminate_live_streamer(pane_id: str, *, wait_s: float = 0.5) -> bool:
+    """If a streamer for `pane_id` is alive, signal it to exit and wait briefly.
+
+    Used by the prompt hook to evict a predecessor before spawning a fresh
+    streamer for the next turn. Returns True if we tried to terminate one,
+    False if no live owner was found. Best-effort — never raises.
+
+    Strategy: remove the pidfile (the streamer polls it every POLL_INTERVAL_S
+    and exits on absence) AND send SIGTERM as a belt-and-suspenders so the
+    predecessor stops even if it's mid-`daemon_post`. We deliberately use the
+    same pidfile-removal signal Stop uses; no new wire.
+
+    Trust model: the pidfile is treated as authoritative for "what pid is the
+    streamer owner". The SIGTERM is sent without process-identity verification
+    (no `comm` / cmdline check, no flock probe before kill). PID reuse on a
+    long-lived host could in principle cause us to SIGTERM an unrelated
+    process that landed on the same numeric pid after a crashed streamer.
+    Acceptable for this experimental hook: the cache dir is per-user, the
+    pidfile lifetime is bounded by Stop / idle-cap (~90s), and SIGTERM is
+    delivered to the user's own uid only (kernel returns EPERM otherwise).
+    Tighten via the lockfile metadata if the experiment graduates.
+    """
+    pid_path = streamer_pid_path(pane_id)
+    try:
+        pid_text = pid_path.read_text().strip()
+    except OSError:
+        return False
+    try:
+        pid = int(pid_text)
+    except ValueError:
+        return False
+    if not _pid_alive(pid):
+        # Stale pidfile from a crashed predecessor — clear it so it doesn't
+        # mislead the next liveness probe.
+        try:
+            pid_path.unlink()
+        except OSError:
+            pass
+        return False
+
+    try:
+        pid_path.unlink()
+    except OSError:
+        pass
+    try:
+        os.kill(pid, 15)  # SIGTERM
+    except (ProcessLookupError, PermissionError):
+        return True
+
+    deadline = time.monotonic() + wait_s
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.02)
+    return True
+
+
+def has_live_streamer(pane_id: str) -> bool:
+    """True if a streamer process for `pane_id` is currently alive.
+
+    Checked by the prompt hook before spawning to avoid the duplicate-streamer
+    race when two prompt hooks fire back-to-back. We deliberately do *not*
+    rely solely on the lockfile: a still-flushing predecessor that already
+    released the lock but hasn't exited would slip through. Reading the pid
+    and probing it is cheap and conclusive.
+    """
+    pid_path = streamer_pid_path(pane_id)
+    try:
+        pid_text = pid_path.read_text().strip()
+    except OSError:
+        return False
+    try:
+        pid = int(pid_text)
+    except ValueError:
+        return False
+    return _pid_alive(pid)
+
+
+def _content_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
+    content = message.get("content")
+    if isinstance(content, list):
+        return [c for c in content if isinstance(c, dict)]
+    return []
+
+
+def _emit_text(
+    peer: str,
+    pane_id: str,
+    turn_id: str,
+    chunk_index: int,
+    text: str,
+) -> bool:
+    payload = {
+        "peer": peer,
+        "role": "assistant",
+        "turn_id": turn_id,
+        "chunk_index": chunk_index,
+        "kind": "text",
+        "text": text,
+        "is_final": False,
+        "pane_id": pane_id,
+    }
+    return daemon_post("/events/chat_delta", payload) is not None
+
+
+def _emit_tool_use(
+    peer: str,
+    pane_id: str,
+    turn_id: str,
+    chunk_index: int,
+    name: str,
+    tool_input: Any,
+) -> bool:
+    summary = _summarize_tool_input(name, tool_input)
+    payload = {
+        "peer": peer,
+        "role": "assistant",
+        "turn_id": turn_id,
+        "chunk_index": chunk_index,
+        "kind": "tool_use",
+        "text": f"{name}: {summary}" if summary else name,
+        "tool_call": {"name": name, "input": summary},
+        "is_final": False,
+        "pane_id": pane_id,
+    }
+    return daemon_post("/events/chat_delta", payload) is not None
+
+
+def _tail_transcript(
+    transcript_path: Path, peer: str, pane_id: str, pid_path: Path,
+) -> None:
+    """Inner tail loop. Exits when pidfile is removed, idle, or wall-clock cap.
+
+    Separated from `run()` so the lock-ownership guard wraps the whole
+    lifetime, including transcript-open and final cleanup.
+    """
+    started = time.monotonic()
+    last_growth = started
+    # Skip lines that already existed at startup so a fresh prompt doesn't
+    # replay the entire prior transcript as deltas.
+    last_size = transcript_path.stat().st_size if transcript_path.exists() else 0
+    line_buffer = b""
+
+    # turn_id is the uuid of the first assistant message we see after start.
+    # Falls back to "<pane>-<started_ts>" if the turn happens to be pure tool_use.
+    turn_id: str | None = None
+    chunk_index = 0
+
+    try:
+        with open(transcript_path, "rb") as fh:
+            fh.seek(last_size)
+            while True:
+                # Pidfile-driven exit: Stop hook deletes it to signal us out.
+                if not pid_path.exists():
+                    break
+                # Foreign owner check: a fresh prompt may have spawned a new
+                # streamer that rewrote the pidfile before our finally clause.
+                # If the pid no longer matches ours, exit immediately without
+                # touching the file in cleanup.
+                try:
+                    if pid_path.read_text().strip() != str(os.getpid()):
+                        return
+                except OSError:
+                    break
+
+                now = time.monotonic()
+                if now - started > WALL_CLOCK_CAP_S:
+                    break
+                if now - last_growth > IDLE_EXIT_AFTER_S:
+                    break
+
+                chunk = fh.read()
+                if not chunk:
+                    time.sleep(POLL_INTERVAL_S)
+                    continue
+
+                last_growth = now
+                line_buffer += chunk
+                while b"\n" in line_buffer:
+                    raw_line, line_buffer = line_buffer.split(b"\n", 1)
+                    raw_line = raw_line.strip()
+                    if not raw_line:
+                        continue
+                    try:
+                        entry = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        continue
+                    if entry.get("type") != "assistant":
+                        continue
+                    message = entry.get("message", {})
+                    if not isinstance(message, dict):
+                        continue
+                    if turn_id is None:
+                        turn_id = entry.get("uuid") or f"{pane_id}-{int(started)}"
+                    for block in _content_blocks(message):
+                        block_type = block.get("type")
+                        if block_type == "text":
+                            text = block.get("text") or ""
+                            if not text.strip():
+                                continue
+                            if _emit_text(peer, pane_id, turn_id, chunk_index, text):
+                                chunk_index += 1
+                        elif block_type == "tool_use":
+                            name = block.get("name", "unknown")
+                            tool_input = block.get("input", {})
+                            if _emit_tool_use(
+                                peer, pane_id, turn_id, chunk_index, name, tool_input,
+                            ):
+                                chunk_index += 1
+    except FileNotFoundError:
+        # Transcript not yet created when we started, or rotated. Either way
+        # the Stop hook will deliver the full turn — nothing useful left to do.
+        pass
+
+
+def run(transcript_path: Path, peer: str, pane_id: str) -> int:
+    """Single-owner streamer entry point.
+
+    Acquires a non-blocking flock on the per-pane lockfile for the whole
+    lifetime. If a prior streamer still holds it (e.g. two prompt hooks
+    fired before Stop cleared the old one), exit cleanly without touching
+    pidfile or transcript — the live owner stays in charge of its turn.
+    The pidfile is rewritten *under the lock* so liveness probes from the
+    prompt hook are always consistent with the active owner.
+    """
+    lock_path = streamer_lock_path(pane_id)
+    pid_path = streamer_pid_path(pane_id)
+    try:
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+    except OSError as e:
+        print(f"chat-delta-streamer: lockfile open failed: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            # Another streamer owns this pane. Don't touch pidfile or transcript.
+            return 0
+
+        try:
+            pid_path.write_text(str(os.getpid()))
+        except OSError as e:
+            print(f"chat-delta-streamer: pidfile write failed: {e}", file=sys.stderr)
+            return 1
+
+        try:
+            _tail_transcript(transcript_path, peer, pane_id, pid_path)
+        finally:
+            # Owner-checked unlink: only remove the pidfile if it still names
+            # us. A fresh streamer that overwrote the pid will release the
+            # lock on its own exit and clean up its own pid.
+            try:
+                current = pid_path.read_text().strip() if pid_path.exists() else None
+                if current == str(os.getpid()):
+                    pid_path.unlink()
+            except OSError:
+                pass
+    finally:
+        try:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_fd.close()
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="repowire chat_turn_delta streamer")
+    parser.add_argument("--transcript", required=True, help="Path to transcript JSONL")
+    parser.add_argument("--peer", required=True, help="Peer display name")
+    parser.add_argument("--pane-id", required=True, help="Tmux pane id (state key)")
+    args = parser.parse_args(argv)
+    return run(Path(args.transcript).expanduser(), args.peer, args.pane_id)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -4,11 +4,71 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
+from pathlib import Path
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.utils import update_status
+from repowire.hooks.utils import get_display_name, update_status
+
+
+def _maybe_spawn_chat_delta_streamer(
+    transcript_path: str | None, pane_id: str | None,
+) -> None:
+    """Spawn the per-turn transcript tailer if the experiment is on.
+
+    Best-effort: config-load or spawn failures must not break the prompt
+    hook. Backend-gated to claude-code — other agents land here through
+    the adapter but their transcript shapes aren't supported yet.
+    """
+    if not transcript_path or not pane_id:
+        return
+    try:
+        from repowire.config.models import load_config
+
+        cfg = load_config()
+    except Exception:
+        return
+    if not cfg.experiments.chat_turn_streaming:
+        return
+    if not Path(transcript_path).expanduser().exists():
+        return
+
+    # Single-owner reset: if a previous streamer for this pane is still alive
+    # (e.g. user submitted a second prompt before Stop cleared the first, or
+    # Stop's pidfile unlink failed), terminate it before starting the new one.
+    # Otherwise the predecessor would keep its old turn_id baseline and
+    # incorrectly group the new turn's blocks under it.
+    from repowire.hooks.chat_delta_streamer import (
+        terminate_live_streamer,
+    )
+
+    terminate_live_streamer(pane_id)
+
+    try:
+        subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+            [
+                sys.executable,
+                "-m",
+                "repowire.hooks.chat_delta_streamer",
+                "--transcript",
+                str(Path(transcript_path).expanduser()),
+                "--peer",
+                get_display_name(),
+                "--pane-id",
+                pane_id,
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as e:
+        print(
+            f"repowire prompt: chat_delta streamer spawn failed: {e}",
+            file=sys.stderr,
+        )
 
 
 def main(backend: str = "claude-code") -> int:
@@ -31,6 +91,9 @@ def main(backend: str = "claude-code") -> int:
                 f"repowire prompt: failed to update status for pane {pane_id}",
                 file=sys.stderr,
             )
+
+    if backend == "claude-code":
+        _maybe_spawn_chat_delta_streamer(payload.transcript_path, pane_id)
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
 from repowire.hooks.ask_lifecycle import fetch_and_filter_pending, format_reminder_block
+from repowire.hooks.chat_delta_streamer import streamer_pid_path
 from repowire.hooks.utils import (
     daemon_post,
     get_display_name,
@@ -18,7 +19,29 @@ from repowire.hooks.utils import (
     update_status,
 )
 from repowire.hooks.ws_hook_supervisor import maybe_respawn
-from repowire.session.transcript import extract_last_turn_pair, extract_last_turn_tool_calls
+from repowire.session.transcript import (
+    extract_last_assistant_turn_id,
+    extract_last_turn_pair,
+    extract_last_turn_tool_calls,
+)
+
+
+def _stop_chat_delta_streamer(pane_id: str | None) -> None:
+    """Signal the per-turn streamer (if any) to exit by removing its pidfile.
+
+    Pidfile-driven shutdown rather than SIGTERM: the streamer is cooperatively
+    polling the pidfile inside its tight loop, so removal is the lowest-coupling
+    end-of-turn signal. Safe to no-op when streaming is disabled or the
+    streamer already exited on its own.
+    """
+    if not pane_id:
+        return
+    try:
+        streamer_pid_path(pane_id).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
 
 
 def _post_chat_turn(
@@ -27,13 +50,21 @@ def _post_chat_turn(
     text: str,
     tool_calls: list[dict[str, str]] | None = None,
     pane_id: str | None = None,
+    turn_id: str | None = None,
 ) -> None:
-    """Post a chat turn to the daemon for dashboard display. Best-effort."""
+    """Post a chat turn to the daemon for dashboard display. Best-effort.
+
+    ``turn_id`` is the assistant message uuid when known; it lets the dashboard
+    reconcile streaming-delta bubbles to their final turn deterministically and
+    lets the daemon reject late deltas server-side.
+    """
     payload: dict = {"peer": peer_name, "role": role, "text": text}
     if tool_calls:
         payload["tool_calls"] = tool_calls
     if pane_id:
         payload["pane_id"] = pane_id
+    if turn_id:
+        payload["turn_id"] = turn_id
     daemon_post("/events/chat", payload)
 
 
@@ -63,6 +94,7 @@ def main(backend: str = "claude-code") -> int:
     assistant_text = payload.response_text
     user_text = None
     tool_calls: list = []
+    turn_id: str | None = None
 
     if payload.transcript_path:
         transcript_path = Path(payload.transcript_path).expanduser().resolve()
@@ -70,6 +102,7 @@ def main(backend: str = "claude-code") -> int:
         if transcript_text:
             assistant_text = transcript_text
         tool_calls = extract_last_turn_tool_calls(transcript_path) if assistant_text else []
+        turn_id = extract_last_assistant_turn_id(transcript_path)
 
     # Strip whitespace-only texts to prevent empty chat bubbles
     if user_text and not user_text.strip():
@@ -77,11 +110,22 @@ def main(backend: str = "claude-code") -> int:
     if assistant_text and not assistant_text.strip():
         assistant_text = None
 
+    # Signal the per-turn delta streamer (if running) to exit before posting
+    # the final chat_turn. Order matters only weakly — the dashboard reconciles
+    # by replacing accumulated deltas with the final turn — but stopping the
+    # streamer first avoids a last-instant delta arriving after the final.
+    _stop_chat_delta_streamer(pane_id)
+
     if user_text:
         _post_chat_turn(peer_display, "user", user_text, pane_id=pane_id)
     if assistant_text:
         _post_chat_turn(
-            peer_display, "assistant", assistant_text, tool_calls or None, pane_id=pane_id,
+            peer_display,
+            "assistant",
+            assistant_text,
+            tool_calls or None,
+            pane_id=pane_id,
+            turn_id=turn_id,
         )
 
     # Deliver response to daemon for legacy /query future resolution.

--- a/repowire/session/transcript.py
+++ b/repowire/session/transcript.py
@@ -7,6 +7,62 @@ from pathlib import Path
 from typing import Any
 
 
+def extract_last_assistant_turn_id(transcript_path: Path) -> str | None:
+    """Return the canonical ``turn_id`` for the current user-prompt turn.
+
+    Definition: the uuid of the *first* assistant entry in the chain following
+    the last real user prompt (a user entry whose content is not pure
+    tool_result). This matches what the per-pane streamer picks up — its
+    first-seen assistant uuid after the prompt fires — so deltas and the final
+    ``chat_turn`` always share the same id regardless of how many
+    assistant/tool_result hops happen mid-turn.
+
+    Returns None if the transcript is missing, empty, or has no assistant
+    entries (e.g. Codex-shaped JSONL).
+    """
+    if not transcript_path.exists():
+        return None
+
+    entries: list[dict[str, Any]] = []
+    with open(transcript_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    if not entries:
+        return None
+
+    # Walk backward to find the last real user prompt (skip user entries whose
+    # content is pure tool_result — those are the agent's own tool-call replies
+    # and don't open a new turn). The first assistant uuid after that boundary
+    # is the canonical turn_id.
+    boundary_index = -1
+    for idx in range(len(entries) - 1, -1, -1):
+        entry = entries[idx]
+        if entry.get("type") != "user":
+            continue
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list) and content and all(
+            isinstance(c, dict) and c.get("type") == "tool_result" for c in content
+        ):
+            continue
+        boundary_index = idx
+        break
+
+    for entry in entries[boundary_index + 1:]:
+        if entry.get("type") != "assistant":
+            continue
+        uuid = entry.get("uuid")
+        if isinstance(uuid, str) and uuid:
+            return uuid
+    return None
+
+
 def extract_last_turn_pair(transcript_path: Path) -> tuple[str | None, str | None]:
     """Single-pass extraction of last user prompt and last assistant response.
 

--- a/tests/test_chat_delta_streamer.py
+++ b/tests/test_chat_delta_streamer.py
@@ -1,0 +1,310 @@
+"""Tests for the per-turn transcript-tailing chat_turn_delta streamer."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from repowire.hooks import chat_delta_streamer as streamer
+
+
+def _claude_assistant_line(text: str | None = None, tool_use: dict | None = None) -> str:
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    if tool_use is not None:
+        content.append({"type": "tool_use", **tool_use})
+    return json.dumps({
+        "type": "assistant",
+        "uuid": "uuid-1",
+        "parentUuid": "uuid-0",
+        "message": {"content": content},
+    }) + "\n"
+
+
+@pytest.fixture(autouse=True)
+def _fast_polling(monkeypatch):
+    """Tighten poll interval so tests don't drag."""
+    monkeypatch.setattr(streamer, "POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(streamer, "IDLE_EXIT_AFTER_S", 0.5)
+
+
+def test_streamer_emits_text_block_delta(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")  # exists but empty at start
+    posts: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, payload: dict, **_kw):
+        posts.append((path, payload))
+        return {}
+
+    def write_after_delay():
+        time.sleep(0.05)
+        with open(transcript, "a") as f:
+            f.write(_claude_assistant_line(text="Hello world"))
+
+    # Run streamer in a thread so we can append and then trigger exit.
+    done = threading.Event()
+
+    def runner():
+        with patch.object(streamer, "daemon_post", side_effect=fake_post):
+            streamer.run(transcript, "peer1", "%42")
+        done.set()
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    write_after_delay()
+    # Let streamer pick up the line, then signal exit via pidfile removal.
+    time.sleep(0.2)
+    pid_path = streamer.streamer_pid_path("%42")
+    if pid_path.exists():
+        pid_path.unlink()
+    done.wait(timeout=2.0)
+
+    text_posts = [p for path, p in posts if path == "/events/chat_delta"]
+    assert text_posts, "streamer should have posted at least one delta"
+    assert text_posts[0]["kind"] == "text"
+    assert text_posts[0]["text"] == "Hello world"
+    assert text_posts[0]["chunk_index"] == 0
+    assert text_posts[0]["peer"] == "peer1"
+    assert text_posts[0]["pane_id"] == "%42"
+    assert text_posts[0]["turn_id"] == "uuid-1"
+
+
+def test_streamer_emits_tool_use_delta(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    posts: list[dict] = []
+
+    def fake_post(_path: str, payload: dict, **_kw):
+        posts.append(payload)
+        return {}
+
+    def runner():
+        with patch.object(streamer, "daemon_post", side_effect=fake_post):
+            streamer.run(transcript, "peer1", "%43")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    with open(transcript, "a") as f:
+        f.write(_claude_assistant_line(
+            tool_use={"name": "Bash", "input": {"command": "ls -la"}},
+        ))
+    time.sleep(0.15)
+    p = streamer.streamer_pid_path("%43")
+    if p.exists():
+        p.unlink()
+    t.join(timeout=2.0)
+
+    tool_posts = [p for p in posts if p.get("kind") == "tool_use"]
+    assert tool_posts
+    assert tool_posts[0]["tool_call"]["name"] == "Bash"
+    assert "ls -la" in tool_posts[0]["tool_call"]["input"]
+
+
+def test_streamer_skips_pre_existing_lines(tmp_path):
+    """Lines written before the streamer starts must not be replayed as deltas."""
+    transcript = tmp_path / "t.jsonl"
+    with open(transcript, "w") as f:
+        f.write(_claude_assistant_line(text="OLD turn from before"))
+        f.write(_claude_assistant_line(text="Also old"))
+
+    posts: list[dict] = []
+
+    def fake_post(_path: str, payload: dict, **_kw):
+        posts.append(payload)
+        return {}
+
+    def runner():
+        with patch.object(streamer, "daemon_post", side_effect=fake_post):
+            streamer.run(transcript, "peer1", "%44")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.2)
+    p = streamer.streamer_pid_path("%44")
+    if p.exists():
+        p.unlink()
+    t.join(timeout=2.0)
+
+    assert not posts, f"expected no deltas for pre-existing lines, got {posts}"
+
+
+def test_streamer_exits_on_pidfile_removal(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+
+    def runner():
+        with patch.object(streamer, "daemon_post", return_value={}):
+            streamer.run(transcript, "peer1", "%45")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    p = streamer.streamer_pid_path("%45")
+    assert p.exists()
+    p.unlink()
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "streamer should exit after pidfile removal"
+
+
+def test_streamer_pidfile_owner_check_on_cleanup(tmp_path):
+    """Streamer must not delete a pidfile whose contents no longer name it.
+
+    With the lock-based single-owner model this collision shouldn't happen in
+    production, but the owner check is a defense-in-depth invariant for any
+    out-of-band pidfile rewrite (manual ops, test harnesses, etc.).
+    """
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    pid_path = streamer.streamer_pid_path("%46")
+
+    def runner():
+        with patch.object(streamer, "daemon_post", return_value={}):
+            streamer.run(transcript, "peer1", "%46")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.05)
+    assert pid_path.exists()
+    other_pid = os.getpid() + 99999
+    pid_path.write_text(str(other_pid))
+    # The streamer reads the pidfile inside its loop and returns immediately
+    # once it sees a foreign pid (we don't even need to wait for idle).
+    t.join(timeout=2.0)
+    assert pid_path.exists(), "streamer must not delete pidfile owned by another process"
+    assert pid_path.read_text().strip() == str(other_pid)
+    pid_path.unlink()
+
+
+def test_second_streamer_exits_when_lock_held(tmp_path):
+    """Two streamers spawning for the same pane: the second must exit cleanly
+    without touching the transcript or pidfile."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    streamer.IDLE_EXIT_AFTER_S = 5.0  # keep first alive
+
+    posts: list[dict] = []
+
+    def fake_post(_path: str, payload: dict, **_kw):
+        posts.append(payload)
+        return {}
+
+    def runner_first():
+        with patch.object(streamer, "daemon_post", side_effect=fake_post):
+            streamer.run(transcript, "first", "%60")
+
+    t1 = threading.Thread(target=runner_first, daemon=True)
+    t1.start()
+    time.sleep(0.1)
+    pid_path = streamer.streamer_pid_path("%60")
+    first_pid = pid_path.read_text().strip()
+    assert first_pid
+
+    # Second invocation in this same process — must observe lock held and
+    # return 0 without overwriting pidfile.
+    with patch.object(streamer, "daemon_post", side_effect=fake_post):
+        rc = streamer.run(transcript, "second", "%60")
+    assert rc == 0
+    assert pid_path.read_text().strip() == first_pid, (
+        "second streamer must not overwrite live owner's pidfile"
+    )
+
+    # Cleanup first.
+    pid_path.unlink()
+    t1.join(timeout=2.0)
+
+
+def test_terminate_live_streamer_kills_predecessor(tmp_path):
+    """prompt-hook's terminate_live_streamer() must signal the running streamer
+    to exit before a fresh one spawns."""
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    streamer.IDLE_EXIT_AFTER_S = 5.0
+
+    def runner():
+        with patch.object(streamer, "daemon_post", return_value={}):
+            streamer.run(transcript, "peer1", "%61")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    time.sleep(0.1)
+    pid_path = streamer.streamer_pid_path("%61")
+    assert pid_path.exists()
+
+    # Terminate. Streamer is in-process — SIGTERM would kill the test runner,
+    # so monkey-patch os.kill to a no-op; pidfile-removal alone exits the loop.
+    with patch.object(streamer.os, "kill"):
+        result = streamer.terminate_live_streamer("%61", wait_s=2.0)
+    assert result is True
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "streamer should exit after terminate_live_streamer"
+
+
+def test_terminate_live_streamer_no_op_when_absent():
+    assert streamer.terminate_live_streamer("%62") is False
+
+
+def test_terminate_live_streamer_clears_stale_pidfile():
+    """A pidfile for a dead pid should be cleared and reported absent."""
+    pid_path = streamer.streamer_pid_path("%63")
+    # PID guaranteed not to be alive (large and randomized — same trick as
+    # the owner-check test).
+    pid_path.write_text(str(2**31 - 1))
+    assert streamer.terminate_live_streamer("%63") is False
+    assert not pid_path.exists()
+
+
+def test_has_live_streamer():
+    """has_live_streamer probes pid liveness, not just pidfile presence."""
+    assert streamer.has_live_streamer("%64") is False
+    pid_path = streamer.streamer_pid_path("%64")
+    pid_path.write_text(str(os.getpid()))
+    try:
+        assert streamer.has_live_streamer("%64") is True
+    finally:
+        pid_path.unlink()
+    pid_path.write_text(str(2**31 - 1))
+    try:
+        assert streamer.has_live_streamer("%64") is False
+    finally:
+        if pid_path.exists():
+            pid_path.unlink()
+
+
+def test_streamer_handles_missing_transcript(tmp_path):
+    """Missing transcript at run-time must exit cleanly, not crash."""
+    missing = tmp_path / "missing.jsonl"
+    with patch.object(streamer, "daemon_post", return_value={}):
+        rc = streamer.run(missing, "peer1", "%47")
+    assert rc == 0
+    assert not streamer.streamer_pid_path("%47").exists()
+
+
+def test_streamer_idle_exit_when_no_writes(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    streamer.IDLE_EXIT_AFTER_S = 0.1
+    with patch.object(streamer, "daemon_post", return_value={}):
+        rc = streamer.run(transcript, "peer1", "%48")
+    assert rc == 0
+    assert not streamer.streamer_pid_path("%48").exists()
+
+
+def test_main_argparse(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text("")
+    streamer.IDLE_EXIT_AFTER_S = 0.05
+    with patch.object(streamer, "daemon_post", return_value={}):
+        rc = streamer.main([
+            "--transcript", str(transcript),
+            "--peer", "peer1",
+            "--pane-id", "%49",
+        ])
+    assert rc == 0

--- a/tests/test_hooks_handlers.py
+++ b/tests/test_hooks_handlers.py
@@ -57,6 +57,106 @@ class TestPromptHandler:
         result = _run_with_input(prompt_main, {"hook_event_name": "UserPromptSubmit"})
         assert result == 0  # returns 0 even on failure
 
+    @patch("repowire.hooks.prompt_handler.subprocess.Popen")
+    @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
+    @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
+    def test_streamer_not_spawned_when_flag_off(
+        self, mock_pane, mock_status, mock_popen, tmp_path,
+    ):
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text("")
+        from repowire.config.models import Config
+
+        with patch("repowire.config.models.load_config", return_value=Config()):
+            result = _run_with_input(prompt_main, {
+                "hook_event_name": "UserPromptSubmit",
+                "transcript_path": str(transcript),
+            })
+        assert result == 0
+        mock_popen.assert_not_called()
+
+    @patch("repowire.hooks.prompt_handler.subprocess.Popen")
+    @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
+    @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
+    def test_streamer_spawned_when_flag_on(
+        self, mock_pane, mock_status, mock_popen, tmp_path,
+    ):
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text("")
+        from repowire.config.models import Config, ExperimentsConfig
+
+        cfg = Config(experiments=ExperimentsConfig(chat_turn_streaming=True))
+        with patch("repowire.config.models.load_config", return_value=cfg):
+            result = _run_with_input(prompt_main, {
+                "hook_event_name": "UserPromptSubmit",
+                "transcript_path": str(transcript),
+            })
+        assert result == 0
+        mock_popen.assert_called_once()
+        argv = mock_popen.call_args[0][0]
+        assert "repowire.hooks.chat_delta_streamer" in argv
+        assert "--transcript" in argv
+        assert "--pane-id" in argv
+
+    @patch("repowire.hooks.prompt_handler.subprocess.Popen")
+    @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
+    @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
+    def test_back_to_back_prompts_terminate_predecessor(
+        self, mock_pane, mock_status, mock_popen, tmp_path,
+    ):
+        """Second prompt with a live predecessor must terminate it before spawning."""
+        import os
+
+        from repowire.config.models import Config, ExperimentsConfig
+        from repowire.hooks.chat_delta_streamer import streamer_pid_path
+
+        # Simulate a live predecessor by writing this test process's pid as
+        # the streamer pid for pane %42 (it's alive).
+        pid_path = streamer_pid_path("%42")
+        pid_path.write_text(str(os.getpid()))
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text("")
+        cfg = Config(experiments=ExperimentsConfig(chat_turn_streaming=True))
+
+        # SIGTERM to our own pid would kill the test runner — patch os.kill.
+        try:
+            with patch("repowire.config.models.load_config", return_value=cfg), \
+                 patch("repowire.hooks.chat_delta_streamer.os.kill"):
+                result = _run_with_input(prompt_main, {
+                    "hook_event_name": "UserPromptSubmit",
+                    "transcript_path": str(transcript),
+                })
+            assert result == 0
+            # Pidfile was removed by terminate_live_streamer.
+            assert not pid_path.exists()
+            # And a fresh streamer was spawned.
+            mock_popen.assert_called_once()
+        finally:
+            if pid_path.exists():
+                pid_path.unlink()
+
+    @patch("repowire.hooks.prompt_handler.subprocess.Popen")
+    @patch("repowire.hooks.prompt_handler.update_status", return_value=True)
+    @patch("repowire.hooks.prompt_handler.get_pane_id", return_value="%42")
+    def test_streamer_skipped_for_non_claude_backend(
+        self, mock_pane, mock_status, mock_popen, tmp_path,
+    ):
+        transcript = tmp_path / "t.jsonl"
+        transcript.write_text("")
+        from repowire.config.models import Config, ExperimentsConfig
+
+        cfg = Config(experiments=ExperimentsConfig(chat_turn_streaming=True))
+        with patch("repowire.config.models.load_config", return_value=cfg):
+            result = _run_with_input(
+                lambda: prompt_main(backend="codex"),
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "transcript_path": str(transcript),
+                },
+            )
+        assert result == 0
+        mock_popen.assert_not_called()
+
 
 # -- Notification Handler --
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -656,6 +656,212 @@ class TestEvents:
         assert len(events) == 1
         assert events[0].get("peer_id") is None
 
+    async def test_post_chat_turn_delta(self, client):
+        """A chat_turn_delta should land as a chat_turn_delta event with all fields."""
+        r = await client.post("/events/chat_delta", json={
+            "peer": "streampeer",
+            "role": "assistant",
+            "turn_id": "turn-abc",
+            "chunk_index": 0,
+            "kind": "text",
+            "text": "Hello, I'll start by",
+        })
+        assert r.status_code == 200
+
+        r = await client.get("/events")
+        events = r.json()
+        assert len(events) == 1
+        e = events[0]
+        assert e["type"] == "chat_turn_delta"
+        assert e["turn_id"] == "turn-abc"
+        assert e["chunk_index"] == 0
+        assert e["kind"] == "text"
+        assert e["text"] == "Hello, I'll start by"
+        assert e["is_final"] is False
+
+    async def test_chat_turn_delta_tool_use(self, client):
+        r = await client.post("/events/chat_delta", json={
+            "peer": "streampeer",
+            "role": "assistant",
+            "turn_id": "turn-xyz",
+            "chunk_index": 1,
+            "kind": "tool_use",
+            "text": "Bash: ls -la",
+            "tool_call": {"name": "Bash", "input": "ls -la"},
+        })
+        assert r.status_code == 200
+
+        r = await client.get("/events")
+        events = r.json()
+        assert events[0]["kind"] == "tool_use"
+        assert events[0]["tool_call"] == {"name": "Bash", "input": "ls -la"}
+
+    async def test_chat_turn_delta_resolves_peer_id_from_pane_id(self, client):
+        from repowire.config.models import AgentType
+        from repowire.daemon.deps import get_peer_registry
+        registry = get_peer_registry()
+        await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/streampane",
+            pane_id="%77",
+        )
+
+        r = await client.post("/events/chat_delta", json={
+            "peer": "streampane",
+            "role": "assistant",
+            "turn_id": "turn-1",
+            "chunk_index": 0,
+            "text": "partial",
+            "pane_id": "%77",
+        })
+        assert r.status_code == 200
+
+        events = (await client.get("/events")).json()
+        assert events[0]["peer_id"] is not None
+        assert events[0]["peer_id"].startswith("repow-")
+
+    async def test_chat_turn_delta_rejects_negative_chunk_index(self, client):
+        r = await client.post("/events/chat_delta", json={
+            "peer": "p",
+            "turn_id": "t",
+            "chunk_index": -1,
+            "text": "x",
+        })
+        assert r.status_code == 422
+
+    async def test_chat_turn_carries_turn_id(self, client):
+        r = await client.post("/events/chat", json={
+            "peer": "testpeer",
+            "role": "assistant",
+            "text": "final",
+            "turn_id": "msg-uuid-9",
+        })
+        assert r.status_code == 200
+        events = (await client.get("/events")).json()
+        assert events[0]["turn_id"] == "msg-uuid-9"
+
+    async def test_tool_use_turn_canonical_id_drops_deltas(self, client):
+        """Multi-assistant tool turn: streamer emits deltas under the *first*
+        assistant uuid (a1); Stop posts final with the same canonical turn_id.
+        Late deltas (e.g. arriving after Stop) must still be dropped."""
+        # Deltas under a1 (streamer's view).
+        r = await client.post("/events/chat_delta", json={
+            "peer": "toolpeer",
+            "role": "assistant",
+            "turn_id": "a1",
+            "chunk_index": 0,
+            "kind": "text",
+            "text": "I'll check",
+        })
+        assert r.status_code == 200
+        r = await client.post("/events/chat_delta", json={
+            "peer": "toolpeer",
+            "role": "assistant",
+            "turn_id": "a1",
+            "chunk_index": 1,
+            "kind": "tool_use",
+            "text": "Bash: ls",
+            "tool_call": {"name": "Bash", "input": "ls"},
+        })
+        assert r.status_code == 200
+        # Stop fires; transcript now has a1 (tool_use) then a2 (final text).
+        # Canonical turn_id is a1 — Stop must post a1, not a2.
+        r = await client.post("/events/chat", json={
+            "peer": "toolpeer",
+            "role": "assistant",
+            "text": "I'll check\nls -la output",
+            "turn_id": "a1",
+        })
+        assert r.status_code == 200
+        # Late delta after Stop — also under a1.
+        r = await client.post("/events/chat_delta", json={
+            "peer": "toolpeer",
+            "role": "assistant",
+            "turn_id": "a1",
+            "chunk_index": 2,
+            "kind": "text",
+            "text": "(racing)",
+        })
+        assert r.status_code == 200
+        events = (await client.get("/events")).json()
+        finals = [e for e in events if e["type"] == "chat_turn"]
+        deltas = [e for e in events if e["type"] == "chat_turn_delta"]
+        late_deltas = [d for d in deltas if d["chunk_index"] == 2]
+        assert len(finals) == 1
+        assert finals[0]["turn_id"] == "a1"
+        assert not late_deltas, "post-final delta with canonical turn_id must be dropped"
+
+    async def test_late_delta_dropped_after_final(self, client):
+        """A delta posted for a turn_id that already has a final chat_turn
+        must not land as a chat_turn_delta event."""
+        # Final arrives first (covers the race where Stop wins).
+        r = await client.post("/events/chat", json={
+            "peer": "racepeer",
+            "role": "assistant",
+            "text": "complete",
+            "turn_id": "race-turn-1",
+        })
+        assert r.status_code == 200
+        # Late delta for the same turn_id.
+        r = await client.post("/events/chat_delta", json={
+            "peer": "racepeer",
+            "role": "assistant",
+            "turn_id": "race-turn-1",
+            "chunk_index": 3,
+            "text": "stale block",
+        })
+        assert r.status_code == 200
+        events = (await client.get("/events")).json()
+        deltas = [e for e in events if e["type"] == "chat_turn_delta"]
+        finals = [e for e in events if e["type"] == "chat_turn"]
+        assert len(finals) == 1
+        assert deltas == [], "late delta for finalized turn must be dropped"
+
+    async def test_delta_before_final_is_kept(self, client):
+        """In-order delta then final: both events land, dashboard reconciles."""
+        r = await client.post("/events/chat_delta", json={
+            "peer": "p",
+            "role": "assistant",
+            "turn_id": "ordered-turn-1",
+            "chunk_index": 0,
+            "text": "streaming",
+        })
+        assert r.status_code == 200
+        r = await client.post("/events/chat", json={
+            "peer": "p",
+            "role": "assistant",
+            "text": "final",
+            "turn_id": "ordered-turn-1",
+        })
+        assert r.status_code == 200
+        events = (await client.get("/events")).json()
+        assert any(e["type"] == "chat_turn_delta" for e in events)
+        assert any(e["type"] == "chat_turn" for e in events)
+
+    async def test_finalized_set_capacity_bounded(self, client):
+        """The finalized turn_id set must not grow without bound."""
+        from repowire.daemon.routes import messages as msgs_mod
+
+        msgs_mod._finalized_turn_ids.clear()
+        msgs_mod._FINALIZED_TURN_IDS_CAPACITY = 5
+        try:
+            for i in range(20):
+                r = await client.post("/events/chat", json={
+                    "peer": "p",
+                    "role": "assistant",
+                    "text": "x",
+                    "turn_id": f"cap-{i}",
+                })
+                assert r.status_code == 200
+            assert len(msgs_mod._finalized_turn_ids) == 5
+            # Oldest evicted.
+            assert "cap-0" not in msgs_mod._finalized_turn_ids
+            assert "cap-19" in msgs_mod._finalized_turn_ids
+        finally:
+            msgs_mod._finalized_turn_ids.clear()
+            msgs_mod._FINALIZED_TURN_IDS_CAPACITY = 4096
+
 
 # -- Notify --
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -3,10 +3,88 @@ import tempfile
 from pathlib import Path
 
 from repowire.session.transcript import (
+    extract_last_assistant_turn_id,
     extract_last_turn_pair,
     extract_last_turn_raw_tool_calls,
     extract_last_turn_tool_calls,
 )
+
+
+class TestExtractLastAssistantTurnId:
+    def test_returns_first_assistant_uuid_after_last_real_user_prompt(self):
+        """Canonical turn_id is the first assistant uuid after the latest
+        non-tool_result user entry. This must match what the streamer picks
+        as its turn_id on the first assistant line it sees post-prompt."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(json.dumps({
+                "type": "user", "uuid": "u1",
+                "message": {"content": [{"type": "text", "text": "prior prompt"}]},
+            }) + "\n")
+            f.write(json.dumps({
+                "type": "assistant", "uuid": "old",
+                "message": {"content": [{"type": "text", "text": "prior"}]},
+            }) + "\n")
+            # New user prompt (real, not tool_result).
+            f.write(json.dumps({
+                "type": "user", "uuid": "u2",
+                "message": {"content": [{"type": "text", "text": "new prompt"}]},
+            }) + "\n")
+            # Assistant tool_use entry — this is what the streamer sees first.
+            f.write(json.dumps({
+                "type": "assistant", "uuid": "a1",
+                "message": {"content": [
+                    {"type": "text", "text": "I'll check"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ]},
+            }) + "\n")
+            # Tool result, framed as a user entry.
+            f.write(json.dumps({
+                "type": "user", "uuid": "u3",
+                "message": {"content": [{"type": "tool_result", "tool_use_id": "x"}]},
+            }) + "\n")
+            # Final assistant entry — different uuid, but the canonical turn_id
+            # must still be a1 so deltas and the final align.
+            f.write(json.dumps({
+                "type": "assistant", "uuid": "a2",
+                "message": {"content": [{"type": "text", "text": "done"}]},
+            }) + "\n")
+            path = Path(f.name)
+        try:
+            assert extract_last_assistant_turn_id(path) == "a1"
+        finally:
+            path.unlink()
+
+    def test_simple_text_turn(self):
+        """No tool use — only one assistant entry follows the user prompt."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(json.dumps({
+                "type": "user", "uuid": "u1",
+                "message": {"content": [{"type": "text", "text": "hi"}]},
+            }) + "\n")
+            f.write(json.dumps({
+                "type": "assistant", "uuid": "only",
+                "message": {"content": [{"type": "text", "text": "hello"}]},
+            }) + "\n")
+            path = Path(f.name)
+        try:
+            assert extract_last_assistant_turn_id(path) == "only"
+        finally:
+            path.unlink()
+
+    def test_missing_file(self, tmp_path):
+        assert extract_last_assistant_turn_id(tmp_path / "missing.jsonl") is None
+
+    def test_no_assistant_entries(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write(json.dumps({
+                "type": "user", "uuid": "u1",
+                "message": {"content": [{"type": "text", "text": "hi"}]},
+            }) + "\n")
+            path = Path(f.name)
+        try:
+            assert extract_last_assistant_turn_id(path) is None
+        finally:
+            path.unlink()
 
 
 class TestExtractLastTurnPair:

--- a/web/app/dashboard/components/MeshFeed.tsx
+++ b/web/app/dashboard/components/MeshFeed.tsx
@@ -7,7 +7,10 @@ import { formatTime } from "./status";
 export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers: Peer[]; onPickPeer: (peer: Peer) => void }) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const feedEvents = useMemo(
-    () => events.filter((event) => event.type !== "chat_turn").sort((a, b) => a.timestamp.localeCompare(b.timestamp)),
+    () =>
+      events
+        .filter((event) => event.type !== "chat_turn" && event.type !== "chat_turn_delta")
+        .sort((a, b) => a.timestamp.localeCompare(b.timestamp)),
     [events]
   );
 

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -32,6 +32,23 @@ const BARE_ACK_TIMEOUT_MS = 120_000;
 
 type PeerTab = "chat" | "mcp" | "history";
 
+/** Pending-turn group built from chat_turn_delta events. Synthetic client-side
+ * shape — not a wire event — carrying a discriminator so the thread renderer
+ * can branch without runtime probing. Declared up here (rather than next to
+ * the renderer) because session-protection generics need it at component
+ * scope. */
+interface ChatTurnDeltaGroup {
+  type: "chat_turn_delta_group";
+  id: string;
+  turn_id: string;
+  peer_id?: string;
+  timestamp: string;
+  text: string;
+  tool_calls: { name: string; input: string }[];
+}
+
+type ThreadItemEntry = Event | ChatTurnDeltaGroup;
+
 export function PeerView({
   peer,
   events,
@@ -70,7 +87,7 @@ export function PeerView({
   // from this component's render. The snapshot survives peer switches and is
   // released by the store when the last protection source for this peer
   // clears.
-  const frozenFromStore = useFrozenThread<Event>(peer.peer_id);
+  const frozenFromStore = useFrozenThread<ThreadItemEntry>(peer.peer_id);
   const liveThreadRef = useRef(liveThread);
   // Layout-effect timing: run before browser paint so that by the time the
   // user can interact (or any post-commit setDraftText fires), the ref and
@@ -85,7 +102,7 @@ export function PeerView({
     // liveThread without us writing to the store from this component's
     // render. Layout-effect ensures the provider is registered before paint
     // and therefore before any post-commit user input.
-    return registerSnapshotProvider<Event>(peer.peer_id, () => liveThreadRef.current);
+    return registerSnapshotProvider<ThreadItemEntry>(peer.peer_id, () => liveThreadRef.current);
   }, [peer.peer_id]);
   const thread = protectedNow && frozenFromStore ? frozenFromStore : liveThread;
 
@@ -1190,20 +1207,6 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
     </div>
   );
 }
-
-/** Pending-turn group built from chat_turn_delta events. Carries `type` so
- * the thread renderer can branch without runtime probing. */
-interface ChatTurnDeltaGroup {
-  type: "chat_turn_delta_group";
-  id: string;
-  turn_id: string;
-  peer_id?: string;
-  timestamp: string;
-  text: string;
-  tool_calls: { name: string; input: string }[];
-}
-
-type ThreadItemEntry = Event | ChatTurnDeltaGroup;
 
 /** Coalesce chat_turn_delta events into one pending bubble per turn_id, then
  * drop any group whose turn_id has a matching final `chat_turn`.

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -50,12 +50,16 @@ export function PeerView({
   const protectedNow = useIsPeerProtected(peer.peer_id);
   const liveThread = useMemo(() => {
     const id = peer.peer_id;
-    return events
-      .filter((event) => {
-        if (event.type === "chat_turn") return event.peer_id === id;
-        return event.from_peer_id === id || event.to_peer_id === id;
-      })
-      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return coalesceDeltas(
+      events
+        .filter((event) => {
+          if (event.type === "chat_turn" || event.type === "chat_turn_delta") {
+            return event.peer_id === id;
+          }
+          return event.from_peer_id === id || event.to_peer_id === id;
+        })
+        .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+    );
   }, [events, peer.peer_id]);
 
   // While the peer is protected (e.g. unsubmitted compose draft), freeze the
@@ -150,7 +154,13 @@ export function PeerView({
                 <span>send one to begin a query.</span>
               </div>
             ) : (
-              thread.map((event) => <ThreadItem key={event.id} event={event} peer={peer} />)
+              thread.map((event) =>
+                event.type === "chat_turn_delta_group" ? (
+                  <StreamingTurnItem key={`stream-${event.turn_id}`} group={event} peer={peer} />
+                ) : (
+                  <ThreadItem key={event.id} event={event as Event} peer={peer} />
+                )
+              )
             )}
             <div ref={bottomRef} />
           </div>
@@ -1177,6 +1187,111 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
           </option>
         ))}
       </select>
+    </div>
+  );
+}
+
+/** Pending-turn group built from chat_turn_delta events. Carries `type` so
+ * the thread renderer can branch without runtime probing. */
+interface ChatTurnDeltaGroup {
+  type: "chat_turn_delta_group";
+  id: string;
+  turn_id: string;
+  peer_id?: string;
+  timestamp: string;
+  text: string;
+  tool_calls: { name: string; input: string }[];
+}
+
+type ThreadItemEntry = Event | ChatTurnDeltaGroup;
+
+/** Coalesce chat_turn_delta events into one pending bubble per turn_id, then
+ * drop any group whose turn_id has a matching final `chat_turn`.
+ *
+ * Reconciliation rule: the final `chat_turn` carries the same `turn_id` as
+ * its deltas (assistant message uuid). Matching by id is order-independent —
+ * a late delta arriving after the final still gets dropped, fixing the
+ * "permanent streaming bubble" race that timestamp-based reconcile had.
+ * Falls back to the timestamp heuristic only for deltas whose turn_id never
+ * gets a matching final (network drop, agent crash mid-turn): a chat_turn
+ * for the same peer that came *after* the delta absorbs it. */
+function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
+  const groups = new Map<string, ChatTurnDeltaGroup>();
+
+  // Final chat_turns carrying turn_id — exact match drops their deltas
+  // regardless of arrival order.
+  const finalizedTurnIds = new Set<string>();
+  // Fallback: per-peer last final-chat_turn timestamp, for turns where the
+  // final didn't carry turn_id (legacy or codex transcripts without uuid).
+  const peerLastChatTurnTs = new Map<string, string>();
+  for (const ev of sorted) {
+    if (ev.type !== "chat_turn" || ev.role !== "assistant") continue;
+    if (ev.turn_id) finalizedTurnIds.add(ev.turn_id);
+    if (ev.peer_id) {
+      const prev = peerLastChatTurnTs.get(ev.peer_id);
+      if (!prev || prev < ev.timestamp) peerLastChatTurnTs.set(ev.peer_id, ev.timestamp);
+    }
+  }
+
+  for (const ev of sorted) {
+    if (ev.type !== "chat_turn_delta" || !ev.turn_id) continue;
+    if (finalizedTurnIds.has(ev.turn_id)) continue;
+    const lastFinalTs = ev.peer_id ? peerLastChatTurnTs.get(ev.peer_id) : undefined;
+    if (lastFinalTs && ev.timestamp <= lastFinalTs) continue;
+
+    let group = groups.get(ev.turn_id);
+    if (!group) {
+      group = {
+        type: "chat_turn_delta_group",
+        id: `delta-group-${ev.turn_id}`,
+        turn_id: ev.turn_id,
+        peer_id: ev.peer_id,
+        timestamp: ev.timestamp,
+        text: "",
+        tool_calls: [],
+      };
+      groups.set(ev.turn_id, group);
+    }
+    if (ev.kind === "tool_use" && ev.tool_call) {
+      group.tool_calls.push(ev.tool_call);
+    } else if (ev.kind === "text" || ev.kind === undefined) {
+      // Adjacent text blocks within one turn are conceptually paragraphs.
+      group.text = group.text ? `${group.text}\n\n${ev.text}` : ev.text;
+    }
+    group.timestamp = ev.timestamp;
+  }
+
+  const out: ThreadItemEntry[] = [];
+  for (const ev of sorted) {
+    if (ev.type === "chat_turn_delta") continue;
+    out.push(ev);
+  }
+  for (const group of groups.values()) {
+    if (!group.text && group.tool_calls.length === 0) continue;
+    out.push(group);
+  }
+  out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return out;
+}
+
+function StreamingTurnItem({ group, peer }: { group: ChatTurnDeltaGroup; peer: Peer }) {
+  return (
+    <div className="mb-4 flex flex-col items-start">
+      <div className="mb-1 flex items-center gap-2 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-outline">
+        <span>{peerLabel(peer)} · {formatTime(group.timestamp)}</span>
+        <span className="inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/10 px-1.5 py-px text-[9px] text-primary">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
+          streaming
+        </span>
+      </div>
+      {group.text && (
+        <div className="max-w-[82%] min-w-0 rounded border-l-2 border-primary/70 bg-surface-container-high p-3 font-mono text-[13px] leading-6 text-on-surface [overflow-wrap:anywhere]">
+          <div className="prose prose-invert prose-sm max-w-none break-words [&_pre]:overflow-x-auto">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{group.text}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+      {group.tool_calls.length > 0 && <ToolCallBlock toolCalls={group.tool_calls} />}
     </div>
   );
 }

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -40,7 +40,15 @@ export function peerLabel(peer: Peer): string {
 
 export interface Event {
   id: string;
-  type: "query" | "response" | "notification" | "broadcast" | "status_change" | "chat_turn" | "ask";
+  type:
+    | "query"
+    | "response"
+    | "notification"
+    | "broadcast"
+    | "status_change"
+    | "chat_turn"
+    | "chat_turn_delta"
+    | "ask";
   timestamp: string;
   from?: string;
   to?: string;
@@ -55,4 +63,10 @@ export interface Event {
   query_id?: string;
   correlation_id?: string;
   tool_calls?: { name: string; input: string }[];
+  // chat_turn_delta fields
+  turn_id?: string;
+  chunk_index?: number;
+  kind?: "text" | "tool_use";
+  tool_call?: { name: string; input: string };
+  is_final?: boolean;
 }


### PR DESCRIPTION
## Summary

Implements §4.3 from `claudecodeui-adoption.md` — live streaming of chat turn deltas as the assistant writes the transcript JSONL. Long turns now render progressively in PeerView instead of one big landing at Stop.

- New event type `chat_turn_delta` and route `POST /events/chat_delta`. Final `chat_turn` at Stop is unchanged and authoritative.
- Per-turn streamer subprocess (`repowire/hooks/chat_delta_streamer.py`) spawned by the prompt hook, terminated by the Stop hook via pidfile removal. Tails the transcript JSONL, posts one delta per assistant `text` or `tool_use` block. Bounded by idle and wall-clock caps.
- Dashboard `PeerView` coalesces deltas by `turn_id` into a pending bubble with a `streaming` chip; the final `chat_turn` replaces accumulated deltas idempotently. `MeshFeed` excludes deltas (same as final turns).
- Feature flag `experiments.chat_turn_streaming` (off by default), Claude Code transports only.

### Why block-level, not token-level

Claude Code writes one *completed* content block per JSONL line. claudecodeui gets token frames because it spawns `claude` as a child and reads stdout JSON — a path the hook model never sees. Token-level streaming belongs on the ACP / channel transport track (§4.5+), and `chat/update` will be its natural carrier. Block-level still delivers the §4.3 UX win.

### Backward compatibility

Deltas are additive. Clients listening only for `chat_turn` keep working with no change. The flag is off by default — existing deployments see zero behavior change.

## Test plan

- [x] `pytest` — 968 passed (10 new tests for route, hook spawn, streamer module)
- [x] `ruff check repowire/ tests/` — no new errors
- [x] `ty check repowire/` — clean
- [ ] Live smoke: enable flag in `~/.repowire/config.yaml`, send a multi-block ask, watch deltas land in dashboard PeerView ahead of Stop
- [ ] Verify the streaming bubble is replaced by the final turn cleanly when Stop fires