### PR TITLE
web: render homepage hero content statically

### DIFF
--- a/web/components/Hero.tsx
+++ b/web/components/Hero.tsx
@@ -1,9 +1,6 @@
-"use client";
-
 import { ArrowRight, Github, Terminal } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion } from "framer-motion";
 
 export default function Hero() {
   return (
@@ -19,12 +16,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-surface/88" />
 
       <div className="relative z-10 mx-auto grid max-w-7xl items-center gap-8 px-4 pb-10 sm:px-6 sm:pb-12 lg:grid-cols-[0.95fr_1.05fr] lg:px-8 lg:pb-14">
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4 }}
-          className="max-w-3xl"
-        >
+        <div className="max-w-3xl">
           <div className="mb-6 inline-flex items-center gap-2 border border-primary/30 bg-primary/10 px-3 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-primary-fixed">
             <span className="h-1.5 w-1.5 rounded-full bg-secondary" aria-hidden="true" />
             Local-first agent team harness
@@ -59,13 +51,9 @@ export default function Hero() {
             <Metric label="Messages" value="ask / notify / schedule" />
             <Metric label="Surfaces" value="dashboard / Telegram / Slack" />
           </dl>
-        </motion.div>
+        </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.45, delay: 0.08 }}
-        >
+        <div>
           <div className="overflow-hidden rounded-lg border border-border-strong bg-surface-container-low shadow-[var(--shadow-3)]">
             <div className="flex items-center justify-between border-b border-border-faint bg-surface-container px-4 py-3">
               <div className="flex items-center gap-2" aria-hidden="true">
@@ -92,7 +80,7 @@ export default function Hero() {
               </div>
             </div>
           </div>
-        </motion.div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

- Render the public homepage hero content statically instead of behind Framer Motion initial hidden state.
- Remove the Hero client boundary so the H1, copy, CTAs, metrics, and dashboard preview are visible in the initial server render.

## Root Cause

The live page kept the hero wrappers at Framer Motion's initial inline style (`opacity: 0; transform: translateY(...)`) after hydration, leaving the first viewport mostly empty on desktop and mobile.

## Validation

- `npm run build` passes.
- `npm run lint` still fails on existing dashboard React hook lint errors in `web/app/dashboard/components/PeerView.tsx` and `web/app/dashboard/page.tsx`; untouched by this PR.
- Local browser desktop screenshot: `/tmp/repowire-hero-local-desktop.png`.
- Local browser mobile screenshot: `/tmp/repowire-hero-local-mobile.png`.
- Browser eval confirmed the H1 renders in the first viewport with computed opacity `1` at 1440x900 and 390x844.
