### PR TITLE
refactor: extract peer transport router

### DIFF
--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -28,15 +28,12 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from repowire.acp import (
-    AcpClientManager,
-    maybe_decide_acp_route,
-)
 from repowire.daemon.ask_tracker import AskerIdentity, AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
 from repowire.daemon.routes._shared import OkResponse
+from repowire.daemon.transport_router import AskEnvelope, transport_router_from_state
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer
 
@@ -307,59 +304,34 @@ async def open_ask(
             },
         ) from e
 
-    # ACP routing (experiments.acp_broker_client). When the flag is on and the
-    # target peer carries an `acp` metadata block, bypass the WS transport and
-    # drive a session/prompt against the peer's ACP subprocess. The reply is
-    # delivered back to the asker via the normal ack pipeline once the prompt
-    # turn settles.
-    cfg = state.config
-    acp_manager = getattr(state, "acp_manager", None)
-    flag = bool(cfg.experiments.acp_broker_client) if cfg.experiments else False
-    decision = maybe_decide_acp_route(peer, flag_enabled=flag, manager=acp_manager)
-    if decision is not None:
-        from repowire.acp import deliver_ask_via_acp
-
-        assert acp_manager is not None  # narrowed by maybe_decide_acp_route
-        assert decision.spec is not None
-        spec = decision.spec
-        manager: AcpClientManager = acp_manager
-
-        async def _on_complete(
-            correlation_id: str, reply: str | None, error: str | None,
-        ) -> None:
-            await _acp_complete(
-                correlation_id=correlation_id,
-                reply=reply,
-                error=error,
-                ask_tracker=ask_tracker,
-                peer_registry=peer_registry,
-            )
-
-        await deliver_ask_via_acp(
-            manager=manager,
-            spec=spec,
-            correlation_id=cid,
-            text=request.text,
-            on_complete=_on_complete,
+    async def _on_acp_complete(
+        correlation_id: str, reply: str | None, error: str | None,
+    ) -> None:
+        await _acp_complete(
+            correlation_id=correlation_id,
+            reply=reply,
+            error=error,
+            ask_tracker=ask_tracker,
+            peer_registry=peer_registry,
         )
-        if request.reply_to:
-            prior = await ask_tracker.close(request.reply_to, reason="reply_to")
-            if prior is None:
-                logger.debug(
-                    "ask reply_to=%s: prior ask not found or already closed",
-                    request.reply_to,
-                )
-        return AskResponse(correlation_id=cid)
 
     try:
-        await peer_registry.deliver_ask(
-            from_peer=from_peer_id,
-            to_peer=peer.peer_id,
-            text=request.text,
-            correlation_id=cid,
-            reply_to=request.reply_to,
-            bypass_circle=request.bypass_circle,
-            circle=request.circle,
+        transport_router = transport_router_from_state(
+            config=state.config,
+            registry=peer_registry,
+            state=state,
+        )
+        await transport_router.send_ask(
+            AskEnvelope(
+                from_peer_id=from_peer_id,
+                from_peer_name=from_peer_name,
+                target=peer,
+                text=request.text,
+                correlation_id=cid,
+                reply_to=request.reply_to,
+                intended_recipient_name=request.to_peer,
+            ),
+            on_acp_complete=_on_acp_complete,
         )
     except ValueError as e:
         await ask_tracker.close(cid, reason="evicted")

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 import asyncio
 import json
-import uuid
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
-from repowire.acp import deliver_ask_via_acp, maybe_decide_acp_route
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.routes._shared import OkResponse
+from repowire.daemon.transport_router import (
+    NotifyEnvelope,
+    transport_router_from_state,
+)
 from repowire.protocol.peers import PeerStatus, TurnState
 
 router = APIRouter(tags=["messages"])
@@ -210,38 +212,22 @@ async def notify_peer(
             status_code=status.HTTP_403_FORBIDDEN, detail=msg,
         ) from e
 
-    cfg = state.config
-    acp_manager = getattr(state, "acp_manager", None)
-    flag = bool(cfg.experiments.acp_broker_client) if cfg.experiments else False
-    decision = maybe_decide_acp_route(target, flag_enabled=flag, manager=acp_manager)
-    if decision is not None:
-        assert acp_manager is not None  # narrowed by maybe_decide_acp_route
-        assert decision.spec is not None
-
-        async def _drop_result(_cid: str, _reply: str | None, _err: str | None) -> None:
-            # Notify is fire-and-forget: any reply or error from the ACP turn
-            # is logged inside deliver_ask_via_acp; nothing to deliver back.
-            return None
-
-        # Synthesize a correlation_id for log/cancel correlation only. No
-        # ask_tracker registration: notify has no thread to close.
-        cid = f"notif-{uuid.uuid4().hex[:8]}"
-        await deliver_ask_via_acp(
-            manager=acp_manager,
-            spec=decision.spec,
-            correlation_id=cid,
-            text=request.text,
-            on_complete=_drop_result,
-        )
-        return NotifyResponse(status="sent")
-
     try:
-        delivery_status = await peer_registry.notify(
-            from_peer=request.from_peer,
-            to_peer=request.to_peer,
-            text=request.text,
-            bypass_circle=request.bypass_circle,
-            circle=request.circle,
+        transport_router = transport_router_from_state(
+            config=state.config,
+            registry=peer_registry,
+            state=state,
+        )
+        from_peer_id = _from_obj.peer_id if _from_obj else None
+        from_peer_name = _from_obj.display_name if _from_obj else request.from_peer
+        delivery_status = await transport_router.send_notify(
+            NotifyEnvelope(
+                from_peer_id=from_peer_id,
+                from_peer_name=from_peer_name,
+                target=target,
+                text=request.text,
+                intended_recipient_name=request.to_peer,
+            )
         )
         return NotifyResponse(status=delivery_status)
     except ValueError as e:

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -1,0 +1,231 @@
+"""Transport selection for peer-to-peer delivery.
+
+Routes resolve identity and authorization, then hand an envelope here. This
+module owns the transport choice (currently ACP-before-WebSocket) without
+moving runtime/session ownership into the HTTP layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from repowire.acp import AcpRouteDecision, deliver_ask_via_acp, maybe_decide_acp_route
+from repowire.config.models import Config
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+@dataclass(frozen=True)
+class AskEnvelope:
+    """Already-authorized ask delivery request."""
+
+    from_peer_id: str
+    from_peer_name: str
+    target: Peer
+    text: str
+    correlation_id: str
+    reply_to: str | None = None
+    intended_recipient_name: str | None = None
+
+
+@dataclass(frozen=True)
+class NotifyEnvelope:
+    """Already-authorized notification delivery request."""
+
+    from_peer_id: str | None
+    from_peer_name: str
+    target: Peer
+    text: str
+    intended_recipient_name: str | None = None
+
+
+class AskCompletion(Protocol):
+    def __call__(
+        self,
+        correlation_id: str,
+        reply: str | None,
+        error: str | None,
+    ) -> Awaitable[None]: ...
+
+
+class WebSocketPeerTransport:
+    """WebSocket delivery using the existing message-router wire format."""
+
+    def __init__(self, registry: PeerRegistry, router: MessageRouter) -> None:
+        self._registry = registry
+        self._router = router
+
+    async def send_ask(self, envelope: AskEnvelope) -> None:
+        self._registry.add_event(
+            "ask",
+            {
+                "from": envelope.from_peer_name,
+                "to": envelope.target.display_name,
+                "text": envelope.text,
+                "from_peer_id": envelope.from_peer_id,
+                "to_peer_id": envelope.target.peer_id,
+                "correlation_id": envelope.correlation_id,
+                "reply_to": envelope.reply_to,
+            },
+        )
+        await self._router.send_ask(
+            from_peer=envelope.from_peer_name,
+            to_session_id=envelope.target.peer_id,
+            to_peer_name=envelope.target.display_name,
+            correlation_id=envelope.correlation_id,
+            text=envelope.text,
+            reply_to=envelope.reply_to,
+            intended_recipient_name=(
+                envelope.intended_recipient_name or envelope.target.display_name
+            ),
+        )
+
+    async def send_notify(
+        self,
+        envelope: NotifyEnvelope,
+    ) -> Literal["sent", "queued"]:
+        delivery_status: Literal["sent", "queued"] = (
+            "queued" if envelope.target.status == PeerStatus.BUSY else "sent"
+        )
+        self._registry.add_event(
+            "notification",
+            {
+                "from": envelope.from_peer_name,
+                "to": envelope.target.display_name,
+                "text": envelope.text,
+                "from_peer_id": envelope.from_peer_id,
+                "to_peer_id": envelope.target.peer_id,
+                "delivery_status": delivery_status,
+            },
+        )
+        await self._router.send_notification(
+            from_peer=envelope.from_peer_name,
+            to_session_id=envelope.target.peer_id,
+            to_peer_name=envelope.target.display_name,
+            text=envelope.text,
+            intended_recipient_name=(
+                envelope.intended_recipient_name or envelope.target.display_name
+            ),
+        )
+        return delivery_status
+
+
+class AcpPeerTransport:
+    """ACP delivery mapped onto prompt calls."""
+
+    def __init__(self, manager: Any) -> None:
+        self._manager = manager
+
+    def decide(self, target: Peer, *, flag_enabled: bool) -> AcpRouteDecision | None:
+        return maybe_decide_acp_route(
+            target,
+            flag_enabled=flag_enabled,
+            manager=self._manager,
+        )
+
+    async def send_ask(
+        self,
+        envelope: AskEnvelope,
+        on_complete: AskCompletion,
+        decision: AcpRouteDecision,
+    ) -> None:
+        if decision is None or decision.spec is None:
+            raise RuntimeError("ACP transport selected without an ACP route")
+        await deliver_ask_via_acp(
+            manager=self._manager,
+            spec=decision.spec,
+            correlation_id=envelope.correlation_id,
+            text=envelope.text,
+            on_complete=on_complete,
+        )
+
+    async def send_notify(
+        self,
+        envelope: NotifyEnvelope,
+        decision: AcpRouteDecision,
+    ) -> Literal["sent"]:
+        if decision is None or decision.spec is None:
+            raise RuntimeError("ACP transport selected without an ACP route")
+
+        async def _drop_result(
+            _cid: str,
+            _reply: str | None,
+            _err: str | None,
+        ) -> None:
+            # Notify is fire-and-forget: ACP prompt replies are intentionally
+            # discarded after deliver_ask_via_acp logs failures.
+            return None
+
+        cid = f"notif-{uuid.uuid4().hex[:8]}"
+        await deliver_ask_via_acp(
+            manager=self._manager,
+            spec=decision.spec,
+            correlation_id=cid,
+            text=envelope.text,
+            on_complete=_drop_result,
+        )
+        return "sent"
+
+
+class PeerTransportRouter:
+    """Choose ACP before WebSocket for peer delivery."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        registry: PeerRegistry,
+        message_router: MessageRouter,
+        acp_manager: Any | None = None,
+    ) -> None:
+        self._config = config
+        self._ws = WebSocketPeerTransport(registry, message_router)
+        self._acp = AcpPeerTransport(acp_manager) if acp_manager is not None else None
+
+    def _acp_decision(self, target: Peer) -> AcpRouteDecision | None:
+        experiments = self._config.experiments
+        flag = bool(experiments.acp_broker_client) if experiments else False
+        if not flag or self._acp is None:
+            return None
+        return self._acp.decide(target, flag_enabled=flag)
+
+    async def send_ask(
+        self,
+        envelope: AskEnvelope,
+        *,
+        on_acp_complete: AskCompletion,
+    ) -> None:
+        decision = self._acp_decision(envelope.target)
+        if decision is not None:
+            assert self._acp is not None
+            await self._acp.send_ask(envelope, on_acp_complete, decision)
+            return
+        await self._ws.send_ask(envelope)
+
+    async def send_notify(self, envelope: NotifyEnvelope) -> Literal["sent", "queued"]:
+        decision = self._acp_decision(envelope.target)
+        if decision is not None:
+            assert self._acp is not None
+            return await self._acp.send_notify(envelope, decision)
+        return await self._ws.send_notify(envelope)
+
+
+def transport_router_from_state(
+    *,
+    config: Config,
+    registry: PeerRegistry,
+    state: object,
+) -> PeerTransportRouter:
+    """Build the request-scoped router from daemon app state."""
+    message_router = getattr(state, "message_router")
+    acp_manager = getattr(state, "acp_manager", None)
+    return PeerTransportRouter(
+        config=config,
+        registry=registry,
+        message_router=message_router,
+        acp_manager=acp_manager,
+    )

--- a/tests/test_transport_router.py
+++ b/tests/test_transport_router.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from repowire.acp import AcpPromptResult
+from repowire.acp.models import AcpPeerConfig
+from repowire.config.models import Config
+from repowire.daemon.transport_router import (
+    AskEnvelope,
+    NotifyEnvelope,
+    PeerTransportRouter,
+)
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+def _config(*, acp_enabled: bool) -> Config:
+    config = Config()
+    config.experiments.acp_broker_client = acp_enabled
+    return config
+
+
+def _acp_peer() -> Peer:
+    peer = Peer(
+        peer_id="target-id",
+        display_name="target-codex",
+        path="/tmp/target",
+        machine="localhost",
+        status=PeerStatus.ONLINE,
+    )
+    peer.metadata["acp"] = AcpPeerConfig(command="python", cwd="/tmp").model_dump()
+    return peer
+
+
+def _ask_envelope(target: Peer) -> AskEnvelope:
+    return AskEnvelope(
+        from_peer_id="sender-id",
+        from_peer_name="sender-codex",
+        target=target,
+        text="question",
+        correlation_id="cid-1",
+        intended_recipient_name=target.display_name,
+    )
+
+
+def _notify_envelope(target: Peer) -> NotifyEnvelope:
+    return NotifyEnvelope(
+        from_peer_id="sender-id",
+        from_peer_name="sender-codex",
+        target=target,
+        text="heads up",
+        intended_recipient_name=target.display_name,
+    )
+
+
+async def _wait_for_await(mock: AsyncMock) -> None:
+    for _ in range(20):
+        if mock.await_count:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("mock was not awaited")
+
+
+@pytest.mark.asyncio
+async def test_ask_routes_to_acp_before_websocket() -> None:
+    target = _acp_peer()
+    registry = SimpleNamespace(add_event=Mock())
+    ws_router = SimpleNamespace(send_ask=AsyncMock(), send_notification=AsyncMock())
+    acp_manager = SimpleNamespace(
+        prompt=AsyncMock(return_value=AcpPromptResult(stop_reason="end_turn", text="answer")),
+    )
+    on_complete = AsyncMock()
+
+    router = PeerTransportRouter(
+        config=_config(acp_enabled=True),
+        registry=registry,
+        message_router=ws_router,
+        acp_manager=acp_manager,
+    )
+    await router.send_ask(_ask_envelope(target), on_acp_complete=on_complete)
+
+    await _wait_for_await(acp_manager.prompt)
+    acp_manager.prompt.assert_awaited_once()
+    ws_router.send_ask.assert_not_awaited()
+    await _wait_for_await(on_complete)
+    on_complete.assert_awaited_once_with("cid-1", "answer", None)
+
+
+@pytest.mark.asyncio
+async def test_notify_routes_to_acp_and_discards_reply() -> None:
+    target = _acp_peer()
+    registry = SimpleNamespace(add_event=Mock())
+    ws_router = SimpleNamespace(send_ask=AsyncMock(), send_notification=AsyncMock())
+    acp_manager = SimpleNamespace(
+        prompt=AsyncMock(
+            return_value=AcpPromptResult(stop_reason="end_turn", text="discarded"),
+        ),
+    )
+
+    router = PeerTransportRouter(
+        config=_config(acp_enabled=True),
+        registry=registry,
+        message_router=ws_router,
+        acp_manager=acp_manager,
+    )
+    status = await router.send_notify(_notify_envelope(target))
+
+    assert status == "sent"
+    await _wait_for_await(acp_manager.prompt)
+    acp_manager.prompt.assert_awaited_once()
+    ws_router.send_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_acp_peer_falls_through_to_websocket() -> None:
+    target = _acp_peer()
+    registry = SimpleNamespace(add_event=Mock())
+    ws_router = SimpleNamespace(send_ask=AsyncMock(), send_notification=AsyncMock())
+    acp_manager = SimpleNamespace(
+        prompt=AsyncMock(return_value=AcpPromptResult(stop_reason="end_turn", text="unused")),
+    )
+    router = PeerTransportRouter(
+        config=_config(acp_enabled=False),
+        registry=registry,
+        message_router=ws_router,
+        acp_manager=acp_manager,
+    )
+
+    await router.send_ask(_ask_envelope(target), on_acp_complete=AsyncMock())
+    status = await router.send_notify(_notify_envelope(target))
+
+    assert status == "sent"
+    acp_manager.prompt.assert_not_awaited()
+    ws_router.send_ask.assert_awaited_once()
+    ws_router.send_notification.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add a narrow transport router boundary for /ask and /notify delivery
- move ACP-before-WS transport selection out of route handlers
- preserve ACP/WS behavior while reducing route and peer_registry pressure

## Verification
- uv run pytest -> 1067 passed
- uv run ruff check repowire/ tests/test_transport_router.py
- uv run ty check repowire/
- focused suite: tests/test_transport_router.py tests/test_acp_broker_client.py tests/test_routes.py::TestNotify tests/test_ask_routes.py tests/test_notification_buffer.py

## Notes
- first v0.13 session-native architecture slice
- no session/timeline/runtime-manager refactor in this PR