### PR TITLE
fix(acp): raise AcpClientError with install hint when SDK missing

### DIFF
--- a/repowire/acp/client.py
+++ b/repowire/acp/client.py
@@ -46,14 +46,29 @@ class AcpPromptResult:
     updates: list[Any] = field(default_factory=list)
 
 
+_ACP_INSTALL_HINT = (
+    "Install the optional ACP runtime: `uv tool upgrade --reinstall "
+    "--with agent-client-protocol repowire` (or `pip install "
+    "'repowire[acp]'`). Then restart the daemon. The ACP broker only "
+    "starts subprocesses when experiments.acp_broker_client is true."
+)
+
+
 def _make_recorder() -> Any:
     """Build a fresh ``acp.Client`` instance that records updates for one peer.
 
     Defined as a factory rather than a top-level class so the ``acp`` import
     stays lazy — the broker only imports the SDK when the ACP path is wired up.
+    Raises ``AcpClientError`` with an install hint when the optional ACP
+    runtime is missing.
     """
-    import acp
-    from acp.schema import AllowedOutcome, DeniedOutcome
+    try:
+        import acp
+        from acp.schema import AllowedOutcome, DeniedOutcome
+    except ModuleNotFoundError as e:
+        raise AcpClientError(
+            f"agent-client-protocol SDK not installed: {e}. {_ACP_INSTALL_HINT}"
+        ) from e
 
     class _BrokerRecorder(acp.Client):
         """Records ``session/update`` notifications for the broker.

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -850,3 +850,39 @@ async def test_pending_reply_kept_when_redelivery_still_fails(tmp_path: Path) ->
     assert ask is not None
     assert ask.closed is False, "ask kept open after failed redelivery"
     assert ask.pending_reply is not None, "stash retained for next reconnect"
+
+
+def test_make_recorder_raises_clean_error_when_acp_sdk_missing(monkeypatch) -> None:
+    """When the optional `agent-client-protocol` runtime isn't installed,
+    AcpClient construction must fail with an AcpClientError carrying an
+    install hint — not a bare ModuleNotFoundError leaked from the import.
+
+    Regression: smoke test of v0.13.27 deployment surfaced bare
+    `ModuleNotFoundError: No module named 'acp'` in daemon logs, blocking
+    diagnosis until reading source. The hint shortcircuits that.
+    """
+    import builtins
+    import sys
+
+    from repowire.acp import client as acp_client_mod
+
+    # Drop any cached acp.* modules so the test sees a real ImportError path.
+    for name in list(sys.modules):
+        if name == "acp" or name.startswith("acp."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "acp" or name.startswith("acp."):
+            raise ModuleNotFoundError(f"No module named '{name}'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(acp_client_mod.AcpClientError) as exc_info:
+        acp_client_mod._make_recorder()
+
+    msg = str(exc_info.value)
+    assert "agent-client-protocol" in msg
+    assert "experiments.acp_broker_client" in msg


### PR DESCRIPTION
Smoke test against v0.13.27 surfaced a bare ModuleNotFoundError in daemon logs when the optional agent-client-protocol SDK isn't installed (uv tool install without [acp] extras). Wrap the import with try/except, raise AcpClientError carrying an install hint pointing at the uv tool upgrade command and the experiments flag gate.

19/19 ACP tests pass (+1 new regression). Bug discovered along the way → patches in same train per goal text.