### PR TITLE
fix: redeliver acp stashed replies after peer takeover

### DIFF
--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -49,6 +49,23 @@ class QuiescedError(Exception):
         self.peer_id = peer_id
 
 
+@dataclass(frozen=True)
+class AskerIdentity:
+    """Snapshot of the asker's stable identity at stash time.
+
+    Captured only when the asker peer has *all* of these fields present and
+    non-default (notably ``machine != "unknown"`` and a non-empty normalized
+    path). Used by the registry's identity-tuple rebind pass to redeliver
+    stashed replies after the original peer_id has been pruned/reaped.
+    """
+
+    display_name: str
+    circle: str
+    backend: str  # AgentType.value
+    path: str  # normalized via os.path.normpath(os.path.realpath(...))
+    machine: str
+
+
 @dataclass
 class Ask:
     """An open ask awaiting ack/reply.
@@ -61,6 +78,11 @@ class Ask:
     asker reconnects — the WS path doesn't need it because /ack's MCP caller
     handles retry on 503. Cleared on successful redelivery (which also closes
     the ask).
+
+    ``asker_identity`` is populated alongside ``pending_reply`` when the asker
+    had a complete stable identity tuple at stash time. The registry uses it
+    to rebind redelivery to a new peer_id after a clean-takeover prune. When
+    None, only same-peer_id reconnect can redeliver.
     """
 
     correlation_id: str
@@ -74,6 +96,8 @@ class Ask:
     closed: bool = False
     close_reason: str | None = None
     pending_reply: str | None = None
+    asker_identity: AskerIdentity | None = None
+    pending_reply_at: datetime | None = None
 
 
 class AskTracker:
@@ -181,20 +205,35 @@ class AskTracker:
         """Look up an ask by corr_id."""
         return self._asks.get(correlation_id)
 
-    async def set_pending_reply(self, correlation_id: str, framed_reply: str) -> bool:
+    async def set_pending_reply(
+        self,
+        correlation_id: str,
+        framed_reply: str,
+        identity: AskerIdentity | None = None,
+    ) -> bool:
         """Stash a completed reply on an open ask for later redelivery.
 
         Used by the ACP-routed `/ask` path when notify fails with
         TransportError: the assembled ACP answer is real and must not be
         dropped just because the asker is currently offline. Returns True
         if the ask exists and was still open, False otherwise.
+
+        ``identity`` is the asker's full stable identity tuple at stash time,
+        captured by the route handler when the asker peer is resolvable and
+        has all required fields. When provided, it enables the registry's
+        pass-2 identity-tuple rebind on asker re-registration.
         """
         async with self._lock:
             ask = self._asks.get(correlation_id)
             if not ask or ask.closed:
                 return False
             ask.pending_reply = framed_reply
-            logger.debug("Stashed pending reply on ask %s", correlation_id)
+            ask.asker_identity = identity
+            ask.pending_reply_at = datetime.now(timezone.utc)
+            logger.debug(
+                "Stashed pending reply on ask %s (identity=%s)",
+                correlation_id, "yes" if identity else "no",
+            )
             return True
 
     async def clear_pending_reply(self, correlation_id: str) -> None:
@@ -207,6 +246,37 @@ class AskTracker:
             ask = self._asks.get(correlation_id)
             if ask is not None:
                 ask.pending_reply = None
+
+    async def rebind_and_close(
+        self,
+        correlation_id: str,
+        new_from_peer_id: str,
+        reason: str,
+    ) -> bool:
+        """Atomic rebind + close + clear under the tracker lock.
+
+        Called by the registry's pass-2 redelivery only after notify
+        succeeds. Rewrites ``from_peer_id`` to the rebound asker,
+        closes the ask, and clears the stash in a single critical
+        section so readers never observe a half-rebound state.
+
+        Returns True if the ask was open and the mutation applied,
+        False if the ask is missing or already closed (in which case
+        no mutation happened).
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is None or ask.closed:
+                return False
+            ask.from_peer_id = new_from_peer_id
+            ask.closed = True
+            ask.close_reason = reason
+            ask.pending_reply = None
+            logger.debug(
+                "Rebound + closed ask %s -> %s (%s)",
+                correlation_id, new_from_peer_id, reason,
+            )
+            return True
 
     async def take_pending_replies_for_asker(self, peer_id: str) -> list[Ask]:
         """Snapshot open asks targeting this asker that have a stashed reply.
@@ -222,6 +292,81 @@ class AskTracker:
                 if ask.from_peer_id == peer_id
                 and not ask.closed
                 and ask.pending_reply is not None
+            ]
+
+    async def take_orphan_pending_replies_matching(
+        self,
+        *,
+        display_name: str,
+        circle: str,
+        backend: str,
+        path: str,
+        machine: str,
+        live_peer_ids: set[str],
+    ) -> list[Ask]:
+        """Pure filter for identity-tuple rebind.
+
+        Returns asks where:
+          * ``asker_identity`` is non-None
+          * every identity field matches the supplied tuple exactly
+          * ``from_peer_id not in live_peer_ids`` (the original asker peer_id
+            is no longer registered — only then is rebind in play)
+          * the ask is open and has a stashed reply
+
+        The tracker performs no liveness lookups and no uniqueness gating.
+        The caller (PeerRegistry) supplies ``live_peer_ids`` from its own
+        snapshot and applies any cross-peer ambiguity gate before
+        delivering.
+        """
+        async with self._lock:
+            out: list[Ask] = []
+            for ask in self._asks.values():
+                if ask.closed or ask.pending_reply is None:
+                    continue
+                ident = ask.asker_identity
+                if ident is None:
+                    continue
+                if (
+                    ident.display_name != display_name
+                    or ident.circle != circle
+                    or ident.backend != backend
+                    or ident.path != path
+                    or ident.machine != machine
+                ):
+                    continue
+                if ask.from_peer_id in live_peer_ids:
+                    continue
+                out.append(ask)
+            return out
+
+    async def snapshot_pending_replies_for_peer(self, peer_id: str) -> list[Ask]:
+        """Pure read: asks involving this peer that carry a stashed reply.
+
+        Used by ``PeerRegistry._reap_dangling_peers`` / ``_evict_stale_peers``
+        before they call ``forget_peer``, so the registry can emit one
+        ``pending_reply_lost`` event per doomed stash. Does not mutate.
+        """
+        async with self._lock:
+            return [
+                ask for ask in self._asks.values()
+                if ask.pending_reply is not None
+                and (ask.to_peer_id == peer_id or ask.from_peer_id == peer_id)
+            ]
+
+    async def snapshot_expired_pending_replies(self) -> list[Ask]:
+        """Pure read: TTL-expired asks that still carry a stashed reply.
+
+        Used by ``PeerRegistry.lazy_repair`` to emit ``pending_reply_lost``
+        events before ``evict_expired`` deletes the entries. Single owner of
+        TTL-loss emission. Does not mutate. Recipient-facing
+        ``pending_for_peer``'s lazy eviction skips stashed-expired asks so
+        the registry-driven path always wins.
+        """
+        cutoff = datetime.now(timezone.utc) - self._ttl
+        async with self._lock:
+            return [
+                ask for ask in self._asks.values()
+                if ask.created_at < cutoff and ask.pending_reply is not None
             ]
 
     async def pending_for_peer(
@@ -260,12 +405,20 @@ class AskTracker:
             return candidates[:max_results]
 
     async def _maybe_evict_expired(self) -> None:
-        """Run TTL eviction if enough wall time has passed since the last sweep."""
+        """Run TTL eviction if enough wall time has passed since the last sweep.
+
+        Skips asks that still carry a stashed pending reply: those are
+        owned exclusively by the registry's ``lazy_repair`` sweep, which
+        snapshots → emits ``pending_reply_lost`` → calls
+        ``evict_expired(include_stashed=True)`` in order. If this
+        Stop-hook-triggered path dropped stashed-expired asks first, the
+        loss would be silent.
+        """
         now = time.monotonic()
         if now - self._last_eviction < _EVICTION_INTERVAL_SECONDS:
             return
         self._last_eviction = now
-        await self.evict_expired()
+        await self.evict_expired(include_stashed=False)
 
     async def forget_peer(self, peer_id: str) -> int:
         """Drop any asks involving this peer.
@@ -288,17 +441,26 @@ class AskTracker:
                 del self._asks[cid]
             return len(doomed)
 
-    async def evict_expired(self) -> int:
+    async def evict_expired(self, *, include_stashed: bool = True) -> int:
         """Drop asks older than TTL. Returns count evicted.
 
         Closes them as 'evicted' before removal so any caller holding a
         reference can see why they vanished.
+
+        ``include_stashed`` controls whether TTL-expired asks that still
+        carry a stashed reply are dropped. Defaults to True for the
+        registry-driven sweep (which has already emitted
+        ``pending_reply_lost`` from the snapshot it took just before this
+        call). The recipient-facing lazy path (``_maybe_evict_expired``)
+        passes False so stashed-expired asks survive until the registry's
+        single-owner emission path runs.
         """
         cutoff = datetime.now(timezone.utc) - self._ttl
         async with self._lock:
             expired = [
                 cid for cid, ask in self._asks.items()
                 if ask.created_at < cutoff
+                and (include_stashed or ask.pending_reply is None)
             ]
             for cid in expired:
                 ask = self._asks[cid]

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -35,6 +35,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def normalize_identity_path(raw: str) -> str:
+    """Canonical path form for asker identity matching.
+
+    Used symmetrically at stash time (in routes/asks.py) and at rebind time
+    (in PeerRegistry._redeliver_pending_replies). Returns "" when ``raw`` is
+    empty so the strictness gate can refuse no-path stashes.
+    """
+    if not raw:
+        return ""
+    try:
+        return os.path.normpath(os.path.realpath(raw))
+    except (OSError, ValueError):
+        return os.path.normpath(raw)
+
+
 class PaneHijackRejectedError(Exception):
     """Raised by allocate_and_register when a fresh SessionStart claim is
     rejected because it appears to be a subprocess of the pane's existing
@@ -515,6 +530,11 @@ class PeerRegistry:
         If ``peer_id`` is provided and matches an existing peer, the peer is
         taken over in-place (WebSocket reconnect after HTTP pre-registration).
         """
+        # Captured inside the lock, used outside it to schedule redelivery.
+        result_peer_id: str | None = None
+        result_name: str | None = None
+        should_redeliver = False
+
         async with self._lock:
             # Reconnect: if caller provides a peer_id that exists, take over
             # only when it still describes the same peer identity. Stale pane
@@ -555,91 +575,109 @@ class PeerRegistry:
                             mapping.agent_pid = agent_pid
                             self._mappings_dirty = True
                     logger.info(f"Peer reconnected: {existing.display_name} ({peer_id})")
-                    return peer_id, existing.display_name
+                    result_peer_id = peer_id
+                    result_name = existing.display_name
+                    should_redeliver = True
 
-            # Pane-hijack guard: a fresh SessionStart claim for a pane that
-            # already has a live peer, where the new hook's parent_pid matches
-            # the existing peer's agent_pid, is almost certainly a subprocess
-            # agent (e.g. `gemini --yolo` run from inside a claude-code pane)
-            # inheriting TMUX_PANE from its parent and trying to register on
-            # the parent's pane. Reject — the original peer keeps the pane.
-            if pane_id and parent_pid is not None:
-                tolerance = self.heartbeat_tolerance()
-                now = datetime.now(timezone.utc)
-                for existing in self._peers.values():
-                    if existing.pane_id != pane_id:
-                        continue
-                    if existing.agent_pid is None or existing.agent_pid != parent_pid:
-                        continue
-                    if existing.last_seen is None:
-                        continue
-                    if (now - existing.last_seen).total_seconds() > tolerance:
-                        continue
-                    logger.error(
-                        "Rejecting pane-hijack SessionStart claim: "
-                        "hook_pid=%s parent_pid=%s existing_agent_pid=%s "
-                        "existing_peer_id=%s existing_display_name=%s pane_id=%s",
-                        agent_pid,
-                        parent_pid,
-                        existing.agent_pid,
-                        existing.peer_id,
-                        existing.display_name,
-                        pane_id,
-                    )
-                    raise PaneHijackRejectedError(
-                        f"pane {pane_id} held by {existing.display_name} "
-                        f"({existing.peer_id}); claimant parent_pid={parent_pid} "
-                        f"matches existing agent_pid={existing.agent_pid}"
-                    )
+            if result_peer_id is None:
+                # Pane-hijack guard: a fresh SessionStart claim for a pane that
+                # already has a live peer, where the new hook's parent_pid matches
+                # the existing peer's agent_pid, is almost certainly a subprocess
+                # agent (e.g. `gemini --yolo` run from inside a claude-code pane)
+                # inheriting TMUX_PANE from its parent and trying to register on
+                # the parent's pane. Reject — the original peer keeps the pane.
+                if pane_id and parent_pid is not None:
+                    tolerance = self.heartbeat_tolerance()
+                    now = datetime.now(timezone.utc)
+                    for existing in self._peers.values():
+                        if existing.pane_id != pane_id:
+                            continue
+                        if existing.agent_pid is None or existing.agent_pid != parent_pid:
+                            continue
+                        if existing.last_seen is None:
+                            continue
+                        if (now - existing.last_seen).total_seconds() > tolerance:
+                            continue
+                        logger.error(
+                            "Rejecting pane-hijack SessionStart claim: "
+                            "hook_pid=%s parent_pid=%s existing_agent_pid=%s "
+                            "existing_peer_id=%s existing_display_name=%s pane_id=%s",
+                            agent_pid,
+                            parent_pid,
+                            existing.agent_pid,
+                            existing.peer_id,
+                            existing.display_name,
+                            pane_id,
+                        )
+                        raise PaneHijackRejectedError(
+                            f"pane {pane_id} held by {existing.display_name} "
+                            f"({existing.peer_id}); claimant parent_pid={parent_pid} "
+                            f"matches existing agent_pid={existing.agent_pid}"
+                        )
 
-            # Fresh registration: daemon owns the name
-            assigned_name = self._build_display_name(path or "", circle, backend)
-            allocated_id = self._find_or_allocate_mapping(
-                assigned_name, circle, backend, path, role=role,
-                agent_pid=agent_pid,
+                # Fresh registration: daemon owns the name
+                assigned_name = self._build_display_name(path or "", circle, backend)
+                allocated_id = self._find_or_allocate_mapping(
+                    assigned_name, circle, backend, path, role=role,
+                    agent_pid=agent_pid,
+                )
+                if pane_id:
+                    self._release_pane(pane_id, allocated_id)
+
+                # Restore circle, role, and description from persisted mapping.
+                # The mapping is the durable source of truth for these fields;
+                # when _find_or_allocate_mapping adopted a prior session, its
+                # stored circle/role may differ from the caller-supplied
+                # defaults and should win.
+                restored = self._mappings.get(allocated_id)
+                effective_circle = restored.circle if restored else circle
+                effective_role = restored.role if restored else role
+                restored_description = restored.description if restored else ""
+                # Caller-supplied agent_pid wins (it's the live process); fall
+                # back to whatever the mapping persisted across daemon restart.
+                effective_agent_pid = (
+                    agent_pid
+                    if agent_pid is not None
+                    else (restored.agent_pid if restored else None)
+                )
+
+                # --- create and insert Peer ---
+                peer = Peer(
+                    peer_id=allocated_id,
+                    display_name=assigned_name,
+                    circle=effective_circle,
+                    backend=backend,
+                    role=effective_role,
+                    status=PeerStatus.ONLINE,
+                    last_seen=datetime.now(timezone.utc),
+                    pane_id=pane_id,
+                    tmux_session=tmux_session,
+                    path=path or "",
+                    machine=machine,
+                    metadata=metadata or {},
+                    description=restored_description,
+                    turn_state=turn_state,
+                    agent_pid=effective_agent_pid,
+                )
+                self._peers[allocated_id] = peer
+                logger.info(f"Peer registered: {assigned_name} ({allocated_id})")
+                result_peer_id = allocated_id
+                result_name = assigned_name
+                should_redeliver = True
+
+        # Out of the lock. Schedule pass-2 (identity-tuple) redelivery for
+        # both fresh allocations and same-id reconnects. The new peer is
+        # already ONLINE, so update_peer_status won't fire — this is the
+        # only redelivery hook on the SessionStart path. Gated on the
+        # acp_broker_client experiment so flag-off has zero new behaviour.
+        if should_redeliver and result_peer_id and self._acp_redelivery_enabled():
+            asyncio.create_task(
+                self._redeliver_pending_replies(result_peer_id),
+                name=f"redeliver-{result_peer_id[:12]}",
             )
-            if pane_id:
-                self._release_pane(pane_id, allocated_id)
 
-            # Restore circle, role, and description from persisted mapping. The
-            # mapping is the durable source of truth for these fields; when
-            # _find_or_allocate_mapping adopted a prior session, its stored
-            # circle/role may differ from the caller-supplied defaults and
-            # should win.
-            restored = self._mappings.get(allocated_id)
-            effective_circle = restored.circle if restored else circle
-            effective_role = restored.role if restored else role
-            restored_description = restored.description if restored else ""
-            # Caller-supplied agent_pid wins (it's the live process); fall
-            # back to whatever the mapping persisted across daemon restart.
-            effective_agent_pid = (
-                agent_pid
-                if agent_pid is not None
-                else (restored.agent_pid if restored else None)
-            )
-
-            # --- create and insert Peer ---
-            peer = Peer(
-                peer_id=allocated_id,
-                display_name=assigned_name,
-                circle=effective_circle,
-                backend=backend,
-                role=effective_role,
-                status=PeerStatus.ONLINE,
-                last_seen=datetime.now(timezone.utc),
-                pane_id=pane_id,
-                tmux_session=tmux_session,
-                path=path or "",
-                machine=machine,
-                metadata=metadata or {},
-                description=restored_description,
-                turn_state=turn_state,
-                agent_pid=effective_agent_pid,
-            )
-            self._peers[allocated_id] = peer
-            logger.info(f"Peer registered: {assigned_name} ({allocated_id})")
-
-            return allocated_id, assigned_name
+        assert result_peer_id is not None and result_name is not None
+        return result_peer_id, result_name
 
     # ------------------------------------------------------------------
     # register_peer (backward-compat for tests that build Peer objects)
@@ -1198,43 +1236,134 @@ class PeerRegistry:
     async def _redeliver_pending_replies(self, asker_peer_id: str) -> None:
         """Drain ACP-stashed replies for an asker that just came back online.
 
-        Best-effort: a failure here just leaves the reply stashed for the next
-        reconnect. Successful redelivery closes the ask (ack_with_msg) and
-        clears the stash so the Ask object isn't holding reply text it can
-        never use again.
+        Two passes:
+          1. ``take_pending_replies_for_asker`` — same peer_id reconnect
+             (original behaviour).
+          2. ``take_orphan_pending_replies_matching`` — full identity-tuple
+             rebind for asks whose original ``from_peer_id`` is no longer in
+             ``_peers`` (i.e. pruned by ``_build_display_name`` or reaped).
+             Guarded by a uniqueness gate over live peers so an ambiguous
+             tuple refuses rebind rather than misrouting.
+
+        Best-effort: a failure here just leaves the reply stashed for the
+        next reconnect / sweep. Successful redelivery closes the ask
+        (ack_with_msg) and clears the stash so the Ask object isn't holding
+        reply text it can never use again.
         """
         if self._ask_tracker is None:
             return
+        # --- Pass 1: same peer_id reconnect ---
         try:
             pending = await self._ask_tracker.take_pending_replies_for_asker(asker_peer_id)
         except Exception as e:  # noqa: BLE001
             logger.warning("redeliver: snapshot failed for %s: %s", asker_peer_id, e)
-            return
+            pending = []
         for ask in pending:
-            reply = ask.pending_reply
-            if reply is None:
-                continue
-            try:
-                await self.notify(
-                    from_peer=ask.to_peer_id,
-                    to_peer=ask.from_peer_id,
-                    text=reply,
-                    bypass_circle=True,
-                )
-            except (ValueError, TransportError) as e:
-                logger.info(
-                    "redeliver: %s still undeliverable to %s: %s",
-                    ask.correlation_id, asker_peer_id, e,
-                )
-                continue
-            await self._ask_tracker.close(ask.correlation_id, reason="ack_with_msg")
-            # Drop the stash from the closed Ask object so we're not
-            # retaining reply text past its useful life.
-            await self._ask_tracker.clear_pending_reply(ask.correlation_id)
-            logger.info(
-                "redeliver: delivered stashed reply for %s to %s",
-                ask.correlation_id, asker_peer_id,
+            await self._deliver_one_stashed(ask, asker_peer_id, rebind=False)
+
+        # --- Pass 2: identity-tuple rebind ---
+        async with self._lock:
+            new_peer = self._peers.get(asker_peer_id)
+            if new_peer is None:
+                return
+            if not (new_peer.display_name and new_peer.circle and new_peer.backend):
+                return
+            if not new_peer.machine or new_peer.machine == "unknown":
+                return
+            norm_path = normalize_identity_path(new_peer.path or "")
+            if not norm_path:
+                return
+            tuple_fields = (
+                new_peer.display_name,
+                new_peer.circle,
+                new_peer.backend.value,
+                norm_path,
+                new_peer.machine,
             )
+            # Uniqueness gate: refuse rebind if any other live peer matches
+            # the same full tuple. We compute matches under the lock so the
+            # live-peers snapshot we pass to the tracker is consistent with
+            # the gate decision.
+            matches = [
+                p for p in self._peers.values()
+                if p.display_name == new_peer.display_name
+                and p.circle == new_peer.circle
+                and p.backend == new_peer.backend
+                and (p.machine or "") == new_peer.machine
+                and normalize_identity_path(p.path or "") == norm_path
+            ]
+            live_peer_ids = set(self._peers.keys())
+
+        if len(matches) != 1 or matches[0].peer_id != asker_peer_id:
+            logger.debug(
+                "redeliver pass-2: ambiguous live tuple match for %s "
+                "(%d candidates); refusing rebind",
+                asker_peer_id, len(matches),
+            )
+            return
+
+        try:
+            orphans = await self._ask_tracker.take_orphan_pending_replies_matching(
+                display_name=tuple_fields[0],
+                circle=tuple_fields[1],
+                backend=tuple_fields[2],
+                path=tuple_fields[3],
+                machine=tuple_fields[4],
+                live_peer_ids=live_peer_ids,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "redeliver pass-2: orphan scan failed for %s: %s",
+                asker_peer_id, e,
+            )
+            return
+        for ask in orphans:
+            await self._deliver_one_stashed(ask, asker_peer_id, rebind=True)
+
+    async def _deliver_one_stashed(
+        self, ask: Any, asker_peer_id: str, *, rebind: bool,
+    ) -> None:
+        """Deliver a single stashed reply and close the ask on success.
+
+        The Ask object is **never mutated** outside ``AskTracker`` locks.
+        Notify targets ``asker_peer_id`` directly (the registry already
+        knows the live id from its own pass-1/pass-2 caller); only on
+        successful delivery do we ask the tracker to atomically rebind
+        + close + clear (rebind path) or close + clear (same-id path).
+        On notify failure the stash is left exactly as we found it.
+        """
+        reply = ask.pending_reply
+        if reply is None:
+            return
+        try:
+            await self.notify(
+                from_peer=ask.to_peer_id,
+                to_peer=asker_peer_id,
+                text=reply,
+                bypass_circle=True,
+            )
+        except (ValueError, TransportError) as e:
+            logger.info(
+                "redeliver: %s still undeliverable to %s: %s",
+                ask.correlation_id, asker_peer_id, e,
+            )
+            return
+        if self._ask_tracker is None:
+            return
+        if rebind:
+            await self._ask_tracker.rebind_and_close(
+                ask.correlation_id, asker_peer_id, reason="ack_with_msg",
+            )
+        else:
+            await self._ask_tracker.close(
+                ask.correlation_id, reason="ack_with_msg",
+            )
+            await self._ask_tracker.clear_pending_reply(ask.correlation_id)
+        logger.info(
+            "redeliver%s: delivered stashed reply for %s to %s",
+            " (rebound)" if rebind else "",
+            ask.correlation_id, asker_peer_id,
+        )
 
     async def update_peer_turn_state(
         self, identifier: str, turn_state: TurnState | None,
@@ -1520,6 +1649,7 @@ class PeerRegistry:
             await self._demote_unsafe_connected_peers()
             await self._reap_dangling_peers()
             await self._evict_stale_peers()
+            await self._emit_and_evict_expired_stashes()
             self._save_events()
             self._persist_mappings()
 
@@ -1617,6 +1747,21 @@ class PeerRegistry:
                 self._description_set_at.pop(peer.peer_id, None)
                 self._mappings_dirty = True
 
+        # Snapshot doomed-with-stash asks BEFORE any destructive cleanup
+        # so observers see the pending_reply_lost event before the ask
+        # disappears. Order: snapshot → emit → forget/evict.
+        doomed_stashes: list[tuple[Any, str]] = []
+        if self._ask_tracker is not None:
+            for peer in stale:
+                snap = await self._ask_tracker.snapshot_pending_replies_for_peer(
+                    peer.peer_id,
+                )
+                for ask in snap:
+                    doomed_stashes.append((ask, "offline_ttl_reap"))
+
+        for ask, reason in doomed_stashes:
+            self._emit_pending_reply_lost(ask, reason)
+
         for peer in stale:
             if self._transport is not None:
                 try:
@@ -1666,9 +1811,64 @@ class PeerRegistry:
                 self._mappings_dirty = True
                 logger.info("evicted %d stale offline peers", len(stale))
         if stale and self._ask_tracker is not None:
+            doomed_stashes: list[Any] = []
+            for pid in stale:
+                snap = await self._ask_tracker.snapshot_pending_replies_for_peer(pid)
+                doomed_stashes.extend(snap)
+            # snapshot → emit → forget so observers see the loss event
+            # before the ask disappears.
+            for ask in doomed_stashes:
+                self._emit_pending_reply_lost(ask, "stale_evict")
             for pid in stale:
                 await self._ask_tracker.forget_peer(pid)
         return len(stale)
+
+    async def _emit_and_evict_expired_stashes(self) -> None:
+        """Single owner for TTL-loss emission on stashed asks.
+
+        Snapshot expired stashes, emit pointer-only ``pending_reply_lost``
+        events, then call ``evict_expired(include_stashed=True)`` to delete.
+        The Stop-hook-triggered ``_maybe_evict_expired`` path skips
+        stashed asks specifically so this ordering can run.
+        """
+        if self._ask_tracker is None:
+            return
+        snap = await self._ask_tracker.snapshot_expired_pending_replies()
+        # snapshot → emit → evict so observers see the loss event before
+        # the ask disappears.
+        for ask in snap:
+            self._emit_pending_reply_lost(ask, "ttl_evicted")
+        await self._ask_tracker.evict_expired(include_stashed=True)
+
+    def _emit_pending_reply_lost(self, ask: Any, reason: str) -> None:
+        """Pointer-only ``pending_reply_lost`` event.
+
+        Carries enough to look up the lost correlation and the answerer
+        that produced the reply; deliberately omits reply text, asker
+        path, and asker machine.
+        """
+        ident = ask.asker_identity
+        self.add_event(
+            "pending_reply_lost",
+            {
+                "correlation_id": ask.correlation_id,
+                "answerer_peer_id": ask.to_peer_id,
+                "answerer_name": ask.to_peer_name,
+                # asker_name is always present on the Ask itself, even when
+                # asker_identity wasn't captured at stash time. Pointer-only:
+                # never the reply text, never path, never machine.
+                "asker_name": ask.from_peer_name,
+                "asker_display_name": ident.display_name if ident else None,
+                "asker_circle": ident.circle if ident else None,
+                "asker_backend": ident.backend if ident else None,
+                "asker_peer_id": ask.from_peer_id,
+                "reason": reason,
+                "pending_reply_at": (
+                    ask.pending_reply_at.isoformat()
+                    if ask.pending_reply_at else None
+                ),
+            },
+        )
 
     async def active_repair(self) -> None:
         """Full liveness sweep: ping ONLINE/BUSY peers, mark dead ones OFFLINE.

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -32,10 +32,10 @@ from repowire.acp import (
     AcpClientManager,
     maybe_decide_acp_route,
 )
-from repowire.daemon.ask_tracker import AskTracker, QuiescedError
+from repowire.daemon.ask_tracker import AskerIdentity, AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
-from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
 from repowire.daemon.routes._shared import OkResponse
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer
@@ -122,6 +122,42 @@ async def _resolve_sender_for_target(from_peer: str, target: Peer) -> Peer | Non
         raise HTTPException(status_code=409, detail=str(e)) from e
 
 
+async def _capture_asker_identity(
+    peer_registry: PeerRegistry, asker_peer_id: str,
+) -> AskerIdentity | None:
+    """Snapshot the asker's full stable identity for stash-time rebind.
+
+    Returns None unless every field is present and non-default:
+      * display_name, circle, backend all non-empty
+      * path non-empty after normalization
+      * machine non-empty AND not "unknown"
+
+    Partial identity is deliberately refused — misrouting an ACP answer to
+    the wrong peer on rebind is worse than non-delivery + visible event.
+    """
+    try:
+        peer = await peer_registry.get_peer(asker_peer_id)
+    except ValueError:
+        return None
+    if peer is None:
+        return None
+    if not (peer.display_name and peer.circle and peer.backend):
+        return None
+    if not peer.machine or peer.machine == "unknown":
+        return None
+    raw_path = peer.path or ""
+    norm_path = normalize_identity_path(raw_path)
+    if not norm_path:
+        return None
+    return AskerIdentity(
+        display_name=peer.display_name,
+        circle=peer.circle,
+        backend=peer.backend.value,
+        path=norm_path,
+        machine=peer.machine,
+    )
+
+
 async def _acp_complete(
     *,
     correlation_id: str,
@@ -185,11 +221,16 @@ async def _acp_complete(
             )
             await ask_tracker.close(correlation_id, reason="send_failed")
             return
-        stashed = await ask_tracker.set_pending_reply(correlation_id, framed)
+        identity = await _capture_asker_identity(peer_registry, ask.from_peer_id)
+        stashed = await ask_tracker.set_pending_reply(
+            correlation_id, framed, identity=identity,
+        )
         logger.warning(
-            "ACP ack reply for cid=%s: asker offline (%s). %s; will redeliver on reconnect.",
+            "ACP ack reply for cid=%s: asker offline (%s). %s%s; "
+            "will redeliver on reconnect.",
             correlation_id, e,
             "Reply stashed" if stashed else "Stash failed (ask closed)",
+            " with identity tuple" if (stashed and identity) else "",
         )
         return
     except ValueError as e:

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -1246,3 +1246,617 @@ def test_make_recorder_raises_clean_error_when_acp_sdk_missing(monkeypatch) -> N
     msg = str(exc_info.value)
     assert "agent-client-protocol" in msg
     assert "experiments.acp_broker_client" in msg
+
+
+# ----------------------------------------------------------------------
+# #207 — identity-tuple rebind, pointer-only loss events, TTL ordering
+# ----------------------------------------------------------------------
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _make_registry_with_at(tmp_path: Path, *, flag: bool = True) -> tuple:
+    cfg = Config()
+    cfg.experiments.acp_broker_client = flag
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg, message_router=router, query_tracker=qt,
+        transport=transport, persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._last_repair = time.monotonic() + 3600  # block auto lazy_repair
+    return cfg, registry, router, at
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_rebinds_on_new_peer_id_after_clean_takeover(
+    tmp_path: Path,
+) -> None:
+    """#207 path A: clean-takeover prune leaves a stash; rebind via identity tuple.
+
+    Drives the bug through the real SessionStart entry point —
+    ``allocate_and_register`` — so we prove pass-2 redelivery is wired into
+    the path users actually hit (fresh ONLINE allocation), not just
+    update_peer_status's OFFLINE→ONLINE bump.
+
+    1. Asker A registered via allocate_and_register, goes OFFLINE with a
+       stashed reply (full identity captured).
+    2. Second allocate_and_register call with the same path/backend/circle
+       — _build_display_name prunes the OFFLINE A and a fresh peer_id is
+       allocated, ONLINE from birth.
+    3. allocate_and_register's post-lock scheduler kicks
+       _redeliver_pending_replies on the new id; pass-2 identity match
+       finds the orphan and delivers. Ask closes; no pending_reply_lost
+       event.
+    """
+    from repowire.daemon.routes.asks import _acp_complete
+
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+
+    # Real path: allocate_and_register for both asker and answerer.
+    asker_a_id, asker_name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%a",
+        machine="localhost",
+    )
+    answerer_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path / "answerer"),
+        pane_id="%ans",
+        machine="localhost",
+    )
+    await registry.update_peer_status(asker_a_id, PeerStatus.OFFLINE)
+
+    # Stash a reply via the real _acp_complete path so identity is captured.
+    fail_first = {"n": 0}
+
+    async def _maybe_fail(**kwargs):
+        fail_first["n"] += 1
+        if fail_first["n"] == 1:
+            from repowire.daemon.websocket_transport import TransportError
+            raise TransportError("asker offline")
+    router.send_notification = AsyncMock(side_effect=_maybe_fail)
+
+    cid = await at.register(
+        from_peer_id=asker_a_id, from_peer_name=asker_name,
+        to_peer_id=answerer_id, to_peer_name="answerer", text="q",
+    )
+    await _acp_complete(
+        correlation_id=cid, reply="42", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+    ask = await at.get(cid)
+    assert ask is not None and ask.pending_reply is not None
+    assert ask.asker_identity is not None, "identity should have been captured"
+
+    # Real clean-takeover: a second allocate_and_register for the same
+    # name/circle/backend with the OFFLINE asker-A still present prunes A
+    # (via _build_display_name) and issues a brand new peer_id.
+    asker_b_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%a",
+        machine="localhost",
+    )
+    assert asker_b_id != asker_a_id, "takeover should yield a fresh peer_id"
+    # Give the post-lock redelivery task a tick to run.
+    await asyncio.sleep(0.1)
+
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is True, "rebind should have delivered + closed the ask"
+    assert ask.close_reason == "ack_with_msg"
+    assert ask.pending_reply is None, "stash should be cleared after delivery"
+    assert ask.from_peer_id == asker_b_id, "from_peer_id should be rewritten on rebind"
+    # No loss event emitted
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_rebind_refused_when_identity_incomplete(
+    tmp_path: Path,
+) -> None:
+    """If the stash was captured without identity (e.g. asker had machine=unknown
+    at stash time), pass-2 cannot rebind — reply stays stashed."""
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+    notify_calls: list[dict] = []
+
+    async def _record(**kwargs):
+        notify_calls.append(kwargs)
+    router.send_notification = AsyncMock(side_effect=_record)
+
+    asker_a = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker_a)
+    await registry.register_peer(answerer)
+
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    # Stash without identity (simulating machine=unknown gate refusal at stash time)
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42", identity=None)
+
+    # Prune A; register B with same tuple
+    async with registry._lock:
+        del registry._peers["asker-A"]
+        registry._mappings.pop("asker-A", None)
+    asker_b = Peer(
+        peer_id="asker-B", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker_b)
+    await registry.update_peer_status("asker-B", PeerStatus.OFFLINE)
+    await registry.update_peer_status("asker-B", PeerStatus.ONLINE)
+    await asyncio.sleep(0.1)
+
+    ask = await at.get(cid)
+    assert ask is not None and ask.closed is False
+    assert ask.pending_reply is not None
+    assert notify_calls == [], "no rebind should have fired without identity"
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_rebind_refused_on_ambiguous_live_match(
+    tmp_path: Path,
+) -> None:
+    """True full-tuple collision: two live peers share every identity field.
+
+    Reachable only via the lower-level register_peer path because
+    allocate_and_register's name-builder suffixes collisions. The registry
+    uniqueness gate must refuse rebind rather than misroute.
+    """
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+    notify_calls: list[dict] = []
+    async def _record(**kwargs):
+        notify_calls.append(kwargs)
+    router.send_notification = AsyncMock(side_effect=_record)
+
+    asker_a = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker_a)
+    await registry.register_peer(answerer)
+    await registry.update_peer_status("asker-A", PeerStatus.OFFLINE)
+
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    from repowire.daemon.ask_tracker import AskerIdentity
+    from repowire.daemon.peer_registry import normalize_identity_path
+    norm = normalize_identity_path(str(tmp_path))
+    ident = AskerIdentity(
+        display_name="asker", circle="default", backend="claude-code",
+        path=norm, machine="localhost",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42", identity=ident)
+
+    # Construct the pathological state: two live peers, same full tuple,
+    # different peer_ids. (Use direct dict insertion to bypass the
+    # de-duplication path inside register_peer.)
+    async with registry._lock:
+        del registry._peers["asker-A"]
+        registry._mappings.pop("asker-A", None)
+    asker_b = Peer(
+        peer_id="asker-B", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    asker_c = Peer(
+        peer_id="asker-C", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id=None, circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    async with registry._lock:
+        registry._peers["asker-B"] = asker_b
+        registry._peers["asker-C"] = asker_c
+
+    await registry.update_peer_status("asker-B", PeerStatus.OFFLINE)
+    await registry.update_peer_status("asker-B", PeerStatus.ONLINE)
+    await asyncio.sleep(0.1)
+
+    ask = await at.get(cid)
+    assert ask is not None and ask.closed is False
+    assert ask.pending_reply is not None
+    assert notify_calls == [], "ambiguous tuple must refuse rebind"
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert events == [], "no loss event yet — still recoverable on next sweep"
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_lost_event_on_reap(tmp_path: Path) -> None:
+    """Reap-time pointer-only loss event with answerer fields."""
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+    # Configure short reap TTL so we can backdate cheaply.
+    cfg.daemon.peer_reap_ttl_seconds = 60
+
+    asker = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
+    from repowire.daemon.ask_tracker import AskerIdentity
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    ident = AskerIdentity(
+        display_name="asker", circle="default", backend="claude-code",
+        path=str(tmp_path), machine="localhost",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] secret answer", identity=ident)
+
+    # Backdate asker to past reap TTL and mark OFFLINE
+    async with registry._lock:
+        live = registry._peers["asker-A"]
+        live.status = PeerStatus.OFFLINE
+        live.last_seen = datetime.now(timezone.utc) - timedelta(seconds=120)
+
+    # Allow lazy_repair to run
+    registry._last_repair = 0.0
+    await registry.lazy_repair()
+
+    # Ask should be gone (forget_peer dropped it after the snapshot)
+    assert await at.get(cid) is None
+    # And we should have one pointer-only loss event
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["correlation_id"] == cid
+    assert ev["answerer_peer_id"] == "answerer"
+    assert ev["answerer_name"] == "answerer"
+    # asker_name is always present (from Ask.from_peer_name)
+    assert ev["asker_name"] == "asker"
+    assert ev["asker_display_name"] == "asker"
+    assert ev["asker_circle"] == "default"
+    assert ev["asker_backend"] == "claude-code"
+    assert ev["asker_peer_id"] == "asker-A"
+    assert ev["reason"] == "offline_ttl_reap"
+    # Pointer-only: no reply text, no asker path, no asker machine
+    assert "reply" not in ev and "text" not in ev
+    assert "path" not in ev and "machine" not in ev
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_lost_event_on_ttl_eviction(tmp_path: Path) -> None:
+    """24h TTL eviction emits a loss event via lazy_repair's single-owner path."""
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+
+    asker = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42")
+
+    # Backdate created_at past 24h TTL
+    ask = await at.get(cid)
+    ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+
+    registry._last_repair = 0.0
+    await registry.lazy_repair()
+
+    assert await at.get(cid) is None
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert len(events) == 1
+    assert events[0]["reason"] == "ttl_evicted"
+    assert events[0]["correlation_id"] == cid
+    assert events[0]["answerer_peer_id"] == "answerer"
+
+
+@pytest.mark.asyncio
+async def test_stop_hook_poll_does_not_silently_evict_stashed_ask(
+    tmp_path: Path,
+) -> None:
+    """The Stop-hook-driven pending_for_peer path must NOT drop stashed-expired
+    asks before the registry's lazy_repair gets a chance to emit the loss event.
+    """
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+
+    asker = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42")
+    ask = await at.get(cid)
+    ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+
+    # Force _maybe_evict_expired to run on the next pending_for_peer call.
+    at._last_eviction = 0.0
+    _ = await at.pending_for_peer("answerer")
+
+    # Ask is still present; no loss event yet.
+    assert await at.get(cid) is not None
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert events == []
+
+    # Registry sweep is the single owner — now it should emit + delete.
+    registry._last_repair = 0.0
+    await registry.lazy_repair()
+    assert await at.get(cid) is None
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert len(events) == 1
+    assert events[0]["reason"] == "ttl_evicted"
+
+
+@pytest.mark.asyncio
+async def test_path_normalization_symmetry(tmp_path: Path) -> None:
+    """Stash with raw path; live peer normalized variant; rebind succeeds."""
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+    notify_calls: list[dict] = []
+    async def _record(**kwargs):
+        notify_calls.append(kwargs)
+    router.send_notification = AsyncMock(side_effect=_record)
+
+    from repowire.daemon.ask_tracker import AskerIdentity
+    from repowire.daemon.peer_registry import normalize_identity_path
+
+    raw = str(tmp_path) + "/./"  # un-normalized
+    norm = normalize_identity_path(raw)
+
+    asker_a = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker_a)
+    await registry.register_peer(answerer)
+    await registry.update_peer_status("asker-A", PeerStatus.OFFLINE)
+
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    ident = AskerIdentity(
+        display_name="asker", circle="default", backend="claude-code",
+        path=norm, machine="localhost",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42", identity=ident)
+
+    # Prune A, register B with the un-normalized variant. Registry's pass-2
+    # normalizes both sides, so the rebind tuple should match.
+    async with registry._lock:
+        del registry._peers["asker-A"]
+        registry._mappings.pop("asker-A", None)
+    asker_b = Peer(
+        peer_id="asker-B", display_name="asker", path=raw,
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker_b)
+    await registry.update_peer_status("asker-B", PeerStatus.OFFLINE)
+    await registry.update_peer_status("asker-B", PeerStatus.ONLINE)
+    await asyncio.sleep(0.1)
+
+    ask = await at.get(cid)
+    assert ask is not None and ask.closed is True
+    assert ask.pending_reply is None
+
+
+@pytest.mark.asyncio
+async def test_same_id_reconnect_via_allocate_and_register_redelivers(
+    tmp_path: Path,
+) -> None:
+    """Same-peer_id reconnect through allocate_and_register also triggers
+    redelivery — not just update_peer_status's OFFLINE→ONLINE bump.
+
+    HTTP /peers pre-registration followed by a WebSocket reconnect calls
+    allocate_and_register with the original peer_id; the peer takes over
+    in place (no new peer_id). Pass-1 (same-id) redelivery should fire.
+    """
+    from repowire.daemon.routes.asks import _acp_complete
+
+    cfg, registry, router, at = _make_registry_with_at(tmp_path)
+
+    asker_id, asker_name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%a",
+        machine="localhost",
+    )
+    answerer_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path / "answerer"),
+        pane_id="%ans",
+        machine="localhost",
+    )
+    await registry.update_peer_status(asker_id, PeerStatus.OFFLINE)
+
+    fail_first = {"n": 0}
+
+    async def _maybe_fail(**kwargs):
+        fail_first["n"] += 1
+        if fail_first["n"] == 1:
+            from repowire.daemon.websocket_transport import TransportError
+            raise TransportError("asker offline")
+    router.send_notification = AsyncMock(side_effect=_maybe_fail)
+
+    cid = await at.register(
+        from_peer_id=asker_id, from_peer_name=asker_name,
+        to_peer_id=answerer_id, to_peer_name="answerer", text="q",
+    )
+    await _acp_complete(
+        correlation_id=cid, reply="42", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+
+    # Same-id reconnect through allocate_and_register: peer_id carried in.
+    same_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(tmp_path),
+        pane_id="%a",
+        machine="localhost",
+        peer_id=asker_id,
+    )
+    assert same_id == asker_id, "reconnect must keep the original peer_id"
+    await asyncio.sleep(0.1)
+
+    ask = await at.get(cid)
+    assert ask is not None
+    assert ask.closed is True, "pass-1 redelivery should have closed the ask"
+    assert ask.pending_reply is None
+    assert ask.from_peer_id == asker_id  # unchanged, no rebind needed
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_lost_includes_asker_name_without_identity(
+    tmp_path: Path,
+) -> None:
+    """Blocker #4: asker_name must be populated from Ask.from_peer_name
+    even when asker_identity is None (e.g. stash captured without identity
+    because machine=='unknown' at stash time)."""
+    cfg, registry, _, at = _make_registry_with_at(tmp_path)
+    cfg.daemon.peer_reap_ttl_seconds = 60
+
+    asker = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    answerer = Peer(
+        peer_id="answerer", display_name="answerer", path=str(tmp_path),
+        machine="localhost", pane_id="%ans", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker)
+    await registry.register_peer(answerer)
+
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker-display",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    # No identity captured (simulates pre-strictness-gate stash)
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42", identity=None)
+
+    async with registry._lock:
+        live = registry._peers["asker-A"]
+        live.status = PeerStatus.OFFLINE
+        live.last_seen = datetime.now(timezone.utc) - timedelta(seconds=120)
+
+    registry._last_repair = 0.0
+    await registry.lazy_repair()
+
+    events = [e for e in registry.get_events() if e["type"] == "pending_reply_lost"]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["asker_name"] == "asker-display", "asker_name must come from Ask.from_peer_name"
+    assert ev["asker_display_name"] is None  # identity wasn't captured
+    assert ev["asker_circle"] is None
+    assert ev["asker_backend"] is None
+    # Pointer-only invariants still hold
+    assert "reply" not in ev and "text" not in ev
+    assert "path" not in ev and "machine" not in ev
+
+
+@pytest.mark.asyncio
+async def test_pending_reply_lost_emitted_before_destruction(
+    tmp_path: Path,
+) -> None:
+    """Blocker #3: snapshot → emit → forget ordering. Capture the event
+    payload at emit time AND confirm the ask is still present at that
+    moment, then absent after lazy_repair completes."""
+    cfg, registry, _, at = _make_registry_with_at(tmp_path)
+    cfg.daemon.peer_reap_ttl_seconds = 60
+
+    asker = Peer(
+        peer_id="asker-A", display_name="asker", path=str(tmp_path),
+        machine="localhost", pane_id="%a", circle="default",
+        backend=AgentType.CLAUDE_CODE,
+    )
+    await registry.register_peer(asker)
+    cid = await at.register(
+        from_peer_id="asker-A", from_peer_name="asker",
+        to_peer_id="answerer", to_peer_name="answerer", text="q",
+    )
+    await at.set_pending_reply(cid, "[ack #x from @answerer] 42")
+
+    async with registry._lock:
+        live = registry._peers["asker-A"]
+        live.status = PeerStatus.OFFLINE
+        live.last_seen = datetime.now(timezone.utc) - timedelta(seconds=120)
+
+    # Hook add_event so we can check the ask still exists at emission time.
+    seen_at_emit: dict = {}
+    original_add_event = registry.add_event
+
+    def _spy_add_event(name, payload):
+        if name == "pending_reply_lost":
+            # If ordering is wrong (delete first), the tracker would already
+            # have removed the ask by now.
+            seen_at_emit["ask_exists"] = cid in at._asks
+        return original_add_event(name, payload)
+    registry.add_event = _spy_add_event  # type: ignore[assignment]
+
+    registry._last_repair = 0.0
+    await registry.lazy_repair()
+
+    assert seen_at_emit.get("ask_exists") is True, (
+        "event must fire BEFORE the ask is forgotten — observed deleted at emit"
+    )
+    assert await at.get(cid) is None, "ask must be gone after lazy_repair completes"

--- a/tests/test_ask_tracker.py
+++ b/tests/test_ask_tracker.py
@@ -129,3 +129,148 @@ class TestEvictExpired:
         await tracker.register("a", "a", "b-id", "b", "x")
         evicted = await tracker.evict_expired()
         assert evicted == 0
+
+
+# ----------------------------------------------------------------------
+# #207 — identity-tuple rebind helpers
+# ----------------------------------------------------------------------
+
+from repowire.daemon.ask_tracker import AskerIdentity  # noqa: E402
+
+
+def _ident(
+    *,
+    display_name="asker",
+    circle="default",
+    backend="claude-code",
+    path="/repo/asker",
+    machine="localhost",
+) -> AskerIdentity:
+    return AskerIdentity(
+        display_name=display_name,
+        circle=circle,
+        backend=backend,
+        path=path,
+        machine=machine,
+    )
+
+
+class TestSetPendingReplyIdentity:
+    async def test_records_identity_when_passed(self, tracker):
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        ok = await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        assert ok is True
+        ask = await tracker.get(cid)
+        assert ask is not None
+        assert ask.asker_identity == _ident()
+        assert ask.pending_reply == "framed"
+        assert ask.pending_reply_at is not None
+
+    async def test_accepts_none_identity(self, tracker):
+        """Stash without identity is supported (pass-1 reconnect still works)."""
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        ok = await tracker.set_pending_reply(cid, "framed", identity=None)
+        assert ok is True
+        ask = await tracker.get(cid)
+        assert ask is not None and ask.asker_identity is None
+
+    async def test_default_identity_is_none(self, tracker):
+        """Back-compat: set_pending_reply without identity kwarg still works."""
+        cid = await tracker.register("a", "a", "b-id", "b", "x")
+        ok = await tracker.set_pending_reply(cid, "framed")
+        assert ok is True
+        ask = await tracker.get(cid)
+        assert ask is not None and ask.asker_identity is None
+
+
+class TestTakeOrphanPendingRepliesMatching:
+    async def test_requires_all_fields(self, tracker):
+        cid = await tracker.register("asker-old-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        # Wrong machine → no match (every field must match exactly)
+        out = await tracker.take_orphan_pending_replies_matching(
+            display_name="asker", circle="default", backend="claude-code",
+            path="/repo/asker", machine="other-host",
+            live_peer_ids=set(),
+        )
+        assert out == []
+        # Right tuple AND original peer_id not in live set → match
+        out = await tracker.take_orphan_pending_replies_matching(
+            display_name="asker", circle="default", backend="claude-code",
+            path="/repo/asker", machine="localhost",
+            live_peer_ids=set(),
+        )
+        assert len(out) == 1 and out[0].correlation_id == cid
+
+    async def test_skipped_when_original_peer_still_live(self, tracker):
+        cid = await tracker.register("asker-old-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        out = await tracker.take_orphan_pending_replies_matching(
+            display_name="asker", circle="default", backend="claude-code",
+            path="/repo/asker", machine="localhost",
+            live_peer_ids={"asker-old-id"},  # original still alive ⇒ no orphan
+        )
+        assert out == []
+
+    async def test_no_identity_means_no_match(self, tracker):
+        cid = await tracker.register("asker-old-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed")  # no identity captured
+        out = await tracker.take_orphan_pending_replies_matching(
+            display_name="asker", circle="default", backend="claude-code",
+            path="/repo/asker", machine="localhost",
+            live_peer_ids=set(),
+        )
+        assert out == []
+
+
+class TestSnapshotHelpers:
+    async def test_snapshot_pending_replies_for_peer_does_not_mutate(self, tracker):
+        cid = await tracker.register("asker-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        snap = await tracker.snapshot_pending_replies_for_peer("asker-id")
+        assert len(snap) == 1 and snap[0].correlation_id == cid
+        # Tracker still has the ask after snapshot
+        assert await tracker.get(cid) is not None
+
+    async def test_snapshot_pending_replies_for_peer_excludes_unstashed(self, tracker):
+        await tracker.register("asker-id", "asker", "b-id", "b", "x")  # no stash
+        snap = await tracker.snapshot_pending_replies_for_peer("asker-id")
+        assert snap == []
+
+    async def test_snapshot_expired_pending_replies_filters_by_ttl(self, tracker):
+        cid = await tracker.register("asker-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        # Not expired yet
+        snap = await tracker.snapshot_expired_pending_replies()
+        assert snap == []
+        # Backdate to past TTL
+        ask = await tracker.get(cid)
+        ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        snap = await tracker.snapshot_expired_pending_replies()
+        assert len(snap) == 1 and snap[0].correlation_id == cid
+        # Snapshot is non-mutating
+        assert await tracker.get(cid) is not None
+
+    async def test_snapshot_expired_excludes_unstashed(self, tracker):
+        cid = await tracker.register("asker-id", "asker", "b-id", "b", "x")
+        ask = await tracker.get(cid)
+        ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        snap = await tracker.snapshot_expired_pending_replies()
+        assert snap == []
+
+
+class TestEvictExpiredStashedFlag:
+    async def test_maybe_evict_skips_stashed(self, tracker):
+        cid = await tracker.register("asker-id", "asker", "b-id", "b", "x")
+        await tracker.set_pending_reply(cid, "framed", identity=_ident())
+        ask = await tracker.get(cid)
+        ask.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        # Default include_stashed=True drops it
+        # but include_stashed=False (the path used by _maybe_evict_expired)
+        # leaves it.
+        evicted = await tracker.evict_expired(include_stashed=False)
+        assert evicted == 0
+        assert await tracker.get(cid) is not None
+        evicted = await tracker.evict_expired(include_stashed=True)
+        assert evicted == 1
+        assert await tracker.get(cid) is None

--- a/tests/test_lazy_repair.py
+++ b/tests/test_lazy_repair.py
@@ -165,6 +165,9 @@ class TestLazyRepairReaper:
         transport.disconnect = AsyncMock(return_value=True)
         ask_tracker = MagicMock()
         ask_tracker.forget_peer = AsyncMock(return_value=1)
+        ask_tracker.snapshot_pending_replies_for_peer = AsyncMock(return_value=[])
+        ask_tracker.snapshot_expired_pending_replies = AsyncMock(return_value=[])
+        ask_tracker.evict_expired = AsyncMock(return_value=0)
         manager = _make_manager(
             transport=transport,
             ask_tracker=ask_tracker,


### PR DESCRIPTION
## Summary
- Closes #207. ACP replies stashed for an offline asker are now redelivered after the asker's peer_id rotates (clean-takeover prune or same-id reconnect), gated by `experiments.acp_broker_client`.
- New `AskerIdentity` tuple (`display_name`, `circle`, `backend`, normalized `path`, `machine`) is snapshotted on the Ask at stash time only when every field is present and `machine != "unknown"` — partial identity is refused rather than risk misrouting.
- `PeerRegistry._redeliver_pending_replies` runs two passes: pass-1 same-peer_id (existing), pass-2 full-tuple rebind guarded by a uniqueness check across live peers. `allocate_and_register` schedules redelivery for both fresh allocations and same-id reconnects outside the registry lock.
- Destructive cleanup sites (`_reap_dangling_peers`, `_evict_stale_peers`, `lazy_repair`'s new `_emit_and_evict_expired_stashes`) reordered to **snapshot → emit → forget/evict** so `pending_reply_lost` observers always see the event before the ask disappears.
- `pending_reply_lost` payload is pointer-only (no reply text, no asker path, no asker machine) and now carries `asker_name` from `Ask.from_peer_name` so the event is meaningful even when `asker_identity` wasn't captured.
- New `AskTracker.rebind_and_close` is the single async-locked mutation point for rebound asks; `_deliver_one_stashed` never mutates the shared Ask outside the tracker lock and leaves the stash exactly as found on notify failure.
- Stop-hook-driven `_maybe_evict_expired` now skips stashed-expired asks so the registry-owned TTL emission path is the single source of `pending_reply_lost` events.

## Test plan
- [x] `pytest` — 1048 passed (was 1027, +21 new tests across `tests/test_ask_tracker.py` and `tests/test_acp_broker_client.py`)
- [x] `ruff check` clean on changed files
- [x] `uv run ty check repowire/` clean
- [x] Focused #207 slice: 62 tests passed
- [x] Path-A takeover driven through real `allocate_and_register` (no manual OFFLINE→ONLINE workaround)
- [x] Same-id reconnect through `allocate_and_register` proven to fire pass-1 redelivery
- [x] `pending_reply_lost` ordering test (spy on `add_event`) confirms ask still exists at emit time