### PR TITLE
fix: tolerate missing web build output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: |
-          mkdir -p web/out
-          uv sync --all-extras
+        run: uv sync --all-extras
 
       - name: Lint
         run: uvx ruff check repowire/

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,22 @@
+"""Build hook: include web/out only when it exists.
+
+Prebuilt UI assets (web/out) ship in published wheels/sdists, but a clean
+checkout has no web/out until `npm run build` runs. A static force-include
+breaks editable installs and `uv sync` from a fresh clone. This hook makes
+the inclusion conditional so backend installs work without the UI build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class WebOutHook(BuildHookInterface):
+    PLUGIN_NAME = "web-out"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        web_out = Path(self.root) / "web" / "out"
+        if web_out.is_dir() and any(web_out.iterdir()):
+            build_data.setdefault("force_include", {})[str(web_out)] = "web/out"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,14 +73,17 @@ exclude = [
     "mkdocs.yml",
 ]
 
-[tool.hatch.build.targets.sdist.force-include]
-"web/out" = "web/out"
-
 [tool.hatch.build.targets.wheel]
 packages = ["repowire"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"web/out" = "web/out"
+# web/out is included conditionally via hatch_build.py — present in release
+# builds, absent in clean dev checkouts. A static force-include would error
+# on missing path and break `uv sync` / editable installs (#208).
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary\n- make web/out package inclusion conditional via Hatch build hook\n- remove CI workaround that created an empty web/out before install\n- preserve web/out inclusion for release builds when assets exist\n\nFixes #208.\n\n## Verification\n- Author: clean uv build without web/out succeeded; populated web/out included in sdist and wheel; uv run --isolated import repowire OK; uv sync --all-extras OK; pytest 1016 passed\n- Codex review: PASS, no blocking findings; verified hatch hook behavior for sdist/wheel and built-wheel import outside repo\n\n## Notes\n- No automated regression test for conditional asset inclusion yet; relies on build smoke coverage.