### PR TITLE
docs: productize orchestrator operating guidance

### DIFF
--- a/repowire/orchestrator/template/AGENTS.md
+++ b/repowire/orchestrator/template/AGENTS.md
@@ -57,6 +57,20 @@ The user delegates merge authority for verified-clean PRs (95% case). Use it; do
 
 If unsure whether something is no-go, surface once. Cheap to ask, expensive to unship.
 
+## Surface change discipline
+
+When a task changes tools, commands, prompts, or user-visible behavior, require a surface matrix before implementation. Check every user and agent entrypoint for that product, not just the one implementation path:
+
+- Agent tools and protocol/MCP registrations
+- Direct tool wrappers exposed by the local coding harness
+- CLI commands, flags, and help text
+- Web or desktop dashboard controls and docs pages
+- Chat/bot/mobile surfaces
+- Installer/setup/bootstrap prompts and generated templates
+- README, reference docs, and examples
+
+Use the matrix to decide what ships together, what needs compatibility shims, and what docs must change. Missing surfaces become explicit follow-up issues, not hidden assumptions.
+
 ## Release discipline
 
 - **Never tag from a branch.** Tag and publish only from `main`, only after PR merged AND review confirmed against merged-main commit.
@@ -64,9 +78,26 @@ If unsure whether something is no-go, surface once. Cheap to ask, expensive to u
 - **Semver judgment:** patch for fixes/small additions, minor for significant features. Ask if unsure. Never auto-bump to 1.0 — that's an intentional decision, not an increment.
 - For projects with PyPI/release CI: tag-push fires irreversible publish. Pause for review on merged-main before tagging.
 
+## Runtime dogfood guardrails
+
+Before risky or experimental runtime work (service restarts, hook/protocol changes, scheduler work, deploys, migrations), schedule self-wakes or watchdog asks so silence is observable. If the wake fires and the worker is silent or status looks stale, inspect the underlying terminal, logs, or panes before assuming the mesh state is complete.
+
 ## Cleanup hygiene
 
-For any "is X clean?" check (machine switch, kill-peer prep, prune, audit), enumerate worktrees with `git worktree list` for every project, not just `git status` on the root. Sibling worktrees with unique unpushed commits are invisible to root-dir status. Cross-check `list_peers()` against `tmux list-windows` — orphan tmux windows are the gap.
+Cleanup is a triad: **registered peer/session + terminal/process + workspace artifacts**. For git work, that means worktrees, branches, and generated artifacts too. For any "is X clean?" check (machine switch, kill-peer prep, prune, audit), enumerate all relevant worktrees/workspaces, not just the root `git status`. Sibling worktrees with unique unpushed commits are invisible to root-dir status. Cross-check the mesh registry against terminal/session state — orphan panes or processes are the common gap. Preserve dirty, unmerged, or unpushed user work unless the user explicitly tells you to clear it.
+
+## Version-skew checks
+
+If a newly shipped tool, command, or agent method appears missing, verify the installed surface before debugging the implementation:
+
+```bash
+which <tool>
+<tool> --version
+<service> version          # or its health/version endpoint
+<source-runner> <tool> ... # repo-local command for comparison, e.g. uv run/npm exec/cargo run
+```
+
+Installed binaries, long-running services/daemons, agent tool servers, and source checkouts can all be on different versions. Reinstall or restart the right component before concluding the feature is absent.
 
 ## Spawn flags per runtime
 

--- a/repowire/orchestrator/template/AGENTS.md
+++ b/repowire/orchestrator/template/AGENTS.md
@@ -86,6 +86,8 @@ Before risky or experimental runtime work (service restarts, hook/protocol chang
 
 Cleanup is a triad: **registered peer/session + terminal/process + workspace artifacts**. For git work, that means worktrees, branches, and generated artifacts too. For any "is X clean?" check (machine switch, kill-peer prep, prune, audit), enumerate all relevant worktrees/workspaces, not just the root `git status`. Sibling worktrees with unique unpushed commits are invisible to root-dir status. Cross-check the mesh registry against terminal/session state — orphan panes or processes are the common gap. Preserve dirty, unmerged, or unpushed user work unless the user explicitly tells you to clear it.
 
+Stale visible peers may represent resumable terminal sessions whose mesh registration is stale. Treat deregistration and process killing as separate decisions: prune or deregister bad registry rows when needed, but only kill the terminal/process after verifying it is disposable or the user asked for destructive cleanup. If a terminal still exists with useful state, prefer resume/reattach by session/window/pane plus project path over kill-and-respawn. If the platform lacks a `resume_peer`/`reattach_peer` primitive, surface that as the safer desired action rather than destroying state.
+
 ## Version-skew checks
 
 If a newly shipped tool, command, or agent method appears missing, verify the installed surface before debugging the implementation:

--- a/repowire/orchestrator/template/patterns/post-merge-cleanup.md
+++ b/repowire/orchestrator/template/patterns/post-merge-cleanup.md
@@ -1,6 +1,6 @@
 # Pattern: post-merge cleanup
 
-After a PR merges and the work is complete: prune the worktree, kill the peer, verify the tmux pane is actually gone, update local main.
+After a PR merges and the work is complete: clean up the registered peer/session, verify the terminal/process is actually gone, prune the worktree/branch/artifacts, and update local main.
 
 ## When to reach for it
 
@@ -20,8 +20,9 @@ After a PR merges and the work is complete: prune the worktree, kill the peer, v
    ```bash
    git fetch origin
    git log origin/main..HEAD  # should be empty on the feature branch
+   git status --short
    ```
-   If the branch has unpushed commits beyond what was merged, stop — investigate before destroying.
+   If the branch has unpushed commits, unmerged work, or dirty user changes beyond what was merged, stop — preserve it and investigate before destroying anything.
 
 2. **Update the project's main worktree.**
    ```bash
@@ -29,12 +30,12 @@ After a PR merges and the work is complete: prune the worktree, kill the peer, v
    git pull --rebase origin main
    ```
 
-3. **Kill the peer in the feature worktree.**
+3. **Clear the registered peer/session in the feature worktree.**
    ```python
    mcp__repowire__kill_peer(name="<project>.<feature>-<runtime>")
    ```
 
-4. **VERIFY the tmux pane is actually gone.** `kill_peer` clears mesh registration but does not always kill the underlying tmux window. Check:
+4. **VERIFY the terminal/process is actually gone.** A registry cleanup may not kill the underlying tmux window, pane, shell, or worker process. Check:
    ```bash
    tmux list-windows -t <circle>
    ```
@@ -55,20 +56,20 @@ After a PR merges and the work is complete: prune the worktree, kill the peer, v
    git branch -d <feature-branch>  # local cleanup; -D if not merged-by-name
    ```
 
-6. **Sanity-check cleanup.**
+6. **Sanity-check the cleanup triad.**
    ```bash
    git worktree list   # feature worktree should be gone
-   tmux list-windows -t <circle>   # window gone
+   tmux list-windows -t <circle>   # window/pane gone
    mcp__repowire__list_peers()   # peer gone from mesh
    ```
 
 ## Anti-patterns
 
 - **Skipping the tmux verify step.** `kill_peer` lies about pane death. Orphan tmux windows accumulate; eats memory; confuses later audits.
-- **Pruning the worktree before confirming the pane is dead.** Orphan claude/codex process is then pointing at a deleted directory. Harmless functionally but pollutes state.
+- **Pruning the worktree before confirming the pane/process is dead.** Orphan agents can keep running in a deleted directory. Harmless functionally but pollutes state.
 - **Cleaning up before a parallel review is done.** They need the worktree to verify against. Wait for ✅.
 
 ## When something looks wrong
 
-- **Branch has unpushed commits not on main:** check `git log @{u}..HEAD` and `git ls-remote origin <branch>`. Could be abandoned work. Surface before destroying.
+- **Branch has unpushed commits, dirty files, or unmerged work not on main:** check `git log @{u}..HEAD`, `git status --short`, and `git ls-remote origin <branch>`. Could be abandoned work or user work. Surface before destroying.
 - **`kill_peer` returns 404:** peer was already deregistered (likely from a SessionEnd hook). Tmux pane may still be live; check anyway.

--- a/repowire/orchestrator/template/patterns/post-merge-cleanup.md
+++ b/repowire/orchestrator/template/patterns/post-merge-cleanup.md
@@ -11,6 +11,7 @@ After a PR merges and the work is complete: clean up the registered peer/session
 ## When NOT to reach for it
 
 - The peer has follow-up work queued (continuation turns)
+- The visible peer is stale but its terminal/session may be resumable
 - The worktree is the main project worktree, not a feature clone
 - A parallel review is still verifying the merge — don't clean up until they ✅
 
@@ -35,11 +36,11 @@ After a PR merges and the work is complete: clean up the registered peer/session
    mcp__repowire__kill_peer(name="<project>.<feature>-<runtime>")
    ```
 
-4. **VERIFY the terminal/process is actually gone.** A registry cleanup may not kill the underlying tmux window, pane, shell, or worker process. Check:
+4. **VERIFY the terminal/process state.** A registry cleanup may not kill the underlying tmux window, pane, shell, or worker process. Check:
    ```bash
    tmux list-windows -t <circle>
    ```
-   If the window is still there:
+   If the terminal still exists and may contain useful state, prefer resume/reattach by session/window/pane and project path over destructive cleanup. If the work is disposable and cleanup was requested, then kill it:
    ```bash
    tmux kill-window -t <circle>:<window-name>
    ```
@@ -65,11 +66,12 @@ After a PR merges and the work is complete: clean up the registered peer/session
 
 ## Anti-patterns
 
-- **Skipping the tmux verify step.** `kill_peer` lies about pane death. Orphan tmux windows accumulate; eats memory; confuses later audits.
-- **Pruning the worktree before confirming the pane/process is dead.** Orphan agents can keep running in a deleted directory. Harmless functionally but pollutes state.
+- **Treating stale registry rows as proof the session is dead.** The terminal may still be resumable. Deregister stale mesh state separately from killing processes.
+- **Skipping the tmux verify step.** `kill_peer` may deregister without killing a pane if ownership was lost. Orphan tmux windows accumulate; eats memory; confuses later audits.
+- **Pruning the worktree before confirming the pane/process is dead or resumable.** Orphan agents can keep running in a deleted directory. Harmless functionally but pollutes state.
 - **Cleaning up before a parallel review is done.** They need the worktree to verify against. Wait for ✅.
 
 ## When something looks wrong
 
 - **Branch has unpushed commits, dirty files, or unmerged work not on main:** check `git log @{u}..HEAD`, `git status --short`, and `git ls-remote origin <branch>`. Could be abandoned work or user work. Surface before destroying.
-- **`kill_peer` returns 404:** peer was already deregistered (likely from a SessionEnd hook). Tmux pane may still be live; check anyway.
+- **`kill_peer` returns 404 or only deregisters:** peer was already deregistered, or the orchestrator lost ownership of the terminal process. Tmux pane may still be live; check anyway and offer resume/reattach if it has useful state.


### PR DESCRIPTION
## Summary
- add project-agnostic orchestrator guidance for surface matrices and version-skew checks
- document watchdog/self-wake guardrails for risky runtime work
- generalize cleanup hygiene around peer/session, terminal/process, and workspace artifacts

## Checks
- git diff --check
- uv run --extra docs mkdocs build --strict