### PR TITLE
[codex] Polish localhost HTTP MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ https://repowire.io/dashboard
 
 ```bash
 repowire setup                         # install hooks/MCP/plugin/service for detected agents
+repowire setup --http-mcp              # opt in to localhost Streamable HTTP MCP at /mcp
 repowire status                        # show installed components and daemon status
 repowire doctor                        # run diagnostics
 repowire service restart               # restart the installed daemon service
@@ -188,7 +189,12 @@ Config lives at `~/.repowire/config.yaml`.
 daemon:
   host: "127.0.0.1"
   port: 8377
-  auth_token: "optional-secret"
+  auth_token: "rw_local_..."
+  mcp_http:
+    enabled: false
+    bind: "localhost-only"
+    require_auth: true
+    allow_dangerous_tools: false
   spawn:
     allowed_commands: [claude, codex, gemini]
     allowed_paths: [~/git, ~/projects]
@@ -203,7 +209,8 @@ Security defaults:
 
 - Local daemon binds to `127.0.0.1`.
 - Relay is opt-in and uses outbound WebSocket.
-- WebSocket auth is available through `daemon.auth_token`.
+- WebSocket and local HTTP auth are available through `daemon.auth_token`.
+- Experimental HTTP MCP is opt-in, localhost-only, bearer-authenticated by default, and not exposed through the hosted relay.
 - Spawn requires explicit command and path allowlists.
 - Experimental channel/ACP transport is opt-in.
 

--- a/docs/quickstart/setup.md
+++ b/docs/quickstart/setup.md
@@ -19,12 +19,15 @@ When setup finishes, the daemon is listening on `127.0.0.1:8377`. Open a new age
 ```bash
 repowire setup --relay                  # also connect to the hosted relay at repowire.io
 repowire setup --experimental-channels  # use the MCP channel transport (Claude Code v2.1.80+, claude.ai login, bun)
+repowire setup --http-mcp               # enable localhost Streamable HTTP MCP at /mcp
 repowire setup --non-interactive        # take flag values only, no prompts
 ```
 
 `--relay` makes the dashboard available at `https://repowire.io/dashboard` over an outbound WebSocket. See [hosted relay](../relay/hosted.md).
 
 `--experimental-channels` replaces tmux-injection delivery with direct MCP-channel / ACP delivery for Claude Code only. It is experimental. See [Claude Code setup](../agents/claude-code.md).
+
+`--http-mcp` is a local-only experimental MCP endpoint for clients that need Streamable HTTP instead of the default stdio server. It generates a `daemon.auth_token` if needed and requires clients to send `Authorization: Bearer <token>`. The normal `repowire mcp` stdio server remains the default setup path.
 
 ## Verifying
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,13 +5,14 @@ The `repowire` command is a thin wrapper around setup, the daemon, and the bot p
 ## `repowire setup`
 
 ```bash
-repowire setup [--relay] [--experimental-channels] [--non-interactive]
+repowire setup [--relay] [--experimental-channels] [--http-mcp] [--non-interactive]
 ```
 
-One-time install. Detects every agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode, Pi), wires the appropriate Repowire transport for each, and installs the daemon as a user service.
+One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service.
 
 - `--relay` opts in to the hosted relay at `repowire.io`.
 - `--experimental-channels` enables the experimental MCP channel / ACP transport for Claude Code (v2.1.80+, claude.ai login, bun).
+- `--http-mcp` enables the experimental localhost Streamable HTTP MCP endpoint at `http://127.0.0.1:8377/mcp` and generates `daemon.auth_token` if needed.
 - `--non-interactive` skips prompts and uses flag values only.
 
 ## `repowire serve`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,4 +1,35 @@
 # Configuration
 
-!!! note "Stub"
-    Per-key reference for `~/.repowire/config.yaml`. Content lands in step 4.
+Config lives at `~/.repowire/config.yaml`. `repowire setup` creates the file with `0600` permissions.
+
+```yaml
+daemon:
+  host: "127.0.0.1"
+  port: 8377
+  auth_token: "rw_local_..."
+  mcp_http:
+    enabled: false
+    bind: "localhost-only"
+    require_auth: true
+    allow_unauthenticated_localhost: false
+    allow_dangerous_tools: false
+  spawn:
+    allowed_commands: []
+    allowed_paths: []
+```
+
+## `daemon.auth_token`
+
+Optional local bearer token for daemon HTTP routes, WebSocket connections, hooks, and the opt-in HTTP MCP endpoint. `repowire setup --http-mcp` generates one automatically if missing. Treat it as a local password; rotate it by replacing the value and restarting the daemon service.
+
+## `daemon.mcp_http`
+
+Experimental Streamable HTTP MCP endpoint mounted at `http://127.0.0.1:8377/mcp`.
+
+- `enabled`: opt in to mounting `/mcp`. Default: `false`.
+- `bind`: only `localhost-only` is supported. If `daemon.host` is not `127.0.0.1`, `::1`, or `localhost`, `/mcp` is not mounted.
+- `require_auth`: require `Authorization: Bearer <daemon.auth_token>`. Default: `true`.
+- `allow_unauthenticated_localhost`: development-only escape hatch that disables bearer auth when `require_auth` is also disabled. Do not use on shared machines.
+- `allow_dangerous_tools`: allow lifecycle/admin MCP tools over HTTP MCP. Default: `false`; spawn, kill, and schedule mutation stay disabled.
+
+HTTP MCP is never exposed through the hosted relay. The default stdio MCP server installed by `repowire setup` is unchanged and remains the stable path for agents.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -8,14 +8,46 @@ The default, stable transport is the per-agent stdio MCP server installed by `re
 
 An experimental Streamable HTTP MCP endpoint can also be mounted on the local daemon at `/mcp` with:
 
+```bash
+repowire setup --http-mcp
+repowire service restart
+```
+
+Or by editing `~/.repowire/config.yaml`:
+
 ```yaml
 daemon:
-  auth_token: "..."
+  auth_token: "rw_local_..."
   mcp_http:
     enabled: true
 ```
 
-This endpoint is opt-in, localhost-only, requires `Authorization: Bearer <daemon.auth_token>` by default, and is not exposed through the hosted relay. HTTP MCP uses a daemon-owned `mcp-http` identity instead of tmux/cwd session inference. Lifecycle/admin tools such as spawn, kill, and schedule mutation are disabled for HTTP MCP unless explicitly enabled with `daemon.mcp_http.allow_dangerous_tools`.
+`repowire setup --http-mcp` generates `daemon.auth_token` if one is not already set. This endpoint is opt-in, localhost-only, requires `Authorization: Bearer <daemon.auth_token>` by default, and is not exposed through the hosted relay. HTTP MCP uses a daemon-owned `mcp-http` identity instead of tmux/cwd session inference, so it is useful for local MCP clients that cannot run the stdio server in an agent session.
+
+Client registration examples:
+
+```json
+{
+  "mcpServers": {
+    "repowire": {
+      "type": "http",
+      "url": "http://127.0.0.1:8377/mcp",
+      "headers": {
+        "Authorization": "Bearer rw_local_..."
+      }
+    }
+  }
+}
+```
+
+For Claude Code, the equivalent CLI shape is:
+
+```bash
+claude mcp add --transport http repowire http://127.0.0.1:8377/mcp \
+  --header "Authorization: Bearer rw_local_..."
+```
+
+Lifecycle/admin tools such as spawn, kill, and schedule mutation are disabled for HTTP MCP unless explicitly enabled with `daemon.mcp_http.allow_dangerous_tools`. The stdio server installed by `repowire setup` remains the stable default and still runs as `repowire mcp`.
 
 ## Routing
 

--- a/docs/relay/security.md
+++ b/docs/relay/security.md
@@ -17,13 +17,13 @@ For the hosted relay at `repowire.io`, this means the operators *could* see your
 
 - **Local-only traffic.** A daemon running without `relay.enabled: true` never connects to the relay. Mesh traffic stays on `127.0.0.1:8377`.
 - **Other users' traffic.** API keys scope by user id; daemons in different scopes cannot reach each other.
-- **MCP-server traffic.** MCP tool calls travel agent → MCP stdio → daemon HTTP, locally. Only when a tool call reaches across the relay (e.g. dashboard-initiated) does the relay see it.
+- **MCP-server traffic.** Default MCP tool calls travel agent → MCP stdio → daemon HTTP, locally. The opt-in HTTP MCP endpoint is also localhost-only and is not tunneled through the hosted relay.
 
 ## Authentication
 
 - The daemon authenticates to the relay with `relay.api_key`. The key is auto-generated and stored in `~/.repowire/config.yaml`.
 - The dashboard authenticates to the relay with a cookie set after submitting the same API key at `/auth`. Possession of the key grants dashboard access; treat it like a password.
-- Local-daemon `daemon.auth_token` is independent and gates the local WebSocket / HTTP API. Set it if other processes on the machine should not have free access.
+- Local-daemon `daemon.auth_token` is independent and gates the local WebSocket / HTTP API. `repowire setup --http-mcp` generates one because HTTP MCP requires bearer auth by default. Set or rotate it manually if other processes on the machine should not have free access.
 
 ## Trust boundaries
 
@@ -31,7 +31,7 @@ For the hosted relay at `repowire.io`, this means the operators *could* see your
 | --- | --- |
 | Browser ↔ relay | TLS (you trust the relay's certificate) |
 | Relay ↔ daemon | TLS-over-WSS (you trust the relay's network and process) |
-| Daemon ↔ agent (MCP) | Local stdio; not network-exposed |
+| Daemon ↔ agent (MCP) | Local stdio by default; optional HTTP MCP is localhost-only with bearer auth |
 | Daemon ↔ agent (hooks) | Local HTTP on `127.0.0.1`; gated by `daemon.auth_token` if set |
 
 ## Hardening recommendations

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import secrets
 from pathlib import Path
 from typing import Any
 
@@ -147,6 +148,24 @@ def _prompt_bot_config(
         console.print(f"[green]✓[/] {name} configured")
 
 
+def _generate_daemon_auth_token() -> str:
+    """Generate a local bearer token suitable for daemon HTTP/WebSocket auth."""
+    return "rw_local_" + secrets.token_urlsafe(32)
+
+
+def _enable_http_mcp(config: object) -> bool:
+    """Enable localhost HTTP MCP and create a bearer token if missing."""
+    daemon = getattr(config, "daemon")
+    changed = False
+    if not getattr(daemon.mcp_http, "enabled", False):
+        daemon.mcp_http.enabled = True
+        changed = True
+    if not daemon.auth_token:
+        daemon.auth_token = _generate_daemon_auth_token()
+        changed = True
+    return changed
+
+
 @main.command()
 @click.option("--no-service", is_flag=True, help="Skip daemon service installation")
 @click.option("--relay", is_flag=True, help="Enable hosted relay via repowire.io")
@@ -154,9 +173,18 @@ def _prompt_bot_config(
     "--experimental-channels", is_flag=True,
     help="Use channel transport (experimental, requires claude.ai login and bun)",
 )
+@click.option(
+    "--http-mcp",
+    is_flag=True,
+    help="Enable the experimental localhost Streamable HTTP MCP endpoint at /mcp",
+)
 @click.option("--non-interactive", is_flag=True, help="Skip prompts, use flags only")
 def setup(
-    no_service: bool, relay: bool, experimental_channels: bool, non_interactive: bool
+    no_service: bool,
+    relay: bool,
+    experimental_channels: bool,
+    http_mcp: bool,
+    non_interactive: bool,
 ) -> None:
     """One-time setup: install hooks/plugins, MCP server, and daemon service."""
     import shutil
@@ -205,9 +233,10 @@ def setup(
     if not agents_setup:
         console.print("[yellow]No agent types detected.[/]")
         console.print("Install claude, codex, gemini, opencode, or pi first.")
-        return
-
-    console.print(f"[green]✓[/] Configured agents: {', '.join(agents_setup)}")
+        if not (http_mcp or relay or interactive):
+            return
+    else:
+        console.print(f"[green]✓[/] Configured agents: {', '.join(agents_setup)}")
 
     # Install tmux lifecycle hooks if tmux is available
     try:
@@ -239,6 +268,24 @@ def setup(
             config.relay.ensure_api_key()
             console.print("[green]✓[/] Relay enabled")
             console.print(f"  Dashboard: {config.relay.dashboard_url}")
+
+    if config.daemon.mcp_http.enabled:
+        if not config.daemon.auth_token:
+            _enable_http_mcp(config)
+            console.print("[green]✓[/] HTTP MCP bearer token generated")
+        else:
+            console.print("[green]✓[/] HTTP MCP enabled (existing config)")
+    elif http_mcp:
+        _enable_http_mcp(config)
+        console.print("[green]✓[/] HTTP MCP enabled at http://127.0.0.1:8377/mcp")
+        console.print(f"  Bearer token: {_mask_token(config.daemon.auth_token or '')}")
+    elif interactive and click.confirm(
+        "Enable experimental localhost HTTP MCP endpoint?",
+        default=False,
+    ):
+        _enable_http_mcp(config)
+        console.print("[green]✓[/] HTTP MCP enabled at http://127.0.0.1:8377/mcp")
+        console.print(f"  Bearer token: {_mask_token(config.daemon.auth_token or '')}")
 
     # Bot integrations: show existing config or prompt
     if config.telegram.bot_token:

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import secrets
 import signal
 import time
 from collections.abc import AsyncIterator
@@ -70,12 +71,24 @@ class _MCPAuthASGIWrapper:
             return
         if self.require_auth:
             if not self.token:
-                await self._reject(send, 503, b"HTTP MCP requires daemon.auth_token")
+                await self._reject(
+                    send,
+                    503,
+                    (
+                        b"HTTP MCP auth is enabled but daemon.auth_token is not set; "
+                        b"run `repowire setup --http-mcp` or set daemon.auth_token"
+                    ),
+                )
                 return
             headers = {k.lower(): v for k, v in scope.get("headers", [])}
-            expected = f"Bearer {self.token}".encode()
-            if headers.get(b"authorization") != expected:
-                await self._reject(send, 401, b"Missing or invalid bearer token")
+            expected = f"Bearer {self.token}"
+            provided = headers.get(b"authorization", b"").decode("utf-8", errors="ignore")
+            if not secrets.compare_digest(provided, expected):
+                await self._reject(
+                    send,
+                    401,
+                    b"Missing or invalid bearer token for localhost HTTP MCP",
+                )
                 return
         if scope.get("path") == "":
             scope = dict(scope)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
 from pydantic import ValidationError
 
 from repowire.config.models import (
@@ -75,6 +76,47 @@ class TestConfig:
                     assert config.relay.url == "wss://custom.relay.io"
                     assert config.relay.api_key == "rw_test123"
                     assert config.relay.enabled is True
+
+    def test_setup_http_mcp_helper_generates_local_token(self):
+        from repowire.cli import _enable_http_mcp
+
+        config = Config()
+        changed = _enable_http_mcp(config)
+
+        assert changed is True
+        assert config.daemon.mcp_http.enabled is True
+        assert config.daemon.auth_token is not None
+        assert config.daemon.auth_token.startswith("rw_local_")
+        assert len(config.daemon.auth_token) > 40
+
+    def test_setup_http_mcp_helper_preserves_existing_token(self):
+        from repowire.cli import _enable_http_mcp
+
+        config = Config(daemon=DaemonConfig(auth_token="existing-secret"))
+        _enable_http_mcp(config)
+
+        assert config.daemon.mcp_http.enabled is True
+        assert config.daemon.auth_token == "existing-secret"
+
+    def test_setup_http_mcp_flag_writes_config_without_detected_agents(self, tmp_path, monkeypatch):
+        from repowire.cli import main
+
+        config_path = tmp_path / "config.yaml"
+        monkeypatch.setattr(Config, "get_config_dir", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(Config, "get_config_path", classmethod(lambda cls: config_path))
+        monkeypatch.setattr("repowire.cli._cleanup_legacy_artifacts", lambda: None)
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+
+        result = CliRunner().invoke(
+            main,
+            ["setup", "--http-mcp", "--non-interactive", "--no-service"],
+        )
+
+        assert result.exit_code == 0
+        loaded = load_config()
+        assert loaded.daemon.mcp_http.enabled is True
+        assert loaded.daemon.auth_token is not None
+        assert loaded.daemon.auth_token.startswith("rw_local_")
 
 
 class TestRelayConfig:

--- a/tests/test_http_mcp.py
+++ b/tests/test_http_mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import anyio
 import pytest
@@ -64,6 +65,18 @@ class TestHttpMCPMount:
             async with await _client(app) as client:
                 r = await client.post("/mcp", headers={"Authorization": "Bearer wrong"})
                 assert r.status_code == 401
+                assert "localhost HTTP MCP" in r.text
+            cleanup_deps()
+
+        anyio.run(run)
+
+    def test_mcp_enabled_with_auth_requires_configured_token(self):
+        async def run():
+            app = create_test_app(_cfg(enabled=True, token=None))
+            async with await _client(app) as client:
+                r = await client.post("/mcp")
+                assert r.status_code == 503
+                assert "daemon.auth_token is not set" in r.text
             cleanup_deps()
 
         anyio.run(run)
@@ -161,5 +174,44 @@ def test_http_mcp_identity_does_not_use_daemon_cwd(monkeypatch):
         assert register_body["path"] == ""
         assert register_body["backend"] == "mcp-http"
         assert register_body["role"] == "human"
+
+    anyio.run(run)
+
+
+def test_http_mcp_dangerous_tools_disabled_by_default():
+    async def run():
+        import repowire.mcp.server as server
+
+        server.configure_http_mcp_context(auth_token="secret")
+        mcp = server.create_mcp_server()
+        spawn_tool = mcp._tool_manager._tools["spawn_peer"].fn
+
+        with pytest.raises(PermissionError) as exc:
+            await spawn_tool(path="/tmp/project", command="claude")
+
+        assert "spawn_peer is disabled for HTTP MCP by default" in str(exc.value)
+
+    anyio.run(run)
+
+
+def test_http_mcp_can_opt_into_dangerous_tools():
+    async def run():
+        import repowire.mcp.server as server
+
+        server.configure_http_mcp_context(
+            auth_token="secret",
+            allow_dangerous_tools=True,
+        )
+        mcp = server.create_mcp_server()
+        spawn_tool = mcp._tool_manager._tools["spawn_peer"].fn
+
+        with patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock) as request:
+            request.return_value = {
+                "display_name": "project",
+                "tmux_session": "default:project",
+            }
+            result = await spawn_tool(path="/tmp/project", command="claude")
+
+        assert "Spawned project" in result
 
     anyio.run(run)

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -15,9 +15,9 @@ export default function CliReference() {
         The <Mono>repowire</Mono> command is a thin wrapper around setup, the daemon, and the bot peers. Most users only ever need <Mono>setup</Mono>. Everything else is for operators running their own daemon or control surfaces.
       </p>
 
-      <Cmd name="repowire setup" usage="repowire setup [--relay] [--experimental-channels] [--non-interactive]">
+      <Cmd name="repowire setup" usage="repowire setup [--relay] [--experimental-channels] [--http-mcp] [--non-interactive]">
         <p>
-          One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
+          One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--http-mcp</Mono> enables localhost Streamable HTTP MCP at <Mono>/mcp</Mono> and generates a bearer token if needed. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
         </p>
       </Cmd>
 

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -14,6 +14,9 @@ export default function ToolsReference() {
       <p className="mt-4 text-base leading-7 text-on-surface-variant">
         Every agent in the mesh exposes the same set of MCP tools through the repowire server. Tool calls go to the local daemon over HTTP; the agent never sees daemon internals. Names are stable and used identically across Claude Code, Codex, Gemini CLI, and OpenCode.
       </p>
+      <p className="mt-4 text-base leading-7 text-on-surface-variant">
+        The stable transport is the stdio server installed by <Mono>repowire setup</Mono>. The experimental localhost Streamable HTTP endpoint can be enabled with <Mono>repowire setup --http-mcp</Mono>; clients connect to <Mono>http://127.0.0.1:8377/mcp</Mono> with <Mono>Authorization: Bearer &lt;daemon.auth_token&gt;</Mono>. HTTP MCP is local-only, is not relayed, and disables spawn, kill, and schedule mutation unless explicitly opted in with <Mono>daemon.mcp_http.allow_dangerous_tools</Mono>.
+      </p>
 
       <Tool
         name="ask"


### PR DESCRIPTION
## Summary
- add `repowire setup --http-mcp` to enable the opt-in localhost Streamable HTTP MCP endpoint and generate a local bearer token when needed
- harden HTTP MCP auth errors and token comparison, and cover dangerous-tool defaults with regression tests
- document config, threat model, client registration, and stdio compatibility in README, docs, and web docs

## Validation
- `uv run pytest tests/test_http_mcp.py tests/test_config.py`
- `uv run --extra dev ruff check repowire/daemon/app.py repowire/cli.py tests/test_http_mcp.py tests/test_config.py`
- `uv run --extra dev ty check repowire/daemon/app.py repowire/cli.py`