### PR TITLE
Add session-scoped dashboard timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,11 @@ Give peers tasks and disconnect. They work autonomously, report back via Telegra
 Monitor your agent mesh at `http://localhost:8377/dashboard`, or remotely via [repowire.io](https://repowire.io):
 
 - **Peer overview** - online/busy/offline status, descriptions, project paths
-- **Chat view** - conversation history per peer with tool call details
+- **Chat view** - selected-session timeline with Claude transcript history merged with realtime chat events and tool call details
 - **Compose bar** - send notifications or queries to any peer from the browser
 - **Mobile responsive** - hamburger menu, touch-friendly compose
 
-Roadmap: the dashboard is moving toward a durable session timeline that merges persisted history with realtime stream events. Controls that change runtime behavior should attach to session commands as they land, while peer IDs remain implementation details of the runtime executor currently doing the work.
+Roadmap: the dashboard is moving toward fuller durable session controls. The current v0.13 slice merges Claude transcript history with realtime stream events for the selected peer/session; controls that change runtime behavior should attach to session commands as they land, while peer IDs remain implementation details of the runtime executor currently doing the work.
 
 For remote access: `repowire setup --relay` connects your daemon to [repowire.io](https://repowire.io) via outbound WebSocket. Access your dashboard from any browser. No port forwarding, no VPN.
 

--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -6,17 +6,17 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 
 - **Peer overview** — every peer's status (`online` / `busy` / `offline`), description, project path, circle, backend.
 - **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, and broadcasts.
-- **Per-peer chat** — selecting a peer replaces the live log with that peer's conversation history. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
+- **Per-peer chat** — selecting a peer replaces the live log with that peer's selected-session timeline. For Claude Code peers, the chat view merges persisted transcript history with realtime `chat_turn` and `chat_turn_delta` events; other backends contribute realtime events. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
 - **Compose bar** — send a notification or ask to any peer. The dashboard registers as the `dashboard` peer so it shows up in `list_peers` and message routing.
 - **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL) and the resulting path is included in the notification so the recipient agent can read it.
 
 ## Where chat turns come from
 
-The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemini session extracts the response and tool calls from the transcript or runtime output, then posts them to `POST /events/chat` on the daemon. The dashboard streams events over Server-Sent Events. OpenCode bridges the same shape via its plugin.
+The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemini session extracts the response and tool calls from the transcript or runtime output, then posts them to `POST /events/chat` on the daemon. Claude Code can also stream block-level `chat_turn_delta` events while a turn is in progress. The dashboard streams events over Server-Sent Events and merges them with Claude transcript history for the selected peer/session. OpenCode bridges the same realtime shape via its plugin.
 
 ## Roadmap: session timeline
 
-The v0.13 dashboard direction is a timeline-centered view: persisted history and realtime stream events in one durable session timeline. Peers remain the runtime executors, but future controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions should attach to shared session commands as those features land.
+The v0.13 dashboard direction is a timeline-centered view. The current slice merges Claude transcript history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.
 
 ## Mobile
 

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -367,6 +367,10 @@ class ChatTurnRequest(BaseModel):
     peer: str
     role: Literal["user", "assistant"]
     text: str
+    session_id: str | None = Field(
+        None,
+        description="Hook/runtime transcript session id used for dashboard scoping",
+    )
     tool_calls: list[ToolCallInfo] | None = None
     turn_id: str | None = Field(
         None,
@@ -391,18 +395,23 @@ _FINALIZED_TURN_IDS_CAPACITY: int = 4096
 _finalized_turn_ids: dict[str, None] = {}
 
 
-def _mark_turn_finalized(turn_id: str) -> None:
-    if turn_id in _finalized_turn_ids:
+def _turn_finalized_key(session_id: str | None, turn_id: str) -> str:
+    return f"{session_id or 'legacy'}:{turn_id}"
+
+
+def _mark_turn_finalized(turn_id: str, session_id: str | None = None) -> None:
+    key = _turn_finalized_key(session_id, turn_id)
+    if key in _finalized_turn_ids:
         # Refresh recency so a finalized id stays in the set as long as deltas
         # might still trickle in.
-        del _finalized_turn_ids[turn_id]
-    _finalized_turn_ids[turn_id] = None
+        del _finalized_turn_ids[key]
+    _finalized_turn_ids[key] = None
     while len(_finalized_turn_ids) > _FINALIZED_TURN_IDS_CAPACITY:
         _finalized_turn_ids.pop(next(iter(_finalized_turn_ids)))
 
 
-def _is_turn_finalized(turn_id: str) -> bool:
-    return turn_id in _finalized_turn_ids
+def _is_turn_finalized(turn_id: str, session_id: str | None = None) -> bool:
+    return _turn_finalized_key(session_id, turn_id) in _finalized_turn_ids
 
 
 @router.post("/events/chat", response_model=OkResponse)
@@ -421,7 +430,7 @@ async def ingest_chat_turn(
             data["peer"] = peer.display_name  # canonicalize to registered name
 
     if request.turn_id and request.role == "assistant":
-        _mark_turn_finalized(request.turn_id)
+        _mark_turn_finalized(request.turn_id, request.session_id)
 
     peer_registry.add_event("chat_turn", data)
     return OkResponse()
@@ -438,6 +447,10 @@ class ChatTurnDeltaRequest(BaseModel):
 
     peer: str
     role: Literal["assistant"] = "assistant"
+    session_id: str | None = Field(
+        None,
+        description="Hook/runtime transcript session id used for dashboard scoping",
+    )
     turn_id: str = Field(..., description="Stable id for the assistant turn (deltas group by this)")
     chunk_index: int = Field(..., ge=0, description="Monotonic 0-based index within the turn")
     kind: Literal["text", "tool_use"] = Field(default="text", description="Block kind")
@@ -460,7 +473,7 @@ async def ingest_chat_turn_delta(
     200 on drop so the streamer's best-effort post doesn't retry into a
     failure loop.
     """
-    if _is_turn_finalized(request.turn_id):
+    if _is_turn_finalized(request.turn_id, request.session_id):
         return OkResponse()
 
     peer_registry = get_peer_registry()

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -358,6 +358,7 @@ class TranscriptTurn(BaseModel):
     text: str
     timestamp: str
     session_id: str
+    turn_id: str
     tool_calls: list[dict[str, str]] = Field(default_factory=list)
 
 
@@ -379,6 +380,14 @@ async def get_peer_transcript(
             "stable pagination across same-timestamp boundaries."
         ),
     ),
+    session_id: str | None = Query(
+        None,
+        description=(
+            "Optional hook/runtime transcript session id used for dashboard "
+            "scoping. When set, "
+            "only turns from that session are returned."
+        ),
+    ),
     circle: str | None = Query(None),
     _: str | None = Depends(require_auth),
 ) -> TranscriptResponse:
@@ -397,6 +406,8 @@ async def get_peer_transcript(
         )
 
     turns = await asyncio.to_thread(load_peer_turns, peer.path, peer.backend)
+    if session_id:
+        turns = [turn for turn in turns if turn.session_id == session_id]
     page, next_before = page_turns(turns, limit, before)
     return TranscriptResponse(
         turns=[
@@ -405,6 +416,7 @@ async def get_peer_transcript(
                 text=t.text,
                 timestamp=t.timestamp,
                 session_id=t.session_id,
+                turn_id=t.turn_id,
                 tool_calls=t.tool_calls,
             )
             for t in page

--- a/repowire/hooks/chat_delta_streamer.py
+++ b/repowire/hooks/chat_delta_streamer.py
@@ -162,6 +162,7 @@ def _content_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
 def _emit_text(
     peer: str,
     pane_id: str,
+    session_id: str | None,
     turn_id: str,
     chunk_index: int,
     text: str,
@@ -176,12 +177,15 @@ def _emit_text(
         "is_final": False,
         "pane_id": pane_id,
     }
+    if session_id:
+        payload["session_id"] = session_id
     return daemon_post("/events/chat_delta", payload) is not None
 
 
 def _emit_tool_use(
     peer: str,
     pane_id: str,
+    session_id: str | None,
     turn_id: str,
     chunk_index: int,
     name: str,
@@ -199,11 +203,13 @@ def _emit_tool_use(
         "is_final": False,
         "pane_id": pane_id,
     }
+    if session_id:
+        payload["session_id"] = session_id
     return daemon_post("/events/chat_delta", payload) is not None
 
 
 def _tail_transcript(
-    transcript_path: Path, peer: str, pane_id: str, pid_path: Path,
+    transcript_path: Path, peer: str, pane_id: str, session_id: str | None, pid_path: Path,
 ) -> None:
     """Inner tail loop. Exits when pidfile is removed, idle, or wall-clock cap.
 
@@ -274,13 +280,13 @@ def _tail_transcript(
                             text = block.get("text") or ""
                             if not text.strip():
                                 continue
-                            if _emit_text(peer, pane_id, turn_id, chunk_index, text):
+                            if _emit_text(peer, pane_id, session_id, turn_id, chunk_index, text):
                                 chunk_index += 1
                         elif block_type == "tool_use":
                             name = block.get("name", "unknown")
                             tool_input = block.get("input", {})
                             if _emit_tool_use(
-                                peer, pane_id, turn_id, chunk_index, name, tool_input,
+                                peer, pane_id, session_id, turn_id, chunk_index, name, tool_input,
                             ):
                                 chunk_index += 1
     except FileNotFoundError:
@@ -289,7 +295,12 @@ def _tail_transcript(
         pass
 
 
-def run(transcript_path: Path, peer: str, pane_id: str) -> int:
+def run(
+    transcript_path: Path,
+    peer: str,
+    pane_id: str,
+    session_id: str | None = None,
+) -> int:
     """Single-owner streamer entry point.
 
     Acquires a non-blocking flock on the per-pane lockfile for the whole
@@ -321,7 +332,7 @@ def run(transcript_path: Path, peer: str, pane_id: str) -> int:
             return 1
 
         try:
-            _tail_transcript(transcript_path, peer, pane_id, pid_path)
+            _tail_transcript(transcript_path, peer, pane_id, session_id, pid_path)
         finally:
             # Owner-checked unlink: only remove the pidfile if it still names
             # us. A fresh streamer that overwrote the pid will release the
@@ -347,8 +358,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--transcript", required=True, help="Path to transcript JSONL")
     parser.add_argument("--peer", required=True, help="Peer display name")
     parser.add_argument("--pane-id", required=True, help="Tmux pane id (state key)")
+    parser.add_argument("--session-id", help="Hook/runtime session id for dashboard scoping")
     args = parser.parse_args(argv)
-    return run(Path(args.transcript).expanduser(), args.peer, args.pane_id)
+    return run(Path(args.transcript).expanduser(), args.peer, args.pane_id, args.session_id)
 
 
 if __name__ == "__main__":

--- a/repowire/hooks/prompt_handler.py
+++ b/repowire/hooks/prompt_handler.py
@@ -14,7 +14,7 @@ from repowire.hooks.utils import get_display_name, update_status
 
 
 def _maybe_spawn_chat_delta_streamer(
-    transcript_path: str | None, pane_id: str | None,
+    transcript_path: str | None, pane_id: str | None, session_id: str | None = None,
 ) -> None:
     """Spawn the per-turn transcript tailer if the experiment is on.
 
@@ -47,18 +47,21 @@ def _maybe_spawn_chat_delta_streamer(
     terminate_live_streamer(pane_id)
 
     try:
+        argv = [
+            sys.executable,
+            "-m",
+            "repowire.hooks.chat_delta_streamer",
+            "--transcript",
+            str(Path(transcript_path).expanduser()),
+            "--peer",
+            get_display_name(),
+            "--pane-id",
+            pane_id,
+        ]
+        if session_id:
+            argv.extend(["--session-id", session_id])
         subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            [
-                sys.executable,
-                "-m",
-                "repowire.hooks.chat_delta_streamer",
-                "--transcript",
-                str(Path(transcript_path).expanduser()),
-                "--peer",
-                get_display_name(),
-                "--pane-id",
-                pane_id,
-            ],
+            argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -93,7 +96,11 @@ def main(backend: str = "claude-code") -> int:
             )
 
     if backend == "claude-code":
-        _maybe_spawn_chat_delta_streamer(payload.transcript_path, pane_id)
+        _maybe_spawn_chat_delta_streamer(
+            payload.transcript_path,
+            pane_id,
+            payload.session_id or None,
+        )
 
     hook_output(backend)
     return 0

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -282,6 +282,8 @@ def main(backend: str = "claude-code") -> int:
         hint_pending_first_turn = bool(hint and hint.get("pending_first_turn"))
         initial_turn_state = "pending_first_turn" if hint_pending_first_turn else None
         metadata: dict = {"project": folder_name}
+        if hook_session_id:
+            metadata["hook_session_id"] = hook_session_id
         branch = get_git_branch(cwd)
         if branch:
             metadata["branch"] = branch

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -50,6 +50,7 @@ def _post_chat_turn(
     text: str,
     tool_calls: list[dict[str, str]] | None = None,
     pane_id: str | None = None,
+    session_id: str | None = None,
     turn_id: str | None = None,
 ) -> None:
     """Post a chat turn to the daemon for dashboard display. Best-effort.
@@ -63,6 +64,8 @@ def _post_chat_turn(
         payload["tool_calls"] = tool_calls
     if pane_id:
         payload["pane_id"] = pane_id
+    if session_id:
+        payload["session_id"] = session_id
     if turn_id:
         payload["turn_id"] = turn_id
     daemon_post("/events/chat", payload)
@@ -117,7 +120,13 @@ def main(backend: str = "claude-code") -> int:
     _stop_chat_delta_streamer(pane_id)
 
     if user_text:
-        _post_chat_turn(peer_display, "user", user_text, pane_id=pane_id)
+        _post_chat_turn(
+            peer_display,
+            "user",
+            user_text,
+            pane_id=pane_id,
+            session_id=payload.session_id or None,
+        )
     if assistant_text:
         _post_chat_turn(
             peer_display,
@@ -125,6 +134,7 @@ def main(backend: str = "claude-code") -> int:
             assistant_text,
             tool_calls or None,
             pane_id=pane_id,
+            session_id=payload.session_id or None,
             turn_id=turn_id,
         )
 

--- a/repowire/session/history.py
+++ b/repowire/session/history.py
@@ -32,6 +32,7 @@ class Turn:
     text: str
     timestamp: str  # ISO-8601; "" if missing
     session_id: str
+    turn_id: str
     tool_calls: list[dict[str, str]]  # [{name, input}] — empty for user turns
     line_offset: int = 0  # tie-breaker for same-timestamp turns within a session file
 
@@ -86,6 +87,43 @@ def _iter_claude_turns(path: Path) -> Iterator[Turn]:
     Skips tool-only assistant entries (no text) and tool_result-only user
     entries, which match the semantics of the dashboard's live chat_turn ring.
     """
+    assistant_session_id = ""
+    assistant_turn_id: str | None = None
+    assistant_text: str | None = None
+    assistant_timestamp = ""
+    assistant_line_offset = 0
+    assistant_tool_calls: list[dict[str, str]] = []
+
+    def flush_assistant() -> Turn | None:
+        nonlocal assistant_turn_id
+        nonlocal assistant_text
+        nonlocal assistant_timestamp
+        nonlocal assistant_line_offset
+        nonlocal assistant_tool_calls
+        if not assistant_turn_id or not assistant_text:
+            assistant_turn_id = None
+            assistant_text = None
+            assistant_timestamp = ""
+            assistant_line_offset = 0
+            assistant_tool_calls = []
+            return None
+
+        turn = Turn(
+            role="assistant",
+            text=assistant_text,
+            timestamp=assistant_timestamp,
+            session_id=assistant_session_id,
+            turn_id=assistant_turn_id,
+            tool_calls=assistant_tool_calls,
+            line_offset=assistant_line_offset,
+        )
+        assistant_turn_id = None
+        assistant_text = None
+        assistant_timestamp = ""
+        assistant_line_offset = 0
+        assistant_tool_calls = []
+        return turn
+
     try:
         with open(path) as f:
             for line_no, line in enumerate(f):
@@ -110,11 +148,37 @@ def _iter_claude_turns(path: Path) -> Iterator[Turn]:
                     continue
 
                 text = _extract_text(content)
-                tool_calls: list[dict[str, str]] = []
-                if entry_type == "assistant" and isinstance(content, list):
+                session_id = entry.get("sessionId", "") or path.stem
+
+                if entry_type == "user":
+                    assistant_turn = flush_assistant()
+                    if assistant_turn:
+                        yield assistant_turn
+                    if not text:
+                        continue
+                    yield Turn(
+                        role="user",
+                        text=text,
+                        timestamp=entry.get("timestamp", "") or "",
+                        session_id=session_id,
+                        turn_id=f"history:{session_id}:{line_no}",
+                        tool_calls=[],
+                        line_offset=line_no,
+                    )
+                    continue
+
+                if assistant_turn_id is None:
+                    message_id = message.get("id") if isinstance(message, dict) else None
+                    entry_id = entry.get("uuid") or entry.get("id")
+                    assistant_turn_id = str(
+                        entry_id or message_id or f"history:{session_id}:{line_no}"
+                    )
+                    assistant_session_id = session_id
+
+                if isinstance(content, list):
                     for item in content:
                         if isinstance(item, dict) and item.get("type") == "tool_use":
-                            tool_calls.append({
+                            assistant_tool_calls.append({
                                 "name": item.get("name", "unknown"),
                                 "input": _summarize_tool_input(
                                     item.get("name", "unknown"),
@@ -122,17 +186,13 @@ def _iter_claude_turns(path: Path) -> Iterator[Turn]:
                                 ),
                             })
 
-                if not text and not tool_calls:
-                    continue
-
-                yield Turn(
-                    role=entry_type,
-                    text=text,
-                    timestamp=entry.get("timestamp", "") or "",
-                    session_id=entry.get("sessionId", "") or path.stem,
-                    tool_calls=tool_calls,
-                    line_offset=line_no,
-                )
+                if text:
+                    assistant_text = text
+                    assistant_timestamp = entry.get("timestamp", "") or ""
+                    assistant_line_offset = line_no
+            assistant_turn = flush_assistant()
+            if assistant_turn:
+                yield assistant_turn
     except OSError:
         return
 

--- a/tests/test_chat_delta_streamer.py
+++ b/tests/test_chat_delta_streamer.py
@@ -53,7 +53,7 @@ def test_streamer_emits_text_block_delta(tmp_path):
 
     def runner():
         with patch.object(streamer, "daemon_post", side_effect=fake_post):
-            streamer.run(transcript, "peer1", "%42")
+            streamer.run(transcript, "peer1", "%42", "session-1")
         done.set()
 
     t = threading.Thread(target=runner, daemon=True)
@@ -73,6 +73,7 @@ def test_streamer_emits_text_block_delta(tmp_path):
     assert text_posts[0]["chunk_index"] == 0
     assert text_posts[0]["peer"] == "peer1"
     assert text_posts[0]["pane_id"] == "%42"
+    assert text_posts[0]["session_id"] == "session-1"
     assert text_posts[0]["turn_id"] == "uuid-1"
 
 

--- a/tests/test_hooks_handlers.py
+++ b/tests/test_hooks_handlers.py
@@ -70,6 +70,7 @@ class TestPromptHandler:
         with patch("repowire.config.models.load_config", return_value=Config()):
             result = _run_with_input(prompt_main, {
                 "hook_event_name": "UserPromptSubmit",
+                "session_id": "hook-session-1",
                 "transcript_path": str(transcript),
             })
         assert result == 0
@@ -89,6 +90,7 @@ class TestPromptHandler:
         with patch("repowire.config.models.load_config", return_value=cfg):
             result = _run_with_input(prompt_main, {
                 "hook_event_name": "UserPromptSubmit",
+                "session_id": "hook-session-1",
                 "transcript_path": str(transcript),
             })
         assert result == 0
@@ -97,6 +99,8 @@ class TestPromptHandler:
         assert "repowire.hooks.chat_delta_streamer" in argv
         assert "--transcript" in argv
         assert "--pane-id" in argv
+        assert "--session-id" in argv
+        assert "hook-session-1" in argv
 
     @patch("repowire.hooks.prompt_handler.subprocess.Popen")
     @patch("repowire.hooks.prompt_handler.update_status", return_value=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -661,6 +661,7 @@ class TestEvents:
         r = await client.post("/events/chat_delta", json={
             "peer": "streampeer",
             "role": "assistant",
+            "session_id": "stream-session",
             "turn_id": "turn-abc",
             "chunk_index": 0,
             "kind": "text",
@@ -673,6 +674,7 @@ class TestEvents:
         assert len(events) == 1
         e = events[0]
         assert e["type"] == "chat_turn_delta"
+        assert e["session_id"] == "stream-session"
         assert e["turn_id"] == "turn-abc"
         assert e["chunk_index"] == 0
         assert e["kind"] == "text"
@@ -735,10 +737,12 @@ class TestEvents:
             "peer": "testpeer",
             "role": "assistant",
             "text": "final",
+            "session_id": "session-9",
             "turn_id": "msg-uuid-9",
         })
         assert r.status_code == 200
         events = (await client.get("/events")).json()
+        assert events[0]["session_id"] == "session-9"
         assert events[0]["turn_id"] == "msg-uuid-9"
 
     async def test_tool_use_turn_canonical_id_drops_deltas(self, client):
@@ -856,8 +860,8 @@ class TestEvents:
                 assert r.status_code == 200
             assert len(msgs_mod._finalized_turn_ids) == 5
             # Oldest evicted.
-            assert "cap-0" not in msgs_mod._finalized_turn_ids
-            assert "cap-19" in msgs_mod._finalized_turn_ids
+            assert "legacy:cap-0" not in msgs_mod._finalized_turn_ids
+            assert "legacy:cap-19" in msgs_mod._finalized_turn_ids
         finally:
             msgs_mod._finalized_turn_ids.clear()
             msgs_mod._FINALIZED_TURN_IDS_CAPACITY = 4096

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -85,6 +85,11 @@ class TestStopHandler:
         paths = [c[0][0] for c in calls]
         assert "/events/chat" in paths
         assert "/response" in paths
+        chat_payloads = [c[0][1] for c in calls if c[0][0] == "/events/chat"]
+        assert [payload["session_id"] for payload in chat_payloads] == [
+            "abc12345-rest",
+            "abc12345-rest",
+        ]
 
     @patch("repowire.hooks.stop_handler.daemon_post")
     @patch("repowire.hooks.stop_handler.update_status", return_value=True)

--- a/tests/test_transcript_history.py
+++ b/tests/test_transcript_history.py
@@ -42,6 +42,7 @@ def _a(ts: str, text: str, tool_uses: list[dict] | None = None) -> dict:
         content.extend(tool_uses)
     return {
         "type": "assistant",
+        "uuid": "assistant-uuid",
         "timestamp": ts,
         "sessionId": "s1",
         "message": {"content": content},
@@ -137,6 +138,87 @@ class TestLoadPeerTurnsClaude:
             turns = load_peer_turns(peer_path, "claude-code")
         assert turns[0].tool_calls == [{"name": "Bash", "input": "ls -la"}]
 
+    def test_assistant_turn_id_prefers_claude_uuid(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                {
+                    "type": "assistant",
+                    "uuid": "live-equivalent-id",
+                    "id": "entry-id",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "sessionId": "s1",
+                    "message": {
+                        "id": "message-id",
+                        "content": [{"type": "text", "text": "hello"}],
+                    },
+                }
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert turns[0].turn_id == "live-equivalent-id"
+
+    def test_tool_turn_final_text_uses_first_assistant_uuid(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                {
+                    "type": "user",
+                    "uuid": "u1",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "sessionId": "s1",
+                    "message": {"content": "check files"},
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "uuid-1",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "sessionId": "s1",
+                    "message": {"content": [
+                        {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                    ]},
+                },
+                {
+                    "type": "user",
+                    "uuid": "tool-result",
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "sessionId": "s1",
+                    "message": {"content": [{"type": "tool_result", "content": "ok"}]},
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "uuid-2",
+                    "timestamp": "2026-01-01T00:00:03Z",
+                    "sessionId": "s1",
+                    "message": {"content": [{"type": "text", "text": "done"}]},
+                },
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assistant_turns = [turn for turn in turns if turn.role == "assistant"]
+        assert len(assistant_turns) == 1
+        assert assistant_turns[0].text == "done"
+        assert assistant_turns[0].turn_id == "uuid-1"
+        assert assistant_turns[0].tool_calls == [{"name": "Bash", "input": "ls"}]
+
+    def test_turn_id_falls_back_when_no_live_equivalent_id(self, tmp_path: Path):
+        peer_path, projects_root = self._setup(
+            tmp_path,
+            [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "sessionId": "s1",
+                    "message": {"content": [{"type": "text", "text": "hello"}]},
+                }
+            ],
+        )
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            turns = load_peer_turns(peer_path, "claude-code")
+        assert turns[0].turn_id == "history:s1:0"
+
     def test_skips_malformed_lines(self, tmp_path: Path):
         peer_path, projects_root = self._setup(tmp_path, [_a("2026-01-01T00:00:00Z", "ok")])
         session_dir = projects_root / _encode_cwd(peer_path)
@@ -177,6 +259,7 @@ def _t(ts: str, session_id: str = "s", line_offset: int = 0, text: str | None = 
         text=text if text is not None else ts,
         timestamp=ts,
         session_id=session_id,
+        turn_id=f"history:{session_id}:{line_offset}",
         tool_calls=[],
         line_offset=line_offset,
     )

--- a/tests/test_transcript_history_routes.py
+++ b/tests/test_transcript_history_routes.py
@@ -129,6 +129,7 @@ async def test_returns_paginated_turns(tmp_path: Path):
                 body = res.json()
                 assert res.status_code == 200
                 assert [t["text"] for t in body["turns"]] == ["a2", "q2"]
+                assert body["turns"][0]["turn_id"].startswith("history:s1:")
                 assert body["next_before"] is not None
 
                 res2 = await ac.get(
@@ -137,6 +138,66 @@ async def test_returns_paginated_turns(tmp_path: Path):
                 )
                 body2 = res2.json()
                 assert [t["text"] for t in body2["turns"]] == ["a1", "q1"]
+                assert body2["next_before"] is None
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_session_id_filter_applies_before_pagination_and_returns_turn_id(tmp_path: Path):
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        _, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        _write_session(projects_root, peer_path, [
+            {"type": "user", "timestamp": "2026-01-01T00:00:00Z",
+             "sessionId": "s1", "message": {"content": "s1 old prompt"}},
+            {"type": "assistant", "uuid": "s1-old-id", "timestamp": "2026-01-01T00:00:00Z",
+             "sessionId": "s1", "message": {"content": [{"type": "text", "text": "s1 old"}]}},
+            {"type": "user", "timestamp": "2026-01-03T00:00:00Z",
+             "sessionId": "s2", "message": {"content": "s2 prompt"}},
+            {"type": "assistant", "uuid": "s2-new-id", "timestamp": "2026-01-03T00:00:00Z",
+             "sessionId": "s2", "message": {"content": [{"type": "text", "text": "s2 new"}]}},
+            {"type": "user", "timestamp": "2026-01-02T00:00:00Z",
+             "sessionId": "s1", "message": {"content": "s1 new prompt"}},
+            {"type": "assistant", "uuid": "s1-new-id", "timestamp": "2026-01-02T00:00:00Z",
+             "sessionId": "s1", "message": {"content": [{"type": "text", "text": "s1 new"}]}},
+        ])
+
+        with patch(
+            "repowire.session.history._claude_projects_dir",
+            return_value=projects_root,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                res = await ac.get(
+                    f"/peers/{name}/transcript",
+                    params={"session_id": "s1", "limit": 2},
+                )
+                body = res.json()
+                assert [t["text"] for t in body["turns"]] == ["s1 new", "s1 new prompt"]
+                assert body["turns"][0]["turn_id"] == "s1-new-id"
+                assert body["next_before"] is not None
+
+                res2 = await ac.get(
+                    f"/peers/{name}/transcript",
+                    params={
+                        "session_id": "s1",
+                        "limit": 2,
+                        "before": body["next_before"],
+                    },
+                )
+                body2 = res2.json()
+                assert [t["text"] for t in body2["turns"]] == ["s1 old", "s1 old prompt"]
+                assert body2["turns"][0]["turn_id"] == "s1-old-id"
                 assert body2["next_before"] is None
     finally:
         cleanup_deps()

--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { PeerView } from "./PeerView";
 import { __resetProtectionForTests, getFrozenThread, isProtected } from "../lib/protection";
 import { __resetDraftsForTests, getDraftText, setDraftText } from "../lib/drafts";
@@ -41,14 +41,220 @@ beforeEach(() => {
   scrollSpy.mockClear();
   __resetProtectionForTests();
   __resetDraftsForTests();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise<Response>(() => {})),
+  );
 });
 
 afterEach(() => {
   __resetProtectionForTests();
   __resetDraftsForTests();
+  vi.unstubAllGlobals();
 });
 
 describe("PeerView session protection", () => {
+  it("renders persisted transcript turns in the primary chat timeline", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/spawn/config")) return new Promise<Response>(() => {});
+      return new Response(
+        JSON.stringify({
+          turns: [
+            {
+              role: "assistant",
+              text: "persisted answer",
+              timestamp: "2025-01-01T00:00:00Z",
+              session_id: "session-a",
+              turn_id: "turn-a",
+              tool_calls: [],
+            },
+          ],
+          next_before: null,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <PeerView
+        peer={{ ...PEER, metadata: { hook_session_id: "session-a" } }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("persisted answer")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("session_id=session-a"),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("keeps active session sticky after choosing newest realtime session", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/spawn/config")) return new Promise<Response>(() => {});
+      return new Response(JSON.stringify({ turns: [], next_before: null }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const liveS1 = {
+      ...chatTurn("s1-final", "session one", "2025-01-01T00:00:02Z"),
+      session_id: "s1",
+      turn_id: "t1",
+    };
+    const lateOlder = {
+      ...chatTurn("s0-final", "older session", "2025-01-01T00:00:01Z"),
+      session_id: "s0",
+      turn_id: "t0",
+    };
+
+    const { rerender } = render(
+      <PeerView peer={PEER} events={[liveS1]} apiBase="" onClose={() => {}} onSent={() => {}} />,
+    );
+    expect(await screen.findByText("session one")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((call) => String(call[0]).includes("session_id=s1"))).toBe(true);
+    });
+
+    rerender(<PeerView peer={PEER} events={[lateOlder, liveS1]} apiBase="" onClose={() => {}} onSent={() => {}} />);
+    expect(screen.getByText("session one")).toBeInTheDocument();
+    expect(screen.queryByText("older session")).not.toBeInTheDocument();
+  });
+
+  it("does not let delayed transcript discovery overwrite realtime session fallback", async () => {
+    let resolveDiscovery: (response: Response) => void = () => {};
+    const discovery = new Promise<Response>((resolve) => {
+      resolveDiscovery = resolve;
+    });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/spawn/config")) return new Promise<Response>(() => {});
+      if (url.includes("session_id=session-new")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ turns: [], next_before: null }), { status: 200 }),
+        );
+      }
+      return discovery;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const liveNew = {
+      ...chatTurn("new-final", "new realtime session", "2025-01-01T00:00:02Z"),
+      session_id: "session-new",
+      turn_id: "turn-new",
+    };
+
+    render(<PeerView peer={PEER} events={[liveNew]} apiBase="" onClose={() => {}} onSent={() => {}} />);
+    expect(await screen.findByText("new realtime session")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveDiscovery(
+        new Response(
+          JSON.stringify({
+            turns: [
+              {
+                role: "assistant",
+                text: "stale transcript session",
+                timestamp: "2025-01-01T00:00:01Z",
+                session_id: "session-old",
+                turn_id: "turn-old",
+                tool_calls: [],
+              },
+            ],
+            next_before: null,
+          }),
+          { status: 200 },
+        ),
+      );
+      await discovery;
+    });
+
+    expect(screen.getByText("new realtime session")).toBeInTheDocument();
+    expect(screen.queryByText("stale transcript session")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((call) => String(call[0]).includes("session_id=session-new"))).toBe(true);
+    });
+  });
+
+  it("collapses persisted assistant rows when matching realtime final arrives", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes("/spawn/config")) return new Promise<Response>(() => {});
+        return new Response(
+          JSON.stringify({
+            turns: [
+              {
+                role: "assistant",
+                text: "persisted duplicate",
+                timestamp: "2025-01-01T00:00:00Z",
+                session_id: "session-a",
+                turn_id: "turn-a",
+                tool_calls: [],
+              },
+            ],
+            next_before: null,
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+    const live = {
+      ...chatTurn("live-a", "live final wins", "2025-01-01T00:00:01Z"),
+      session_id: "session-a",
+      turn_id: "turn-a",
+    };
+
+    render(
+      <PeerView
+        peer={{ ...PEER, metadata: { hook_session_id: "session-a" } }}
+        events={[live]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("live final wins")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("persisted duplicate")).not.toBeInTheDocument());
+  });
+
+  it("renders streaming deltas only for the active session", async () => {
+    const deltaActive: Event = {
+      id: "delta-active",
+      type: "chat_turn_delta",
+      timestamp: "2025-01-01T00:00:00Z",
+      peer_id: PEER.peer_id,
+      session_id: "session-a",
+      turn_id: "turn-a",
+      chunk_index: 0,
+      kind: "text",
+      text: "active stream",
+    };
+    const deltaOther: Event = {
+      ...deltaActive,
+      id: "delta-other",
+      session_id: "session-b",
+      text: "other stream",
+    };
+
+    render(
+      <PeerView
+        peer={{ ...PEER, metadata: { hook_session_id: "session-a" } }}
+        events={[deltaOther, deltaActive]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("active stream")).toBeInTheDocument();
+    expect(screen.queryByText("other stream")).not.toBeInTheDocument();
+  });
+
   it("auto-scrolls on new events when not protected", () => {
     const initial: Event[] = [chatTurn("e1", "hello", "2025-01-01T00:00:00Z")];
     const { rerender } = render(

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { AlertCircle, Check, Clock, Copy, Paperclip, RefreshCw, Send, X } from "lucide-react";
@@ -14,6 +14,7 @@ interface TranscriptTurn {
   text: string;
   timestamp: string;
   session_id: string;
+  turn_id: string;
   tool_calls: { name: string; input: string }[];
 }
 
@@ -40,6 +41,7 @@ type PeerTab = "chat" | "mcp" | "history";
 interface ChatTurnDeltaGroup {
   type: "chat_turn_delta_group";
   id: string;
+  session_id?: string;
   turn_id: string;
   peer_id?: string;
   timestamp: string;
@@ -47,7 +49,12 @@ interface ChatTurnDeltaGroup {
   tool_calls: { name: string; input: string }[];
 }
 
-type ThreadItemEntry = Event | ChatTurnDeltaGroup;
+interface HistoryTimelineTurn extends TranscriptTurn {
+  type: "history_turn";
+  id: string;
+}
+
+type ThreadItemEntry = Event | ChatTurnDeltaGroup | HistoryTimelineTurn;
 
 export function PeerView({
   peer,
@@ -64,20 +71,160 @@ export function PeerView({
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [activeTab, setActiveTab] = useState<PeerTab>("chat");
+  const metadataSession = typeof peer.metadata?.hook_session_id === "string"
+    ? peer.metadata.hook_session_id
+    : null;
+  const [activeSessionState, setActiveSessionState] = useState<{ peerId: string; sessionId: string | null }>({
+    peerId: peer.peer_id,
+    sessionId: metadataSession,
+  });
+  const activeSessionId = activeSessionState.peerId === peer.peer_id
+    ? activeSessionState.sessionId
+    : metadataSession;
+  const activeSessionRef = useRef(activeSessionState);
+  const [timelineTurns, setTimelineTurns] = useState<TranscriptTurn[]>([]);
+  const [timelineNextBefore, setTimelineNextBefore] = useState<string | null>(null);
+  const [timelineLoading, setTimelineLoading] = useState(false);
+  const [timelineError, setTimelineError] = useState<string | null>(null);
+  const [timelineInitialized, setTimelineInitialized] = useState(false);
+  const timelineTopSentinelRef = useRef<HTMLDivElement>(null);
+  const lastMetadataSessionRef = useRef<string | null>(metadataSession);
   const protectedNow = useIsPeerProtected(peer.peer_id);
+  useEffect(() => {
+    activeSessionRef.current = activeSessionState;
+  }, [activeSessionState]);
+  const realtimeSessionIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const event of events) {
+      if (
+        (event.type === "chat_turn" || event.type === "chat_turn_delta") &&
+        event.peer_id === peer.peer_id &&
+        event.session_id
+      ) {
+        ids.push(event.session_id);
+      }
+    }
+    return ids;
+  }, [events, peer.peer_id]);
   const liveThread = useMemo(() => {
     const id = peer.peer_id;
-    return coalesceDeltas(
-      events
-        .filter((event) => {
-          if (event.type === "chat_turn" || event.type === "chat_turn_delta") {
-            return event.peer_id === id;
+    const scopedEvents = events
+      .filter((event) => {
+        if (event.type === "chat_turn" || event.type === "chat_turn_delta") {
+          if (event.peer_id !== id) return false;
+          if (activeSessionId) return event.session_id === activeSessionId;
+          return !event.session_id;
+        }
+        return event.from_peer_id === id || event.to_peer_id === id;
+      })
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    return mergeTimeline(timelineTurns, scopedEvents, activeSessionId);
+  }, [activeSessionId, events, peer.peer_id, timelineTurns]);
+
+  const fetchTimelinePage = useCallback(
+    async (before: string | null, sessionId: string | null) => {
+      setTimelineLoading(true);
+      setTimelineError(null);
+      try {
+        const url = new URL(
+          `${apiBase}/peers/${encodeURIComponent(peer.name)}/transcript`,
+          window.location.origin,
+        );
+        url.searchParams.set("limit", sessionId ? "50" : "1");
+        if (sessionId) url.searchParams.set("session_id", sessionId);
+        if (before) url.searchParams.set("before", before);
+        const res = await fetch(url.toString().replace(window.location.origin, ""), {
+          credentials: "include",
+        });
+        if (!res.ok) {
+          setTimelineError(`Error ${res.status}`);
+          return;
+        }
+        const data = (await res.json()) as { turns: TranscriptTurn[]; next_before: string | null };
+        if (!sessionId) {
+          const currentSelection = activeSessionRef.current;
+          if (
+            data.turns[0]?.session_id &&
+            currentSelection.peerId === peer.peer_id &&
+            currentSelection.sessionId === null &&
+            !lastMetadataSessionRef.current
+          ) {
+            setActiveSessionState({ peerId: peer.peer_id, sessionId: data.turns[0].session_id });
           }
-          return event.from_peer_id === id || event.to_peer_id === id;
-        })
-        .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+          return;
+        }
+        setTimelineTurns((prev) => {
+          const seen = new Set(prev.map((turn) => `${turn.session_id}:${turn.turn_id}`));
+          const next = [...prev];
+          for (const turn of data.turns) {
+            const key = `${turn.session_id}:${turn.turn_id}`;
+            if (!seen.has(key)) {
+              seen.add(key);
+              next.push(turn);
+            }
+          }
+          return next;
+        });
+        setTimelineNextBefore(data.next_before);
+      } catch (e) {
+        setTimelineError(e instanceof Error ? e.message : "Request failed");
+      } finally {
+        setTimelineLoading(false);
+        setTimelineInitialized(true);
+      }
+    },
+    [apiBase, peer.name, peer.peer_id],
+  );
+
+  useEffect(() => {
+    lastMetadataSessionRef.current = metadataSession;
+    setActiveSessionState({ peerId: peer.peer_id, sessionId: metadataSession });
+    setTimelineTurns([]);
+    setTimelineNextBefore(null);
+    setTimelineError(null);
+    setTimelineInitialized(false);
+    // Sticky selection resets only on peer changes; metadata changes are handled below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [peer.peer_id]);
+
+  useEffect(() => {
+    if (!metadataSession || metadataSession === lastMetadataSessionRef.current) return;
+    lastMetadataSessionRef.current = metadataSession;
+    setActiveSessionState({ peerId: peer.peer_id, sessionId: metadataSession });
+    setTimelineTurns([]);
+    setTimelineNextBefore(null);
+    setTimelineError(null);
+    setTimelineInitialized(false);
+  }, [metadataSession, peer.peer_id]);
+
+  useEffect(() => {
+    if (activeSessionId || realtimeSessionIds.length === 0) return;
+    setActiveSessionState({
+      peerId: peer.peer_id,
+      sessionId: realtimeSessionIds[realtimeSessionIds.length - 1],
+    });
+  }, [activeSessionId, peer.peer_id, realtimeSessionIds]);
+
+  useEffect(() => {
+    setTimelineTurns([]);
+    setTimelineNextBefore(null);
+    setTimelineError(null);
+    setTimelineInitialized(false);
+    void fetchTimelinePage(null, activeSessionId);
+  }, [activeSessionId, fetchTimelinePage]);
+
+  useEffect(() => {
+    const el = timelineTopSentinelRef.current;
+    if (!el || !activeSessionId || !timelineNextBefore || timelineLoading) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) void fetchTimelinePage(timelineNextBefore, activeSessionId);
+      },
+      { rootMargin: "100px" },
     );
-  }, [events, peer.peer_id]);
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [activeSessionId, fetchTimelinePage, timelineLoading, timelineNextBefore]);
 
   // While the peer is protected (e.g. unsubmitted compose draft), freeze the
   // rendered thread so new SSE events don't reorder/clobber it mid-compose.
@@ -165,15 +312,34 @@ export function PeerView({
       {activeTab === "chat" ? (
         <>
           <div className="min-h-0 flex-1 px-4 py-4 md:overflow-y-auto md:px-6">
+            {activeSessionId && timelineNextBefore && (
+              <div ref={timelineTopSentinelRef} className="py-2 text-center font-mono text-[10px] text-outline">
+                {timelineLoading ? "loading older..." : "scroll up for older"}
+              </div>
+            )}
+            {timelineError && (
+              <div className="mb-2 flex items-center gap-2 font-mono text-xs text-error">
+                <AlertCircle className="h-3.5 w-3.5" />
+                <span>{timelineError}</span>
+              </div>
+            )}
             {thread.length === 0 ? (
               <div className="py-10 font-mono text-xs leading-6 text-outline">
-                &gt; no messages with {peerLabel(peer)}.<br />
-                <span>send one to begin a query.</span>
+                {timelineLoading && !timelineInitialized ? (
+                  <>&gt; loading...</>
+                ) : (
+                  <>
+                    &gt; no messages with {peerLabel(peer)}.<br />
+                    <span>send one to begin a query.</span>
+                  </>
+                )}
               </div>
             ) : (
               thread.map((event) =>
                 event.type === "chat_turn_delta_group" ? (
-                  <StreamingTurnItem key={`stream-${event.turn_id}`} group={event} peer={peer} />
+                  <StreamingTurnItem key={`stream-${event.session_id || "legacy"}-${event.turn_id}`} group={event} peer={peer} />
+                ) : event.type === "history_turn" ? (
+                  <HistoryTurn key={event.id} turn={event} peer={peer} />
                 ) : (
                   <ThreadItem key={event.id} event={event as Event} peer={peer} />
                 )
@@ -1208,6 +1374,59 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
   );
 }
 
+function timelineKey(sessionId?: string, turnId?: string): string | null {
+  if (!turnId) return null;
+  return `${sessionId || "legacy"}:${turnId}`;
+}
+
+function mergeTimeline(
+  historyTurns: TranscriptTurn[],
+  sortedEvents: Event[],
+  activeSessionId: string | null,
+): ThreadItemEntry[] {
+  const historyItems: HistoryTimelineTurn[] = historyTurns
+    .filter((turn) => !activeSessionId || turn.session_id === activeSessionId)
+    .map((turn) => ({
+      ...turn,
+      type: "history_turn",
+      id: `history-${turn.session_id}-${turn.turn_id}`,
+    }));
+  const historyByKey = new Map<string, HistoryTimelineTurn>();
+  for (const turn of historyItems) {
+    const key = timelineKey(turn.session_id, turn.turn_id);
+    if (key) historyByKey.set(key, turn);
+  }
+
+  const liveItems = coalesceDeltas(sortedEvents);
+  const out: ThreadItemEntry[] = [];
+  const replacedHistoryKeys = new Set<string>();
+
+  for (const item of liveItems) {
+    if (item.type === "chat_turn") {
+      const key = timelineKey(item.session_id, item.turn_id);
+      if (key) replacedHistoryKeys.add(key);
+      out.push(item);
+      continue;
+    }
+    if (item.type === "chat_turn_delta_group") {
+      const key = timelineKey(item.session_id, item.turn_id);
+      if (key && historyByKey.has(key)) continue;
+      out.push(item);
+      continue;
+    }
+    out.push(item);
+  }
+
+  for (const item of historyItems) {
+    const key = timelineKey(item.session_id, item.turn_id);
+    if (key && replacedHistoryKeys.has(key)) continue;
+    out.push(item);
+  }
+
+  out.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  return out;
+}
+
 /** Coalesce chat_turn_delta events into one pending bubble per turn_id, then
  * drop any group whose turn_id has a matching final `chat_turn`.
  *
@@ -1229,7 +1448,8 @@ function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
   const peerLastChatTurnTs = new Map<string, string>();
   for (const ev of sorted) {
     if (ev.type !== "chat_turn" || ev.role !== "assistant") continue;
-    if (ev.turn_id) finalizedTurnIds.add(ev.turn_id);
+    const key = timelineKey(ev.session_id, ev.turn_id);
+    if (key) finalizedTurnIds.add(key);
     if (ev.peer_id) {
       const prev = peerLastChatTurnTs.get(ev.peer_id);
       if (!prev || prev < ev.timestamp) peerLastChatTurnTs.set(ev.peer_id, ev.timestamp);
@@ -1238,22 +1458,25 @@ function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
 
   for (const ev of sorted) {
     if (ev.type !== "chat_turn_delta" || !ev.turn_id) continue;
-    if (finalizedTurnIds.has(ev.turn_id)) continue;
+    const key = timelineKey(ev.session_id, ev.turn_id);
+    if (key && finalizedTurnIds.has(key)) continue;
     const lastFinalTs = ev.peer_id ? peerLastChatTurnTs.get(ev.peer_id) : undefined;
     if (lastFinalTs && ev.timestamp <= lastFinalTs) continue;
 
-    let group = groups.get(ev.turn_id);
+    const groupKey = key || `event:${ev.id}`;
+    let group = groups.get(groupKey);
     if (!group) {
       group = {
         type: "chat_turn_delta_group",
         id: `delta-group-${ev.turn_id}`,
+        session_id: ev.session_id,
         turn_id: ev.turn_id,
         peer_id: ev.peer_id,
         timestamp: ev.timestamp,
         text: "",
         tool_calls: [],
       };
-      groups.set(ev.turn_id, group);
+      groups.set(groupKey, group);
     }
     if (ev.kind === "tool_use" && ev.tool_call) {
       group.tool_calls.push(ev.tool_call);

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -62,6 +62,7 @@ export interface Event {
   new_status?: "online" | "busy" | "offline";
   query_id?: string;
   correlation_id?: string;
+  session_id?: string;
   tool_calls?: { name: string; input: string }[];
   // chat_turn_delta fields
   turn_id?: string;


### PR DESCRIPTION
## Summary
- add optional session_id/turn_id passthrough for chat turns, chat deltas, and transcript history
- merge Claude transcript history with realtime chat_turn/chat_turn_delta events in the dashboard chat view for the selected peer/session
- keep session identity v0.13-compatible: hook_session_id is only an active-session hint; no /sessions API or runtime manager changes
- keep the raw History tab as a fallback/debug surface and update dashboard docs/README wording

## Tests
- uv run --extra dev pytest
- uv run --extra dev ruff check repowire/ tests/test_transcript_history.py tests/test_transcript_history_routes.py tests/test_stop_handler.py tests/test_chat_delta_streamer.py tests/test_hooks_handlers.py tests/test_routes.py
- uv run --extra dev ty check repowire/
- npm test
- npm run build

## Notes
- npm run lint with file-scoped args is unsupported under the flat ESLint config; direct npx eslint on touched dashboard files currently hits an existing react-hooks/set-state-in-effect issue in SwitchBackendControl (pre-existing code in PeerView.tsx), so I did not fold that unrelated cleanup into this slice.
- PLAN_210.md was used as local review planning context and is intentionally left untracked, not committed.