### PR TITLE
feat(acp): broker-side ACP client behind experiments flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dev = [
     "pytest-httpx>=0.30.0",
     "ruff>=0.1.0",
     "ty",
+    "agent-client-protocol>=0.10.0",
+]
+acp = [
+    "agent-client-protocol>=0.10.0",
 ]
 docs = [
     "mkdocs>=1.6.0",

--- a/repowire/acp/__init__.py
+++ b/repowire/acp/__init__.py
@@ -1,0 +1,36 @@
+"""Broker-side ACP (Agent Client Protocol) client.
+
+Phase-3 of the ACP migration (see notes-vault/repowire-mesh/acp-mapping-delta-claude.md).
+Lets the broker act as an ACP client against an ACP-speaking agent subprocess
+(e.g. `codex-acp`) instead of routing asks through the WebSocket / tmux-paste path.
+
+Gated by `experiments.acp_broker_client` in config; only peers whose registry
+metadata carries an `acp` block are routed through this client. All other peers
+keep using the existing wire transport unchanged.
+
+Built on the official `agent-client-protocol` python SDK — this package owns
+the broker-side lifecycle and a small notification recorder, not JSON-RPC plumbing.
+"""
+
+from repowire.acp.broker import (
+    AcpAckCallback,
+    AcpRouteDecision,
+    decide_acp_route,
+    deliver_ask_via_acp,
+)
+from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
+from repowire.acp.manager import AcpClientManager, AcpPeerSpec
+from repowire.acp.models import AcpPeerConfig
+
+__all__ = [
+    "AcpAckCallback",
+    "AcpClient",
+    "AcpClientError",
+    "AcpClientManager",
+    "AcpPeerConfig",
+    "AcpPeerSpec",
+    "AcpPromptResult",
+    "AcpRouteDecision",
+    "decide_acp_route",
+    "deliver_ask_via_acp",
+]

--- a/repowire/acp/broker.py
+++ b/repowire/acp/broker.py
@@ -1,0 +1,116 @@
+"""Glue between repowire's broker (ask/ack pipeline) and the ACP client.
+
+When the ``experiments.acp_broker_client`` flag is on and the target peer
+carries an ``acp`` metadata block, an incoming ``/ask`` is routed here instead
+of through the WebSocket transport.
+
+Flow:
+
+    /ask (asker, ACP-peer)
+        ─► register in ask_tracker (same as today)
+        ─► ACP: session/prompt against codex-acp subprocess
+        ─► on completion: notify asker with the assembled reply + close ask
+
+Phase-3 keeps everything else on the WS path (notify, broadcast, ack outbound
+from non-ACP peers, …). The session is persistent per peer, so successive
+asks to the same ACP peer reuse the same ACP session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from repowire.acp.manager import AcpClientManager, AcpPeerSpec
+from repowire.acp.models import AcpPeerConfig
+from repowire.protocol.peers import Peer
+
+logger = logging.getLogger(__name__)
+
+# Default per-prompt timeout; matches DEFAULT_QUERY_TIMEOUT roughly but capped
+# lower so a single hung codex-acp turn doesn't pin an ask thread for 5 min.
+DEFAULT_PROMPT_TIMEOUT = 180.0
+
+
+@dataclass
+class AcpRouteDecision:
+    """Outcome of "should this ask go via ACP?".
+
+    ``spec`` is set iff routing should happen. ``reason`` is human-readable.
+    """
+
+    route: bool
+    spec: AcpPeerSpec | None = None
+    reason: str = ""
+
+
+def decide_acp_route(peer: Peer, *, flag_enabled: bool) -> AcpRouteDecision:
+    """Inspect a peer + the experiments flag to decide on ACP routing.
+
+    Routes if and only if:
+      * ``experiments.acp_broker_client`` is on, AND
+      * peer carries a well-formed ``metadata["acp"]`` block.
+
+    Bad ``metadata["acp"]`` content (wrong shape) is logged and treated as
+    "do not route" — the caller falls back to the WS path.
+    """
+    if not flag_enabled:
+        return AcpRouteDecision(route=False, reason="experiments.acp_broker_client off")
+    raw = peer.metadata.get("acp") if peer.metadata else None
+    if not raw:
+        return AcpRouteDecision(route=False, reason="peer has no acp metadata block")
+    try:
+        config = AcpPeerConfig.model_validate(raw)
+    except ValidationError as e:
+        logger.warning(
+            "ACP route declined for peer_id=%s: invalid metadata.acp block: %s",
+            peer.peer_id, e,
+        )
+        return AcpRouteDecision(route=False, reason=f"invalid acp metadata: {e}")
+    spec = AcpPeerSpec(peer_id=peer.peer_id, config=config, fallback_cwd=peer.path)
+    return AcpRouteDecision(route=True, spec=spec, reason="acp routing engaged")
+
+
+AcpAckCallback = Callable[[str, str | None, str | None], Awaitable[None]]
+"""Callback fired when an ACP-routed ask completes.
+
+Args: (correlation_id, reply_text_or_None, error_or_None).
+- reply_text non-None: successful turn; deliver as ack reply.
+- error non-None: ACP path failed; close the ask with an error frame.
+"""
+
+
+async def deliver_ask_via_acp(
+    *,
+    manager: AcpClientManager,
+    spec: AcpPeerSpec,
+    correlation_id: str,
+    text: str,
+    on_complete: AcpAckCallback,
+    timeout: float = DEFAULT_PROMPT_TIMEOUT,
+) -> asyncio.Task[None]:
+    """Spawn a background task that prompts the ACP peer and acks the asker.
+
+    Returned task is not awaited here; the ``/ask`` handler still returns the
+    correlation_id immediately (matching the existing non-blocking semantics).
+    The task acks via ``on_complete`` regardless of success or failure so an
+    open ask never silently dies.
+    """
+
+    async def _run() -> None:
+        try:
+            result = await manager.prompt(spec, text, timeout=timeout)
+            reply = result.text or f"[acp stop_reason={result.stop_reason}, no text]"
+            await on_complete(correlation_id, reply, None)
+        except Exception as e:  # noqa: BLE001 — surface every failure to the asker
+            logger.exception(
+                "ACP ask delivery failed for cid=%s peer_id=%s: %s",
+                correlation_id, spec.peer_id, e,
+            )
+            await on_complete(correlation_id, None, str(e))
+
+    return asyncio.create_task(_run(), name=f"acp-ask-{correlation_id[:8]}")

--- a/repowire/acp/client.py
+++ b/repowire/acp/client.py
@@ -126,6 +126,7 @@ class AcpClient:
         self._exit_stack: Any = None
         self._lock = asyncio.Lock()
         self._closed = False
+        self._crashed = False
 
     @property
     def session_id(self) -> str | None:
@@ -180,16 +181,35 @@ class AcpClient:
         logger.info("ACP session/new ok: session_id=%s cwd=%s", self._session_id, cwd)
         return self._session_id
 
+    @property
+    def crashed(self) -> bool:
+        """True if a prompt failed in a way that poisoned the session/subprocess.
+
+        The manager checks this after every ``prompt`` to decide whether to
+        drop the cached client so the next ask respawns a fresh subprocess.
+        """
+        return self._crashed
+
     async def prompt(self, text: str, *, timeout: float = 120.0) -> AcpPromptResult:
         """Send a ``session/prompt`` and return the assistant's final turn.
 
         Streams ``session/update`` notifications into the recorder while waiting
         for ``session/prompt`` to settle. Phase-3 returns the concatenated
         ``agent_message_chunk`` text as the ack reply.
+
+        On timeout: send ``session/cancel`` (best-effort), then close the
+        subprocess so a late stream of chunks can't leak into the next ask's
+        recorder. The client is marked ``crashed`` and the manager drops it.
+
+        On any transport / protocol failure: same — close + mark crashed.
+        Phase-3 favours respawn-on-error over silently reusing a wedged
+        connection, since asks are cheap to retry.
         """
         import acp
 
         async with self._lock:
+            if self._closed:
+                raise AcpClientError("client is closed")
             await self._ensure_started()
             session_id = await self._ensure_session()
             assert self._connection is not None
@@ -205,9 +225,19 @@ class AcpClient:
                     timeout=timeout,
                 )
             except asyncio.TimeoutError as e:
+                await self._abort_after_failure(cancel_first=True)
                 raise AcpClientError(f"prompt timed out after {timeout}s") from e
             except Exception as e:
+                await self._abort_after_failure(cancel_first=False)
                 raise AcpClientError(f"prompt failed: {e}") from e
+
+            # session/update notifications arrive on the same stdio stream as
+            # the session/prompt response, but the SDK dispatches them as
+            # separate asyncio tasks. The prompt future can resolve before all
+            # pending notification handlers have run, especially against a
+            # fast agent like our echo stub. Drain the loop briefly so any
+            # in-flight `session/update` is recorded before we read it.
+            await _drain_pending_updates(self._recorder)
 
             assembled = _assemble_agent_text(self._recorder.updates)
             return AcpPromptResult(
@@ -215,6 +245,25 @@ class AcpClient:
                 stop_reason=str(resp.stop_reason),
                 updates=list(self._recorder.updates),
             )
+
+    async def _abort_after_failure(self, *, cancel_first: bool) -> None:
+        """Mark the client crashed and tear it down so the manager drops it.
+
+        ``cancel_first`` covers the timeout case: send ``session/cancel`` so
+        the agent stops working before we drop its stdio. For protocol errors
+        we skip the cancel — the connection is already in a bad state.
+        """
+        self._crashed = True
+        if cancel_first:
+            try:
+                if self._connection is not None and self._session_id is not None:
+                    await self._connection.cancel(self._session_id)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("ACP cancel during abort failed: %s", e)
+        try:
+            await self._close_locked()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("ACP close during abort failed: %s", e)
 
     async def cancel(self) -> None:
         """Send ``session/cancel`` for the current session, if one exists."""
@@ -227,6 +276,14 @@ class AcpClient:
 
     async def close(self) -> None:
         """Tear down the subprocess and clear session state. Idempotent."""
+        await self._close_locked()
+
+    async def _close_locked(self) -> None:
+        """Inner close used both from ``close()`` and from the prompt lock.
+
+        Idempotent. Does NOT acquire ``self._lock`` so it's safe to call while
+        the prompt path already holds it.
+        """
         if self._closed:
             return
         self._closed = True
@@ -238,6 +295,41 @@ class AcpClient:
                 await stack.__aexit__(None, None, None)
             except Exception as e:  # noqa: BLE001
                 logger.warning("ACP teardown error: %s", e)
+
+
+async def _drain_pending_updates(
+    recorder: Any,
+    *,
+    quiescent_ticks: int = 4,
+    max_wait_seconds: float = 0.25,
+    sleep_step: float = 0.01,
+) -> None:
+    """Yield control until in-flight session/update tasks have all recorded.
+
+    The SDK dispatches each incoming JSON-RPC frame as a separate task, so a
+    session/prompt response future can resolve before sibling session/update
+    handlers — and even before the notification frame has been read off the
+    pipe in the first place. We poll the recorder for new updates, exiting
+    when ``quiescent_ticks`` consecutive polls observe no growth, or when
+    ``max_wait_seconds`` elapses.
+
+    The bound is intentionally small: phase-3 is interested in the assistant
+    reply that was already streamed by the time stop_reason arrived. Long
+    tails belong to later phases (chat_turn_delta streaming).
+    """
+    deadline = asyncio.get_running_loop().time() + max_wait_seconds
+    quiet = 0
+    last = len(recorder.updates)
+    while asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(sleep_step)
+        current = len(recorder.updates)
+        if current == last:
+            quiet += 1
+            if quiet >= quiescent_ticks:
+                return
+        else:
+            quiet = 0
+            last = current
 
 
 def _assemble_agent_text(updates: list[Any]) -> str:

--- a/repowire/acp/client.py
+++ b/repowire/acp/client.py
@@ -1,0 +1,253 @@
+"""Broker-side ACP client.
+
+One ``AcpClient`` instance owns one ACP subprocess and one persistent session
+(per peer). The session is created lazily on first ``prompt`` and reused across
+asks so context is preserved within the peer.
+
+Streaming ``session/update`` notifications (``agent_message_chunk``,
+``tool_call``, ``plan``…) are recorded into the ``AcpPromptResult`` returned
+from ``prompt``. Phase-3 surfaces the accumulated assistant text as the ack
+reply; later phases will translate the same updates into ``chat_turn_delta``
+mesh-bus events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from repowire.acp.models import AcpPeerConfig
+from repowire.acp.transport import spawn_acp_subprocess
+
+if TYPE_CHECKING:
+    from acp.client.connection import ClientSideConnection
+
+logger = logging.getLogger(__name__)
+
+
+class AcpClientError(RuntimeError):
+    """Wrapper for ACP failures (initialize, new_session, prompt). Always retriable."""
+
+
+@dataclass
+class AcpPromptResult:
+    """Result of one ``session/prompt`` round-trip.
+
+    ``text`` is the concatenated ``agent_message_chunk`` body — what the broker
+    surfaces as the ack reply to the original asker. ``stop_reason`` is the
+    raw ACP termination reason; ``end_turn`` is the success case.
+    """
+
+    text: str
+    stop_reason: str
+    updates: list[Any] = field(default_factory=list)
+
+
+def _make_recorder() -> Any:
+    """Build a fresh ``acp.Client`` instance that records updates for one peer.
+
+    Defined as a factory rather than a top-level class so the ``acp`` import
+    stays lazy — the broker only imports the SDK when the ACP path is wired up.
+    """
+    import acp
+    from acp.schema import AllowedOutcome, DeniedOutcome
+
+    class _BrokerRecorder(acp.Client):
+        """Records ``session/update`` notifications for the broker.
+
+        Auto-allows permission requests for phase-3. Later phases will surface
+        permission UX to the dashboard or telegram peer.
+        """
+
+        def __init__(self) -> None:
+            self.updates: list[Any] = []
+
+        async def session_update(self, session_id: str, update: Any, **_: Any) -> None:
+            del session_id  # logged at debug level below
+            self.updates.append(update)
+            logger.debug("ACP session/update kind=%s", type(update).__name__)
+
+        async def request_permission(
+            self,
+            options: list[Any],
+            session_id: str,
+            tool_call: Any,
+            **_: Any,
+        ) -> Any:
+            del session_id, tool_call
+            chosen = options[0] if options else None
+            if chosen is None:
+                return acp.RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+            return acp.RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", option_id=chosen.option_id),
+            )
+
+        async def read_text_file(
+            self,
+            path: str,
+            session_id: str,
+            limit: int | None = None,
+            line: int | None = None,
+            **_: Any,
+        ) -> Any:
+            del session_id, limit, line
+            return acp.ReadTextFileResponse(content=Path(path).read_text())
+
+        async def write_text_file(
+            self,
+            content: str,
+            path: str,
+            session_id: str,
+            **_: Any,
+        ) -> Any:
+            del session_id
+            Path(path).write_text(content)
+            return acp.WriteTextFileResponse()
+
+    return _BrokerRecorder()
+
+
+class AcpClient:
+    """One ACP subprocess + one persistent session, per peer.
+
+    Use as an async context manager (``async with AcpClient(cfg) as c: await c.prompt(...)``)
+    or via ``AcpClientManager`` which handles the lifetime.
+    """
+
+    def __init__(self, config: AcpPeerConfig, *, fallback_cwd: str | None = None) -> None:
+        self._config = config
+        self._fallback_cwd = fallback_cwd
+        self._recorder = _make_recorder()
+        self._connection: ClientSideConnection | None = None
+        self._session_id: str | None = None
+        self._exit_stack: Any = None
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    async def __aenter__(self) -> AcpClient:
+        await self._ensure_started()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        del exc_info
+        await self.close()
+
+    async def _ensure_started(self) -> None:
+        if self._connection is not None:
+            return
+        import contextlib
+
+        import acp
+
+        self._exit_stack = contextlib.AsyncExitStack()
+        await self._exit_stack.__aenter__()
+        cwd = self._config.cwd or self._fallback_cwd
+        try:
+            sub = await self._exit_stack.enter_async_context(
+                spawn_acp_subprocess(
+                    self._recorder,
+                    self._config.command,
+                    *self._config.args,
+                    cwd=cwd,
+                    env=self._config.env,
+                )
+            )
+            self._connection = sub.connection
+            await self._connection.initialize(protocol_version=acp.PROTOCOL_VERSION)
+        except Exception as e:
+            await self._exit_stack.__aexit__(type(e), e, e.__traceback__)
+            self._exit_stack = None
+            self._connection = None
+            raise AcpClientError(f"failed to start ACP subprocess: {e}") from e
+
+    async def _ensure_session(self) -> str:
+        if self._session_id is not None:
+            return self._session_id
+        assert self._connection is not None
+        cwd = self._config.cwd or self._fallback_cwd or str(Path.cwd())
+        try:
+            resp = await self._connection.new_session(cwd=str(Path(cwd).resolve()), mcp_servers=[])
+        except Exception as e:
+            raise AcpClientError(f"new_session failed: {e}") from e
+        self._session_id = resp.session_id
+        logger.info("ACP session/new ok: session_id=%s cwd=%s", self._session_id, cwd)
+        return self._session_id
+
+    async def prompt(self, text: str, *, timeout: float = 120.0) -> AcpPromptResult:
+        """Send a ``session/prompt`` and return the assistant's final turn.
+
+        Streams ``session/update`` notifications into the recorder while waiting
+        for ``session/prompt`` to settle. Phase-3 returns the concatenated
+        ``agent_message_chunk`` text as the ack reply.
+        """
+        import acp
+
+        async with self._lock:
+            await self._ensure_started()
+            session_id = await self._ensure_session()
+            assert self._connection is not None
+
+            self._recorder.updates.clear()
+
+            try:
+                resp = await asyncio.wait_for(
+                    self._connection.prompt(
+                        prompt=[acp.text_block(text)],
+                        session_id=session_id,
+                    ),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError as e:
+                raise AcpClientError(f"prompt timed out after {timeout}s") from e
+            except Exception as e:
+                raise AcpClientError(f"prompt failed: {e}") from e
+
+            assembled = _assemble_agent_text(self._recorder.updates)
+            return AcpPromptResult(
+                text=assembled,
+                stop_reason=str(resp.stop_reason),
+                updates=list(self._recorder.updates),
+            )
+
+    async def cancel(self) -> None:
+        """Send ``session/cancel`` for the current session, if one exists."""
+        if self._connection is None or self._session_id is None:
+            return
+        try:
+            await self._connection.cancel(self._session_id)
+        except Exception as e:  # noqa: BLE001 — best-effort cancel
+            logger.warning("ACP session/cancel failed: %s", e)
+
+    async def close(self) -> None:
+        """Tear down the subprocess and clear session state. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        stack, self._exit_stack = self._exit_stack, None
+        self._connection = None
+        self._session_id = None
+        if stack is not None:
+            try:
+                await stack.__aexit__(None, None, None)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("ACP teardown error: %s", e)
+
+
+def _assemble_agent_text(updates: list[Any]) -> str:
+    """Concatenate ``agent_message_chunk`` text payloads from a list of updates."""
+    parts: list[str] = []
+    for u in updates:
+        if type(u).__name__ != "AgentMessageChunk":
+            continue
+        content = getattr(u, "content", None)
+        text = getattr(content, "text", None) if content is not None else None
+        if text:
+            parts.append(text)
+    return "".join(parts)

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -1,0 +1,86 @@
+"""Lifetime cache for broker-side ACP clients.
+
+One ``AcpClient`` per ACP-routed peer, lazily started on first use and torn
+down on shutdown. Keyed by ``peer_id`` so display-name reuse across circles
+doesn't collide.
+
+Phase-3 scope: ``ask`` only. Notify, broadcast, etc. continue to flow over the
+WS path even when the experiments flag is on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
+from repowire.acp.models import AcpPeerConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AcpPeerSpec:
+    """Resolved spec for spawning an ACP client on behalf of a peer."""
+
+    peer_id: str
+    config: AcpPeerConfig
+    fallback_cwd: str | None = None
+
+
+class AcpClientManager:
+    """Holds one ``AcpClient`` per ACP-routed peer.
+
+    Clients are started lazily on first ``prompt`` so registering a peer is
+    cheap even if no ask ever flows through ACP. ``close`` is idempotent and
+    safe to call from the daemon lifespan shutdown hook.
+    """
+
+    def __init__(self) -> None:
+        self._clients: dict[str, AcpClient] = {}
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    async def get_or_create(self, spec: AcpPeerSpec) -> AcpClient:
+        """Return the live ``AcpClient`` for ``spec.peer_id``, starting it if needed."""
+        if self._closed:
+            raise AcpClientError("AcpClientManager is closed")
+        async with self._lock:
+            client = self._clients.get(spec.peer_id)
+            if client is None:
+                client = AcpClient(spec.config, fallback_cwd=spec.fallback_cwd)
+                self._clients[spec.peer_id] = client
+        return client
+
+    async def prompt(
+        self,
+        spec: AcpPeerSpec,
+        text: str,
+        *,
+        timeout: float = 120.0,
+    ) -> AcpPromptResult:
+        """Route one ask to its ACP-routed peer and return the assistant turn."""
+        client = await self.get_or_create(spec)
+        return await client.prompt(text, timeout=timeout)
+
+    async def drop(self, peer_id: str) -> None:
+        """Tear down the client for ``peer_id`` if any. Used on peer eviction."""
+        async with self._lock:
+            client = self._clients.pop(peer_id, None)
+        if client is not None:
+            await client.close()
+
+    async def close(self) -> None:
+        """Tear down every live client. Safe to call multiple times."""
+        if self._closed:
+            return
+        self._closed = True
+        async with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+        for c in clients:
+            try:
+                await c.close()
+            except Exception as e:  # noqa: BLE001 — best-effort shutdown
+                logger.warning("AcpClientManager: close error: %s", e)

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -60,9 +60,37 @@ class AcpClientManager:
         *,
         timeout: float = 120.0,
     ) -> AcpPromptResult:
-        """Route one ask to its ACP-routed peer and return the assistant turn."""
+        """Route one ask to its ACP-routed peer and return the assistant turn.
+
+        On any ``AcpClientError`` (timeout, transport failure, protocol error)
+        the cached client is dropped so the *next* ask for this peer respawns
+        a fresh subprocess. Without this, one crash would poison the cache:
+        ``AcpClient.prompt`` already closes itself on failure, so a retained
+        cache entry would just be a corpse.
+        """
         client = await self.get_or_create(spec)
-        return await client.prompt(text, timeout=timeout)
+        try:
+            result = await client.prompt(text, timeout=timeout)
+        except AcpClientError:
+            await self._drop_if_crashed(spec.peer_id, client)
+            raise
+        # Belt-and-braces: if the client decided it's crashed after a "successful"
+        # call (shouldn't happen today, but cheap to guard), evict it too.
+        if client.crashed:
+            await self._drop_if_crashed(spec.peer_id, client)
+        return result
+
+    async def _drop_if_crashed(self, peer_id: str, client: AcpClient) -> None:
+        """Drop ``peer_id`` from cache iff the cached entry is ``client``.
+
+        Guards against races where two prompts targeted the same peer, one
+        crashed, the other already started a fresh respawn — we don't want to
+        evict the fresh one.
+        """
+        async with self._lock:
+            if self._clients.get(peer_id) is client:
+                self._clients.pop(peer_id, None)
+        await client.close()
 
     async def drop(self, peer_id: str) -> None:
         """Tear down the client for ``peer_id`` if any. Used on peer eviction."""

--- a/repowire/acp/models.py
+++ b/repowire/acp/models.py
@@ -1,0 +1,36 @@
+"""Pydantic shapes the broker uses to describe ACP-routed peers.
+
+These are *broker-side* models — the on-wire ACP messages themselves come from
+the `agent-client-protocol` SDK (`acp.PromptRequest`, `acp.SessionNotification`,
+etc.). This module only models the configuration the broker needs to spawn and
+talk to an ACP agent subprocess on behalf of a registered peer.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AcpPeerConfig(BaseModel):
+    """How the broker spawns and talks to an ACP-routed peer.
+
+    Persisted in `Peer.metadata["acp"]`. When the experiments flag is on and a
+    peer carries this block, the broker bypasses the WS transport and routes
+    asks through an ACP subprocess instead.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    command: str = Field(..., description="Executable that speaks ACP over stdio")
+    args: list[str] = Field(default_factory=list, description="Args appended to command")
+    cwd: str | None = Field(
+        None,
+        description=(
+            "Working directory for the subprocess; defaults to the peer's "
+            "registered `path` if absent."
+        ),
+    )
+    env: dict[str, str] | None = Field(
+        None,
+        description="Extra environment overlaid on the daemon's environment.",
+    )

--- a/repowire/acp/transport.py
+++ b/repowire/acp/transport.py
@@ -1,0 +1,70 @@
+"""ACP subprocess transport.
+
+Thin wrapper around `acp.spawn_agent_process` that owns the subprocess and the
+JSON-RPC connection lifecycle. The high-level `AcpClient` in `client.py` drives
+the connection; this module exists to keep subprocess setup and teardown
+isolated from the broker-side wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import acp
+    from acp.client.connection import ClientSideConnection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AcpSubprocess:
+    """Bundle of a live ACP connection and the subprocess backing it."""
+
+    connection: ClientSideConnection
+    process: asyncio.subprocess.Process
+
+
+@asynccontextmanager
+async def spawn_acp_subprocess(
+    client: acp.Client,
+    command: str,
+    *args: str,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> AsyncIterator[AcpSubprocess]:
+    """Spawn an ACP agent subprocess and yield a live connection bound to ``client``.
+
+    The SDK's ``spawn_agent_process`` already handles stdio framing and JSON-RPC
+    routing; we just record the process handle so the broker can correlate
+    crashes with peer state and so tests can introspect lifecycle.
+    """
+    import acp
+
+    async with acp.spawn_agent_process(
+        client,
+        command,
+        *args,
+        cwd=cwd,
+        env=dict(env) if env else None,
+    ) as (connection, process):
+        logger.info(
+            "ACP subprocess up: pid=%s command=%s cwd=%s",
+            getattr(process, "pid", None),
+            command,
+            cwd,
+        )
+        try:
+            yield AcpSubprocess(connection=connection, process=process)
+        finally:
+            logger.info(
+                "ACP subprocess down: pid=%s exit=%s",
+                getattr(process, "pid", None),
+                process.returncode,
+            )

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -203,6 +203,28 @@ class SlackConfig(BaseModel):
     channel_id: str | None = Field(None, description="Slack channel ID (C...)")
 
 
+class ExperimentsConfig(BaseModel):
+    """Feature flags for experimental subsystems.
+
+    Each flag gates a code path that is not yet ready to be default-on.
+    Off-by-default; opt-in via `~/.repowire/config.yaml`:
+
+        experiments:
+          acp_broker_client: true
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    acp_broker_client: bool = Field(
+        default=False,
+        description=(
+            "Route asks to ACP-marked peers through a broker-side ACP client "
+            "(initialize / session/new / session/prompt) instead of the WS path. "
+            "Phase-3: codex-acp only."
+        ),
+    )
+
+
 class Config(BaseModel):
     """Main Repowire configuration."""
 
@@ -214,6 +236,7 @@ class Config(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     slack: SlackConfig = Field(default_factory=SlackConfig)
+    experiments: ExperimentsConfig = Field(default_factory=ExperimentsConfig)
 
     @classmethod
     def get_config_dir(cls) -> Path:

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -125,6 +125,9 @@ def create_app(
         )
         app.state.schedule_store = schedule_store
         app.state.scheduler = scheduler
+        from repowire.acp import AcpClientManager
+        acp_manager = AcpClientManager()
+        app.state.acp_manager = acp_manager
 
         lifecycle_handler = LifecycleHandler(
             peer_registry=peer_registry,
@@ -195,6 +198,7 @@ def create_app(
             logger.info("%s service stopped", name)
         if relay_client:
             await relay_client.stop()
+        await acp_manager.close()
         await scheduler.stop()
         peer_registry._save_events()
         peer_registry._persist_mappings()
@@ -360,6 +364,9 @@ def create_test_app(
         app.state.review_queue_store = ReviewQueueStore(rq_dir / "review_queue.json")
         app.state.schedule_store = schedule_store
         app.state.scheduler = scheduler
+        from repowire.acp import AcpClientManager
+        acp_manager = AcpClientManager()
+        app.state.acp_manager = acp_manager
 
         lh = LifecycleHandler(
             peer_registry=registry,
@@ -373,6 +380,7 @@ def create_test_app(
 
         yield
 
+        await acp_manager.close()
         await scheduler.stop()
         await registry.stop()
         cleanup_deps()

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -54,6 +54,13 @@ class Ask:
     """An open ask awaiting ack/reply.
 
     close_reason: 'ack' | 'ack_with_msg' | 'reply_to' | 'evicted' | 'send_failed'.
+
+    ``pending_reply`` is the durable home for a completed reply whose first
+    delivery attempt failed because the asker had no live transport. The
+    ACP-routed `/ask` path uses this to retain a successful ACP answer across
+    asker reconnects — the WS path doesn't need it because /ack's MCP caller
+    handles retry on 503. Cleared on successful redelivery (which also closes
+    the ask).
     """
 
     correlation_id: str
@@ -66,6 +73,7 @@ class Ask:
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     closed: bool = False
     close_reason: str | None = None
+    pending_reply: str | None = None
 
 
 class AskTracker:
@@ -172,6 +180,38 @@ class AskTracker:
     async def get(self, correlation_id: str) -> Ask | None:
         """Look up an ask by corr_id."""
         return self._asks.get(correlation_id)
+
+    async def set_pending_reply(self, correlation_id: str, framed_reply: str) -> bool:
+        """Stash a completed reply on an open ask for later redelivery.
+
+        Used by the ACP-routed `/ask` path when notify fails with
+        TransportError: the assembled ACP answer is real and must not be
+        dropped just because the asker is currently offline. Returns True
+        if the ask exists and was still open, False otherwise.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if not ask or ask.closed:
+                return False
+            ask.pending_reply = framed_reply
+            logger.debug("Stashed pending reply on ask %s", correlation_id)
+            return True
+
+    async def take_pending_replies_for_asker(self, peer_id: str) -> list[Ask]:
+        """Snapshot open asks targeting this asker that have a stashed reply.
+
+        Caller (peer_registry reconnect path) attempts redelivery for each;
+        on success it closes the ask via ``close`` and the reply will not
+        be re-driven. We snapshot rather than drain so a failed redelivery
+        leaves the reply in place for the next reconnect.
+        """
+        async with self._lock:
+            return [
+                ask for ask in self._asks.values()
+                if ask.from_peer_id == peer_id
+                and not ask.closed
+                and ask.pending_reply is not None
+            ]
 
     async def pending_for_peer(
         self,

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -197,6 +197,17 @@ class AskTracker:
             logger.debug("Stashed pending reply on ask %s", correlation_id)
             return True
 
+    async def clear_pending_reply(self, correlation_id: str) -> None:
+        """Drop the stashed reply from an ask (idempotent).
+
+        Used after successful redelivery so the closed Ask object doesn't
+        retain reply text it can never use again.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is not None:
+                ask.pending_reply = None
+
     async def take_pending_replies_for_asker(self, peer_id: str) -> list[Ask]:
         """Snapshot open asks targeting this asker that have a stashed reply.
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -1098,10 +1098,12 @@ class PeerRegistry:
     async def update_peer_status(self, identifier: str, status: PeerStatus) -> None:
         """Update peer status + last_seen.
 
-        On an OFFLINE→ONLINE/BUSY transition, opportunistically redeliver any
-        ACP-stashed pending replies that targeted this peer as the asker.
-        Runs in a background task so the status update itself stays
-        side-effect-free for callers that don't care.
+        When ``experiments.acp_broker_client`` is on, OFFLINE→ONLINE/BUSY
+        transitions also schedule a background task that redelivers any
+        ACP-stashed pending replies targeting this peer as the asker. The
+        scheduling is gated on the flag so the default flag-off path has
+        zero new behaviour or perf overhead vs. pre-phase-3: no extra task,
+        no extra ask-tracker scan, no extra notify.
         """
         async with self._lock:
             peer = self._lookup_peer_unlocked(identifier)
@@ -1122,18 +1124,33 @@ class PeerRegistry:
             )
             asker_peer_id = peer.peer_id if became_live else None
 
-        if asker_peer_id is not None and self._ask_tracker is not None:
+        if (
+            asker_peer_id is not None
+            and self._ask_tracker is not None
+            and self._acp_redelivery_enabled()
+        ):
             asyncio.create_task(
                 self._redeliver_pending_replies(asker_peer_id),
                 name=f"redeliver-{asker_peer_id[:12]}",
             )
 
+    def _acp_redelivery_enabled(self) -> bool:
+        """Whether the ACP-routed stash/redeliver path is opted in.
+
+        Defensive against future Config refactors: a missing
+        ``experiments`` block or attribute is treated as flag-off, never
+        a crash.
+        """
+        experiments = getattr(self._config, "experiments", None)
+        return bool(getattr(experiments, "acp_broker_client", False))
+
     async def _redeliver_pending_replies(self, asker_peer_id: str) -> None:
         """Drain ACP-stashed replies for an asker that just came back online.
 
         Best-effort: a failure here just leaves the reply stashed for the next
-        reconnect. Successful redelivery closes the ask (ack_with_msg) so the
-        same reply can't be delivered twice.
+        reconnect. Successful redelivery closes the ask (ack_with_msg) and
+        clears the stash so the Ask object isn't holding reply text it can
+        never use again.
         """
         if self._ask_tracker is None:
             return
@@ -1160,6 +1177,9 @@ class PeerRegistry:
                 )
                 continue
             await self._ask_tracker.close(ask.correlation_id, reason="ack_with_msg")
+            # Drop the stash from the closed Ask object so we're not
+            # retaining reply text past its useful life.
+            await self._ask_tracker.clear_pending_reply(ask.correlation_id)
             logger.info(
                 "redeliver: delivered stashed reply for %s to %s",
                 ask.correlation_id, asker_peer_id,

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT, AgentType, Config
+from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 
 if TYPE_CHECKING:
@@ -1095,7 +1096,13 @@ class PeerRegistry:
     # ------------------------------------------------------------------
 
     async def update_peer_status(self, identifier: str, status: PeerStatus) -> None:
-        """Update peer status + last_seen. No side effects beyond that."""
+        """Update peer status + last_seen.
+
+        On an OFFLINE→ONLINE/BUSY transition, opportunistically redeliver any
+        ACP-stashed pending replies that targeted this peer as the asker.
+        Runs in a background task so the status update itself stays
+        side-effect-free for callers that don't care.
+        """
         async with self._lock:
             peer = self._lookup_peer_unlocked(identifier)
             if not peer:
@@ -1109,6 +1116,54 @@ class PeerRegistry:
             peer.status = status
             peer.last_seen = datetime.now(timezone.utc)
             self._emit_status_change(peer, old_status, status)
+            became_live = (
+                old_status == PeerStatus.OFFLINE
+                and status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+            )
+            asker_peer_id = peer.peer_id if became_live else None
+
+        if asker_peer_id is not None and self._ask_tracker is not None:
+            asyncio.create_task(
+                self._redeliver_pending_replies(asker_peer_id),
+                name=f"redeliver-{asker_peer_id[:12]}",
+            )
+
+    async def _redeliver_pending_replies(self, asker_peer_id: str) -> None:
+        """Drain ACP-stashed replies for an asker that just came back online.
+
+        Best-effort: a failure here just leaves the reply stashed for the next
+        reconnect. Successful redelivery closes the ask (ack_with_msg) so the
+        same reply can't be delivered twice.
+        """
+        if self._ask_tracker is None:
+            return
+        try:
+            pending = await self._ask_tracker.take_pending_replies_for_asker(asker_peer_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("redeliver: snapshot failed for %s: %s", asker_peer_id, e)
+            return
+        for ask in pending:
+            reply = ask.pending_reply
+            if reply is None:
+                continue
+            try:
+                await self.notify(
+                    from_peer=ask.to_peer_id,
+                    to_peer=ask.from_peer_id,
+                    text=reply,
+                    bypass_circle=True,
+                )
+            except (ValueError, TransportError) as e:
+                logger.info(
+                    "redeliver: %s still undeliverable to %s: %s",
+                    ask.correlation_id, asker_peer_id, e,
+                )
+                continue
+            await self._ask_tracker.close(ask.correlation_id, reason="ack_with_msg")
+            logger.info(
+                "redeliver: delivered stashed reply for %s to %s",
+                ask.correlation_id, asker_peer_id,
+            )
 
     async def update_peer_turn_state(
         self, identifier: str, turn_state: TurnState | None,

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -28,9 +28,16 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from repowire.daemon.ask_tracker import QuiescedError
+from repowire.acp import (
+    AcpClientManager,
+    AcpRouteDecision,
+    decide_acp_route,
+)
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
+from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.routes._shared import OkResponse
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer
@@ -117,6 +124,66 @@ async def _resolve_sender_for_target(from_peer: str, target: Peer) -> Peer | Non
         raise HTTPException(status_code=409, detail=str(e)) from e
 
 
+def _maybe_decide_acp_route(
+    peer: Peer,
+    config: Config,
+    manager: AcpClientManager | None,
+) -> AcpRouteDecision | None:
+    """Return a positive route decision iff ACP routing applies. Else ``None``.
+
+    Keeps the route handler readable: the only fact the caller needs is "use
+    ACP for this ask, yes/no". Reasons / diagnostics are logged inside.
+    """
+    if manager is None:
+        return None
+    flag = bool(config.experiments.acp_broker_client) if config.experiments else False
+    decision = decide_acp_route(peer, flag_enabled=flag)
+    if decision.route and decision.spec is not None:
+        return decision
+    return None
+
+
+async def _acp_complete(
+    *,
+    correlation_id: str,
+    reply: str | None,
+    error: str | None,
+    ask_tracker: AskTracker,
+    peer_registry: PeerRegistry,
+) -> None:
+    """Deliver an ACP-routed ask result back to the asker and close the thread.
+
+    Mirrors the success path of the synchronous ``/ack`` handler: build a framed
+    `[ack #cid from @recipient] reply` notification, route via the asker's
+    existing transport, then close the ask. On error, surface a framed error
+    line instead so the asker is never silently dropped.
+    """
+    ask = await ask_tracker.get(correlation_id)
+    if ask is None or ask.closed:
+        return
+    if error is not None:
+        framed = f"[ack #{correlation_id} from @{ask.to_peer_name}] ACP error: {error}"
+    else:
+        body = reply or ""
+        framed = f"[ack #{correlation_id} from @{ask.to_peer_name}] {body}"
+    try:
+        await peer_registry.notify(
+            from_peer=ask.to_peer_id,
+            to_peer=ask.from_peer_id,
+            text=framed,
+            bypass_circle=True,
+        )
+    except (ValueError, TransportError) as e:
+        logger.warning(
+            "ACP ack reply delivery failed for cid=%s: %s. Closing ask anyway.",
+            correlation_id, e,
+        )
+    finally:
+        await ask_tracker.close(
+            correlation_id, reason="ack_with_msg" if error is None else "send_failed",
+        )
+
+
 @router.post("/ask", response_model=AskResponse)
 async def open_ask(
     request: AskRequest,
@@ -165,6 +232,49 @@ async def open_ask(
                 "peer_id": e.peer_id,
             },
         ) from e
+
+    # ACP routing (experiments.acp_broker_client). When the flag is on and the
+    # target peer carries an `acp` metadata block, bypass the WS transport and
+    # drive a session/prompt against the peer's ACP subprocess. The reply is
+    # delivered back to the asker via the normal ack pipeline once the prompt
+    # turn settles.
+    cfg = state.config
+    acp_manager = getattr(state, "acp_manager", None)
+    decision = _maybe_decide_acp_route(peer, cfg, acp_manager)
+    if decision is not None:
+        from repowire.acp import deliver_ask_via_acp
+
+        assert acp_manager is not None  # narrowed by _maybe_decide_acp_route
+        assert decision.spec is not None
+        spec = decision.spec
+        manager: AcpClientManager = acp_manager
+
+        async def _on_complete(
+            correlation_id: str, reply: str | None, error: str | None,
+        ) -> None:
+            await _acp_complete(
+                correlation_id=correlation_id,
+                reply=reply,
+                error=error,
+                ask_tracker=ask_tracker,
+                peer_registry=peer_registry,
+            )
+
+        await deliver_ask_via_acp(
+            manager=manager,
+            spec=spec,
+            correlation_id=cid,
+            text=request.text,
+            on_complete=_on_complete,
+        )
+        if request.reply_to:
+            prior = await ask_tracker.close(request.reply_to, reason="reply_to")
+            if prior is None:
+                logger.debug(
+                    "ask reply_to=%s: prior ask not found or already closed",
+                    request.reply_to,
+                )
+        return AskResponse(correlation_id=cid)
 
     try:
         await peer_registry.deliver_ask(

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -151,12 +151,29 @@ async def _acp_complete(
     ask_tracker: AskTracker,
     peer_registry: PeerRegistry,
 ) -> None:
-    """Deliver an ACP-routed ask result back to the asker and close the thread.
+    """Deliver an ACP-routed ask result back to the asker.
 
-    Mirrors the success path of the synchronous ``/ack`` handler: build a framed
-    `[ack #cid from @recipient] reply` notification, route via the asker's
-    existing transport, then close the ask. On error, surface a framed error
-    line instead so the asker is never silently dropped.
+    Mirrors the delivery semantics of the synchronous ``/ack`` handler exactly:
+
+      * Successful ACP turn + successful notify        → close (ack_with_msg)
+      * ACP error (subprocess crash, timeout, …)       → close (send_failed)
+                                                          with an error frame so
+                                                          the asker is not
+                                                          silently dropped
+      * ValueError on notify (asker evicted from
+        registry)                                       → close; nothing to retry
+                                                          against
+      * TransportError on notify (asker has no live
+        WS)                                             → LEAVE ASK OPEN. The
+                                                          asker will see the
+                                                          ack via the Stop-hook
+                                                          reminder loop once it
+                                                          reconnects, exactly
+                                                          like /ack does today.
+
+    The asymmetry between TransportError (retain) and the other failure modes
+    matches the existing fail-loud / no-queue contract: don't silently drop a
+    successful reply just because the asker is currently offline.
     """
     ask = await ask_tracker.get(correlation_id)
     if ask is None or ask.closed:
@@ -173,15 +190,25 @@ async def _acp_complete(
             text=framed,
             bypass_circle=True,
         )
-    except (ValueError, TransportError) as e:
+    except TransportError as e:
+        # Asker has no live WS. Leave the ask open so the reply can be
+        # redelivered on reconnect — matches /ack's fail-loud contract.
         logger.warning(
-            "ACP ack reply delivery failed for cid=%s: %s. Closing ask anyway.",
+            "ACP ack reply for cid=%s: asker offline (%s). Ask kept open.",
             correlation_id, e,
         )
-    finally:
-        await ask_tracker.close(
-            correlation_id, reason="ack_with_msg" if error is None else "send_failed",
+        return
+    except ValueError as e:
+        # Asker is gone from the registry; nothing to retry against.
+        logger.warning(
+            "ACP ack reply for cid=%s: asker missing (%s). Closing.",
+            correlation_id, e,
         )
+        await ask_tracker.close(correlation_id, reason="ack_with_msg")
+        return
+    await ask_tracker.close(
+        correlation_id, reason="ack_with_msg" if error is None else "send_failed",
+    )
 
 
 @router.post("/ask", response_model=AskResponse)

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -153,32 +153,40 @@ async def _acp_complete(
 ) -> None:
     """Deliver an ACP-routed ask result back to the asker.
 
-    Mirrors the delivery semantics of the synchronous ``/ack`` handler exactly:
+    Delivery semantics:
 
-      * Successful ACP turn + successful notify        → close (ack_with_msg)
-      * ACP error (subprocess crash, timeout, …)       → close (send_failed)
-                                                          with an error frame so
-                                                          the asker is not
-                                                          silently dropped
-      * ValueError on notify (asker evicted from
-        registry)                                       → close; nothing to retry
-                                                          against
-      * TransportError on notify (asker has no live
-        WS)                                             → LEAVE ASK OPEN. The
-                                                          asker will see the
-                                                          ack via the Stop-hook
-                                                          reminder loop once it
-                                                          reconnects, exactly
-                                                          like /ack does today.
+      * Successful ACP turn + successful notify   → close (ack_with_msg)
+      * ACP error (crash/timeout/…)               → close (send_failed) with
+                                                     an error frame so the
+                                                     asker is not silently
+                                                     dropped
+      * ValueError on notify (asker evicted)      → close; nothing to retry
+      * TransportError on notify, **success path**→ stash the assembled reply
+                                                     on the ask + leave it
+                                                     open. ``PeerRegistry``
+                                                     drains stashed replies
+                                                     when the asker comes back
+                                                     online (see
+                                                     ``_redeliver_pending_replies``).
+      * TransportError on notify, **error path**  → close (send_failed). The
+                                                     ACP error frame is
+                                                     ephemeral diagnostic
+                                                     text, not a real reply;
+                                                     redelivery would just
+                                                     spam the asker with a
+                                                     stale failure they can't
+                                                     act on.
 
-    The asymmetry between TransportError (retain) and the other failure modes
-    matches the existing fail-loud / no-queue contract: don't silently drop a
-    successful reply just because the asker is currently offline.
+    The stash-and-redeliver path is the ACP analogue of /ack's 503 retry
+    contract: /ack returns 503 so the MCP caller retries; ACP has no caller
+    to bounce the error to (the originating turn is gone), so the broker
+    holds the reply until the asker is reachable.
     """
     ask = await ask_tracker.get(correlation_id)
     if ask is None or ask.closed:
         return
-    if error is not None:
+    is_error = error is not None
+    if is_error:
         framed = f"[ack #{correlation_id} from @{ask.to_peer_name}] ACP error: {error}"
     else:
         body = reply or ""
@@ -191,15 +199,21 @@ async def _acp_complete(
             bypass_circle=True,
         )
     except TransportError as e:
-        # Asker has no live WS. Leave the ask open so the reply can be
-        # redelivered on reconnect — matches /ack's fail-loud contract.
+        if is_error:
+            logger.warning(
+                "ACP ack error-frame for cid=%s undeliverable (%s); closing.",
+                correlation_id, e,
+            )
+            await ask_tracker.close(correlation_id, reason="send_failed")
+            return
+        stashed = await ask_tracker.set_pending_reply(correlation_id, framed)
         logger.warning(
-            "ACP ack reply for cid=%s: asker offline (%s). Ask kept open.",
+            "ACP ack reply for cid=%s: asker offline (%s). %s; will redeliver on reconnect.",
             correlation_id, e,
+            "Reply stashed" if stashed else "Stash failed (ask closed)",
         )
         return
     except ValueError as e:
-        # Asker is gone from the registry; nothing to retry against.
         logger.warning(
             "ACP ack reply for cid=%s: asker missing (%s). Closing.",
             correlation_id, e,
@@ -207,7 +221,7 @@ async def _acp_complete(
         await ask_tracker.close(correlation_id, reason="ack_with_msg")
         return
     await ask_tracker.close(
-        correlation_id, reason="ack_with_msg" if error is None else "send_failed",
+        correlation_id, reason="ack_with_msg" if not is_error else "send_failed",
     )
 
 

--- a/tests/fixtures/acp_crash_agent.py
+++ b/tests/fixtures/acp_crash_agent.py
@@ -1,0 +1,78 @@
+"""ACP agent stub that exits hard on the second prompt.
+
+Used to exercise the "subprocess died mid-prompt" branch of the broker: the
+manager should drop the cached client so the next ask respawns a fresh one.
+
+First prompt: returns a normal echo response.
+Second prompt: ``sys.exit(1)`` before responding — the client side sees the
+stdio close mid-request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from typing import Any
+
+import acp
+from acp.schema import (
+    AgentCapabilities,
+    AgentMessageChunk,
+    TextContentBlock,
+)
+
+
+class CrashOnSecondPromptAgent:
+    def __init__(self) -> None:
+        self._conn: Any = None
+        self._prompt_count = 0
+
+    def on_connect(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def initialize(self, protocol_version: int, **_: Any) -> acp.InitializeResponse:
+        return acp.InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(),
+        )
+
+    async def new_session(self, cwd: str, **_: Any) -> acp.NewSessionResponse:
+        del cwd
+        return acp.NewSessionResponse(session_id=f"crash-{uuid.uuid4().hex[:8]}")
+
+    async def prompt(
+        self,
+        prompt: list[Any],
+        session_id: str,
+        **_: Any,
+    ) -> acp.PromptResponse:
+        self._prompt_count += 1
+        if self._prompt_count >= 2:
+            sys.stderr.write("crash agent: exiting on second prompt\n")
+            sys.stderr.flush()
+            sys.exit(1)
+        body = " ".join(getattr(b, "text", "") for b in prompt)
+        if self._conn is not None:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=TextContentBlock(type="text", text=f"[ok] {body}"),
+                ),
+            )
+        return acp.PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id: str, **_: Any) -> None:
+        del session_id
+
+
+async def main() -> None:
+    await acp.run_agent(CrashOnSecondPromptAgent())  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, BrokenPipeError):
+        sys.exit(0)

--- a/tests/fixtures/acp_echo_agent.py
+++ b/tests/fixtures/acp_echo_agent.py
@@ -1,0 +1,93 @@
+"""Minimal ACP-speaking agent used as a subprocess in integration tests.
+
+Implements just enough of the ACP ``Agent`` interface to:
+  * complete ``initialize``,
+  * accept ``session/new``,
+  * answer ``session/prompt`` with one streamed ``agent_message_chunk`` whose
+    body echoes the original prompt text framed as ``[echo] <text>``,
+  * report ``stop_reason=end_turn``.
+
+That's enough to exercise the broker-side ACP client end-to-end without
+shelling out to a real ``codex-acp`` (or any other adapter) — which is the
+phase-3 integration test we want.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from typing import Any
+
+import acp
+from acp.schema import (
+    AgentCapabilities,
+    AgentMessageChunk,
+    TextContentBlock,
+)
+
+
+class EchoAgent:
+    """ACP agent that echoes prompt text as one streamed agent_message_chunk.
+
+    Implements the structural ``Agent`` protocol — duck-typed by the SDK's
+    JSON-RPC router. Inheriting from ``acp.Agent`` is unnecessary and trips
+    type-checker LSP rules because of the SDK's protocol-decorator dance.
+    """
+
+    def __init__(self) -> None:
+        self._conn: Any = None
+
+    def on_connect(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def initialize(self, protocol_version: int, **_: Any) -> acp.InitializeResponse:
+        return acp.InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(),
+        )
+
+    async def new_session(self, cwd: str, **_: Any) -> acp.NewSessionResponse:
+        del cwd
+        return acp.NewSessionResponse(session_id=f"echo-{uuid.uuid4().hex[:8]}")
+
+    async def prompt(
+        self,
+        prompt: list[Any],
+        session_id: str,
+        **_: Any,
+    ) -> acp.PromptResponse:
+        body = _extract_text(prompt)
+        reply = f"[echo] {body}"
+        if self._conn is not None:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=TextContentBlock(type="text", text=reply),
+                ),
+            )
+        return acp.PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id: str, **_: Any) -> None:
+        del session_id
+
+
+def _extract_text(prompt: list[Any]) -> str:
+    parts: list[str] = []
+    for block in prompt:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return " ".join(parts)
+
+
+async def main() -> None:
+    await acp.run_agent(EchoAgent())  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, BrokenPipeError):
+        sys.exit(0)

--- a/tests/fixtures/acp_slow_agent.py
+++ b/tests/fixtures/acp_slow_agent.py
@@ -1,0 +1,62 @@
+"""ACP agent stub that sleeps forever on prompt.
+
+Used to exercise the prompt-timeout branch: the client should call
+``session/cancel``, close the subprocess, and mark itself crashed so the
+manager evicts it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from typing import Any
+
+import acp
+from acp.schema import AgentCapabilities
+
+
+class SlowAgent:
+    def __init__(self) -> None:
+        self._cancelled: dict[str, asyncio.Event] = {}
+
+    async def initialize(self, protocol_version: int, **_: Any) -> acp.InitializeResponse:
+        return acp.InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(),
+        )
+
+    async def new_session(self, cwd: str, **_: Any) -> acp.NewSessionResponse:
+        del cwd
+        sid = f"slow-{uuid.uuid4().hex[:8]}"
+        self._cancelled[sid] = asyncio.Event()
+        return acp.NewSessionResponse(session_id=sid)
+
+    async def prompt(
+        self,
+        prompt: list[Any],
+        session_id: str,
+        **_: Any,
+    ) -> acp.PromptResponse:
+        del prompt
+        event = self._cancelled.setdefault(session_id, asyncio.Event())
+        try:
+            await asyncio.wait_for(event.wait(), timeout=30.0)
+            return acp.PromptResponse(stop_reason="cancelled")
+        except asyncio.TimeoutError:
+            return acp.PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id: str, **_: Any) -> None:
+        event = self._cancelled.setdefault(session_id, asyncio.Event())
+        event.set()
+
+
+async def main() -> None:
+    await acp.run_agent(SlowAgent())  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, BrokenPipeError):
+        sys.exit(0)

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -672,6 +672,128 @@ async def test_pending_reply_redelivered_on_asker_reconnect(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_reconnect_redelivery_is_skipped_when_flag_off(tmp_path: Path) -> None:
+    """Codex re-review BLOCKER: flag-off ⇒ zero new behaviour on reconnect.
+
+    With ``experiments.acp_broker_client`` off, an OFFLINE→ONLINE transition
+    must NOT scan the ask tracker and must NOT call notify on the asker's
+    behalf — even if a pending_reply somehow ended up stashed. The phase-3
+    contract is strict: flag off means the WS/MCP path runs unchanged.
+
+    We seed a stashed reply directly into the tracker (bypassing the
+    flag-gated _acp_complete write path) and assert that the reconnect
+    hook leaves it untouched. With the flag on, the same scenario would
+    drain and deliver — proven by the redelivery test above.
+    """
+    cfg = Config()
+    cfg.experiments.acp_broker_client = False  # explicitly off
+
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+    await registry.update_peer_status(asker.peer_id, PeerStatus.OFFLINE)
+
+    notify_calls: list[dict] = []
+
+    async def _record(**kwargs):
+        notify_calls.append(kwargs)
+
+    router.send_notification = AsyncMock(side_effect=_record)
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="hi",
+    )
+    # Seed the stash directly (the flag-gated _acp_complete is the only normal
+    # source, but the assertion is "if a stash exists, flag-off must ignore it")
+    stashed = await at.set_pending_reply(cid, f"[ack #{cid} from @answerer] stale")
+    assert stashed is True
+
+    await registry.update_peer_status(asker.peer_id, PeerStatus.ONLINE)
+    await asyncio.sleep(0.05)
+
+    # With flag off: no redeliver task scheduled → no notify call,
+    # ask still open, pending_reply still on the ask.
+    assert notify_calls == [], "flag-off path called notify on reconnect"
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is False
+    assert ask.pending_reply is not None
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_cleared_after_successful_redelivery(tmp_path: Path) -> None:
+    """NIT from codex: don't retain reply text past its useful life.
+
+    After a redelivery succeeds the ask is closed, but the Ask object would
+    still carry the stashed text without an explicit clear. Verify the
+    redelivery path nulls pending_reply.
+    """
+    cfg = Config()
+    cfg.experiments.acp_broker_client = True
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+    await registry.update_peer_status(asker.peer_id, PeerStatus.OFFLINE)
+
+    router.send_notification = AsyncMock()  # succeeds
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="hi",
+    )
+    await at.set_pending_reply(cid, f"[ack #{cid} from @answerer] body")
+
+    await registry.update_peer_status(asker.peer_id, PeerStatus.ONLINE)
+    await asyncio.sleep(0.05)
+
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is True
+    assert ask.pending_reply is None
+
+
+@pytest.mark.asyncio
 async def test_pending_reply_kept_when_redelivery_still_fails(tmp_path: Path) -> None:
     """Redelivery is best-effort: if it still fails, the stash stays put.
 

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -1,0 +1,320 @@
+"""Integration tests for the broker-side ACP client (phase-3).
+
+End-to-end: register an ACP-routed peer in the daemon, post `/ask` with the
+experiments flag on, and assert the prompt reaches an ACP subprocess and the
+reply flows back through the existing ack pipeline.
+
+The subprocess is a minimal echo agent at `tests/fixtures/acp_echo_agent.py`
+that uses the official `acp` python SDK — same wire protocol codex-acp speaks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.acp import AcpClientManager, decide_acp_route
+from repowire.acp.broker import AcpRouteDecision
+from repowire.acp.client import _assemble_agent_text
+from repowire.acp.models import AcpPeerConfig
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import asks, peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import AgentType, Peer, PeerStatus
+
+STUB_PATH = Path(__file__).parent / "fixtures" / "acp_echo_agent.py"
+PYTHON = sys.executable
+
+
+@pytest.fixture
+def acp_peer_config(tmp_path: Path) -> AcpPeerConfig:
+    """Spawn config for the echo stub. Real codex-acp would slot in here."""
+    return AcpPeerConfig(
+        command=PYTHON,
+        args=[str(STUB_PATH)],
+        cwd=str(tmp_path),
+    )
+
+
+# ----- unit-level: route decision and text assembly -----
+
+
+class TestRouteDecision:
+    def test_flag_off_never_routes(self, acp_peer_config: AcpPeerConfig) -> None:
+        peer = _peer_with_acp("p1", acp_peer_config)
+        d = decide_acp_route(peer, flag_enabled=False)
+        assert isinstance(d, AcpRouteDecision)
+        assert d.route is False
+        assert "off" in d.reason
+
+    def test_flag_on_no_metadata_does_not_route(self) -> None:
+        peer = _bare_peer("p2")
+        d = decide_acp_route(peer, flag_enabled=True)
+        assert d.route is False
+        assert "no acp metadata" in d.reason
+
+    def test_flag_on_with_metadata_routes(self, acp_peer_config: AcpPeerConfig) -> None:
+        peer = _peer_with_acp("p3", acp_peer_config)
+        d = decide_acp_route(peer, flag_enabled=True)
+        assert d.route is True
+        assert d.spec is not None
+        assert d.spec.peer_id == "p3"
+        assert d.spec.config.command == PYTHON
+
+    def test_malformed_metadata_is_logged_and_skipped(self) -> None:
+        peer = _bare_peer("p4")
+        peer.metadata["acp"] = {"args": ["only-args-no-command"]}
+        d = decide_acp_route(peer, flag_enabled=True)
+        assert d.route is False
+        assert "invalid acp metadata" in d.reason
+
+
+def test_assemble_agent_text_concatenates_chunks() -> None:
+    from acp.schema import AgentMessageChunk, TextContentBlock
+
+    updates = [
+        AgentMessageChunk(
+            session_update="agent_message_chunk",
+            content=TextContentBlock(type="text", text="hello "),
+        ),
+        AgentMessageChunk(
+            session_update="agent_message_chunk",
+            content=TextContentBlock(type="text", text="world"),
+        ),
+    ]
+    assert _assemble_agent_text(updates) == "hello world"
+
+
+# ----- integration: client + stub subprocess -----
+
+
+@pytest.mark.asyncio
+async def test_acp_client_prompt_roundtrip(acp_peer_config: AcpPeerConfig) -> None:
+    """Direct ``AcpClient`` against the echo stub: prompt → end_turn + echoed text."""
+    from repowire.acp import AcpClient
+
+    async with AcpClient(acp_peer_config) as client:
+        result = await client.prompt("hello world", timeout=15.0)
+        assert result.stop_reason == "end_turn"
+        assert result.text == "[echo] hello world"
+        # session persists across asks
+        result2 = await client.prompt("second turn", timeout=15.0)
+        assert result2.text == "[echo] second turn"
+        assert client.session_id is not None
+
+
+@pytest.mark.asyncio
+async def test_acp_manager_reuses_session_for_peer(acp_peer_config: AcpPeerConfig) -> None:
+    """``AcpClientManager`` caches one client per peer_id; close tears it down."""
+    from repowire.acp import AcpPeerSpec
+
+    mgr = AcpClientManager()
+    spec = AcpPeerSpec(peer_id="peer-xyz", config=acp_peer_config)
+    try:
+        r1 = await mgr.prompt(spec, "ping")
+        r2 = await mgr.prompt(spec, "pong")
+        assert r1.text == "[echo] ping"
+        assert r2.text == "[echo] pong"
+        c1 = await mgr.get_or_create(spec)
+        c2 = await mgr.get_or_create(spec)
+        assert c1 is c2  # same instance
+    finally:
+        await mgr.close()
+
+
+# ----- end-to-end: /ask via ACP delivers reply via notify -----
+
+
+def _make_app(tmp_path: Path, *, flag: bool):
+    cfg = Config()
+    cfg.experiments.acp_broker_client = flag
+
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    acp_manager = AcpClientManager()
+
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+        acp_manager=acp_manager,
+    )
+    init_deps(cfg, registry, state)
+
+    # The asker peer is a plain WS-routed peer; we intercept its notify path
+    # because we don't run a real WS in the unit test. The captured payload IS
+    # the assertion target for this test (does the ack reply round-trip?).
+    sent_notifications: list[dict] = []
+
+    async def _capture_notify(**kwargs):
+        sent_notifications.append(kwargs)
+
+    router.send_notification = AsyncMock(side_effect=_capture_notify)
+    router.send_ask = AsyncMock()  # not used on the ACP path, but registered peers may use it
+
+    app = FastAPI()
+    app.include_router(peers.router)
+    app.include_router(asks.router)
+    return app, registry, at, acp_manager, sent_notifications
+
+
+async def _register_acp_peer(
+    client: AsyncClient, *, name: str, acp_config: AcpPeerConfig,
+) -> str:
+    """Register a peer in the daemon with `metadata.acp` set + a fake pane_id."""
+    body = {
+        "name": name,
+        "path": acp_config.cwd or "/tmp",
+        "circle": "default",
+        "backend": AgentType.CODEX.value,
+        "pane_id": f"%fake-{name}",
+        "metadata": {"acp": acp_config.model_dump()},
+    }
+    r = await client.post("/peers", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()["display_name"]
+
+
+async def _register_plain_peer(client: AsyncClient, *, name: str) -> str:
+    r = await client.post("/peers", json={
+        "name": name,
+        "path": f"/tmp/{name}",
+        "circle": "default",
+        "backend": AgentType.CLAUDE_CODE.value,
+        "pane_id": f"%fake-{name}",
+    })
+    assert r.status_code == 200, r.text
+    return r.json()["display_name"]
+
+
+@pytest.mark.asyncio
+async def test_ask_routes_through_acp_when_flag_on(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """Phase-3 happy path: flag on + ACP-marked peer ⇒ prompt routed to subprocess,
+    reply delivered to asker via the same notify pipeline ack uses today."""
+    app, registry, at, manager, sent = _make_app(tmp_path, flag=True)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            asker = await _register_plain_peer(http, name="asker")
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            # Force both peers to ONLINE so notify doesn't trip the offline guard
+            for p in await registry.get_all_peers():
+                await registry.update_peer_status(p.peer_id, PeerStatus.ONLINE)
+
+            r = await http.post("/ask", json={
+                "from_peer": asker,
+                "to_peer": answerer,
+                "text": "what is the answer",
+            })
+            assert r.status_code == 200, r.text
+            cid = r.json()["correlation_id"]
+
+            # The /ask returns immediately; the ACP turn runs in a background task.
+            # Wait for the ack notification to land.
+            reply = await _wait_for_notification(sent, timeout=15.0)
+            assert reply["text"].startswith(f"[ack #{cid} from @{answerer}]")
+            assert "[echo] what is the answer" in reply["text"]
+
+            # Ask thread is closed on success
+            ask = await at.get(cid)
+            assert ask is not None and ask.closed
+    finally:
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_ask_falls_back_to_ws_when_flag_off(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """Flag off ⇒ ACP path is never taken, even if peer has acp metadata.
+
+    The existing WS path is exercised; we just check that send_ask was called
+    (i.e. the legacy delivery was attempted), and no ACP child was spawned.
+    """
+    app, registry, _at, manager, _sent = _make_app(tmp_path, flag=False)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            asker = await _register_plain_peer(http, name="asker")
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+            for p in await registry.get_all_peers():
+                await registry.update_peer_status(p.peer_id, PeerStatus.ONLINE)
+
+            r = await http.post("/ask", json={
+                "from_peer": asker,
+                "to_peer": answerer,
+                "text": "x",
+            })
+            assert r.status_code == 200, r.text
+
+            # No ACP client should have been started
+            assert manager._clients == {}  # type: ignore[attr-defined]
+    finally:
+        await manager.close()
+        cleanup_deps()
+
+
+# ----- helpers -----
+
+
+async def _wait_for_notification(sink: list[dict], timeout: float) -> dict:
+    deadline = time.monotonic() + timeout
+    while not sink and time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+    assert sink, f"no notification received within {timeout}s"
+    return sink[0]
+
+
+def _bare_peer(peer_id: str) -> Peer:
+    return Peer(
+        peer_id=peer_id,
+        display_name=peer_id,
+        path="/tmp",
+        machine="localhost",
+    )
+
+
+def _peer_with_acp(peer_id: str, cfg: AcpPeerConfig) -> Peer:
+    p = _bare_peer(peer_id)
+    p.metadata["acp"] = cfg.model_dump()
+    return p

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -36,6 +36,8 @@ from repowire.daemon.websocket_transport import WebSocketTransport
 from repowire.protocol.peers import AgentType, Peer, PeerStatus
 
 STUB_PATH = Path(__file__).parent / "fixtures" / "acp_echo_agent.py"
+CRASH_STUB_PATH = Path(__file__).parent / "fixtures" / "acp_crash_agent.py"
+SLOW_STUB_PATH = Path(__file__).parent / "fixtures" / "acp_slow_agent.py"
 PYTHON = sys.executable
 
 
@@ -318,3 +320,181 @@ def _peer_with_acp(peer_id: str, cfg: AcpPeerConfig) -> Peer:
     p = _bare_peer(peer_id)
     p.metadata["acp"] = cfg.model_dump()
     return p
+
+
+# ----- lifecycle regression tests (codex BLOCKING #1, #2, #3) -----
+
+
+@pytest.mark.asyncio
+async def test_manager_drops_client_when_subprocess_crashes(tmp_path: Path) -> None:
+    """Codex BLOCKING #2: a crashed subprocess must not poison the manager cache.
+
+    The crash-stub returns one normal response, then ``sys.exit(1)`` on the
+    second prompt. Without the fix the manager would keep handing out the dead
+    client forever; with the fix the second prompt raises ``AcpClientError``
+    and the manager drops the cached entry so the third prompt respawns.
+    """
+    from repowire.acp import AcpClient, AcpClientError, AcpPeerSpec
+
+    cfg = AcpPeerConfig(command=PYTHON, args=[str(CRASH_STUB_PATH)], cwd=str(tmp_path))
+    mgr = AcpClientManager()
+    spec = AcpPeerSpec(peer_id="crash-peer", config=cfg)
+    try:
+        # 1: ok
+        r1 = await mgr.prompt(spec, "first")
+        assert r1.text == "[ok] first"
+        first_client = await mgr.get_or_create(spec)
+
+        # 2: subprocess exits → AcpClientError, cached client evicted
+        with pytest.raises(AcpClientError):
+            await mgr.prompt(spec, "second")
+        assert "crash-peer" not in mgr._clients  # type: ignore[attr-defined]
+        assert first_client.crashed is True
+
+        # 3: a fresh client is spawned; we should get a normal echo again
+        r3 = await mgr.prompt(spec, "third")
+        assert r3.text == "[ok] third"
+        respawned = await mgr.get_or_create(spec)
+        assert respawned is not first_client
+        assert isinstance(respawned, AcpClient)
+    finally:
+        await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_prompt_timeout_closes_client_and_evicts_from_manager(tmp_path: Path) -> None:
+    """Codex BLOCKING #3: a timed-out prompt must cancel + close, not leak.
+
+    The slow-stub blocks forever in ``prompt``. With a short broker-side
+    timeout we expect:
+      * the prompt raises ``AcpClientError``
+      * the client is marked crashed and closed
+      * the manager has dropped the entry
+      * a follow-up prompt respawns a fresh subprocess
+    """
+    from repowire.acp import AcpClientError, AcpPeerSpec
+
+    cfg = AcpPeerConfig(command=PYTHON, args=[str(SLOW_STUB_PATH)], cwd=str(tmp_path))
+    mgr = AcpClientManager()
+    spec = AcpPeerSpec(peer_id="slow-peer", config=cfg)
+    try:
+        client = await mgr.get_or_create(spec)
+        with pytest.raises(AcpClientError) as exc_info:
+            await mgr.prompt(spec, "this will hang", timeout=1.0)
+        assert "timed out" in str(exc_info.value)
+        assert client.crashed is True
+        assert "slow-peer" not in mgr._clients  # type: ignore[attr-defined]
+
+        # A fresh prompt against a fresh stub (echo this time) should work,
+        # proving the manager evicted cleanly. Using the echo stub keeps the
+        # assertion strong without spending another full timeout.
+        echo_cfg = AcpPeerConfig(command=PYTHON, args=[str(STUB_PATH)], cwd=str(tmp_path))
+        r = await mgr.prompt(AcpPeerSpec(peer_id="slow-peer", config=echo_cfg), "alive")
+        assert r.text == "[echo] alive"
+    finally:
+        await mgr.close()
+
+
+@pytest.mark.asyncio
+async def test_acp_complete_keeps_ask_open_when_asker_offline(tmp_path: Path) -> None:
+    """Codex BLOCKING #1: TransportError from notify must leave ask open.
+
+    Mirrors /ack's fail-loud contract: a successful ACP turn whose ack
+    notification can't be delivered (asker has no live WS) is NOT silently
+    dropped. The ask stays open so the reply can be redelivered on reconnect.
+
+    To reach the TransportError branch the asker peer must be registered (so
+    registry lookup succeeds) but its underlying transport.send must raise.
+    """
+    from repowire.daemon.routes.asks import _acp_complete
+    from repowire.daemon.websocket_transport import TransportError
+
+    cfg = Config()
+    cfg.experiments.acp_broker_client = True
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    # Register both peers so registry lookups succeed; we want the TransportError
+    # to come from the wire layer, not from "unknown peer".
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
+    # Make the wire-level send raise TransportError (asker WS dead)
+    async def _boom(**_):
+        raise TransportError("no live ws")
+
+    router.send_notification = AsyncMock(side_effect=_boom)
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="hi",
+    )
+
+    await _acp_complete(
+        correlation_id=cid,
+        reply="here is your answer",
+        error=None,
+        ask_tracker=at,
+        peer_registry=registry,
+    )
+
+    # Ask MUST still be open after a TransportError so the reply can retry.
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is False, "ask was closed despite asker being offline"
+
+
+@pytest.mark.asyncio
+async def test_acp_complete_closes_ask_on_success(tmp_path: Path) -> None:
+    """Happy path: successful notify closes the ask exactly once."""
+    from repowire.daemon.routes.asks import _acp_complete
+
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+    router.send_notification = AsyncMock()
+
+    cid = await at.register(
+        from_peer_id="asker-id", from_peer_name="asker",
+        to_peer_id="answerer-id", to_peer_name="answerer",
+        text="hi",
+    )
+    await _acp_complete(
+        correlation_id=cid, reply="answer", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+    ask = await at.get(cid)
+    assert ask is not None and ask.closed is True

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -460,15 +460,84 @@ async def test_acp_complete_keeps_ask_open_when_asker_offline(tmp_path: Path) ->
         peer_registry=registry,
     )
 
-    # Ask MUST still be open after a TransportError so the reply can retry.
+    # Ask MUST still be open after a TransportError so the reply can retry,
+    # AND the assembled reply must be stashed on the ask for redelivery.
     ask = await at.get(cid)
     assert ask is not None
     assert ask.closed is False, "ask was closed despite asker being offline"
+    assert ask.pending_reply is not None
+    assert "here is your answer" in ask.pending_reply
+    assert ask.pending_reply.startswith(f"[ack #{cid} from @{answerer.display_name}]")
+
+
+@pytest.mark.asyncio
+async def test_acp_complete_drops_error_frame_when_asker_offline(tmp_path: Path) -> None:
+    """Error-frame replies are not worth redelivering — close on TransportError.
+
+    The framed ``ACP error: ...`` body is ephemeral diagnostic text; the asker
+    can't act on a stale failure they didn't observe in real time. Surfacing
+    it on reconnect would just confuse the agent's later context. Codex's
+    review correctly flagged the success-vs-error asymmetry as worth making
+    explicit.
+    """
+    from repowire.daemon.routes.asks import _acp_complete
+    from repowire.daemon.websocket_transport import TransportError
+
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
+    async def _boom(**_):
+        raise TransportError("no live ws")
+
+    router.send_notification = AsyncMock(side_effect=_boom)
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="hi",
+    )
+    await _acp_complete(
+        correlation_id=cid, reply=None, error="subprocess died",
+        ask_tracker=at, peer_registry=registry,
+    )
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is True
+    assert ask.close_reason == "send_failed"
+    assert ask.pending_reply is None
 
 
 @pytest.mark.asyncio
 async def test_acp_complete_closes_ask_on_success(tmp_path: Path) -> None:
-    """Happy path: successful notify closes the ask exactly once."""
+    """Happy path: successful notify closes the ask with ack_with_msg.
+
+    The earlier revision of this test did NOT register the asker/answerer in
+    the registry, so ``peer_registry.notify`` actually hit the ValueError
+    branch and closed the ask as 'unknown peer' — not as success. Codex's
+    re-review flagged that the test name was misleading because of this.
+    """
     from repowire.daemon.routes.asks import _acp_complete
 
     cfg = Config()
@@ -477,19 +546,29 @@ async def test_acp_complete_closes_ask_on_success(tmp_path: Path) -> None:
     at = AskTracker(ttl_hours=24.0)
     router = MessageRouter(transport=transport, query_tracker=qt)
     registry = PeerRegistry(
-        config=cfg,
-        message_router=router,
-        query_tracker=qt,
-        transport=transport,
-        persistence_path=tmp_path / "sessions.json",
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
     )
     registry._events_path = tmp_path / "events.json"
     registry._last_repair = time.monotonic() + 3600
     router.send_notification = AsyncMock()
 
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+        status=PeerStatus.ONLINE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
     cid = await at.register(
-        from_peer_id="asker-id", from_peer_name="asker",
-        to_peer_id="answerer-id", to_peer_name="answerer",
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
         text="hi",
     )
     await _acp_complete(
@@ -497,4 +576,155 @@ async def test_acp_complete_closes_ask_on_success(tmp_path: Path) -> None:
         ask_tracker=at, peer_registry=registry,
     )
     ask = await at.get(cid)
-    assert ask is not None and ask.closed is True
+    assert ask is not None
+    assert ask.closed is True
+    assert ask.close_reason == "ack_with_msg"
+    # send_notification was actually invoked with our framed reply
+    router.send_notification.assert_called_once()
+    kwargs = router.send_notification.call_args.kwargs
+    assert "answer" in kwargs["text"]
+    assert kwargs["text"].startswith(f"[ack #{cid}")
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_redelivered_on_asker_reconnect(tmp_path: Path) -> None:
+    """End-to-end of codex BLOCKING #1's durable fix.
+
+    1. ACP-routed ask completes successfully, but asker is offline
+       (TransportError on notify) → reply stashed on the ask.
+    2. Asker transitions OFFLINE → ONLINE via update_peer_status.
+    3. peer_registry kicks off _redeliver_pending_replies; on this second
+       notify attempt the transport succeeds → ask closed, stash cleared.
+
+    This is the contract codex held us to: the answer is durable across the
+    reconnect, not silently lost.
+    """
+    cfg = Config()
+    cfg.experiments.acp_broker_client = True
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+    # register_peer always lands at ONLINE — drop the asker to OFFLINE so the
+    # next transition is a real OFFLINE → ONLINE bump.
+    await registry.update_peer_status(asker.peer_id, PeerStatus.OFFLINE)
+
+    from repowire.daemon.routes.asks import _acp_complete
+    from repowire.daemon.websocket_transport import TransportError
+
+    delivery_attempts: list[dict] = []
+    fail_first = {"count": 0}
+
+    async def _maybe_fail(**kwargs):
+        delivery_attempts.append(kwargs)
+        fail_first["count"] += 1
+        if fail_first["count"] == 1:
+            raise TransportError("asker not connected yet")
+
+    router.send_notification = AsyncMock(side_effect=_maybe_fail)
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="what's the time",
+    )
+
+    # Step 1: ACP completes; first notify attempt fails → stash
+    await _acp_complete(
+        correlation_id=cid, reply="42 minutes past noon", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+    ask = await at.get(cid)
+    assert ask is not None and not ask.closed
+    assert ask.pending_reply is not None
+
+    # Step 2: asker comes back online. update_peer_status schedules a redeliver
+    # background task; await it directly so we don't rely on event-loop timing.
+    await registry.update_peer_status(asker.peer_id, PeerStatus.ONLINE)
+    # Give the spawned redeliver task one tick to run.
+    await asyncio.sleep(0.05)
+
+    # Step 3: second notify attempt succeeded → ask closed, stash drained
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is True, "ask should be closed after successful redelivery"
+    assert ask.close_reason == "ack_with_msg"
+    assert len(delivery_attempts) == 2, f"expected 2 notify attempts, got {len(delivery_attempts)}"
+    assert "42 minutes past noon" in delivery_attempts[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_kept_when_redelivery_still_fails(tmp_path: Path) -> None:
+    """Redelivery is best-effort: if it still fails, the stash stays put.
+
+    Future reconnects of the same asker will trigger another redelivery
+    attempt. We don't drop the reply just because one attempt was wasted.
+    """
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600
+
+    asker = Peer(
+        peer_id="asker-id", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%asker", circle="default",
+    )
+    answerer = Peer(
+        peer_id="answerer-id", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%answerer", circle="default",
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+    # register_peer always lands at ONLINE — drop the asker to OFFLINE so the
+    # next transition is a real OFFLINE → ONLINE bump.
+    await registry.update_peer_status(asker.peer_id, PeerStatus.OFFLINE)
+
+    from repowire.daemon.routes.asks import _acp_complete
+    from repowire.daemon.websocket_transport import TransportError
+
+    async def _always_boom(**_):
+        raise TransportError("still offline")
+    router.send_notification = AsyncMock(side_effect=_always_boom)
+
+    cid = await at.register(
+        from_peer_id=asker.peer_id, from_peer_name=asker.display_name,
+        to_peer_id=answerer.peer_id, to_peer_name=answerer.display_name,
+        text="ping",
+    )
+    await _acp_complete(
+        correlation_id=cid, reply="pong", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+    await registry.update_peer_status(asker.peer_id, PeerStatus.ONLINE)
+    await asyncio.sleep(0.05)
+
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is False, "ask kept open after failed redelivery"
+    assert ask.pending_reply is not None, "stash retained for next reconnect"

--- a/uv.lock
+++ b/uv.lock
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.20"
+version = "0.13.25"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1369,10 +1369,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+acp = [
+    { name = "agent-client-protocol" },
+]
 acp-probe = [
     { name = "agent-client-protocol" },
 ]
 dev = [
+    { name = "agent-client-protocol" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
@@ -1393,7 +1397,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.10.0" },
     { name = "agent-client-protocol", marker = "extra == 'acp-probe'", specifier = ">=0.10.0" },
+    { name = "agent-client-protocol", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "httpx", specifier = ">=0.26.0" },
@@ -1414,7 +1420,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["relay", "dev", "docs", "acp-probe"]
+provides-extras = ["relay", "dev", "acp", "docs", "acp-probe"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Phase-3 of the ACP migration (see [acp-mapping-delta-claude.md](../../notes-vault/repowire-mesh/acp-mapping-delta-claude.md), issue #163, PR #174).

- New `repowire/acp/` module: async client (`client.py`), subprocess transport (`transport.py`), pydantic models (`models.py`), lifetime cache (`manager.py`), and the `/ask` glue (`broker.py`). Built on the official `agent-client-protocol` SDK — same wire protocol the phase-2 probes used.
- New feature flag `experiments.acp_broker_client` (off by default) in `Config`.
- `/ask` route wired: when the flag is on AND the target peer carries a `metadata.acp` block, the ask is delivered via `session/prompt` against an ACP subprocess instead of the WS transport. The streamed `agent_message_chunk` text is surfaced back to the asker as an ack-with-message via the existing notify pipeline. One persistent session per peer; lazy spawn on first ask; torn down on daemon shutdown.
- Integration test (`tests/test_acp_broker_client.py` + `tests/fixtures/acp_echo_agent.py`) spawns a minimal ACP-speaking echo agent as a subprocess and asserts the prompt round-trips end-to-end through `/ask` → ACP subprocess → ack.

Out of scope for phase-3 (documented in the design doc): notify/broadcast via ACP, `session/load`/`list`, `fs/terminal` capabilities, removing the WS path.

## Test plan

- [x] `uv run ruff check repowire/` — clean
- [x] `uv run ty check repowire/` — clean
- [x] `uv run pytest` — 964 passed (955 existing + 9 new)
- [x] New tests cover: route decision matrix, text assembly, direct `AcpClient` round-trip, `AcpClientManager` session reuse, `/ask` end-to-end with flag on, `/ask` fallback when flag off
- [x] Manual smoke against the echo stub confirms streamed `agent_message_chunk` is reassembled and surfaced as the ack reply