### PR TITLE
fix(acp): route public surfaces before ws checks

### DIFF
--- a/repowire/acp/__init__.py
+++ b/repowire/acp/__init__.py
@@ -17,6 +17,7 @@ from repowire.acp.broker import (
     AcpRouteDecision,
     decide_acp_route,
     deliver_ask_via_acp,
+    maybe_decide_acp_route,
 )
 from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
 from repowire.acp.manager import AcpClientManager, AcpPeerSpec
@@ -33,4 +34,5 @@ __all__ = [
     "AcpRouteDecision",
     "decide_acp_route",
     "deliver_ask_via_acp",
+    "maybe_decide_acp_route",
 ]

--- a/repowire/acp/broker.py
+++ b/repowire/acp/broker.py
@@ -48,6 +48,28 @@ class AcpRouteDecision:
     reason: str = ""
 
 
+def maybe_decide_acp_route(
+    peer: Peer,
+    *,
+    flag_enabled: bool,
+    manager: AcpClientManager | None,
+) -> AcpRouteDecision | None:
+    """Return a positive route decision iff ACP routing should be used.
+
+    Thin convenience wrapper for HTTP route handlers: collapses the manager
+    presence check and the broker decision into a single "use ACP, yes/no"
+    answer. Returns ``None`` when the caller should fall through to the
+    WebSocket dispatch path; returns the decision (with ``spec`` populated)
+    when ACP routing applies.
+    """
+    if manager is None:
+        return None
+    decision = decide_acp_route(peer, flag_enabled=flag_enabled)
+    if decision.route and decision.spec is not None:
+        return decision
+    return None
+
+
 def decide_acp_route(peer: Peer, *, flag_enabled: bool) -> AcpRouteDecision:
     """Inspect a peer + the experiments flag to decide on ACP routing.
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -842,6 +842,57 @@ class PeerRegistry:
                 f"cannot access {to_obj.display_name} ({to_obj.circle})"
             )
 
+    async def check_circle_access(
+        self,
+        from_obj: Peer | None,
+        to_obj: Peer,
+        *,
+        bypass_circle: bool = False,
+    ) -> None:
+        """Public wrapper for the circle-access check.
+
+        Use from non-WS dispatch paths (ACP broker routing) that need to
+        enforce the same access semantics as the WS path without going
+        through the full ``notify`` / ``deliver_ask`` pipeline.
+
+        Raises ``ValueError`` on circle boundary violation.
+        """
+        async with self._lock:
+            self._check_circle_access_by_peers(from_obj, to_obj, bypass_circle)
+
+    async def check_access(
+        self,
+        *,
+        from_peer: str,
+        to_peer: str,
+        bypass_circle: bool = False,
+        circle: str | None = None,
+    ) -> tuple[Peer | None, Peer]:
+        """Resolve sender/target and enforce circle access for a non-WS dispatch.
+
+        Mirrors the lookup + circle-check that ``query``/``notify``/
+        ``deliver_ask`` run inline before sending. Use from route handlers
+        that dispatch outside the WS path (e.g. ACP-broker routing) so the
+        same access semantics apply — circle boundaries, ambiguity 409s,
+        and unknown-peer 404s should not depend on the transport.
+
+        Returns ``(from_obj, target)``. ``from_obj`` is ``None`` if the
+        sender display-name is unknown (matches existing notify behavior:
+        unresolved senders log + proceed, they don't fail the call).
+
+        Raises:
+            ValueError: target unknown / circle boundary violation /
+                ambiguous display-name lookup.
+        """
+        async with self._lock:
+            target = self._lookup_peer_unlocked(to_peer, circle=circle)
+            if not target:
+                raise ValueError(f"Unknown peer: {to_peer}")
+            from_obj = self._resolve_from_peer_unlocked(
+                from_peer, target, bypass_circle,
+            )
+            return from_obj, target
+
     # ------------------------------------------------------------------
     # Message routing (query / notify / broadcast)
     # ------------------------------------------------------------------
@@ -1477,14 +1528,26 @@ class PeerRegistry:
 
         Catches ghost peers that registered via HTTP but whose ws-hook
         never connected (e.g. pane died before ws-hook could start).
+
+        Peers carrying ``metadata["acp"]`` are exempt while the
+        ``experiments.acp_broker_client`` flag is on: brokered ACP peers are
+        live as long as their subprocess is, not their WebSocket. Demoting
+        them solely because no WS exists would silently take them offline
+        between asks and eventually reap them (repowire#206).
         """
         if not self._transport:
             return 0
+        acp_flag = (
+            bool(self._config.experiments.acp_broker_client)
+            if self._config.experiments
+            else False
+        )
         async with self._lock:
             ghosts = [
                 p for p in self._peers.values()
                 if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
                 and not self._transport.is_connected(p.peer_id)
+                and not (acp_flag and p.metadata and p.metadata.get("acp"))
             ]
         count = 0
         for peer in ghosts:

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -30,10 +30,8 @@ from pydantic import BaseModel, Field
 
 from repowire.acp import (
     AcpClientManager,
-    AcpRouteDecision,
-    decide_acp_route,
+    maybe_decide_acp_route,
 )
-from repowire.config.models import Config
 from repowire.daemon.ask_tracker import AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
@@ -122,25 +120,6 @@ async def _resolve_sender_for_target(from_peer: str, target: Peer) -> Peer | Non
         )
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-
-
-def _maybe_decide_acp_route(
-    peer: Peer,
-    config: Config,
-    manager: AcpClientManager | None,
-) -> AcpRouteDecision | None:
-    """Return a positive route decision iff ACP routing applies. Else ``None``.
-
-    Keeps the route handler readable: the only fact the caller needs is "use
-    ACP for this ask, yes/no". Reasons / diagnostics are logged inside.
-    """
-    if manager is None:
-        return None
-    flag = bool(config.experiments.acp_broker_client) if config.experiments else False
-    decision = decide_acp_route(peer, flag_enabled=flag)
-    if decision.route and decision.spec is not None:
-        return decision
-    return None
 
 
 async def _acp_complete(
@@ -255,6 +234,19 @@ async def open_ask(
     from_peer_id = from_peer_obj.peer_id if from_peer_obj else request.from_peer
     from_peer_name = from_peer_obj.display_name if from_peer_obj else request.from_peer
 
+    # Enforce circle access BEFORE registering the ask. On the WS path
+    # ``deliver_ask`` runs the same check inside ``_resolve_from_peer_unlocked``
+    # and a violation rolls the tracker registration back; the ACP branch
+    # never reaches ``deliver_ask``, so we front-load the check via the
+    # public ``check_circle_access`` helper so both transports apply the
+    # same gate.
+    try:
+        await peer_registry.check_circle_access(
+            from_peer_obj, peer, bypass_circle=request.bypass_circle,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+
     try:
         cid = await ask_tracker.register(
             from_peer_id=from_peer_id,
@@ -281,11 +273,12 @@ async def open_ask(
     # turn settles.
     cfg = state.config
     acp_manager = getattr(state, "acp_manager", None)
-    decision = _maybe_decide_acp_route(peer, cfg, acp_manager)
+    flag = bool(cfg.experiments.acp_broker_client) if cfg.experiments else False
+    decision = maybe_decide_acp_route(peer, flag_enabled=flag, manager=acp_manager)
     if decision is not None:
         from repowire.acp import deliver_ask_via_acp
 
-        assert acp_manager is not None  # narrowed by _maybe_decide_acp_route
+        assert acp_manager is not None  # narrowed by maybe_decide_acp_route
         assert decision.spec is not None
         spec = decision.spec
         manager: AcpClientManager = acp_manager

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from repowire.acp import deliver_ask_via_acp, maybe_decide_acp_route
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
@@ -156,15 +158,82 @@ async def notify_peer(
 ) -> NotifyResponse:
     """Send a notification to a peer (fire-and-forget).
 
-    Direct WS send. 503 if the recipient has no live connection so the
-    caller knows to retry later. Returns ``status=sent`` when the recipient
-    was ONLINE at send-time, ``status=queued`` when the recipient was BUSY
-    (ws-hook holds the paste until the agent's current turn ends).
+    Routing is transport-agnostic:
+
+      * ACP-marked target peer + ``experiments.acp_broker_client`` flag on →
+        delivered as a fire-and-forget ACP prompt against the peer's
+        subprocess. There is no notify primitive in ACP; we map notify onto
+        prompt and discard the assembled reply so the call stays
+        fire-and-forget. Returns ``status=sent`` once the prompt is dispatched.
+      * All other peers → direct WS send. 503 if the recipient has no live
+        connection so the caller knows to retry. Returns ``status=sent`` when
+        the recipient was ONLINE at send-time, ``status=queued`` when BUSY
+        (ws-hook holds the paste until the current turn ends).
+
+    The ACP-first ordering is critical: an ACP peer never has a live WS
+    connection, so the WS-presence check would 503 every brokered peer if it
+    ran before the ACP decision (repowire#206).
     """
     from repowire.daemon.websocket_transport import TransportError
 
     peer_registry = get_peer_registry()
+    state = get_app_state()
     await peer_registry.lazy_repair()
+
+    # ACP routing decision happens before any WS dispatch so that ACP-marked
+    # peers (which have no WS by design) don't 503 in the route layer.
+    # check_access runs the same lookup + circle-boundary enforcement that
+    # peer_registry.notify would apply on the WS path — we must not let the
+    # ACP branch silently bypass circle gates.
+    try:
+        _from_obj, target = await peer_registry.check_access(
+            from_peer=request.from_peer,
+            to_peer=request.to_peer,
+            bypass_circle=request.bypass_circle,
+            circle=request.circle,
+        )
+    except ValueError as e:
+        msg = str(e)
+        if msg.startswith("Unknown peer"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=msg,
+            ) from e
+        if msg.startswith("Ambiguous peer name"):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail=msg,
+            ) from e
+        # Circle boundary violation → 403. This is the established "no
+        # cross-circle traffic" semantic; previously the WS path bubbled
+        # the same ValueError up to the catch-all 404 branch below, which
+        # masked the real error. Keep this path consistent for ACP + WS.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=msg,
+        ) from e
+
+    cfg = state.config
+    acp_manager = getattr(state, "acp_manager", None)
+    flag = bool(cfg.experiments.acp_broker_client) if cfg.experiments else False
+    decision = maybe_decide_acp_route(target, flag_enabled=flag, manager=acp_manager)
+    if decision is not None:
+        assert acp_manager is not None  # narrowed by maybe_decide_acp_route
+        assert decision.spec is not None
+
+        async def _drop_result(_cid: str, _reply: str | None, _err: str | None) -> None:
+            # Notify is fire-and-forget: any reply or error from the ACP turn
+            # is logged inside deliver_ask_via_acp; nothing to deliver back.
+            return None
+
+        # Synthesize a correlation_id for log/cancel correlation only. No
+        # ask_tracker registration: notify has no thread to close.
+        cid = f"notif-{uuid.uuid4().hex[:8]}"
+        await deliver_ask_via_acp(
+            manager=acp_manager,
+            spec=decision.spec,
+            correlation_id=cid,
+            text=request.text,
+            on_complete=_drop_result,
+        )
+        return NotifyResponse(status="sent")
 
     try:
         delivery_status = await peer_registry.notify(

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -296,6 +296,366 @@ async def test_ask_falls_back_to_ws_when_flag_off(
         cleanup_deps()
 
 
+# ----- public route-layer regression tests (repowire#206) -----
+
+
+class _StubAcpManager:
+    """In-process stand-in for ``AcpClientManager`` for route-layer tests.
+
+    Records every prompt routed through it and returns canned results — no
+    subprocess, no agent-client-protocol I/O. The route-layer tests only
+    care that the /ask and /notify handlers reach an ACP manager at all;
+    real subprocess plumbing is exercised by the existing end-to-end test.
+    """
+
+    def __init__(self) -> None:
+        self.prompts: list[tuple[str, str]] = []  # (peer_id, text)
+        self._clients: dict[str, object] = {}
+
+    async def prompt(self, spec, text, timeout=180.0):  # noqa: ARG002
+        from repowire.acp.client import AcpPromptResult
+        self.prompts.append((spec.peer_id, text))
+        return AcpPromptResult(stop_reason="end_turn", text=f"[stub] {text}")
+
+    async def get_or_create(self, spec):  # noqa: ARG002
+        return None  # unused in tests
+
+    async def close(self) -> None:
+        return None
+
+
+def _make_public_app(tmp_path: Path, *, flag: bool, skip_lazy_repair: bool = False):
+    """Mirror prod wiring: no peer-status fakery, no router-method mocks.
+
+    This is the minimum set of components needed for /peers + /ask + /notify
+    to behave like the real daemon. Notably:
+
+      * peers register via real ``POST /peers`` (status starts at ONLINE),
+      * no ``update_peer_status`` calls force ACP peers to look connected,
+      * the WS transport is real but has zero connections (which is exactly
+        the prod scenario for ACP peers),
+      * ``lazy_repair`` is NOT short-circuited by default — the route handlers
+        invoke it on entry just like prod. The audit on repowire#206 found
+        that the original test suite skipped lazy_repair entirely, which
+        hid the fact that ACP peers were being demoted/reaped for missing
+        their (intentionally absent) WebSocket. Pass
+        ``skip_lazy_repair=True`` only when you specifically want the
+        prod-skip behavior.
+
+    The asker-side reply notification will fail with TransportError (no WS
+    on the asker), which is the right behavior — these tests assert on the
+    /ask + /notify response only, not on the downstream ack delivery.
+    """
+    from repowire.daemon.routes import messages as messages_routes
+
+    cfg = Config()
+    cfg.experiments.acp_broker_client = flag
+
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    if skip_lazy_repair:
+        registry._last_repair = time.monotonic() + 3600
+
+    manager = _StubAcpManager()
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+        acp_manager=manager,
+    )
+    init_deps(cfg, registry, state)
+
+    app = FastAPI()
+    app.include_router(peers.router)
+    app.include_router(asks.router)
+    app.include_router(messages_routes.router)
+    return app, registry, at, manager
+
+
+@pytest.mark.asyncio
+async def test_public_ask_route_does_not_503_for_acp_peer(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """repowire#206: ``POST /ask`` against an ACP peer must not 503.
+
+    Mirrors the bug repro from the issue exactly: register an ACP peer via
+    HTTP, register an asker via HTTP, do not force any peer ONLINE, then
+    POST /ask. The route-layer ACP decision MUST fire before any
+    WS-presence check, otherwise the brokered peer 503s the public surface
+    (and MCP ``ask()`` along with it).
+    """
+    app, _registry, _at, manager = _make_public_app(tmp_path, flag=True)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            asker = await _register_plain_peer(http, name="asker")
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            r = await http.post("/ask", json={
+                "from_peer": asker,
+                "to_peer": answerer,
+                "text": "ping",
+            })
+            assert r.status_code == 200, (
+                f"/ask 503'd for ACP peer (regression of repowire#206): {r.text}"
+            )
+            assert r.json()["correlation_id"]
+    finally:
+        # Cancel any background ACP tasks before closing the manager so the
+        # _run() coroutine doesn't see a closed manager mid-flight.
+        await asyncio.sleep(0)
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_public_notify_route_does_not_503_for_acp_peer(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """repowire#206 sibling: ``POST /notify`` toward an ACP peer must not 503.
+
+    Same route-layer issue as /ask — the WS-presence check inside
+    ``peer_registry.notify`` fires before any ACP decision unless the route
+    handler routes brokered targets to the ACP path explicitly. Asserts the
+    HTTP surface returns 200 with ``status=sent`` (fire-and-forget mapping
+    onto an ACP prompt).
+    """
+    app, _registry, _at, manager = _make_public_app(tmp_path, flag=True)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            asker = await _register_plain_peer(http, name="asker")
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            r = await http.post("/notify", json={
+                "from_peer": asker,
+                "to_peer": answerer,
+                "text": "fyi",
+            })
+            assert r.status_code == 200, (
+                f"/notify 503'd for ACP peer (regression of repowire#206): {r.text}"
+            )
+            assert r.json()["status"] == "sent"
+    finally:
+        await asyncio.sleep(0)
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_lazy_repair_does_not_demote_acp_peers_with_flag_on(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """repowire#206 audit follow-up: lazy_repair must not demote ACP peers.
+
+    ``_demote_disconnected_peers`` marks any ONLINE peer without a WS
+    connection as OFFLINE. ACP-brokered peers have no WS by design, so the
+    original sweep silently took them offline ~30s after registration —
+    and the reaper then evicted them entirely after the TTL. The fix
+    exempts peers carrying ``metadata.acp`` while the
+    ``experiments.acp_broker_client`` flag is on.
+    """
+    app, registry, _at, manager = _make_public_app(
+        tmp_path, flag=True, skip_lazy_repair=True,
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+            peer = await registry.get_peer(answerer)
+            assert peer is not None
+            assert peer.status == PeerStatus.ONLINE
+
+            demoted = await registry._demote_disconnected_peers()
+            assert demoted == 0, (
+                "ACP peer was demoted despite metadata.acp + flag on"
+            )
+            peer = await registry.get_peer(answerer)
+            assert peer is not None and peer.status == PeerStatus.ONLINE
+    finally:
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_lazy_repair_still_demotes_acp_peers_when_flag_off(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """Symmetric guard: the exemption is gated on the experiments flag.
+
+    With the flag off, ACP routing isn't engaged, so metadata.acp is a dead
+    annotation; brokered peers behave like any other paneless HTTP-registered
+    peer and the ghost sweep should still demote them. Otherwise turning the
+    flag off wouldn't be a clean way to disable the feature.
+    """
+    app, registry, _at, manager = _make_public_app(
+        tmp_path, flag=False, skip_lazy_repair=True,
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+            demoted = await registry._demote_disconnected_peers()
+            assert demoted == 1, (
+                "flag-off ACP peer was unexpectedly exempted from demotion"
+            )
+            peer = await registry.get_peer(answerer)
+            assert peer is not None and peer.status == PeerStatus.OFFLINE
+    finally:
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_acp_routing_enforces_circle_boundary(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """Review BLOCKING: ACP branch must not bypass circle enforcement.
+
+    Pre-fix the ACP branch in /ask and /notify resolved the target peer
+    only — the sender resolution + circle gate that the WS path runs
+    inside ``peer_registry.notify`` / ``deliver_ask`` were silently
+    skipped. A peer in circle A could ask/notify an ACP peer in circle B
+    even without ``bypass_circle=True``. This test pins all three legs:
+
+      * cross-circle without bypass → 403 on both /ask and /notify,
+      * cross-circle WITH bypass → 200,
+      * same-circle without bypass → 200.
+    """
+    app, _registry, _at, _manager = _make_public_app(
+        tmp_path, flag=True, skip_lazy_repair=True,
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            # Asker in circle "alpha", ACP target in circle "beta".
+            asker_resp = await http.post("/peers", json={
+                "name": "asker", "path": "/tmp/asker", "circle": "alpha",
+                "backend": AgentType.CLAUDE_CODE.value, "pane_id": "%fake-asker",
+            })
+            assert asker_resp.status_code == 200
+            asker = asker_resp.json()["display_name"]
+
+            target_resp = await http.post("/peers", json={
+                "name": "answerer", "path": "/tmp/answerer", "circle": "beta",
+                "backend": AgentType.CODEX.value, "pane_id": "%fake-answerer",
+                "metadata": {"acp": acp_peer_config.model_dump()},
+            })
+            assert target_resp.status_code == 200
+            answerer = target_resp.json()["display_name"]
+
+            # 1: cross-circle without bypass → 403 on /ask
+            r = await http.post("/ask", json={
+                "from_peer": asker, "to_peer": answerer,
+                "circle": "beta", "text": "x",
+            })
+            assert r.status_code == 403, r.text
+            assert "Circle boundary" in r.text
+
+            # 2: cross-circle without bypass → 403 on /notify
+            r = await http.post("/notify", json={
+                "from_peer": asker, "to_peer": answerer,
+                "circle": "beta", "text": "x",
+            })
+            assert r.status_code == 403, r.text
+            assert "Circle boundary" in r.text
+
+            # 3: cross-circle WITH bypass → 200 (both endpoints)
+            r = await http.post("/ask", json={
+                "from_peer": asker, "to_peer": answerer,
+                "circle": "beta", "text": "x", "bypass_circle": True,
+            })
+            assert r.status_code == 200, r.text
+            r = await http.post("/notify", json={
+                "from_peer": asker, "to_peer": answerer,
+                "circle": "beta", "text": "x", "bypass_circle": True,
+            })
+            assert r.status_code == 200, r.text
+
+            # 4: same-circle without bypass → 200. Register a same-circle
+            # ACP peer and confirm the gate isn't over-applied.
+            same_circle_resp = await http.post("/peers", json={
+                "name": "peer-in-alpha", "path": "/tmp/answerer2",
+                "circle": "alpha", "backend": AgentType.CODEX.value,
+                "pane_id": "%fake-answerer2",
+                "metadata": {"acp": acp_peer_config.model_dump()},
+            })
+            assert same_circle_resp.status_code == 200
+            same = same_circle_resp.json()["display_name"]
+            r = await http.post("/ask", json={
+                "from_peer": asker, "to_peer": same,
+                "circle": "alpha", "text": "x",
+            })
+            assert r.status_code == 200, r.text
+            r = await http.post("/notify", json={
+                "from_peer": asker, "to_peer": same,
+                "circle": "alpha", "text": "x",
+            })
+            assert r.status_code == 200, r.text
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_public_notify_flag_off_still_503s_acp_peer(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    """Guard: with the experiments flag off, ACP peers fall through to WS.
+
+    Locks in the contract that ACP routing is strictly opt-in. Without the
+    flag, brokered peers behave like any other peer with no live WS — the
+    route 503s, the manager stays empty.
+    """
+    app, _registry, _at, manager = _make_public_app(tmp_path, flag=False)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            asker = await _register_plain_peer(http, name="asker")
+            answerer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            r = await http.post("/notify", json={
+                "from_peer": asker,
+                "to_peer": answerer,
+                "text": "fyi",
+            })
+            assert r.status_code == 503, r.text
+            assert manager._clients == {}  # type: ignore[attr-defined]
+    finally:
+        await manager.close()
+        cleanup_deps()
+
+
 # ----- helpers -----
 
 


### PR DESCRIPTION
## Summary\n- keep ACP-marked peers alive through lazy repair when acp_broker_client is enabled\n- route /notify to ACP before WS dispatch, preserving sender/circle validation\n- front-load circle validation for ACP /ask before ask registration\n- add public route-layer ACP tests for /ask, /notify, lazy_repair, flag-off, and circle-boundary behavior\n\nFixes #206.\n\n## Verification\n- Author: tests/test_acp_broker_client.py -> 25 passed; full pytest -> 1022 passed; ruff + ty clean\n- Codex review: initial BLOCKING on ACP /notify circle validation fixed; re-review PASS\n- Reviewer focused run: uv run pytest tests/test_acp_broker_client.py tests/test_routes.py::TestNotify -> 28 passed\n\n## Notes\n- /notify to ACP maps to a fire-and-forget ACP prompt and discards reply text because ACP has no notify primitive.\n- Full PeerTransport/lifecycle ownership remains v0.14 scope.