### PR TITLE
Bump release to v0.13.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.13.32"
+version = "0.13.33"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.32"
+version = "0.13.33"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary\n- Bump package version to v0.13.33 for the post-v0.13.32 patch bundle.\n- Includes the merged bot ack service identity fix and static homepage hero rendering fix already on main.\n\n## Verification\n- git diff --check\n- uv run --extra docs mkdocs build --strict\n\n## Release note\nPatch release for Telegram/Slack bot ack routing correctness and public website hero visibility.