### PR TITLE
Make Telegram and Slack human messages asks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Project A needs the real API shape from Project B. Ask `project-b`; the peer ans
 
 ### Drive from phone or dashboard
 
-Send work to a peer from Telegram or the dashboard, then receive progress updates from agents as notifications. See [mobile mesh management](https://docs.repowire.io/patterns/mobile-mesh/).
+Send work to a peer from Telegram, Slack, or the dashboard, then receive progress updates from agents as notifications. Telegram and Slack human messages open tracked asks by default; use their notify/FYI commands for fire-and-forget nudges. See [mobile mesh management](https://docs.repowire.io/patterns/mobile-mesh/).
 
 ### Coordinate with an orchestrator
 

--- a/docs/concepts/control-surfaces.md
+++ b/docs/concepts/control-surfaces.md
@@ -3,12 +3,12 @@
 The dashboard, Telegram bot, and Slack bot are peers too. They show up in `list_peers` alongside agents and use the same `ask` / `notify_peer` / `broadcast` primitives.
 
 - `dashboard` — Next.js UI at `localhost:8377/dashboard`, with a live mesh log and per-peer chat. See [web dashboard](../surfaces/dashboard.md).
-- `telegram` — bot you talk to from your phone. Sticky routing: `/select peer` sends subsequent messages to that peer until `/clear`. See [Telegram bot](../surfaces/telegram.md).
-- `slack` — Socket Mode bot. Same sticky-routing pattern with Block Kit peer pickers. See [Slack bot](../surfaces/slack.md).
+- `telegram` — bot you talk to from your phone. Sticky routing: `/select peer` sends subsequent messages as asks to that peer until `/clear`; `/notify` and `/fyi` remain fire-and-forget. See [Telegram bot](../surfaces/telegram.md).
+- `slack` — Socket Mode bot. Same sticky-routing pattern with Block Kit peer pickers; `notify` and `fyi` remain fire-and-forget. See [Slack bot](../surfaces/slack.md).
 
 ## Human framing
 
-Messages from `@telegram` and `@dashboard` are humans. Agents that receive messages from these peers treat them as direct user instructions, not as agent-to-agent traffic. This framing is injected by repowire at delivery time — agents do not need to special-case the names themselves.
+Messages from `@telegram`, `@slack`, and `@dashboard` are humans. Agents that receive messages from these peers treat them as direct user instructions, not as agent-to-agent traffic. Telegram and Slack human inbound messages open tracked ask threads by default, so the recipient is reminded until it acks or replies. This framing is injected by repowire at delivery time — agents do not need to special-case the names themselves.
 
 When an agent wants to reach the human, the move is `notify_peer("telegram", "...")` (or `notify_peer("dashboard", ...)`, though the dashboard already sees turns and rarely needs an explicit notification). These peers have the human role, which bypasses circle filtering — they resolve and appear in `list_peers` mesh-wide regardless of the caller's circle.
 

--- a/docs/patterns/mobile-mesh.md
+++ b/docs/patterns/mobile-mesh.md
@@ -23,7 +23,7 @@ Or one-shot without sticky routing:
 @project-a fix the failing CI on main, push when green
 ```
 
-The bot registers as the `telegram` peer. Agents on the receiving side see your message framed as a human instruction, not as agent-to-agent traffic.
+The bot registers as the `telegram` peer. Agents on the receiving side see your message framed as a human instruction, not as agent-to-agent traffic. Messages you type open tracked ask threads by default; use `/notify [@peer] message` or `/fyi [@peer] message` for fire-and-forget nudges.
 
 ## Dashboard
 
@@ -45,7 +45,7 @@ The Telegram bot is a real Telegram bot, so push notifications work out of the b
 
 ## Attachments
 
-Send a photo or document in the Telegram chat. The bot downloads it, uploads it to the daemon's `/attachments` endpoint (10 MB limit, 24 h TTL), and includes the local path in the resulting notification. The receiving agent reads the image via its multimodal tool (Claude `Read`, for example).
+Send a photo or document in the Telegram chat. The bot downloads it, uploads it to the daemon's `/attachments` endpoint (10 MB limit, 24 h TTL), and includes the local path in the resulting ask. The receiving agent reads the image via its multimodal tool (Claude `Read`, for example).
 
 ## When this isn't the right tool
 

--- a/docs/surfaces/slack.md
+++ b/docs/surfaces/slack.md
@@ -33,8 +33,10 @@ The bot watches one channel. In that channel:
 | Input | What happens |
 | --- | --- |
 | `select <peer>` or `switch <peer>` | Sticky-route messages to that peer |
-| `@peer message` | One-shot send |
-| Plain text after `select` | Routes to the sticky target |
+| `@peer message` | Open an ask to a specific peer |
+| Plain text after `select` | Opens an ask to the sticky target |
+| `notify [@peer] message` | Fire-and-forget notification/FYI; uses sticky target if `@peer` is omitted |
+| `fyi [@peer] message` | Alias for `notify` |
 | Tap a Block Kit peer button | Equivalent to `select` |
 
 The bot posts a Block Kit message with peer buttons on demand, similar to the Telegram inline keyboard.
@@ -45,7 +47,7 @@ Socket Mode means the bot opens an outbound WebSocket to Slack — Slack doesn't
 
 ## Human framing
 
-Messages from `@slack` are framed as human input to the receiving agent, exactly like `@telegram` and `@dashboard`. Agents treat them as direct user instructions.
+Messages from `@slack` are framed as human input to the receiving agent, exactly like `@telegram` and `@dashboard`. Human inbound Slack messages open tracked ask threads by default, so agents are reminded until they ack or reply. Use `notify` / `fyi` for fire-and-forget nudges.
 
 ## Differences from the Telegram bot
 

--- a/docs/surfaces/telegram.md
+++ b/docs/surfaces/telegram.md
@@ -1,6 +1,6 @@
 # Telegram bot
 
-The Telegram bot is a peer. It registers as `telegram`. Notifications agents send to it appear in your Telegram chat; messages you send route back into the mesh.
+The Telegram bot is a peer. It registers as `telegram`. Notifications agents send to it appear in your Telegram chat; messages you send route back into the mesh as tracked asks by default.
 
 ## Setup
 
@@ -22,15 +22,17 @@ telegram:
 
 | Command | What it does |
 | --- | --- |
-| `/peers` (or `/start`, `/list`) | Show online peers as inline buttons; tap to pick a notify target |
+| `/peers` (or `/start`, `/list`) | Show online peers as inline buttons; tap to pick a target |
 | `/select <peer>` | Sticky-route subsequent messages to that peer until `/clear` |
 | `/switch <peer>` | Alias for `/select` |
 | `/clear` | Clear the sticky target |
-| `@peer message` | One-shot send to a specific peer (also updates sticky) |
+| `@peer message` | Open an ask to a specific peer (also updates sticky) |
+| `/notify [@peer] message` | Fire-and-forget notification/FYI; uses sticky target if `@peer` is omitted |
+| `/fyi [@peer] message` | Alias for `/notify` |
 
 ## Sticky routing
 
-After `/select repowire`, every message you type goes to `repowire` as a notification until you `/clear` or `/select` another peer. The bot displays the current sticky target in its reply keyboard so you can see where messages are going.
+After `/select repowire`, every message you type opens a tracked ask to `repowire` until you `/clear` or `/select` another peer. Use `/notify message` or `/fyi message` when you explicitly want a fire-and-forget FYI instead. The bot displays the current sticky target in its reply keyboard so you can see where messages are going.
 
 The reply keyboard shows up to three current peers and three recent peers, with markers indicating which is which.
 
@@ -46,7 +48,7 @@ notify_peer("telegram", "deploy finished, green across CI")
 
 ## Attachments
 
-The bot downloads photos sent in Telegram, uploads them to the daemon via `POST /attachments`, and includes the resulting local path in the outgoing notification. The recipient agent can then read the image via its multimodal tool — Claude's `Read` tool, for instance, accepts the local path directly.
+The bot downloads photos sent in Telegram, uploads them to the daemon via `POST /attachments`, and includes the resulting local path in the outgoing ask. The recipient agent can then read the image via its multimodal tool — Claude's `Read` tool, for instance, accepts the local path directly.
 
 Attachments live in `~/.repowire/attachments/` with a 24-hour TTL.
 

--- a/repowire/slack/bot.py
+++ b/repowire/slack/bot.py
@@ -1,7 +1,7 @@
 """Slack bot peer for the repowire mesh.
 
 Bridges Slack <> repowire: notifications become Slack messages,
-Slack messages become peer notifications. Buttons for quick peer selection.
+Slack messages become peer asks by default. Buttons for quick peer selection.
 
 Usage:
     SLACK_BOT_TOKEN=xoxb-... SLACK_APP_TOKEN=xapp-... SLACK_CHANNEL_ID=C... repowire slack start
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -36,6 +36,27 @@ def _ws_url(http_url: str) -> str:
     """Convert http(s) URL to ws(s)."""
     p = urlparse(http_url)
     return urlunparse(p._replace(scheme="wss" if p.scheme == "https" else "ws"))
+
+
+def parse_notify_command(text: str) -> tuple[str | None, str] | None:
+    """Parse explicit fire-and-forget commands.
+
+    Supported forms:
+        notify @peer message
+        notify message       (uses sticky target)
+        fyi @peer message
+        fyi message          (uses sticky target)
+    """
+    m = re.match(r"^(?:notify|fyi)(?:\s+(.+))?$", text, re.DOTALL | re.IGNORECASE)
+    if not m:
+        return None
+    body = (m.group(1) or "").strip()
+    if not body:
+        return (None, "")
+    target = re.match(r"^@(\S+)\s+(.+)", body, re.DOTALL)
+    if target:
+        return (target.group(1), target.group(2))
+    return (None, body)
 
 
 class SlackPeer:
@@ -297,17 +318,35 @@ class SlackPeer:
                 await self._slack_send(f"Now talking to *@{_esc(peer)}*. All messages go there.")
             return
 
-        # @peer message — explicit target (also sets sticky)
+        notify_cmd = parse_notify_command(text)
+        if notify_cmd is not None:
+            peer, message = notify_cmd
+            if not message:
+                await self._slack_send("Usage: `notify [@peer] message` or `fyi [@peer] message`")
+                return
+            target = peer or self._reply_target
+            if not target:
+                await self._slack_send(
+                    "No active peer. Use `notify @peer message` or `select peer` first."
+                )
+                return
+            if peer:
+                self._reply_target = peer
+            await self._notify(target, message)
+            return
+
+        # @peer message — explicit target (also sets sticky). Human inbound
+        # messages default to ask/ack so the agent is reminded until it replies.
         m = re.match(r"^@(\S+)\s+(.+)", text, re.DOTALL)
         if m:
             peer = m.group(1)
             self._reply_target = peer
-            await self._notify(peer, m.group(2))
+            await self._ask(peer, m.group(2))
             return
 
-        # Sticky conversation
+        # Sticky conversation asks current peer by default.
         if self._reply_target:
-            await self._notify(self._reply_target, text)
+            await self._ask(self._reply_target, text)
             return
 
         # No conversation active
@@ -365,10 +404,23 @@ class SlackPeer:
             logger.warning("Failed to list peers", exc_info=True)
             await self._slack_send(f"Error listing peers: {e}")
 
+    async def _ask(self, peer: str, message: str) -> None:
+        await self._send_peer_message(peer, message, mode="ask")
+
     async def _notify(self, peer: str, message: str) -> None:
+        await self._send_peer_message(peer, message, mode="notify")
+
+    async def _send_peer_message(
+        self,
+        peer: str,
+        message: str,
+        *,
+        mode: Literal["ask", "notify"],
+    ) -> None:
+        endpoint = "/ask" if mode == "ask" else "/notify"
         try:
             r = await self._daemon_http.post(
-                "/notify",
+                endpoint,
                 json={
                     "from_peer": self._display_name,
                     "to_peer": peer,
@@ -377,15 +429,21 @@ class SlackPeer:
             )
             if r.status_code == 200:
                 try:
-                    delivery_status = r.json().get("status", "sent")
+                    data = r.json()
                 except Exception:
-                    delivery_status = "sent"
-                icon = (
-                    ":hourglass_flowing_sand:"
-                    if delivery_status == "queued"
-                    else ":white_check_mark:"
-                )
-                await self._slack_send(f"{icon} → *@{_esc(peer)}*")
+                    data = {}
+                if mode == "ask":
+                    cid = data.get("correlation_id")
+                    suffix = f" `#{_esc(str(cid)[:12])}`" if cid else ""
+                    await self._slack_send(f":question: → *@{_esc(peer)}*{suffix}")
+                else:
+                    delivery_status = data.get("status", "sent")
+                    icon = (
+                        ":hourglass_flowing_sand:"
+                        if delivery_status == "queued"
+                        else ":white_check_mark:"
+                    )
+                    await self._slack_send(f"{icon} → *@{_esc(peer)}*")
             else:
                 try:
                     detail = r.json().get("detail", r.text)
@@ -393,7 +451,7 @@ class SlackPeer:
                     detail = r.text
                 await self._slack_send(f":x: {_esc(detail)}")
         except Exception as e:
-            logger.warning("Failed to notify peer %s", peer, exc_info=True)
+            logger.warning("Failed to send %s to peer %s", mode, peer, exc_info=True)
             await self._slack_send(f"Error sending to {peer}: {e}")
 
     # -- Slack API --

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -1,7 +1,7 @@
 """Telegram bot peer for the repowire mesh.
 
 Bridges Telegram <> repowire: notifications become Telegram messages,
-Telegram messages become peer notifications. A persistent ReplyKeyboard
+Telegram messages become peer asks by default. A persistent ReplyKeyboard
 below the compose bar lets the user switch target peers with one tap.
 
 Usage:
@@ -19,7 +19,7 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
@@ -68,6 +68,7 @@ def _ws_url(http_url: str) -> str:
 class PendingRetry:
     text: str
     expires_at: float
+    mode: Literal["ask", "notify"] = "ask"
 
     def is_active(self, now: float) -> bool:
         return now < self.expires_at
@@ -187,6 +188,27 @@ def parse_keyboard_tap(text: str) -> tuple[str, str | None]:
             if name:
                 return ("select", name)
     return ("text", None)
+
+
+def parse_notify_command(text: str) -> tuple[str | None, str] | None:
+    """Parse explicit fire-and-forget commands.
+
+    Supported forms:
+        /notify @peer message
+        /notify message       (uses sticky target)
+        /fyi @peer message
+        /fyi message          (uses sticky target)
+    """
+    m = re.match(r"^/(?:notify|fyi)(?:\s+(.+))?$", text, re.DOTALL | re.IGNORECASE)
+    if not m:
+        return None
+    body = (m.group(1) or "").strip()
+    if not body:
+        return (None, "")
+    target = re.match(r"^@(\S+)\s+(.+)", body, re.DOTALL)
+    if target:
+        return (target.group(1), target.group(2))
+    return (None, body)
 
 
 class TelegramPeer:
@@ -457,19 +479,38 @@ class TelegramPeer:
             peer = text.split(maxsplit=1)[1].strip().lstrip("@")
             await self._select_peer(peer, message_id=message_id)
             return
+        notify_cmd = parse_notify_command(text)
+        if notify_cmd is not None:
+            peer, message = notify_cmd
+            if not message:
+                await self._tg_send("Usage: `/notify [@peer] message` or `/fyi [@peer] message`")
+                return
+            target = peer or self._reply_target
+            if not target:
+                await self._tg_send(
+                    "No active peer\\. Use `/notify @peer message` "
+                    "or `/select peer` first\\."
+                )
+                return
+            if peer:
+                self._reply_target = peer
+            self._pending_retry = None  # typing cancels retry
+            await self._notify(target, message, message_id=message_id)
+            return
 
-        # @peer message — explicit target (also sets sticky)
+        # @peer message — explicit target (also sets sticky). Human inbound
+        # messages default to ask/ack so the agent is reminded until it replies.
         m = re.match(r"^@(\S+)\s+(.+)", text, re.DOTALL)
         if m:
             self._reply_target = m.group(1)
             self._pending_retry = None  # typing cancels retry
-            await self._notify(m.group(1), m.group(2), message_id=message_id)
+            await self._ask(m.group(1), m.group(2), message_id=message_id)
             return
 
-        # Sticky conversation — send to current peer
+        # Sticky conversation — ask current peer by default
         if self._reply_target:
             self._pending_retry = None  # typing cancels retry
-            await self._notify(self._reply_target, text, message_id=message_id)
+            await self._ask(self._reply_target, text, message_id=message_id)
             return
 
         # No conversation active
@@ -501,7 +542,12 @@ class TelegramPeer:
         if trigger_retry and retry and retry.is_active(time.monotonic()):
             self._reply_target = peer
             self._pending_retry = None
-            await self._notify(peer, retry.text, message_id=message_id)
+            await self._send_peer_message(
+                peer,
+                retry.text,
+                message_id=message_id,
+                mode=retry.mode,
+            )
             return
 
         self._reply_target = peer
@@ -509,7 +555,7 @@ class TelegramPeer:
         await self._tg_send(f"Now talking to *@{_esc(peer)}*\\.")
 
     async def _on_photo(self, photo: dict, caption: str, message_id: int | None = None) -> None:
-        """Handle incoming Telegram photo — upload to daemon, notify peer."""
+        """Handle incoming Telegram photo — upload to daemon, ask peer."""
         if not self._reply_target:
             orchestrator = await self._fetch_orchestrator_status()
             if not orchestrator.present:
@@ -556,7 +602,7 @@ class TelegramPeer:
             msg = caption or "Photo attached"
             msg += f"\n[Attachment: {att['path']}]"
 
-            await self._notify(self._reply_target, msg, message_id=message_id)
+            await self._ask(self._reply_target, msg, message_id=message_id)
         except Exception as e:
             await self._tg_send(f"Error: {_esc(str(e))}")
 
@@ -668,10 +714,24 @@ class TelegramPeer:
 
         await self._tg_send("\n".join(lines), markup=_kb(rows))
 
+    async def _ask(self, peer: str, message: str, message_id: int | None = None) -> None:
+        await self._send_peer_message(peer, message, message_id=message_id, mode="ask")
+
     async def _notify(self, peer: str, message: str, message_id: int | None = None) -> None:
+        await self._send_peer_message(peer, message, message_id=message_id, mode="notify")
+
+    async def _send_peer_message(
+        self,
+        peer: str,
+        message: str,
+        message_id: int | None = None,
+        *,
+        mode: Literal["ask", "notify"],
+    ) -> None:
+        endpoint = "ask" if mode == "ask" else "notify"
         try:
             r = await self._http.post(
-                f"{self._daemon_url}/notify",
+                f"{self._daemon_url}/{endpoint}",
                 json={
                     "from_peer": self._display_name,
                     "to_peer": peer,
@@ -683,10 +743,14 @@ class TelegramPeer:
                     await self._tg_react(message_id, emoji="👍")
                 # No text reply on success — reaction is the confirmation
             else:
-                detail = r.json().get("detail", r.text)
+                try:
+                    detail = r.json().get("detail", r.text)
+                except Exception:
+                    detail = r.text
                 self._pending_retry = PendingRetry(
                     text=message,
                     expires_at=time.monotonic() + RETRY_WINDOW_S,
+                    mode=mode,
                 )
                 await self._tg_send(
                     f"✗ Couldn't reach *@{_esc(peer)}*: {_esc(str(detail))}\n"
@@ -696,6 +760,7 @@ class TelegramPeer:
             self._pending_retry = PendingRetry(
                 text=message,
                 expires_at=time.monotonic() + RETRY_WINDOW_S,
+                mode=mode,
             )
             await self._tg_send(
                 f"⚠️ Daemon unreachable: {_esc(str(e))}\n"

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -1,0 +1,81 @@
+"""Unit tests for Slack bot human inbound routing."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from repowire.slack.bot import SlackPeer, parse_notify_command
+
+
+@pytest.fixture
+def slack_bot() -> SlackPeer:
+    return SlackPeer(
+        bot_token="xoxb-test",
+        app_token="xapp-test",
+        channel_id="C123",
+        daemon_url="http://127.0.0.1:0",
+        display_name="slack",
+        circle="default",
+    )
+
+
+def test_parse_notify_command_with_peer() -> None:
+    assert parse_notify_command("notify @agent build passed") == ("agent", "build passed")
+
+
+def test_parse_fyi_command_without_peer_uses_sticky_target() -> None:
+    assert parse_notify_command("fyi build passed") == (None, "build passed")
+
+
+def test_parse_notify_command_ignores_slash_form() -> None:
+    assert parse_notify_command("/notify @agent build passed") is None
+
+
+@pytest.mark.asyncio
+async def test_at_peer_text_opens_ask_by_default(
+    slack_bot: SlackPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(slack_bot, "_ask", ask)
+    monkeypatch.setattr(slack_bot, "_notify", notify)
+
+    await slack_bot._on_text("@agent please check")
+
+    ask.assert_awaited_once_with("agent", "please check")
+    notify.assert_not_awaited()
+    assert slack_bot._reply_target == "agent"
+
+
+@pytest.mark.asyncio
+async def test_sticky_text_opens_ask_by_default(
+    slack_bot: SlackPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slack_bot._reply_target = "agent"
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(slack_bot, "_ask", ask)
+    monkeypatch.setattr(slack_bot, "_notify", notify)
+
+    await slack_bot._on_text("please check")
+
+    ask.assert_awaited_once_with("agent", "please check")
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_command_keeps_fire_and_forget(
+    slack_bot: SlackPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(slack_bot, "_ask", ask)
+    monkeypatch.setattr(slack_bot, "_notify", notify)
+
+    await slack_bot._on_text("notify @agent build passed")
+
+    notify.assert_awaited_once_with("agent", "build passed")
+    ask.assert_not_awaited()
+    assert slack_bot._reply_target == "agent"

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import time
+from unittest.mock import AsyncMock
+
+import pytest
 
 from repowire.telegram.bot import (
     CLEAR_LABEL,
@@ -12,9 +15,11 @@ from repowire.telegram.bot import (
     PEERS_LABEL,
     RECENT_MARK,
     PendingRetry,
+    TelegramPeer,
     build_reply_keyboard,
     compute_visible_recents,
     parse_keyboard_tap,
+    parse_notify_command,
 )
 
 # -- compute_visible_recents --
@@ -160,6 +165,83 @@ def test_parse_at_mention_is_text():
 def test_parse_marker_alone_without_name_is_text():
     assert parse_keyboard_tap(CURRENT_MARK) == ("text", None)
     assert parse_keyboard_tap(f"{CURRENT_MARK} ") == ("text", None)
+
+
+# -- explicit notify/FYI command parsing --
+
+
+def test_parse_notify_command_with_peer():
+    assert parse_notify_command("/notify @agent build passed") == ("agent", "build passed")
+
+
+def test_parse_fyi_command_without_peer_uses_sticky_target():
+    assert parse_notify_command("/fyi build passed") == (None, "build passed")
+
+
+def test_parse_notify_command_ignores_regular_text():
+    assert parse_notify_command("notify @agent build passed") is None
+
+
+# -- inbound routing --
+
+
+@pytest.fixture
+def telegram_bot() -> TelegramPeer:
+    return TelegramPeer(
+        bot_token="test-token",
+        chat_id="0",
+        daemon_url="http://127.0.0.1:0",
+        display_name="telegram",
+        circle="default",
+    )
+
+
+@pytest.mark.asyncio
+async def test_at_peer_text_opens_ask_by_default(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_ask", ask)
+    monkeypatch.setattr(telegram_bot, "_notify", notify)
+
+    await telegram_bot._on_text("@agent please check", message_id=42)
+
+    ask.assert_awaited_once_with("agent", "please check", message_id=42)
+    notify.assert_not_awaited()
+    assert telegram_bot._reply_target == "agent"
+
+
+@pytest.mark.asyncio
+async def test_sticky_text_opens_ask_by_default(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    telegram_bot._reply_target = "agent"
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_ask", ask)
+    monkeypatch.setattr(telegram_bot, "_notify", notify)
+
+    await telegram_bot._on_text("please check", message_id=42)
+
+    ask.assert_awaited_once_with("agent", "please check", message_id=42)
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_command_keeps_fire_and_forget(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ask = AsyncMock()
+    notify = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_ask", ask)
+    monkeypatch.setattr(telegram_bot, "_notify", notify)
+
+    await telegram_bot._on_text("/notify @agent build passed", message_id=42)
+
+    notify.assert_awaited_once_with("agent", "build passed", message_id=42)
+    ask.assert_not_awaited()
+    assert telegram_bot._reply_target == "agent"
 
 
 # -- PendingRetry TTL --

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -80,14 +80,14 @@ export default function Concepts() {
             <Mono>dashboard</Mono> — Next.js UI at <Mono>localhost:8377/dashboard</Mono> with a live mesh log and per-peer chat.
           </li>
           <li>
-            <Mono>telegram</Mono> — bot you talk to from your phone. Sticky routing: <Mono>/select peer</Mono> sends subsequent messages to that peer.
+            <Mono>telegram</Mono> — bot you talk to from your phone. Sticky routing: <Mono>/select peer</Mono> sends subsequent messages as asks to that peer; <Mono>/notify</Mono> and <Mono>/fyi</Mono> remain fire-and-forget.
           </li>
           <li>
-            <Mono>slack</Mono> — Socket Mode bot. Same sticky-routing pattern with Block Kit peer pickers.
+            <Mono>slack</Mono> — Socket Mode bot. Same sticky-routing pattern with Block Kit peer pickers; <Mono>notify</Mono> and <Mono>fyi</Mono> remain fire-and-forget.
           </li>
         </ul>
         <p className="mt-4">
-          Messages from <Mono>@telegram</Mono> and <Mono>@dashboard</Mono> are humans. Agents treat them as direct user instructions.
+          Messages from <Mono>@telegram</Mono>, <Mono>@slack</Mono>, and <Mono>@dashboard</Mono> are humans. Telegram and Slack inbound messages open tracked ask threads by default, and agents treat them as direct user instructions.
         </p>
       </Section>
     </article>


### PR DESCRIPTION
## Summary
- route Telegram and Slack human inbound messages to agents through /ask by default
- add explicit notify/FYI commands for fire-and-forget nudges
- update focused Telegram/Slack tests and public docs

## Checks
- uv run --extra dev ruff check repowire/telegram/bot.py repowire/slack/bot.py tests/test_telegram_bot.py tests/test_slack_bot.py
- uv run --extra dev pytest tests/test_telegram_bot.py tests/test_telegram_default_target.py tests/test_slack_bot.py
- uv run --extra dev ty check repowire/telegram/bot.py repowire/slack/bot.py