### PR TITLE
[codex] Add CLI orchestrator role claim repair

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,12 +72,15 @@ Exits 0 if all checks pass (or only warn/skip). Exits 1 if any check fails — s
 repowire peer new PATH [--circle CIRCLE]   # spawn a new peer in tmux
 repowire peer list                          # god-view list (all circles, includes caller)
 repowire peer describe NAME_OR_ID [--circle C]  # full state for one peer
+repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
 repowire peer prune                         # remove offline peers from the registry
 ```
 
 `peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP [`list_peers`](mcp-tools.md#list_peers) tool defaults to a peer-facing view (online only, caller hidden).
 
 `peer describe` accepts either a display name (`clitcoin-claude-code`) or a peer id (`repow-5-abd4d21e`). Pass `--circle` when a display name is ambiguous across circles — without it, the command refuses to guess and prints the same misroute-style refusal the daemon emits internally. Output includes identity (project, circle, role, backend), liveness (status, path, machine, last-seen), open ask threads in both directions, and the last few communication events involving the peer. Reads `GET /peers`, `GET /peers/{id}`, `GET /asks/pending?direction=both`, and `GET /events` — no new daemon endpoints.
+
+`peer claim-role orchestrator` repairs an existing registered peer when the durable session mapping has the wrong role after daemon restart. It updates the live peer and its persisted session mapping, demoting offline or stale orchestrator holders in the same circle. It refuses to demote a fresh online/busy holder unless `--force` is passed. Omit `--peer` only from inside a registered peer shell where Repowire can discover the current peer.
 
 ## `repowire schedule`
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1557,10 +1557,14 @@ def _http_error_detail(error: object) -> str:
     response = getattr(error, "response", None)
     if response is None:
         return str(error)
+    return _http_response_detail(response)
+
+
+def _http_response_detail(response: Any) -> str:
     try:
         body = response.json()
     except Exception:
-        return str(error)
+        return str(response)
     return str(body.get("detail") or body)
 
 
@@ -1675,6 +1679,61 @@ def peer_describe(identifier: str, circle: str | None) -> None:
         sys.exit(1)
 
     _render_peer_snapshot(snapshot)
+
+
+@peer.command(name="claim-role")
+@click.argument("role", type=click.Choice(["orchestrator"]))
+@click.option("--peer", "peer_name", help="Existing peer id or display name to update")
+@click.option("--circle", "-c", help="Circle to scope lookup and role ownership")
+@click.option("--force", "-f", is_flag=True, help="Demote an existing live holder")
+def peer_claim_role(role: str, peer_name: str | None, circle: str | None, force: bool) -> None:
+    """Claim a singleton special role for an existing peer."""
+    import sys
+
+    import httpx
+
+    daemon_url = _get_daemon_url()
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            target = peer_name or _current_cli_peer_name(client)
+            resp = client.post(
+                f"{daemon_url}/peers/claim-role",
+                json={
+                    "role": role,
+                    "peer_name": target,
+                    "circle": circle,
+                    "force": force,
+                },
+            )
+            if resp.status_code == 404:
+                console.print(f"[red]Peer not found:[/] {target}")
+                console.print(
+                    "[dim]Pass --peer with an existing peer from "
+                    "`repowire peer list -a`.[/]"
+                )
+                sys.exit(1)
+            if resp.status_code == 409:
+                console.print(f"[red]Cannot claim role:[/] {_http_response_detail(resp)}")
+                console.print("[dim]Use --force only if the current holder should be demoted.[/]")
+                sys.exit(1)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.ConnectError:
+        console.print(
+            f"[red]Cannot connect to daemon at {daemon_url}.[/] Run 'repowire serve' first.",
+        )
+        sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Failed to claim role:[/] {_http_error_detail(e)}")
+        sys.exit(1)
+
+    console.print(
+        f"[green]Claimed role={data.get('role')}[/] for "
+        f"[cyan]{data.get('peer_name')}[/] in circle [magenta]{data.get('circle')}[/]"
+    )
+    holders = data.get("previous_holders") or []
+    if holders:
+        console.print(f"[dim]Demoted {len(holders)} previous holder(s).[/]")
 
 
 def _render_peer_snapshot(snapshot: object) -> None:

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -57,6 +57,19 @@ class PaneHijackRejectedError(Exception):
     """
 
 
+class RoleClaimConflictError(Exception):
+    """Raised when a live peer already holds the requested special role."""
+
+
+@dataclass
+class RoleClaimResult:
+    """Result of claiming a special peer role."""
+
+    peer: Peer
+    previous_holders: list[dict[str, str | None]]
+    already_held: bool = False
+
+
 # ---------------------------------------------------------------------------
 # SessionMapping dataclass (previously in session_mapper.py)
 # ---------------------------------------------------------------------------
@@ -1407,6 +1420,123 @@ class PeerRegistry:
             if old_status != peer.status:
                 self._emit_status_change(peer, old_status, peer.status)
             return True
+
+    async def claim_special_role(
+        self,
+        identifier: str,
+        role: PeerRole,
+        *,
+        circle: str | None = None,
+        force: bool = False,
+    ) -> RoleClaimResult | None:
+        """Claim a singleton special role for an existing live peer.
+
+        Narrow v0.13 repair hook: only orchestrator is supported. The target
+        peer must already exist; this never allocates a new peer. A fresh
+        ONLINE/BUSY holder in the same circle blocks the claim unless force is
+        set. Offline/stale holders are demoted in both live registry state and
+        durable mappings so restarts do not reintroduce the bad role.
+        """
+        if role != PeerRole.ORCHESTRATOR:
+            raise ValueError("Only role=orchestrator can be claimed")
+
+        now = datetime.now(timezone.utc)
+        tolerance = self.heartbeat_tolerance()
+
+        def fresh_holder(peer: Peer) -> bool:
+            return (
+                peer.role == role
+                and peer.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+                and peer.last_seen is not None
+                and (now - peer.last_seen).total_seconds() <= tolerance
+            )
+
+        async with self._lock:
+            target = self._lookup_peer_unlocked(identifier, circle=circle)
+            if not target:
+                return None
+            target_circle = circle or target.circle
+
+            blockers = [
+                p for p in self._peers.values()
+                if p.peer_id != target.peer_id
+                and p.circle == target_circle
+                and fresh_holder(p)
+            ]
+            if blockers and not force:
+                holder = max(blockers, key=lambda p: p.last_seen or now)
+                raise RoleClaimConflictError(
+                    f"role={role.value} is already held by "
+                    f"{holder.display_name} ({holder.peer_id}) in circle {target_circle}"
+                )
+
+            previous_holders: list[dict[str, str | None]] = []
+            for peer in self._peers.values():
+                if (
+                    peer.peer_id == target.peer_id
+                    or peer.circle != target_circle
+                    or peer.role != role
+                ):
+                    continue
+                previous_holders.append(
+                    {
+                        "peer_id": peer.peer_id,
+                        "display_name": peer.display_name,
+                        "status": peer.status.value,
+                        "last_seen": peer.last_seen.isoformat() if peer.last_seen else None,
+                    }
+                )
+                peer.role = PeerRole.AGENT
+                mapping = self._mappings.get(peer.peer_id)
+                if mapping and mapping.role != PeerRole.AGENT:
+                    mapping.role = PeerRole.AGENT
+                    mapping.updated_at = now.isoformat()
+                    self._mappings_dirty = True
+
+            already_held = target.role == role
+            target.role = role
+            target.last_seen = now
+            mapping = self._mappings.get(target.peer_id)
+            if mapping:
+                mapping.role = role
+                mapping.updated_at = now.isoformat()
+                self._mappings_dirty = True
+
+            for sid, mapping in self._mappings.items():
+                if (
+                    sid == target.peer_id
+                    or mapping.circle != target_circle
+                    or mapping.role != role
+                ):
+                    continue
+                previous_holders.append(
+                    {
+                        "peer_id": sid,
+                        "display_name": mapping.display_name,
+                        "status": "mapping-only",
+                        "last_seen": mapping.updated_at,
+                    }
+                )
+                mapping.role = PeerRole.AGENT
+                mapping.updated_at = now.isoformat()
+                self._mappings_dirty = True
+
+            self.add_event(
+                "role_claimed",
+                {
+                    "peer_id": target.peer_id,
+                    "peer": target.display_name,
+                    "role": role.value,
+                    "circle": target_circle,
+                    "force": force,
+                    "previous_holders": previous_holders,
+                },
+            )
+            return RoleClaimResult(
+                peer=target,
+                previous_holders=previous_holders,
+                already_held=already_held,
+            )
 
     async def update_description(
         self, identifier: str, description: str, circle: str | None = None

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -14,7 +14,7 @@ from repowire import peer_mcp
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
-from repowire.daemon.peer_registry import PaneHijackRejectedError
+from repowire.daemon.peer_registry import PaneHijackRejectedError, RoleClaimConflictError
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import load_peer_turns, page_turns
@@ -65,6 +65,27 @@ class PeersResponse(BaseModel):
     """Response containing list of peers."""
 
     peers: list[PeerInfo]
+
+
+class ClaimRoleRequest(BaseModel):
+    """Request to claim a singleton special role for an existing peer."""
+
+    role: PeerRole = Field(..., description="Special role to claim")
+    peer_name: str = Field(..., min_length=1, description="Existing peer id or display name")
+    circle: str | None = Field(None, description="Circle to scope lookup/claim")
+    force: bool = Field(False, description="Demote an existing live holder")
+
+
+class ClaimRoleResponse(BaseModel):
+    """Response from a successful special role claim."""
+
+    ok: bool = True
+    peer_id: str
+    peer_name: str
+    role: PeerRole
+    circle: str
+    already_held: bool = False
+    previous_holders: list[dict[str, str | None]] = Field(default_factory=list)
 
 
 class RegisterPeerRequest(BaseModel):
@@ -173,6 +194,58 @@ async def get_peer_by_pane(
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"No peer for pane: {pane_id}",
+    )
+
+
+@router.post(
+    "/peers/claim-role",
+    response_model=ClaimRoleResponse,
+    include_in_schema=False,
+)
+async def claim_peer_role(
+    request: ClaimRoleRequest,
+    _: str | None = Depends(require_auth),
+) -> ClaimRoleResponse:
+    """Claim a singleton special role for an existing peer.
+
+    CLI repair surface only in v0.13. This route is intentionally not exposed
+    through MCP/Pi tools.
+    """
+    if request.role != PeerRole.ORCHESTRATOR:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only role=orchestrator can be claimed",
+        )
+    peer_registry = get_peer_registry()
+    try:
+        result = await peer_registry.claim_special_role(
+            request.peer_name,
+            request.role,
+            circle=request.circle,
+            force=request.force,
+        )
+    except RoleClaimConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {request.peer_name}",
+        )
+    return ClaimRoleResponse(
+        peer_id=result.peer.peer_id,
+        peer_name=result.peer.display_name,
+        role=result.peer.role,
+        circle=result.peer.circle,
+        already_held=result.already_held,
+        previous_holders=result.previous_holders,
     )
 
 

--- a/tests/test_claim_role.py
+++ b/tests/test_claim_role.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.cli import main
+from repowire.config.models import AgentType, Config
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry, RoleClaimConflictError
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import PeerRole, PeerStatus
+
+
+def _make_registry(tmp_path: Path) -> PeerRegistry:
+    cfg = Config()
+    cfg.daemon.heartbeat_interval = 30
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = 10**9
+    return registry
+
+
+async def _register(
+    registry: PeerRegistry,
+    *,
+    path: str,
+    circle: str = "ops",
+    role: PeerRole = PeerRole.AGENT,
+) -> str:
+    peer_id, _ = await registry.allocate_and_register(
+        circle=circle,
+        backend=AgentType.CODEX,
+        path=path,
+        role=role,
+        machine="m",
+    )
+    return peer_id
+
+
+@pytest.mark.asyncio
+async def test_claim_orchestrator_demotes_offline_live_and_mapping_holders(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    old_id = await _register(
+        registry,
+        path="/tmp/orchestrator-2",
+        role=PeerRole.ORCHESTRATOR,
+    )
+    active_id = await _register(registry, path="/tmp/orchestrator")
+    async with registry._lock:
+        registry._peers[old_id].status = PeerStatus.OFFLINE
+
+    result = await registry.claim_special_role(active_id, PeerRole.ORCHESTRATOR)
+
+    assert result is not None
+    assert result.peer.peer_id == active_id
+    assert result.previous_holders[0]["peer_id"] == old_id
+    assert registry.get_mapping(active_id).role == PeerRole.ORCHESTRATOR
+    assert registry.get_mapping(old_id).role == PeerRole.AGENT
+    old_peer = await registry.get_peer(old_id)
+    assert old_peer is not None
+    assert old_peer.role == PeerRole.AGENT
+    event = registry.get_events()[-1]
+    assert event["type"] == "role_claimed"
+    assert event["peer_id"] == active_id
+
+
+@pytest.mark.asyncio
+async def test_claim_orchestrator_demotes_mapping_only_holder(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    old_id = await _register(
+        registry,
+        path="/tmp/orchestrator-2",
+        role=PeerRole.ORCHESTRATOR,
+    )
+    active_id = await _register(registry, path="/tmp/orchestrator")
+    async with registry._lock:
+        del registry._peers[old_id]
+
+    result = await registry.claim_special_role(active_id, PeerRole.ORCHESTRATOR)
+
+    assert result is not None
+    assert registry.get_mapping(active_id).role == PeerRole.ORCHESTRATOR
+    assert registry.get_mapping(old_id).role == PeerRole.AGENT
+    assert result.previous_holders[0]["status"] == "mapping-only"
+
+
+@pytest.mark.asyncio
+async def test_claim_orchestrator_rejects_fresh_holder_without_force(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    await _register(registry, path="/tmp/orchestrator-2", role=PeerRole.ORCHESTRATOR)
+    active_id = await _register(registry, path="/tmp/orchestrator")
+
+    with pytest.raises(RoleClaimConflictError, match="already held"):
+        await registry.claim_special_role(active_id, PeerRole.ORCHESTRATOR)
+
+
+@pytest.mark.asyncio
+async def test_claim_orchestrator_allows_stale_holder(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    old_id = await _register(
+        registry,
+        path="/tmp/orchestrator-2",
+        role=PeerRole.ORCHESTRATOR,
+    )
+    active_id = await _register(registry, path="/tmp/orchestrator")
+    async with registry._lock:
+        registry._peers[old_id].last_seen = (
+            datetime.now(timezone.utc) - timedelta(seconds=90)
+        )
+
+    result = await registry.claim_special_role(active_id, PeerRole.ORCHESTRATOR)
+
+    assert result is not None
+    assert registry.get_mapping(active_id).role == PeerRole.ORCHESTRATOR
+    assert registry.get_mapping(old_id).role == PeerRole.AGENT
+
+
+@pytest.fixture
+async def client(tmp_path: Path):
+    registry = _make_registry(tmp_path)
+    cfg = registry._config
+    state = SimpleNamespace(
+        config=cfg,
+        transport=registry._transport,
+        query_tracker=registry._query_tracker,
+        message_router=registry._router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+    app = FastAPI()
+    app.include_router(peers.router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, registry
+    cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_claim_role_route_returns_clear_conflict(
+    client: tuple[AsyncClient, PeerRegistry],
+) -> None:
+    http_client, registry = client
+    await _register(registry, path="/tmp/orchestrator-2", role=PeerRole.ORCHESTRATOR)
+    active_id = await _register(registry, path="/tmp/orchestrator")
+
+    resp = await http_client.post(
+        "/peers/claim-role",
+        json={"role": "orchestrator", "peer_name": active_id},
+    )
+
+    assert resp.status_code == 409
+    assert "already held" in resp.json()["detail"]
+
+
+def _mock_client(monkeypatch: pytest.MonkeyPatch, response: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.post.return_value = response
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+    return client
+
+
+def test_cli_claim_role_posts_existing_peer(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "peer_id": "repow-ops-active",
+        "peer_name": "orchestrator-codex",
+        "role": "orchestrator",
+        "circle": "ops",
+        "previous_holders": [{"peer_id": "repow-ops-old"}],
+    }
+    client = _mock_client(monkeypatch, response)
+
+    result = CliRunner().invoke(
+        main,
+        ["peer", "claim-role", "orchestrator", "--peer", "orchestrator-codex", "--circle", "ops"],
+    )
+
+    assert result.exit_code == 0, result.output
+    client.post.assert_called_once_with(
+        "http://127.0.0.1:8377/peers/claim-role",
+        json={
+            "role": "orchestrator",
+            "peer_name": "orchestrator-codex",
+            "circle": "ops",
+            "force": False,
+        },
+    )
+    assert "Claimed role=orchestrator" in result.output
+    assert "Demoted 1 previous holder" in result.output
+
+
+def test_cli_claim_role_reports_live_holder_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.status_code = 409
+    response.json.return_value = {
+        "detail": (
+            "role=orchestrator is already held by old "
+            "(repow-ops-old) in circle ops"
+        ),
+    }
+    _mock_client(monkeypatch, response)
+
+    result = CliRunner().invoke(
+        main,
+        ["peer", "claim-role", "orchestrator", "--peer", "orchestrator-codex"],
+    )
+
+    assert result.exit_code == 1
+    assert "Cannot claim role" in result.output
+    assert "Use --force" in result.output

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -46,6 +46,18 @@ repowire service uninstall`}
       </Cmd>
 
       <Cmd
+        name="repowire peer"
+        usage={`repowire peer list
+repowire peer describe NAME_OR_ID [--circle C]
+repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
+repowire peer prune`}
+      >
+        <p>
+          Inspect and repair registered peers. <Mono>peer list</Mono> is an operator view across all circles. <Mono>peer describe</Mono> shows one peer&apos;s identity, role, liveness, open asks, and recent events. <Mono>peer claim-role orchestrator</Mono> is a narrow repair command for an existing peer whose durable session mapping lost the orchestrator role after daemon restart; it refuses to demote a fresh online or busy holder unless <Mono>--force</Mono> is passed.
+        </p>
+      </Cmd>
+
+      <Cmd
         name="repowire schedule"
         usage={`repowire schedule self WHEN_OR_CRON TEXT [--cron]
 repowire schedule create TO_PEER WHEN_OR_CRON TEXT --from-peer FROM_PEER [--cron]


### PR DESCRIPTION
## Summary

- add `repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]`
- add a hidden daemon repair endpoint that updates an existing peer role without creating a duplicate peer
- update `PeerRegistry` so orchestrator claim demotes stale/offline live holders and mapping-only durable holders in the same circle
- document the CLI repair command in the markdown and shipped web CLI references

## Root Cause

After daemon restart, the active orchestrator process could re-register through its durable session mapping as `role=agent`, while an offline duplicate mapping retained `role=orchestrator`. That stale holder blocked cross-circle orchestration because role ownership was split between live state and durable mapping state.

## Live Repair Verification

Confirmed by live use from the installed worktree after daemon restart:

```bash
repowire peer claim-role orchestrator --peer orchestrator-codex --circle default --force
```

Result: active `orchestrator-codex` is now `role=orchestrator`; duplicate `orchestrator-2-codex` was demoted to `role=agent`.

## Validation

```bash
uv run --extra dev pytest tests/test_orchestrator_liveness.py tests/test_cli_orchestrator.py tests/test_cli_schedule.py tests/test_claim_role.py
uv run --extra dev ruff check repowire/ tests/test_claim_role.py
uv run --extra dev ty check repowire/
```
