### PR TITLE
Fix bot ask ack replies

### DIFF
--- a/repowire/slack/bot.py
+++ b/repowire/slack/bot.py
@@ -151,6 +151,9 @@ class SlackPeer:
                         await asyncio.sleep(backoff)
                         continue
 
+                    assigned_name = resp.get("display_name")
+                    if isinstance(assigned_name, str) and assigned_name:
+                        self._display_name = assigned_name
                     logger.info("Daemon connected: %s", resp.get("session_id"))
                     async for raw in ws:
                         try:

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -284,6 +284,9 @@ class TelegramPeer:
                         logger.error("Connect failed: %s", resp)
                         await asyncio.sleep(backoff)
                         continue
+                    assigned_name = resp.get("display_name")
+                    if isinstance(assigned_name, str) and assigned_name:
+                        self._display_name = assigned_name
                     logger.info("Connected: %s", resp.get("session_id"))
                     # Best-effort: route user messages to the orchestrator by
                     # default if one is registered. User can still /select.

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -79,3 +80,24 @@ async def test_notify_command_keeps_fire_and_forget(
     notify.assert_awaited_once_with("agent", "build passed")
     ask.assert_not_awaited()
     assert slack_bot._reply_target == "agent"
+
+
+@pytest.mark.asyncio
+async def test_send_peer_message_uses_daemon_assigned_service_name(
+    slack_bot: SlackPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ack replies need the real registered service name as from_peer."""
+    slack_bot._display_name = "slack-claude-code"
+    post = AsyncMock()
+    post.return_value = SimpleNamespace(
+        status_code=200,
+        json=lambda: {"correlation_id": "ask-12345678"},
+    )
+    monkeypatch.setattr(slack_bot._daemon_http, "post", post)
+    monkeypatch.setattr(slack_bot, "_slack_send", AsyncMock())
+
+    await slack_bot._ask("agent", "please check")
+
+    post.assert_awaited_once()
+    assert post.await_args.kwargs["json"]["from_peer"] == "slack-claude-code"
+    assert post.await_args.kwargs["json"]["to_peer"] == "agent"

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -242,6 +243,23 @@ async def test_notify_command_keeps_fire_and_forget(
     notify.assert_awaited_once_with("agent", "build passed", message_id=42)
     ask.assert_not_awaited()
     assert telegram_bot._reply_target == "agent"
+
+
+@pytest.mark.asyncio
+async def test_send_peer_message_uses_daemon_assigned_service_name(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ack replies need the real registered service name as from_peer."""
+    telegram_bot._display_name = "telegram-claude-code"
+    post = AsyncMock()
+    post.return_value = SimpleNamespace(status_code=200)
+    monkeypatch.setattr(telegram_bot._http, "post", post)
+
+    await telegram_bot._ask("agent", "please check")
+
+    post.assert_awaited_once()
+    assert post.await_args.kwargs["json"]["from_peer"] == "telegram-claude-code"
+    assert post.await_args.kwargs["json"]["to_peer"] == "agent"
 
 
 # -- PendingRetry TTL --


### PR DESCRIPTION
## Summary
- update Telegram and Slack service peers to adopt the daemon-assigned display name after WebSocket registration
- ensure human-origin asks use the registered service peer name as from_peer so ack replies route back correctly
- add Telegram/Slack tests covering the from_peer identity used for asks

## Tests
- uv run pytest tests/test_telegram_bot.py tests/test_slack_bot.py -q
- uv run ruff check repowire/telegram/bot.py repowire/slack/bot.py tests/test_telegram_bot.py tests/test_slack_bot.py
- uv run --extra dev ty check repowire/telegram/bot.py repowire/slack/bot.py