### PR TITLE
docs(transcript): correct cursor param description to opaque base64

### DIFF
--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -371,7 +371,13 @@ async def get_peer_transcript(
     name: str,
     limit: int = Query(50, ge=1, le=500, description="Max turns to return"),
     before: str | None = Query(
-        None, description="ISO-8601 cursor; return turns strictly older than this."
+        None,
+        description=(
+            "Opaque base64 cursor returned as `next_before` from a prior "
+            "page; return turns strictly older than this position. The "
+            "cursor encodes (timestamp, session_id, line_offset) for "
+            "stable pagination across same-timestamp boundaries."
+        ),
     ),
     circle: str | None = Query(None),
     _: str | None = Depends(require_auth),


### PR DESCRIPTION
Follow-up nit from #188 review (filed as #196). The `before` query param doc still said ISO-8601, but as of #188 the wire cursor is opaque base64 encoding (timestamp, session_id, line_offset) for stable same-timestamp pagination. No behavior change.

Closes #196.