### PR TITLE
Fix dashboard stream delta ordering

### DIFF
--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -255,6 +255,41 @@ describe("PeerView session protection", () => {
     expect(screen.queryByText("other stream")).not.toBeInTheDocument();
   });
 
+  it("orders streaming delta blocks by chunk_index instead of timestamp", async () => {
+    const laterChunkFirstByTimestamp: Event = {
+      id: "delta-1",
+      type: "chat_turn_delta",
+      timestamp: "2025-01-01T00:00:00Z",
+      peer_id: PEER.peer_id,
+      session_id: "session-a",
+      turn_id: "turn-a",
+      chunk_index: 1,
+      kind: "text",
+      text: "second block",
+    };
+    const earlierChunkSecondByTimestamp: Event = {
+      ...laterChunkFirstByTimestamp,
+      id: "delta-0",
+      timestamp: "2025-01-01T00:00:01Z",
+      chunk_index: 0,
+      text: "first block",
+    };
+
+    render(
+      <PeerView
+        peer={{ ...PEER, metadata: { hook_session_id: "session-a" } }}
+        events={[laterChunkFirstByTimestamp, earlierChunkSecondByTimestamp]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    const first = await screen.findByText("first block");
+    const second = screen.getByText("second block");
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("auto-scrolls on new events when not protected", () => {
     const initial: Event[] = [chatTurn("e1", "hello", "2025-01-01T00:00:00Z")];
     const { rerender } = render(

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -1438,7 +1438,13 @@ function mergeTimeline(
  * gets a matching final (network drop, agent crash mid-turn): a chat_turn
  * for the same peer that came *after* the delta absorbs it. */
 function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
-  const groups = new Map<string, ChatTurnDeltaGroup>();
+  const groups = new Map<
+    string,
+    {
+      group: ChatTurnDeltaGroup;
+      deltas: Event[];
+    }
+  >();
 
   // Final chat_turns carrying turn_id — exact match drops their deltas
   // regardless of arrival order.
@@ -1464,27 +1470,25 @@ function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
     if (lastFinalTs && ev.timestamp <= lastFinalTs) continue;
 
     const groupKey = key || `event:${ev.id}`;
-    let group = groups.get(groupKey);
-    if (!group) {
-      group = {
-        type: "chat_turn_delta_group",
-        id: `delta-group-${ev.turn_id}`,
-        session_id: ev.session_id,
-        turn_id: ev.turn_id,
-        peer_id: ev.peer_id,
-        timestamp: ev.timestamp,
-        text: "",
-        tool_calls: [],
+    let entry = groups.get(groupKey);
+    if (!entry) {
+      entry = {
+        deltas: [],
+        group: {
+          type: "chat_turn_delta_group",
+          id: `delta-group-${ev.turn_id}`,
+          session_id: ev.session_id,
+          turn_id: ev.turn_id,
+          peer_id: ev.peer_id,
+          timestamp: ev.timestamp,
+          text: "",
+          tool_calls: [],
+        },
       };
-      groups.set(groupKey, group);
+      groups.set(groupKey, entry);
     }
-    if (ev.kind === "tool_use" && ev.tool_call) {
-      group.tool_calls.push(ev.tool_call);
-    } else if (ev.kind === "text" || ev.kind === undefined) {
-      // Adjacent text blocks within one turn are conceptually paragraphs.
-      group.text = group.text ? `${group.text}\n\n${ev.text}` : ev.text;
-    }
-    group.timestamp = ev.timestamp;
+    entry.deltas.push(ev);
+    if (ev.timestamp > entry.group.timestamp) entry.group.timestamp = ev.timestamp;
   }
 
   const out: ThreadItemEntry[] = [];
@@ -1492,7 +1496,21 @@ function coalesceDeltas(sorted: Event[]): ThreadItemEntry[] {
     if (ev.type === "chat_turn_delta") continue;
     out.push(ev);
   }
-  for (const group of groups.values()) {
+  for (const { group, deltas } of groups.values()) {
+    const ordered = [...deltas].sort((a, b) => {
+      const aIndex = typeof a.chunk_index === "number" ? a.chunk_index : Number.MAX_SAFE_INTEGER;
+      const bIndex = typeof b.chunk_index === "number" ? b.chunk_index : Number.MAX_SAFE_INTEGER;
+      if (aIndex !== bIndex) return aIndex - bIndex;
+      return a.timestamp.localeCompare(b.timestamp);
+    });
+    for (const ev of ordered) {
+      if (ev.kind === "tool_use" && ev.tool_call) {
+        group.tool_calls.push(ev.tool_call);
+      } else if (ev.kind === "text" || ev.kind === undefined) {
+        // Adjacent text blocks within one turn are conceptually paragraphs.
+        group.text = group.text ? `${group.text}\n\n${ev.text}` : ev.text;
+      }
+    }
     if (!group.text && group.tool_calls.length === 0) continue;
     out.push(group);
   }


### PR DESCRIPTION
## Summary
- Fix dashboard streaming turn coalescing so `chat_turn_delta` text/tool blocks are assembled by `chunk_index` instead of event timestamp.
- Add regression coverage for timestamp-skewed/replayed delta events in the selected-session timeline.

## Root Cause
The dashboard grouped delta events by turn but appended blocks in event/timestamp order. During reconnect gap recovery or timestamp skew, a streaming bubble could render chunks out of order even though the wire protocol carries a stable `chunk_index`.

## Checks
- `npm test -- PeerView.test.tsx`
- `uv run pytest tests/test_sse_stream.py tests/test_chat_delta_streamer.py tests/test_routes.py::TestEvents`
- `npm run build`
- Browser smoke: opened `/dashboard` on local Next dev server; API fetches failed as expected without a daemon.

## Caveat
- `npm run lint -- app/dashboard/components/PeerView.tsx app/dashboard/components/PeerView.test.tsx` is blocked by a pre-existing unrelated `react-hooks/set-state-in-effect` error at `PeerView.tsx:911`.

## Notes
- Did not modify `.beads` or `uv.lock`.
