### PR TITLE
feat: add cron-capable schedule commands

### DIFF
--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
 
 import click
 from rich.console import Console
@@ -1311,6 +1312,256 @@ def _get_daemon_url() -> str:
 
     config = load_config()
     return f"http://{config.daemon.host}:{config.daemon.port}"
+
+
+def _parse_schedule_when(raw: str) -> str:
+    """Parse CLI schedule time: ISO-8601 or compact relative duration."""
+    import re
+    from datetime import datetime, timedelta, timezone
+
+    text = raw.strip()
+    rel = text
+    if rel.lower().startswith("in "):
+        rel = rel[3:].strip()
+    match = re.fullmatch(r"(?i)(\d+)\s*([smhdw])", rel)
+    if match:
+        amount = int(match.group(1))
+        unit = match.group(2).lower()
+        seconds = {
+            "s": amount,
+            "m": amount * 60,
+            "h": amount * 3600,
+            "d": amount * 86400,
+            "w": amount * 604800,
+        }[unit]
+        return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+    return text
+
+
+def _current_cli_peer_name(client: Any | None = None) -> str:
+    """Best-effort current peer name for CLI self scheduling."""
+    import os
+    from urllib.parse import quote
+
+    import httpx
+
+    if os.environ.get("REPOWIRE_DISPLAY_NAME"):
+        return os.environ["REPOWIRE_DISPLAY_NAME"]
+    if os.environ.get("REPOWIRE_PEER_ID"):
+        return os.environ["REPOWIRE_PEER_ID"]
+
+    pane_id = os.environ.get("TMUX_PANE")
+    if pane_id:
+        owns_client = client is None
+        http_client = client or httpx.Client(timeout=5.0)
+        try:
+            resp = http_client.get(
+                f"{_get_daemon_url()}/peers/by-pane/{quote(pane_id, safe='')}",
+            )
+            if resp.status_code < 400:
+                body = resp.json()
+                name = body.get("display_name") or body.get("name") or body.get("peer_id")
+                if name:
+                    return name
+        finally:
+            if owns_client:
+                http_client.close()
+
+    from repowire.hooks.utils import get_display_name
+
+    return get_display_name()
+
+
+@main.group()
+def schedule() -> None:
+    """Schedule one-time or recurring mesh messages."""
+    pass
+
+
+@schedule.command(name="self")
+@click.argument("when_or_cron")
+@click.argument("text")
+@click.option(
+    "--cron",
+    "is_cron",
+    is_flag=True,
+    help="Treat WHEN_OR_CRON as a recurring cron expression instead of a one-time time.",
+)
+@click.option("--from-peer", help="Override the calling peer identity")
+@click.option("--kind", default="notify", type=click.Choice(["notify", "ask"]))
+@click.option("--circle", "-c", default=None, help="Circle to scope self lookup")
+def schedule_self_cmd(
+    when_or_cron: str,
+    text: str,
+    is_cron: bool,
+    from_peer: str | None,
+    kind: str,
+    circle: str | None,
+) -> None:
+    """Schedule a future message to this peer.
+
+    WHEN_OR_CRON may be ISO-8601, a relative time like 10m/1h/"in 30s",
+    or a cron expression when --cron is passed.
+    """
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            peer_name = from_peer or _current_cli_peer_name(client)
+            body = {
+                "from_peer": peer_name,
+                "to_peer": peer_name,
+                "text": text,
+                "kind": kind,
+            }
+            if is_cron:
+                body["cron"] = when_or_cron
+            else:
+                body["fire_at"] = _parse_schedule_when(when_or_cron)
+            if circle:
+                body["circle"] = circle
+            resp = client.post(f"{_get_daemon_url()}/schedules", json=body)
+            resp.raise_for_status()
+            _print_schedule_created(resp.json())
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+    except httpx.HTTPStatusError as e:
+        detail = _http_error_detail(e)
+        console.print(f"[red]Failed to create schedule: {detail}[/]")
+
+
+@schedule.command(name="create")
+@click.argument("to_peer")
+@click.argument("when_or_cron")
+@click.argument("text")
+@click.option("--from-peer", required=True, help="Peer identity to send from")
+@click.option(
+    "--cron",
+    "is_cron",
+    is_flag=True,
+    help="Treat WHEN_OR_CRON as a recurring cron expression instead of a one-time time.",
+)
+@click.option("--kind", default="notify", type=click.Choice(["notify", "ask"]))
+@click.option("--circle", "-c", default=None, help="Circle to scope recipient lookup")
+def schedule_create_cmd(
+    to_peer: str,
+    when_or_cron: str,
+    text: str,
+    from_peer: str,
+    is_cron: bool,
+    kind: str,
+    circle: str | None,
+) -> None:
+    """Schedule a future message to another peer."""
+    import httpx
+
+    body = {
+        "from_peer": from_peer,
+        "to_peer": to_peer,
+        "text": text,
+        "kind": kind,
+    }
+    if is_cron:
+        body["cron"] = when_or_cron
+    else:
+        body["fire_at"] = _parse_schedule_when(when_or_cron)
+    if circle:
+        body["circle"] = circle
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(f"{_get_daemon_url()}/schedules", json=body)
+            resp.raise_for_status()
+            _print_schedule_created(resp.json())
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+    except httpx.HTTPStatusError as e:
+        detail = _http_error_detail(e)
+        console.print(f"[red]Failed to create schedule: {detail}[/]")
+
+
+@schedule.command(name="list")
+@click.option("--from-peer", help="Filter by creator peer")
+def schedule_list_cmd(from_peer: str | None) -> None:
+    """List pending schedules."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            params = {"from_peer": from_peer} if from_peer else None
+            resp = client.get(f"{_get_daemon_url()}/schedules", params=params)
+            resp.raise_for_status()
+            schedules = resp.json().get("schedules", [])
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+        return
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Failed to list schedules: {_http_error_detail(e)}[/]")
+        return
+
+    if not schedules:
+        console.print("[yellow]No schedules.[/]")
+        return
+    table = Table(title="Repowire Schedules")
+    table.add_column("ID", style="cyan")
+    table.add_column("From")
+    table.add_column("To")
+    table.add_column("Kind")
+    table.add_column("Next fire")
+    table.add_column("Cron")
+    table.add_column("Text")
+    for s in schedules:
+        table.add_row(
+            s.get("schedule_id", ""),
+            s.get("from_peer", ""),
+            s.get("to_peer", ""),
+            s.get("kind", ""),
+            s.get("fire_at", ""),
+            s.get("cron") or "-",
+            (s.get("text") or "").replace("\n", " "),
+        )
+    console.print(table)
+
+
+@schedule.command(name="delete")
+@click.argument("schedule_id")
+def schedule_delete_cmd(schedule_id: str) -> None:
+    """Cancel a pending schedule."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.delete(f"{_get_daemon_url()}/schedules/{schedule_id}")
+            if resp.status_code == 404:
+                console.print(f"[red]No schedule: {schedule_id}[/]")
+                return
+            resp.raise_for_status()
+            console.print(f"[green]Deleted schedule {schedule_id}[/]")
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Failed to delete schedule: {_http_error_detail(e)}[/]")
+
+
+def _print_schedule_created(schedule: dict) -> None:
+    console.print(f"[green]Scheduled {schedule.get('schedule_id')}[/]")
+    console.print(f"  from: [cyan]{schedule.get('from_peer')}[/]")
+    console.print(f"  to:   [cyan]{schedule.get('to_peer')}[/]")
+    console.print(f"  kind: {schedule.get('kind')}")
+    console.print(f"  next: {schedule.get('fire_at')}")
+    if schedule.get("cron"):
+        console.print(f"  cron: {schedule.get('cron')}")
+
+
+def _http_error_detail(error: object) -> str:
+    response = getattr(error, "response", None)
+    if response is None:
+        return str(error)
+    try:
+        body = response.json()
+    except Exception:
+        return str(error)
+    return str(body.get("detail") or body)
 
 
 @peer.command(name="list")

--- a/repowire/daemon/routes/schedules.py
+++ b/repowire/daemon/routes/schedules.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state
 from repowire.daemon.routes._shared import OkResponse
+from repowire.daemon.schedule_cron import CronExpressionError
 from repowire.daemon.schedule_store import Schedule
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,8 @@ class ScheduleCreateRequest(BaseModel):
     from_peer: str = Field(..., description="Display name of the scheduler")
     to_peer: str = Field(..., description="Display name of the recipient")
     text: str = Field(..., description="Message to deliver")
-    fire_at: str = Field(..., description="ISO-8601 datetime (UTC or with offset)")
+    fire_at: str | None = Field(None, description="ISO-8601 datetime (UTC or with offset)")
+    cron: str | None = Field(None, description="Five-field cron expression for recurrence")
     kind: str = Field("notify", description='"notify" or "ask"')
     circle: str | None = Field(None)
 
@@ -39,6 +41,7 @@ class ScheduleResponse(BaseModel):
     fire_at: str
     kind: str
     circle: str | None
+    cron: str | None
     created_at: str
 
     @classmethod
@@ -51,6 +54,7 @@ class ScheduleResponse(BaseModel):
             fire_at=s.fire_at,
             kind=s.kind,
             circle=s.circle,
+            cron=s.cron,
             created_at=s.created_at,
         )
 
@@ -82,17 +86,32 @@ async def create_schedule(
     store = state.schedule_store
     scheduler = state.scheduler
 
-    fire_at = _parse_fire_at(request.fire_at)
-    try:
-        sched = store.create(
-            from_peer=request.from_peer,
-            to_peer=request.to_peer,
-            text=request.text,
-            fire_at=fire_at,
-            kind=request.kind,
-            circle=request.circle,
+    if (request.fire_at is None) == (request.cron is None):
+        raise HTTPException(
+            status_code=400,
+            detail="provide exactly one of fire_at or cron",
         )
-    except ValueError as e:
+    try:
+        if request.cron is not None:
+            sched = store.create_cron(
+                from_peer=request.from_peer,
+                to_peer=request.to_peer,
+                text=request.text,
+                cron=request.cron,
+                kind=request.kind,
+                circle=request.circle,
+            )
+        else:
+            assert request.fire_at is not None
+            sched = store.create(
+                from_peer=request.from_peer,
+                to_peer=request.to_peer,
+                text=request.text,
+                fire_at=_parse_fire_at(request.fire_at),
+                kind=request.kind,
+                circle=request.circle,
+            )
+    except (ValueError, CronExpressionError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     store.persist()
     scheduler.notify_changed()

--- a/repowire/daemon/schedule_cron.py
+++ b/repowire/daemon/schedule_cron.py
@@ -1,0 +1,148 @@
+"""Small dependency-free cron parser for repowire schedules."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+_ALIASES = {
+    "@hourly": "0 * * * *",
+    "@daily": "0 0 * * *",
+    "@midnight": "0 0 * * *",
+    "@weekly": "0 0 * * 0",
+    "@monthly": "0 0 1 * *",
+}
+
+
+class CronExpressionError(ValueError):
+    """Raised when a cron expression is not supported."""
+
+
+def normalize_cron(expr: str) -> str:
+    """Normalize supported aliases and whitespace."""
+    raw = " ".join(expr.strip().split())
+    return _ALIASES.get(raw.lower(), raw)
+
+
+def validate_cron(expr: str) -> str:
+    """Validate and return normalized cron expression.
+
+    Supported syntax is standard five-field cron:
+    ``minute hour day-of-month month day-of-week``.
+
+    Each field supports ``*``, comma lists, ranges, and steps such as
+    ``*/15`` or ``1-5/2``. Day-of-week uses cron numbering where 0 or 7 is
+    Sunday.
+    """
+    norm = normalize_cron(expr)
+    fields = norm.split()
+    if len(fields) != 5:
+        raise CronExpressionError(
+            "cron must have 5 fields: minute hour day-of-month month day-of-week",
+        )
+    _parse_field(fields[0], 0, 59, "minute")
+    _parse_field(fields[1], 0, 23, "hour")
+    _parse_field(fields[2], 1, 31, "day-of-month")
+    _parse_field(fields[3], 1, 12, "month")
+    _parse_field(fields[4], 0, 7, "day-of-week")
+    return norm
+
+
+def next_fire_after(expr: str, after: datetime) -> datetime:
+    """Return the next UTC minute matching ``expr`` after ``after``."""
+    norm = validate_cron(expr)
+    minute, hour, dom, month, dow = norm.split()
+    minutes = _parse_field(minute, 0, 59, "minute")
+    hours = _parse_field(hour, 0, 23, "hour")
+    days = _parse_field(dom, 1, 31, "day-of-month")
+    months = _parse_field(month, 1, 12, "month")
+    weekdays = _parse_field(dow, 0, 7, "day-of-week")
+    if 7 in weekdays:
+        weekdays = (weekdays - {7}) | {0}
+    dom_any = dom == "*"
+    dow_any = dow == "*"
+
+    base = after.astimezone(timezone.utc) if after.tzinfo else after.replace(tzinfo=timezone.utc)
+    candidate = base.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    deadline = candidate + timedelta(days=366)
+    while candidate <= deadline:
+        cron_weekday = (candidate.weekday() + 1) % 7  # Python Mon=0; cron Sun=0
+        day_match = _day_matches(
+            day=candidate.day,
+            weekday=cron_weekday,
+            days=days,
+            weekdays=weekdays,
+            dom_any=dom_any,
+            dow_any=dow_any,
+        )
+        if (
+            candidate.minute in minutes
+            and candidate.hour in hours
+            and candidate.month in months
+            and day_match
+        ):
+            return candidate
+        candidate += timedelta(minutes=1)
+    raise CronExpressionError("cron expression did not match within one year")
+
+
+def _day_matches(
+    *,
+    day: int,
+    weekday: int,
+    days: set[int],
+    weekdays: set[int],
+    dom_any: bool,
+    dow_any: bool,
+) -> bool:
+    """Match cron day fields.
+
+    When both day-of-month and day-of-week are restricted, cron treats them
+    as OR. When either is "*", the restricted field alone controls matching.
+    """
+    if dom_any and dow_any:
+        return True
+    if dom_any:
+        return weekday in weekdays
+    if dow_any:
+        return day in days
+    return day in days or weekday in weekdays
+
+
+def _parse_field(raw: str, min_value: int, max_value: int, label: str) -> set[int]:
+    values: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            raise CronExpressionError(f"empty {label} field")
+        step = 1
+        if "/" in part:
+            part, step_raw = part.split("/", 1)
+            try:
+                step = int(step_raw)
+            except ValueError as e:
+                raise CronExpressionError(f"{label} step must be an integer") from e
+            if step < 1:
+                raise CronExpressionError(f"{label} step must be >= 1")
+        if part == "*":
+            start, end = min_value, max_value
+        elif "-" in part:
+            start_raw, end_raw = part.split("-", 1)
+            start = _parse_int(start_raw, label)
+            end = _parse_int(end_raw, label)
+            if start > end:
+                raise CronExpressionError(f"{label} range start must be <= end")
+        else:
+            start = end = _parse_int(part, label)
+        if start < min_value or end > max_value:
+            raise CronExpressionError(
+                f"{label} values must be between {min_value} and {max_value}",
+            )
+        values.update(range(start, end + 1, step))
+    return values
+
+
+def _parse_int(raw: str, label: str) -> int:
+    try:
+        return int(raw)
+    except ValueError as e:
+        raise CronExpressionError(f"{label} value must be an integer") from e

--- a/repowire/daemon/schedule_store.py
+++ b/repowire/daemon/schedule_store.py
@@ -18,6 +18,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
+from repowire.daemon.schedule_cron import next_fire_after, validate_cron
+
 logger = logging.getLogger(__name__)
 
 ScheduleKind = str  # "ask" | "notify"
@@ -35,6 +37,7 @@ class Schedule:
     fire_at: str  # ISO-8601 UTC
     kind: ScheduleKind = "notify"
     circle: str | None = None
+    cron: str | None = None
     created_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat(),
     )
@@ -98,11 +101,13 @@ class ScheduleStore:
         fire_at: datetime,
         kind: ScheduleKind = "notify",
         circle: str | None = None,
+        cron: str | None = None,
     ) -> Schedule:
         if kind not in _VALID_KINDS:
             raise ValueError(f"kind must be one of {sorted(_VALID_KINDS)}; got {kind!r}")
         if fire_at.tzinfo is None:
             raise ValueError("fire_at must be timezone-aware")
+        normalized_cron = validate_cron(cron) if cron is not None else None
         sid = f"sched-{uuid4().hex[:8]}"
         sched = Schedule(
             schedule_id=sid,
@@ -112,10 +117,45 @@ class ScheduleStore:
             fire_at=fire_at.astimezone(timezone.utc).isoformat(),
             kind=kind,
             circle=circle,
+            cron=normalized_cron,
         )
         self._schedules[sid] = sched
         self._dirty = True
         return sched
+
+    def create_cron(
+        self,
+        from_peer: str,
+        to_peer: str,
+        text: str,
+        cron: str,
+        *,
+        kind: ScheduleKind = "notify",
+        circle: str | None = None,
+        now: datetime | None = None,
+    ) -> Schedule:
+        """Create a recurring schedule from a cron expression."""
+        base = now or datetime.now(timezone.utc)
+        normalized_cron = validate_cron(cron)
+        return self.create(
+            from_peer=from_peer,
+            to_peer=to_peer,
+            text=text,
+            fire_at=next_fire_after(normalized_cron, base),
+            kind=kind,
+            circle=circle,
+            cron=normalized_cron,
+        )
+
+    def reschedule_next(self, schedule_id: str, after: datetime | None = None) -> bool:
+        """Advance a recurring schedule to its next fire time."""
+        sched = self._schedules.get(schedule_id)
+        if sched is None or sched.cron is None:
+            return False
+        base = after or datetime.now(timezone.utc)
+        sched.fire_at = next_fire_after(sched.cron, base).isoformat()
+        self._dirty = True
+        return True
 
     def delete(self, schedule_id: str) -> Schedule | None:
         s = self._schedules.pop(schedule_id, None)

--- a/repowire/daemon/scheduler.py
+++ b/repowire/daemon/scheduler.py
@@ -1,17 +1,18 @@
-"""One-shot scheduled check-in dispatcher.
+"""Scheduled check-in dispatcher.
 
 A single background task sleeps until the next-due schedule's `fire_at`, then
-fires it and removes it. No polling: the wake event is only set when the
-schedule set changes (create/delete) or when something fires. Past-due
-schedules at startup fire immediately.
+fires it. One-shot schedules are removed after firing; recurring cron
+schedules are advanced to their next fire time. No polling: the wake event is
+only set when the schedule set changes (create/delete) or when something fires.
+Past-due schedules at startup fire immediately.
 
 Delivery reuses the existing peer-registry primitives:
   - kind="notify" -> PeerRegistry.notify (fire-and-forget)
   - kind="ask"    -> PeerRegistry.deliver_ask (registers in AskTracker first)
 
-On delivery failure (peer missing or no live WS) the schedule is dropped
-rather than retried — the MVP is one-shot. We log loudly so misfires are
-visible.
+On delivery failure (peer missing or no live WS), one-shot schedules are
+dropped and recurring schedules advance to their next cron fire. We log loudly
+so misfires are visible.
 """
 
 from __future__ import annotations
@@ -151,7 +152,15 @@ class Scheduler:
                 sched.kind, sched.schedule_id, e,
             )
         finally:
-            # One-shot: always drop from the store after firing (success or
-            # delivery failure). Retry policy is out of scope for the MVP.
-            self._store.delete(sched.schedule_id)
+            if sched.cron:
+                try:
+                    self._store.reschedule_next(sched.schedule_id)
+                except ValueError as e:
+                    logger.warning(
+                        "Recurring schedule %s has invalid cron after fire (%s); dropping",
+                        sched.schedule_id, e,
+                    )
+                    self._store.delete(sched.schedule_id)
+            else:
+                self._store.delete(sched.schedule_id)
             self._store.persist()

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -929,16 +929,103 @@ def create_mcp_server() -> FastMCP:
         return result.get("schedule_id", "")
 
     @mcp.tool()
-    async def schedule_list(mine_only: bool = True) -> str:
+    async def schedule_self(
+        text: str,
+        fire_at: str | None = None,
+        cron: str | None = None,
+        kind: str = "notify",
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] Schedule a future message to yourself.
+
+        Convenience wrapper around schedule_create for self-wake reminders.
+        For one-time schedules, pass `fire_at`. For recurring schedules, pass
+        a five-field `cron` expression (or aliases like `@hourly`, `@daily`).
+        Use `kind="notify"` for a fire-and-forget reminder, or `kind="ask"`
+        when you want the future message to create an ask thread.
+
+        Args:
+            text: Message body to deliver to yourself.
+            fire_at: ISO-8601 datetime (e.g. "2026-05-14T09:00:00Z" or
+                     "2026-05-14T09:00:00+00:00"). Naive datetimes are
+                     interpreted as UTC.
+            cron: Five-field cron expression for recurring delivery.
+            kind: "notify" (default) or "ask".
+            circle: Circle to scope recipient lookup.
+
+        Returns:
+            schedule_id (format: sched-XXXXXXXX). Use it with
+            schedule_delete to cancel.
+        """
+        await _ensure_registered(strict=True)
+        if (fire_at is None) == (cron is None):
+            raise ValueError("provide exactly one of fire_at or cron")
+        from_peer = await _get_my_peer_name()
+        body: dict = {
+            "from_peer": from_peer,
+            "to_peer": from_peer,
+            "text": text,
+            "kind": kind,
+        }
+        if fire_at is not None:
+            body["fire_at"] = fire_at
+        if cron is not None:
+            body["cron"] = cron
+        if circle is not None:
+            body["circle"] = circle
+        result = await daemon_request("POST", "/schedules", body)
+        return result.get("schedule_id", "")
+
+    @mcp.tool()
+    async def schedule_cron(
+        to_peer: str,
+        text: str,
+        cron: str,
+        kind: str = "notify",
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] Schedule a recurring cron message to a peer.
+
+        Args:
+            to_peer: Display name of the recipient.
+            text: Message body to deliver.
+            cron: Five-field cron expression, or alias such as `@hourly`,
+                  `@daily`, `@weekly`, or `@monthly`.
+            kind: "notify" (default) or "ask".
+            circle: Circle to scope recipient lookup.
+
+        Returns:
+            schedule_id (format: sched-XXXXXXXX). Use schedule_delete to cancel.
+        """
+        await _ensure_registered(strict=True)
+        from_peer = await _get_my_peer_name()
+        body: dict = {
+            "from_peer": from_peer,
+            "to_peer": to_peer,
+            "text": text,
+            "cron": cron,
+            "kind": kind,
+        }
+        if circle is not None:
+            body["circle"] = circle
+        result = await daemon_request("POST", "/schedules", body)
+        return result.get("schedule_id", "")
+
+    @mcp.tool()
+    async def schedule_list(mine_only: bool = True, include_cron: bool = False) -> str:
         """[Repowire mesh] List pending scheduled check-ins.
 
         Returns TSV with columns: schedule_id, from_peer, to_peer, kind,
-        fire_at, text. Schedules are sorted by fire_at ascending.
+        fire_at, text. Schedules are sorted by fire_at ascending. Pass
+        include_cron=True to append a trailing cron column for recurring
+        schedules.
 
         Args:
             mine_only: If True (default), return only schedules you
                        created. If False, return all schedules on the
                        daemon.
+            include_cron: If True, append a trailing cron column. Defaults
+                          False to preserve the original TSV schema.
         """
         await _ensure_registered()
         params: dict | None = None
@@ -946,20 +1033,21 @@ def create_mcp_server() -> FastMCP:
             params = {"from_peer": await _get_my_peer_name()}
         result = await daemon_request("GET", "/schedules", params=params)
         header = "schedule_id\tfrom_peer\tto_peer\tkind\tfire_at\ttext"
+        if include_cron:
+            header += "\tcron"
         rows = [header]
         for s in result.get("schedules", []):
-            rows.append(
-                "\t".join(
-                    [
-                        s.get("schedule_id", ""),
-                        s.get("from_peer", ""),
-                        s.get("to_peer", ""),
-                        s.get("kind", ""),
-                        s.get("fire_at", ""),
-                        (s.get("text", "") or "").replace("\t", " ").replace("\n", " "),
-                    ]
-                )
-            )
+            fields = [
+                s.get("schedule_id", ""),
+                s.get("from_peer", ""),
+                s.get("to_peer", ""),
+                s.get("kind", ""),
+                s.get("fire_at", ""),
+                (s.get("text", "") or "").replace("\t", " ").replace("\n", " "),
+            ]
+            if include_cron:
+                fields.append(s.get("cron") or "")
+            rows.append("\t".join(fields))
         return "\n".join(rows)
 
     @mcp.tool()

--- a/tests/test_cli_schedule.py
+++ b/tests/test_cli_schedule.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from repowire.cli import main
+
+
+def _mock_client(monkeypatch, response_json: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = response_json or {
+        "schedule_id": "sched-abc123",
+        "from_peer": "me",
+        "to_peer": "me",
+        "text": "wake",
+        "fire_at": "2026-05-19T09:00:00+00:00",
+        "kind": "notify",
+        "circle": None,
+        "cron": None,
+        "created_at": "2026-05-19T08:00:00+00:00",
+    }
+    response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.post.return_value = response
+    client.get.return_value = response
+    client.delete.return_value = response
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+    return client
+
+
+def test_schedule_self_posts_to_self_with_cron(monkeypatch) -> None:
+    monkeypatch.setenv("REPOWIRE_DISPLAY_NAME", "me")
+    client = _mock_client(monkeypatch, response_json={
+        "schedule_id": "sched-abc123",
+        "from_peer": "me",
+        "to_peer": "me",
+        "text": "stand up",
+        "fire_at": "2026-05-19T09:00:00+00:00",
+        "kind": "notify",
+        "circle": None,
+        "cron": "*/15 * * * *",
+        "created_at": "2026-05-19T08:00:00+00:00",
+    })
+
+    result = CliRunner().invoke(
+        main,
+        ["schedule", "self", "--cron", "*/15 * * * *", "stand up"],
+    )
+
+    assert result.exit_code == 0, result.output
+    client.post.assert_called_once()
+    assert client.post.call_args.kwargs["json"] == {
+        "from_peer": "me",
+        "to_peer": "me",
+        "text": "stand up",
+        "kind": "notify",
+        "cron": "*/15 * * * *",
+    }
+    assert "sched-abc123" in result.output
+
+
+def test_schedule_create_posts_one_shot_with_from_peer(monkeypatch) -> None:
+    client = _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["schedule", "create", "bob", "10m", "ping", "--from-peer", "alice"],
+    )
+
+    assert result.exit_code == 0, result.output
+    body = client.post.call_args.kwargs["json"]
+    assert body["from_peer"] == "alice"
+    assert body["to_peer"] == "bob"
+    assert body["text"] == "ping"
+    assert body["kind"] == "notify"
+    assert "fire_at" in body
+    assert "cron" not in body
+
+
+def test_schedule_delete_calls_route(monkeypatch) -> None:
+    client = _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["schedule", "delete", "sched-abc123"])
+
+    assert result.exit_code == 0, result.output
+    client.delete.assert_called_once_with(
+        "http://127.0.0.1:8377/schedules/sched-abc123",
+    )

--- a/tests/test_mcp_schedule.py
+++ b/tests/test_mcp_schedule.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.mcp.server import create_mcp_server
+
+
+def _tool(name: str):
+    return create_mcp_server()._tool_manager._tools[name].fn
+
+
+@pytest.mark.asyncio
+async def test_schedule_list_preserves_default_tsv_schema() -> None:
+    with (
+        patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock),
+        patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock) as get_name,
+        patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock) as request,
+    ):
+        get_name.return_value = "me"
+        request.return_value = {"schedules": [{
+            "schedule_id": "sched-1",
+            "from_peer": "me",
+            "to_peer": "me",
+            "kind": "notify",
+            "fire_at": "2026-05-19T09:00:00+00:00",
+            "cron": "*/15 * * * *",
+            "text": "stretch",
+        }]}
+
+        result = await _tool("schedule_list")()
+
+    lines = result.splitlines()
+    assert lines[0] == "schedule_id\tfrom_peer\tto_peer\tkind\tfire_at\ttext"
+    assert lines[1].split("\t") == [
+        "sched-1", "me", "me", "notify",
+        "2026-05-19T09:00:00+00:00", "stretch",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_schedule_list_can_opt_into_cron_column() -> None:
+    with (
+        patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock),
+        patch("repowire.mcp.server._get_my_peer_name", new_callable=AsyncMock) as get_name,
+        patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock) as request,
+    ):
+        get_name.return_value = "me"
+        request.return_value = {"schedules": [{
+            "schedule_id": "sched-1",
+            "from_peer": "me",
+            "to_peer": "me",
+            "kind": "notify",
+            "fire_at": "2026-05-19T09:00:00+00:00",
+            "cron": "*/15 * * * *",
+            "text": "stretch",
+        }]}
+
+        result = await _tool("schedule_list")(include_cron=True)
+
+    lines = result.splitlines()
+    assert lines[0] == "schedule_id\tfrom_peer\tto_peer\tkind\tfire_at\ttext\tcron"
+    assert lines[1].split("\t") == [
+        "sched-1", "me", "me", "notify",
+        "2026-05-19T09:00:00+00:00", "stretch", "*/15 * * * *",
+    ]

--- a/tests/test_schedule_cron.py
+++ b/tests/test_schedule_cron.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from repowire.daemon.schedule_cron import CronExpressionError, next_fire_after, validate_cron
+
+
+def test_validate_cron_accepts_alias_and_normalizes() -> None:
+    assert validate_cron("@hourly") == "0 * * * *"
+
+
+def test_validate_cron_rejects_bad_field_count() -> None:
+    with pytest.raises(CronExpressionError):
+        validate_cron("* * *")
+
+
+def test_validate_cron_accepts_steps_ranges_and_lists() -> None:
+    assert validate_cron("*/15 9-17 * * 1,3,5") == "*/15 9-17 * * 1,3,5"
+
+
+def test_next_fire_after_uses_next_matching_minute() -> None:
+    base = datetime(2026, 5, 19, 8, 10, 30, tzinfo=timezone.utc)
+    assert next_fire_after("*/15 * * * *", base) == datetime(
+        2026, 5, 19, 8, 15, tzinfo=timezone.utc,
+    )
+
+
+def test_next_fire_after_supports_sunday_as_zero_or_seven() -> None:
+    base = datetime(2026, 5, 18, 8, 0, tzinfo=timezone.utc)  # Monday
+    assert next_fire_after("0 9 * * 7", base) == datetime(
+        2026, 5, 24, 9, 0, tzinfo=timezone.utc,
+    )
+
+
+def test_day_of_month_and_day_of_week_use_cron_or_semantics() -> None:
+    base = datetime(2026, 5, 19, 8, 0, tzinfo=timezone.utc)  # Tuesday the 19th
+    assert next_fire_after("0 9 20 * 5", base) == datetime(
+        2026, 5, 20, 9, 0, tzinfo=timezone.utc,
+    )

--- a/tests/test_schedule_routes.py
+++ b/tests/test_schedule_routes.py
@@ -89,6 +89,29 @@ class TestCreate:
         assert store.get(body["schedule_id"]) is not None
         scheduler.notify_changed.assert_called_once()
 
+    async def test_accepts_cron_schedule(self, env):
+        client, store, scheduler = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice",
+            "to_peer": "alice",
+            "text": "stretch",
+            "cron": "*/15 * * * *",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["cron"] == "*/15 * * * *"
+        assert body["fire_at"]
+        assert store.get(body["schedule_id"]) is not None
+        scheduler.notify_changed.assert_called_once()
+
+    async def test_rejects_fire_at_and_cron_together(self, env):
+        client, _, _ = env
+        r = await client.post("/schedules", json={
+            "from_peer": "alice", "to_peer": "bob",
+            "text": "x", "fire_at": _future_iso(), "cron": "* * * * *",
+        })
+        assert r.status_code == 400
+
     async def test_rejects_invalid_fire_at(self, env):
         client, _, _ = env
         r = await client.post("/schedules", json={
@@ -101,7 +124,7 @@ class TestCreate:
         client, _, _ = env
         r = await client.post("/schedules", json={
             "from_peer": "alice", "to_peer": "bob",
-            "text": "x", "fire_at": _future_iso(), "kind": "cron",
+            "text": "x", "fire_at": _future_iso(), "kind": "recurring",
         })
         assert r.status_code == 400
 

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -87,6 +87,28 @@ def test_persist_roundtrip(tmp_path: Path) -> None:
     assert loaded.circle == "default"
 
 
+def test_create_cron_sets_next_fire_and_persists_expression(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    now = datetime(2026, 5, 19, 8, 10, tzinfo=timezone.utc)
+    sched = store.create_cron(
+        "alice", "alice", "stand up", "*/15 * * * *", now=now,
+    )
+    assert sched.cron == "*/15 * * * *"
+    assert sched.fire_at == datetime(2026, 5, 19, 8, 15, tzinfo=timezone.utc).isoformat()
+
+
+def test_reschedule_next_advances_recurring_schedule(tmp_path: Path) -> None:
+    store = ScheduleStore(tmp_path / "schedules.json")
+    now = datetime(2026, 5, 19, 8, 10, tzinfo=timezone.utc)
+    sched = store.create_cron("alice", "alice", "ping", "@hourly", now=now)
+    ok = store.reschedule_next(
+        sched.schedule_id,
+        after=datetime(2026, 5, 19, 9, 0, tzinfo=timezone.utc),
+    )
+    assert ok is True
+    assert sched.fire_at == datetime(2026, 5, 19, 10, 0, tzinfo=timezone.utc).isoformat()
+
+
 def test_persist_noop_when_clean(tmp_path: Path) -> None:
     path = tmp_path / "schedules.json"
     store = ScheduleStore(path)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -105,6 +105,23 @@ async def test_delivery_failure_drops_schedule(env) -> None:
     await scheduler.stop()
 
 
+async def test_recurring_schedule_reschedules_after_fire(env) -> None:
+    scheduler, store, registry, _ = env
+    await scheduler.start()
+    sched = store.create(
+        "alice", "alice", "stretch", _now_plus(0.05),
+        kind="notify", cron="* * * * *",
+    )
+    scheduler.notify_changed()
+    await asyncio.sleep(0.2)
+    registry.notify.assert_awaited_once()
+    current = store.get(sched.schedule_id)
+    assert current is not None
+    assert current.cron == "* * * * *"
+    assert current.fire_at_dt() > datetime.now(timezone.utc)
+    await scheduler.stop()
+
+
 async def test_earlier_schedule_added_after_later_fires_first(env) -> None:
     scheduler, store, registry, _ = env
     await scheduler.start()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -455,7 +455,9 @@ class TestMcpToolDescriptions:
         from repowire.mcp.server import create_mcp_server
         mcp = create_mcp_server()
         mesh_tools = ["list_peers", "ask", "ack", "notify_peer", "broadcast",
-                       "spawn_peer", "kill_peer", "whoami", "set_description"]
+                       "spawn_peer", "kill_peer", "whoami", "set_description",
+                       "schedule_create", "schedule_self", "schedule_cron",
+                       "schedule_list", "schedule_delete"]
         for name in mesh_tools:
             tool = mcp._tool_manager._tools.get(name)
             assert tool is not None, f"Tool {name} not found"


### PR DESCRIPTION
## Summary
- add dependency-free five-field cron support for recurring schedules while preserving one-shot fire_at schedules
- add MCP schedule_self and schedule_cron helpers alongside existing schedule_create/list/delete
- add top-level repowire schedule CLI: self, create, list, delete with ISO/relative one-shot times and --cron recurring schedules

## Verification
- uv run pytest -q (1062 passed)
- uv run ruff check touched files
- uv run ty check touched runtime files
- isolated no-hook daemon smoke: schedule self one-shot, schedule self --cron, list, delete, list empty