### PR TITLE
Bump release to v0.13.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Repowire connects your agents into a live mesh. Any agent can query, notify, or 
 
 Read more: [the context breakout problem](https://prassanna.io/blog/vibe-bottleneck/) and [the idea behind Repowire](https://prassanna.io/blog/repowire/).
 
-**Current release:** v0.13.31 adds scheduled mesh messages: one-shot reminders, recurring cron schedules, self-wake scheduling, MCP tools (`schedule_create`, `schedule_self`, `schedule_cron`, `schedule_list`, `schedule_delete`), and CLI commands under `repowire schedule`.
+**Current release:** v0.13.32 bundles the transport-router extraction for ask/notify delivery, the graphify architecture report, refreshed README/docs/images, and the session-scoped dashboard timeline that merges the selected peer/session Claude transcript with realtime events.
 
 <details>
 <summary><strong>How does repowire compare?</strong></summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ hide:
 
 Mesh network for AI coding agents. A local-first daemon routes `ask`, `notify`, and `broadcast` between active Claude Code, Codex, Gemini CLI, and OpenCode sessions.
 
-Current release: v0.13.31 adds scheduled mesh messages, including recurring cron schedules, self-wake reminders, MCP scheduling tools, and `repowire schedule` CLI commands.
+Current release: v0.13.32 bundles the transport-router extraction for ask/notify delivery, the graphify architecture report, refreshed README/docs/images, and the session-scoped dashboard timeline that merges the selected peer/session Claude transcript with realtime events.
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.13.31"
+version = "0.13.32"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump package version to 0.13.32
- update current-release wording in README and docs index for the v0.13.32 bundle
- keep wording conservative around the session-scoped dashboard timeline and transport-router extraction

## Validation
- rg -n "v0\.13\.31|0\.13\.31" pyproject.toml README.md docs web/app/docs
- git diff --check
- uv run --extra docs mkdocs build --strict

No tag or release was created.