### PR TITLE
[codex] Add self-target ask diagnostics

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -1124,6 +1124,7 @@ class PeerRegistry:
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
                 "correlation_id": correlation_id,
                 "reply_to": reply_to,
+                "self_target": from_peer_id == peer_id,
             },
         )
 

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -70,6 +70,7 @@ class WebSocketPeerTransport:
                 "to_peer_id": envelope.target.peer_id,
                 "correlation_id": envelope.correlation_id,
                 "reply_to": envelope.reply_to,
+                "self_target": envelope.from_peer_id == envelope.target.peer_id,
             },
         )
         await self._router.send_ask(

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -178,10 +178,13 @@ def format_peers_context(peers: list[dict], my_name: str) -> str:
     lines.append("")
     lines.append(
         "IMPORTANT: When asked about these projects, ask the peer directly "
-        "via ask() rather than searching locally. ask() is non-blocking and "
+        "via ask() rather than searching locally. Use ask() for tracked work "
+        "that needs explicit ack. ask() is non-blocking and "
         "returns a correlation_id; the peer responds via ack(corr_id) or "
         "ack(corr_id, message). Use ask(reply_to=corr_id, ...) to chain a "
-        "follow-up that closes the prior thread."
+        "follow-up that closes the prior thread. Asking yourself is valid "
+        "for deliberate loopback checks, but use notify_peer for "
+        "self-wakes/reminders."
     )
     lines.append(
         "Messages from @dashboard or @telegram are from the human user "

--- a/repowire/installers/pi.py
+++ b/repowire/installers/pi.py
@@ -336,7 +336,7 @@ async function buildMeshContext(myPeerName: string): Promise<string | null> {
     }
     lines.push("");
     lines.push(
-      "IMPORTANT: When asked about these projects, ask the peer directly via ask() rather than searching locally. Use ask for tracked work that needs an explicit ack; it is non-blocking, returns a correlation_id, and the peer responds via ack(corr_id) or ack(corr_id, message). Use ask(reply_to=corr_id, ...) to chain a follow-up that closes the prior thread.",
+      "IMPORTANT: When asked about these projects, ask the peer directly via ask() rather than searching locally. Use ask for tracked work that needs an explicit ack; it is non-blocking, returns a correlation_id, and the peer responds via ack(corr_id) or ack(corr_id, message). Asking yourself is valid for deliberate loopback checks, but use notify_peer for self-wakes/reminders. Use ask(reply_to=corr_id, ...) to chain a follow-up that closes the prior thread.",
     );
     lines.push(
       "Use notify_peer for fire-and-forget updates, reminders, and nudges. Messages from @dashboard or @telegram are from the human user - treat them like direct instructions. Use notify_peer('telegram', msg) to send updates to the user's phone; dashboard sees chat turns automatically.",
@@ -747,7 +747,7 @@ export default async function repowireExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "ask",
     label: "Repowire: ask peer",
-    description: "Open a non-blocking ask thread with a peer. Use when work needs a tracked thread and explicit ack, such as worker status checks or reviewer checkpoints. Returns a correlation_id immediately; watch notifications for the eventual ack. Use notify_peer for fire-and-forget updates, reminders, and nudges. Do not use SendMessage for mesh peers.",
+    description: "Open a non-blocking ask thread with a peer. Use when work needs a tracked thread and explicit ack, such as worker status checks, reviewer checkpoints, or deliberate loopback checks. Returns a correlation_id immediately; watch notifications for the eventual ack. Use notify_peer for fire-and-forget updates, reminders, self-wakes, and nudges. Do not use SendMessage for mesh peers.",
     parameters: Type.Object({
       peer_name: Type.String({ description: "Display name or peer_id of the peer to ask" }),
       query: Type.String({ description: "The question or request to send" }),

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -473,6 +473,9 @@ def create_mcp_server() -> FastMCP:
         Use ask when you need a tracked thread that the recipient must close
         with `ack`, such as a worker status check or reviewer checkpoint. Use
         notify_peer for fire-and-forget updates, reminders, and nudges.
+        Asking yourself is valid for deliberate loopback checks, but use
+        notify_peer or schedule_self(kind="notify") for self-wakes/reminders
+        that do not need tracked closure.
 
         Returns immediately with a correlation_id. The peer receives the
         ask, and when they respond they call `ack(correlation_id)` (bare

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -185,6 +185,24 @@ class TestAsk:
         assert event["to"] == bob["display_name"]
         assert event["from_peer_id"] == alice["peer_id"]
         assert event["to_peer_id"] == bob["peer_id"]
+        assert event["self_target"] is False
+
+    async def test_self_ask_succeeds_with_diagnostic_event_marker(self, env):
+        client, registry, at, msg_router = env
+        alice = await _register_peer_info(client, "alice")
+
+        r = await client.post("/ask", json={
+            "from_peer": alice["peer_id"], "to_peer": alice["peer_id"], "text": "loopback?",
+        })
+
+        assert r.status_code == 200
+        assert at.open_count() == 1
+        msg_router.send_ask.assert_awaited_once()
+        event = registry.get_events()[-1]
+        assert event["type"] == "ask"
+        assert event["from_peer_id"] == alice["peer_id"]
+        assert event["to_peer_id"] == alice["peer_id"]
+        assert event["self_target"] is True
 
 
 class TestAck:


### PR DESCRIPTION
## Summary
- preserve explicit self-targeted asks while marking ask events with `self_target` diagnostics
- clarify MCP, Pi, and session-context guidance so self-wakes/reminders use notify while loopback asks remain valid
- add route coverage proving self-ask still succeeds and emits the diagnostic marker

## Validation
- `uv run --extra dev pytest tests/test_ask_routes.py tests/test_mcp_circle_scope.py tests/test_scheduler.py`
- `uv run --extra dev ruff check repowire/daemon/peer_registry.py repowire/daemon/transport_router.py repowire/mcp/server.py repowire/installers/pi.py repowire/hooks/session_handler.py tests/test_ask_routes.py`
- `uv run --extra dev ty check repowire/`

## Notes
- `ASK_LIFECYCLE_HYGIENE_PLAN.md` was left untracked per request.
- Dashboard/peer-describe surfacing and ACP-specific event parity are intentionally left as follow-up slices.