### PR TITLE
Document orchestrator memory procedure scope

### DIFF
--- a/docs/concepts/orchestrator.md
+++ b/docs/concepts/orchestrator.md
@@ -14,6 +14,16 @@ A typical orchestrator runs a loop like:
 4. **Review** completed work. `review_queue()` surfaces PRs the peer has touched that you still owe a review on; `mark_reviewed(pr_url)` clears them.
 5. **Release** when a batch lands. Tag, push, notify.
 
+## Memory and procedures
+
+The orchestrator workspace is a curated procedure layer, not a complete history store. Keep user communication preferences in `comms.md`, active project scope in `projects.md`, durable operational lessons in `memory/*.md`, and reusable dispatch/review/release procedures in `patterns/*.md`.
+
+Use markdown memory only for rules that should change future behavior. Detailed recall belongs in session history and, as the v0.13 session-native train lands, SQLite-backed session/timeline search. That split keeps prompt context bounded while preserving the ability to audit past decisions.
+
+This memory is orchestrator-scoped. Other peers do not inherit it implicitly; give them the relevant context through explicit briefs, project-local agent files, native runtime skills, or future session/timeline lookup when that is the right surface.
+
+Pattern files are loaded on demand. The top-level orchestrator instructions should act as an index; the full pattern file carries the procedure and may include optional frontmatter such as `name`, `description`, `triggers`, `risk`, and `surfaces` for future tooling.
+
 ## Co-orchestrators
 
 A second orchestrator peer can co-exist as an observer or learner without colliding. Use [`orchestrator_status`](../reference/mcp-tools.md#orchestrator_status) before dispatching long-running work to confirm a live orchestrator is present in the target circle. The call returns presence, name, peer id, last-seen timestamp, and the staleness threshold — *not* a snapshot of mesh state.

--- a/docs/concepts/session-native-roadmap.md
+++ b/docs/concepts/session-native-roadmap.md
@@ -10,10 +10,24 @@ The v0.13 architecture train is moving toward a **session-native mesh**. This is
 - **Transport-neutral routing.** Ask/notify delivery now goes through a transport router. WebSocket hooks, experimental ACP, relay, and future transports continue moving toward the same message/control boundary.
 - **Timeline-centered dashboard.** Persisted history and realtime events converge into one session timeline instead of separate live/history views.
 - **Shared command surface.** Controls such as send message, switch backend/model, resume, schedule, and approvals target sessions and can be reused from dashboard, MCP, Telegram, and other surfaces.
+- **Search as large recall.** SQLite-backed session/timeline search should carry detailed historical recall, while orchestrator markdown memory remains a small curated procedure layer.
 - **Compatible v0.13.x slices.** The architecture changes land incrementally while preserving current hooks, MCP tools, HTTP routes, and dashboard workflows.
 - **Human approval path.** Permission and plan approval events become first-class timeline/control events instead of transport-specific callbacks.
 
 The ask/notify transport-router extraction has landed. The remaining planned sequence adds a session/timeline store, updates the dashboard to render persisted and realtime conversation state together, moves composer/control actions onto session commands, and centralizes runtime lifecycle plus approval events.
+
+## Memory and audit hooks
+
+Session-native storage should make orchestrator learning auditable without bloating prompt memory. Future session records should be able to point at the memory/pattern snapshot used when a session started or resumed, and memory/procedure changes should appear as timeline events when proposed or applied.
+
+This keeps the layers distinct:
+
+- **SQLite/session search:** long-tail recall for past discussions, asks/acks, releases, logs, transcript-derived chat turns, and why a decision happened.
+- **Orchestrator markdown memory:** compact user/comms preferences, operational lessons, and dispatch procedures that should affect future coordination.
+
+Do not treat markdown memory as a diary or complete recall system. It should hold only curated rules and procedures that change future behavior.
+
+Do not treat orchestrator memory as global peer memory. Project peers should receive relevant context through explicit briefs, project-local agent files, native runtime skills, or future session/timeline lookup where appropriate.
 
 ## What is shipped today
 

--- a/repowire/orchestrator/template/AGENTS.md
+++ b/repowire/orchestrator/template/AGENTS.md
@@ -4,7 +4,7 @@ You are the orchestrator for this user's repowire mesh. You coordinate work acro
 
 ## You evolve this workspace
 
-This workspace is your operating manual. It was scaffolded from a snapshot of one orchestrator's lived practice — it is **not** canonical. Your job includes evolving it. When the user corrects an approach, write the correction into `memory/<topic>.md` using `**Why:**` and `**How to apply:**` structure (prefer "default X UNLESS Y" over "always X"). When you notice a recurring dispatch shape that isn't in `patterns/`, propose a new pattern file before writing. When `comms.md` or `projects.md` is wrong, edit it directly — they're yours, the user reads them too. You inherited residue, not the corrections-in-flight that produced it; grow your own.
+This workspace is your operating manual. It was scaffolded from a snapshot of one orchestrator's lived practice — it is **not** canonical. Your job includes evolving it. Keep the stores separate: `comms.md` is for user communication/routing preferences, `projects.md` is for active project scope, `memory/*.md` is for durable operational lessons, and `patterns/*.md` is for reusable procedures. When the user corrects an approach, propose or write the correction into the right store using the smallest patch that captures the lesson. When you notice a recurring dispatch shape that isn't in `patterns/`, propose a new pattern file before writing. You inherited residue, not the corrections-in-flight that produced it; grow your own.
 
 ## The Core Loop
 
@@ -37,7 +37,7 @@ Where most of your judgment budget goes. Not codifiable as recipes; these are he
 
 ## Patterns reference
 
-Read these on demand when the situation matches.
+Read these on demand when the situation matches. Treat `patterns/` as a progressive-disclosure procedure library: this index is the trigger list, and the pattern file is the full workflow. Pattern files may include optional frontmatter (`name`, `description`, `triggers`, `risk`, `surfaces`) for future tooling; do not depend on a parser being present.
 
 - `patterns/spawn-brief-iterate.md` — core dispatch loop, default shape for any new work
 - `patterns/two-model-critique.md` — when a single peer proposes an architectural-but-bounded plan (provider hierarchy, routing, build pipeline, framework boundaries), spawn a *different-model* peer in the same worktree to critique before code. ~5-10 min cost, catches blind spots.
@@ -113,11 +113,15 @@ When calling `spawn_peer(command=...)`:
 
 ## Memory
 
-`memory/MEMORY.md` is the index. Each `memory/<topic>.md` is a single corrected lesson with `**Why:**` (the incident or strong preference behind the rule) and `**How to apply:**` (when/where the rule kicks in). The Why lets you judge edge cases instead of blindly following.
+`memory/MEMORY.md` is the compact index. Each `memory/<topic>.md` is a single corrected operational lesson with `**Why:**` (the incident or strong preference behind the rule) and `**How to apply:**` (when/where the rule kicks in). The Why lets you judge edge cases instead of blindly following.
 
 Use `bd remember "insight"` to add to persistent knowledge across sessions. Search with `bd memories <keyword>`.
 
-**Filter rule for what to save:** "next time X comes up, do Y differently" → keep. "This happened once, FYI" → log it as a bd note or commit message, not a memory.
+**Filter rule for what to save:** "next time X comes up, do Y differently" → keep. "This happened once, FYI" → log it as a bd note, session note, or commit message, not a memory. Detailed recall belongs in session history/search; memory is only the curated procedural layer.
+
+**Scope rule:** this memory is for the orchestrator. Other peers get relevant context only when you include it in a brief, when it belongs in the project's own agent context files, when their runtime-native skills cover it, or when future session/timeline lookup is the right source.
+
+**Budget rule:** keep the index scannable and each memory short. If two memories overlap, consolidate. If an entry grows into history or status, move the history to the session/timeline layer and keep only the forward rule.
 
 ## Comms and projects
 

--- a/repowire/orchestrator/template/comms.md
+++ b/repowire/orchestrator/template/comms.md
@@ -2,6 +2,8 @@
 
 Per-user communication routing preferences. Edit when the user signals a preference (most signals come in as corrections — "stop doing X", "I prefer Y").
 
+This file is for user/comms memory only: channels, escalation rules, tone, formatting, availability, and notification preferences. Operational lessons belong in `memory/*.md`; active project scope belongs in `projects.md`.
+
 ## Primary channel
 
 <!-- Set by BOOTSTRAP.md ritual: Telegram (phone-only) / Dashboard / Both -->

--- a/repowire/orchestrator/template/memory/MEMORY.md
+++ b/repowire/orchestrator/template/memory/MEMORY.md
@@ -2,6 +2,17 @@
 
 Persistent operational memory. Each entry below points to a file in this directory.
 
+This is the curated procedural layer, not the long-term recall layer. Use it for lessons that should change future orchestration behavior. Use session history/search, issue notes, or commit messages for detailed history, status, and "what happened when" recall.
+
+User communication and routing preferences belong in `../comms.md`. Active project scope belongs in `../projects.md`.
+
+## Budget
+
+- Keep this index compact and scannable; soft limit: about 150 lines.
+- Keep each memory file focused; soft limit: about 1200 characters.
+- Consolidate when two memories overlap or when the index stops being easy to scan.
+- Prefer patch-style updates with a short rationale over full rewrites.
+
 ## Format
 
 Each memory file should be self-contained, with this structure:

--- a/repowire/orchestrator/template/patterns/mesh-roundup.md
+++ b/repowire/orchestrator/template/patterns/mesh-roundup.md
@@ -1,3 +1,11 @@
+---
+name: mesh-roundup
+description: Poll several peers for status and compile an impact-first update.
+triggers: [status-sweep, handoff, morning-review, evening-review]
+risk: low
+surfaces: [mcp, dashboard, telegram]
+---
+
 # Pattern: mesh roundup
 
 Poll N peers for status in parallel; compile impact-first.

--- a/repowire/orchestrator/template/patterns/post-merge-cleanup.md
+++ b/repowire/orchestrator/template/patterns/post-merge-cleanup.md
@@ -1,3 +1,11 @@
+---
+name: post-merge-cleanup
+description: Clean up peer/session, terminal state, worktree, and branch after a PR merges.
+triggers: [post-merge, worktree-prune, peer-cleanup]
+risk: high
+surfaces: [mcp, cli]
+---
+
 # Pattern: post-merge cleanup
 
 After a PR merges and the work is complete: clean up the registered peer/session, verify the terminal/process is actually gone, prune the worktree/branch/artifacts, and update local main.

--- a/repowire/orchestrator/template/patterns/release-bundle-decision.md
+++ b/repowire/orchestrator/template/patterns/release-bundle-decision.md
@@ -1,3 +1,11 @@
+---
+name: release-bundle-decision
+description: Decide whether merged main work should be tagged now or held for a bundle.
+triggers: [release, tag-decision, changelog]
+risk: high
+surfaces: [cli, github]
+---
+
 # Pattern: release bundle decision
 
 Given N merged commits on main, decide tag-now-or-hold + version + changelog shape.

--- a/repowire/orchestrator/template/patterns/spawn-brief-iterate.md
+++ b/repowire/orchestrator/template/patterns/spawn-brief-iterate.md
@@ -1,3 +1,11 @@
+---
+name: spawn-brief-iterate
+description: Default dispatch loop for new work handed to a peer.
+triggers: [new-work, peer-dispatch, review]
+risk: medium
+surfaces: [mcp, dashboard, telegram]
+---
+
 # Pattern: spawn → brief → iterate
 
 The default dispatch loop. Use this for any new piece of work you're handing to a peer.

--- a/repowire/orchestrator/template/patterns/two-model-critique.md
+++ b/repowire/orchestrator/template/patterns/two-model-critique.md
@@ -1,3 +1,11 @@
+---
+name: two-model-critique
+description: Use a different-model peer to critique an architectural-but-bounded plan before code.
+triggers: [architecture-plan, cross-model-review, plan-before-code]
+risk: medium
+surfaces: [mcp]
+---
+
 # Pattern: two-model critique cycle
 
 When a peer proposes an architectural-but-bounded plan, spawn a *different-model* peer in the same worktree to critique the plan **before** code is written.

--- a/repowire/orchestrator/template/projects.md
+++ b/repowire/orchestrator/template/projects.md
@@ -2,6 +2,8 @@
 
 Projects currently in scope for orchestration. Edit as projects spin up or wind down.
 
+This file is for active project scope and routing hints, not detailed status history. Use session history/search, issue notes, or commit messages for "what happened when" recall.
+
 <!-- Each entry should include: project name, GitHub path, what it does in one sentence, current focus / blockers / decisions pending. Keep tight — this is reference, not a status report. -->
 
 <!-- BOOTSTRAP.md ritual populates this on first run by probing local git roots


### PR DESCRIPTION
## Summary
- document orchestrator-scoped memory/procedure boundaries in concepts docs
- update orchestrator templates to separate comms, projects, operational memory, and patterns
- add optional pattern metadata for progressive-disclosure procedure discovery

## Checks
- git diff --check
- uv run --extra docs mkdocs build --strict

Notes: docs/template-only; no runtime code changes. ORCHESTRATOR_MEMORY_PROCEDURES_PLAN.md was left untracked and is not part of this PR.