### PR TITLE
web: polish docs site visuals

### DIFF
--- a/web/app/docs/quickstart/page.tsx
+++ b/web/app/docs/quickstart/page.tsx
@@ -87,7 +87,7 @@ function Step({ n, title, children }: { n: string; title: string; children: Reac
 
 function CodeBlock({ children }: { children: React.ReactNode }) {
   return (
-    <pre className="overflow-x-auto border border-border-faint bg-surface-container-low p-4 font-mono text-xs leading-6 text-on-surface">
+    <pre className="overflow-x-auto whitespace-pre-wrap break-words border border-border-faint bg-surface-container-low p-4 font-mono text-[11px] leading-6 text-on-surface sm:text-xs">
       <code>{children}</code>
     </pre>
   );

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -17,7 +17,7 @@ export default function CliReference() {
 
       <Cmd name="repowire setup" usage="repowire setup [--relay] [--experimental-channels] [--non-interactive]">
         <p>
-          One-time install. Detects every agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode, Pi), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
+          One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
         </p>
       </Cmd>
 

--- a/web/components/Hero.tsx
+++ b/web/components/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
             Coordinate agent teams locally.
           </h1>
           <p className="mt-5 max-w-2xl text-lg leading-8 text-on-surface-variant">
-            Repowire gives Claude Code, Codex, Gemini CLI, OpenCode, and Pi sessions an address in one mesh so they can ask each other questions, send updates, schedule follow-ups, and stay steerable from your browser or phone.
+            Repowire gives Claude Code, Codex, Gemini CLI, and OpenCode sessions an address in one mesh so they can ask each other questions, send updates, schedule follow-ups, and stay steerable from your browser or phone.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
             <Link

--- a/web/components/HowItWorks.tsx
+++ b/web/components/HowItWorks.tsx
@@ -4,7 +4,7 @@ const steps = [
   {
     label: "01",
     title: "Sessions register as peers",
-    description: "Setup wires supported agents into the mesh. Each live Claude Code, Codex, Gemini, OpenCode, or Pi session gets a routable identity.",
+    description: "Setup wires supported agents into the mesh. Each live Claude Code, Codex, Gemini CLI, or OpenCode session gets a routable identity.",
   },
   {
     label: "02",
@@ -56,13 +56,16 @@ export default function HowItWorks() {
             <div className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-outline">
               Architecture, simplified
             </div>
-            <Image
-              src="/brand/repowire-arch.webp"
-              alt="Repowire architecture: a local daemon routes messages between hooks, channel transport, relay, and peers"
-              width={1000}
-              height={700}
-              className="h-auto w-full rounded border border-border-faint bg-surface opacity-90"
-            />
+            <div className="rounded border border-border-faint bg-paper p-2">
+              <Image
+                src="/brand/repowire-arch.webp"
+                alt="Repowire architecture: a local daemon routes messages between hooks, channel transport, relay, and peers"
+                width={1000}
+                height={700}
+                className="h-auto w-full rounded bg-paper"
+                loading="eager"
+              />
+            </div>
             <div className="mt-4 rounded border-l-2 border-primary bg-surface-dim/95 p-4">
               <p className="font-mono text-xs leading-6 text-on-surface-variant">
                 local daemon → transport router → agent session → ack or timeline event


### PR DESCRIPTION
## Summary
- Confirmed PR #241 is merged and live on https://repowire.io before starting the pass.
- Tightened homepage runtime copy to supported public agents only: Claude Code, Codex, Gemini CLI, OpenCode.
- Improved the homepage architecture diagram presentation on mobile with a light backing and eager load while preserving no horizontal page overflow.
- Wrapped quickstart code blocks on mobile so long install commands do not clip off-screen.
- Corrected the generated CLI docs setup copy to avoid listing Pi as a supported setup runtime.

## Live audit screenshots
- /tmp/repowire-visual-pass/live-home-desktop.png
- /tmp/repowire-visual-pass/live-home-mobile.png
- /tmp/repowire-visual-pass/live-docs-quickstart-desktop.png
- /tmp/repowire-visual-pass/live-docs-quickstart-mobile.png
- /tmp/repowire-visual-pass/live-home-mobile-diagram-after-scroll-2.png

## Patched screenshots
- /tmp/repowire-visual-pass/local-home-desktop-v2.png
- /tmp/repowire-visual-pass/local-home-mobile-full-v2.png
- /tmp/repowire-visual-pass/local-docs-quickstart-mobile-v2.png

## Checks
- npm run build: pass
- git diff --check: pass
- Mobile overflow check on local homepage: innerWidth=390, scrollWidth=390
- npm run lint: fails on existing dashboard hook-rule errors in web/app/dashboard/components/PeerView.tsx and web/app/dashboard/page.tsx; this PR did not touch those files.

## Notes
- ACP remains described as experimental and opt-in.
- Session-native remains framed as roadmap/current direction, not fully shipped behavior.
- Did not intentionally edit .beads or uv.lock.