### PR TITLE
fix: allow serve without installing tmux hooks

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -34,8 +34,20 @@ def main() -> None:
 @click.option("--host", default=DEFAULT_HOST, help="Bind address")
 @click.option("--port", default=DEFAULT_PORT, type=int, help="Port")
 @click.option("--relay", is_flag=True, help="Enable relay mode")
-def serve(host: str, port: int, relay: bool) -> None:
+@click.option(
+    "--no-install-hooks",
+    is_flag=True,
+    help=(
+        "Skip installing tmux lifecycle hooks on startup. Useful for smoke/test "
+        "daemons under a temp HOME, since tmux hooks are server-global and would "
+        "otherwise rewrite the user's live mesh hooks. Also honored via "
+        "REPOWIRE_DISABLE_HOOK_INSTALL=1."
+    ),
+)
+def serve(host: str, port: int, relay: bool, no_install_hooks: bool) -> None:
     """Start the repowire HTTP daemon."""
+    import os
+
     import uvicorn
 
     from repowire.config.models import load_config
@@ -49,7 +61,11 @@ def serve(host: str, port: int, relay: bool) -> None:
         config.relay.ensure_api_key()
         config.save()
 
-    app = create_app(config=config)
+    env_disable = os.environ.get("REPOWIRE_DISABLE_HOOK_INSTALL", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+    install_hooks = not (no_install_hooks or env_disable)
+    app = create_app(config=config, install_tmux_hooks=install_hooks)
     console.print(f"[cyan]Starting Repowire daemon on {host}:{port}...[/]")
     if config.relay.dashboard_url:
         console.print(f"[green]Dashboard:[/] {config.relay.dashboard_url}")

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -65,16 +65,22 @@ def _cleanup_stale_artifacts(max_age_hours: float = 72) -> None:
 
 def create_app(
     config: Config | None = None,
+    install_tmux_hooks: bool = True,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
     Args:
         config: Optional configuration. Loaded from disk if not provided.
+        install_tmux_hooks: When False, skip installing server-global tmux
+            lifecycle hooks during startup. Smoke/test daemons running under
+            a temp HOME should pass False so they don't rewrite the user's
+            live tmux hooks (which are not scoped to HOME).
 
     Returns:
         Configured FastAPI application.
     """
     _config = config
+    _install_tmux_hooks = install_tmux_hooks
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -142,16 +148,22 @@ def create_app(
             lifecycle_handler=lifecycle_handler,
         )
 
-        # Install tmux lifecycle hooks if tmux is available
-        try:
-            from repowire.hooks.tmux_lifecycle import install_hooks, is_tmux_available
+        # Install tmux lifecycle hooks if tmux is available.
+        # Skipped when the caller disables it (e.g. smoke daemons under a
+        # temp HOME), because tmux hooks are server-global and would
+        # otherwise rewrite the user's live mesh hooks.
+        if _install_tmux_hooks:
+            try:
+                from repowire.hooks import tmux_lifecycle
 
-            if is_tmux_available():
-                tmux_hooks = install_hooks(cfg.daemon.host, cfg.daemon.port)
-                if tmux_hooks:
-                    logger.info("Installed %d tmux lifecycle hooks", len(tmux_hooks))
-        except Exception:
-            logger.debug("Tmux hooks not installed", exc_info=True)
+                if tmux_lifecycle.is_tmux_available():
+                    tmux_hooks = tmux_lifecycle.install_hooks(cfg.daemon.host, cfg.daemon.port)
+                    if tmux_hooks:
+                        logger.info("Installed %d tmux lifecycle hooks", len(tmux_hooks))
+            except Exception:
+                logger.debug("Tmux hooks not installed", exc_info=True)
+        else:
+            logger.info("Skipping tmux lifecycle hook install (install_tmux_hooks=False)")
 
         # Start relay client if enabled
         relay_client: RelayClient | None = None

--- a/tests/test_serve_no_install_hooks.py
+++ b/tests/test_serve_no_install_hooks.py
@@ -1,0 +1,161 @@
+"""Tests for serve --no-install-hooks guard (issue #209).
+
+The daemon's startup lifespan installs server-global tmux hooks. Smoke/test
+daemons running under a temp HOME need a way to opt out so they don't rewrite
+the user's live mesh hooks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from repowire.config.models import Config, DaemonConfig
+
+
+@pytest.fixture()
+def isolated_config(tmp_path: Path) -> Config:
+    cfg = Config()
+    cfg.daemon = DaemonConfig(host="127.0.0.1", port=19377)
+    cfg._config_path = tmp_path / "config.yaml"
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_create_app_skips_tmux_hooks_when_disabled(monkeypatch, tmp_path, isolated_config):
+    """install_tmux_hooks=False must prevent tmux_lifecycle.install_hooks from running."""
+    from repowire.daemon import app as app_mod
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    called: list[tuple[str, int]] = []
+
+    def fake_install_hooks(host: str, port: int):
+        called.append((host, port))
+        return ["fake-hook"]
+
+    def fake_is_tmux_available() -> bool:
+        return True
+
+    import repowire.hooks.tmux_lifecycle as tmux_mod
+    monkeypatch.setattr(tmux_mod, "install_hooks", fake_install_hooks)
+    monkeypatch.setattr(tmux_mod, "is_tmux_available", fake_is_tmux_available)
+
+    app = app_mod.create_app(config=isolated_config, install_tmux_hooks=False)
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert called == [], "install_hooks should not be called when install_tmux_hooks=False"
+
+
+@pytest.mark.asyncio
+async def test_create_app_installs_tmux_hooks_by_default(monkeypatch, tmp_path, isolated_config):
+    """Default behavior must remain unchanged: tmux hooks install when available."""
+    from repowire.daemon import app as app_mod
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    called: list[tuple[str, int]] = []
+
+    def fake_install_hooks(host: str, port: int):
+        called.append((host, port))
+        return ["fake-hook"]
+
+    import repowire.hooks.tmux_lifecycle as tmux_mod
+    monkeypatch.setattr(tmux_mod, "install_hooks", fake_install_hooks)
+    monkeypatch.setattr(tmux_mod, "is_tmux_available", lambda: True)
+
+    app = app_mod.create_app(config=isolated_config)
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert called == [("127.0.0.1", 19377)]
+
+
+def test_serve_cli_passes_no_install_hooks_flag(monkeypatch):
+    """`repowire serve --no-install-hooks` must call create_app(install_tmux_hooks=False)."""
+    from repowire import cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_create_app(config=None, install_tmux_hooks=True):
+        captured["install_tmux_hooks"] = install_tmux_hooks
+
+        class _Stub:
+            pass
+        return _Stub()
+
+    def fake_uvicorn_run(app, **kwargs):
+        captured["ran"] = True
+
+    import repowire.daemon.app as app_mod
+    monkeypatch.setattr(app_mod, "create_app", fake_create_app)
+
+    import uvicorn
+    monkeypatch.setattr(uvicorn, "run", fake_uvicorn_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.main, ["serve", "--no-install-hooks", "--port", "19377"])
+    assert result.exit_code == 0, result.output
+    assert captured.get("install_tmux_hooks") is False
+    assert captured.get("ran") is True
+
+
+def test_serve_cli_env_var_disables_hooks(monkeypatch):
+    """REPOWIRE_DISABLE_HOOK_INSTALL=1 must disable hook install without the CLI flag."""
+    from repowire import cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_create_app(config=None, install_tmux_hooks=True):
+        captured["install_tmux_hooks"] = install_tmux_hooks
+
+        class _Stub:
+            pass
+        return _Stub()
+
+    def fake_uvicorn_run(app, **kwargs):
+        captured["ran"] = True
+
+    import repowire.daemon.app as app_mod
+    monkeypatch.setattr(app_mod, "create_app", fake_create_app)
+
+    import uvicorn
+    monkeypatch.setattr(uvicorn, "run", fake_uvicorn_run)
+
+    monkeypatch.setenv("REPOWIRE_DISABLE_HOOK_INSTALL", "1")
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.main, ["serve", "--port", "19377"])
+    assert result.exit_code == 0, result.output
+    assert captured.get("install_tmux_hooks") is False
+
+
+def test_serve_cli_default_installs_hooks(monkeypatch):
+    """Default `repowire serve` must keep install_tmux_hooks=True."""
+    from repowire import cli as cli_mod
+
+    captured: dict[str, object] = {}
+
+    def fake_create_app(config=None, install_tmux_hooks=True):
+        captured["install_tmux_hooks"] = install_tmux_hooks
+
+        class _Stub:
+            pass
+        return _Stub()
+
+    def fake_uvicorn_run(app, **kwargs):
+        captured["ran"] = True
+
+    import repowire.daemon.app as app_mod
+    monkeypatch.setattr(app_mod, "create_app", fake_create_app)
+
+    import uvicorn
+    monkeypatch.setattr(uvicorn, "run", fake_uvicorn_run)
+
+    monkeypatch.delenv("REPOWIRE_DISABLE_HOOK_INSTALL", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.main, ["serve", "--port", "19377"])
+    assert result.exit_code == 0, result.output
+    assert captured.get("install_tmux_hooks") is True


### PR DESCRIPTION
## Summary\n- add repowire serve --no-install-hooks\n- honor REPOWIRE_DISABLE_HOOK_INSTALL for serve\n- let create_app skip tmux hook installation for smoke/test daemons\n\nFixes #209.\n\n## Verification\n- Author: pytest 1021/1021 pass; ruff check repowire/ tests/test_serve_no_install_hooks.py clean\n- Codex review: PASS, no blocking findings; verified default behavior unchanged and guard prevents tmux hook mutation on serve path\n\n## Notes\n- Env guard is honored by repowire serve, not direct create_app() callers or deprecated daemon start --foreground.