### PR TITLE
[codex] Add orchestrator active fan-out guidance

### DIFF
--- a/docs/concepts/orchestrator.md
+++ b/docs/concepts/orchestrator.md
@@ -14,6 +14,11 @@ A typical orchestrator runs a loop like:
 4. **Review** completed work. `review_queue()` surfaces PRs the peer has touched that you still owe a review on; `mark_reviewed(pr_url)` clears them.
 5. **Release** when a batch lands. Tag, push, notify.
 
+For independent work, the orchestrator should fan out instead of serializing
+everything through one session. Split board items by owner and worktree, dispatch
+plan/review lanes in parallel where useful, schedule watchdog wakes for
+long-running lanes, and keep the board as the single source of truth.
+
 ## Memory and procedures
 
 The orchestrator workspace is a curated procedure layer, not a complete history store. Keep user communication preferences in `comms.md`, active project scope in `projects.md`, durable operational lessons in `memory/*.md`, and reusable dispatch/review/release procedures in `patterns/*.md`.
@@ -33,6 +38,11 @@ Pair runtimes: a `claude-code` orchestrator alongside a `codex` or `gemini` one 
 ## Scheduled check-ins
 
 `schedule_create(to_peer, text, fire_at, kind="notify")` defers a single future message — fire-and-forget if `kind="notify"`, or an opened ask thread if `kind="ask"`. `schedule_cron(to_peer, text, cron, kind="notify")` adds recurring check-ins, and `schedule_self(text, fire_at=...|cron=...)` is the convenience form for self-wake reminders.
+
+Scheduled background work should stay quiet by default. Use it for watchdogs,
+summaries, cleanup, and review nudges, with a clear owner and cancellation path.
+Durable board or memory writes should happen only for real state transitions or
+forward-applicable lessons, not just because a hook fired.
 
 ## When *not* to orchestrate
 

--- a/docs/patterns/orchestrator-coordination.md
+++ b/docs/patterns/orchestrator-coordination.md
@@ -26,6 +26,31 @@ Or simply work in a session named `orchestrator` — by convention other peers w
 4. **Review** completed work. `review_queue()` surfaces PRs you owe a look. `mark_reviewed(pr_url)` clears them after the pass.
 5. **Release** when a batch lands. Tag, push, notify the team channel.
 
+## Active fan-out
+
+When items are independent, split them into parallel lanes rather than waiting
+for one peer to finish before dispatching the next. A good split has one owner,
+one worktree, and one clear reporting path per lane. Use separate review or
+plan-critique lanes when they can run without touching the same files.
+
+For each fan-out, schedule a watchdog wake before the lane can go stale:
+
+```text
+schedule_self(
+  text="watchdog: check project-a auth refactor lane and update board only if state changed",
+  fire_at="2026-05-20T15:30:00Z",
+  kind="notify",
+)
+```
+
+Keep durable writes quiet. The board owns item state, peer descriptions own
+current focus, session timelines or reports own detailed history, and memory
+owns only lessons that should change future behavior.
+
+One-off external shortcuts are a local policy choice, not a universal
+orchestrator rule. Configure that in the workspace instructions for your team;
+do not bake a generic ban into the pattern.
+
 ## Before dispatching
 
 Call `orchestrator_status(circle="...")` first to confirm a live orchestrator (you) is present in the target circle. Returns `present, peer_name, peer_id, last_seen, stale_after_seconds`. This is a presence check, not a mesh snapshot.

--- a/repowire/orchestrator/template/AGENTS.md
+++ b/repowire/orchestrator/template/AGENTS.md
@@ -12,6 +12,8 @@ This workspace is your operating manual. It was scaffolded from a snapshot of on
 
 The default dispatch shape: **spawn → brief with memory refs → iterate before code → review before merge**. See `patterns/spawn-brief-iterate.md` for the full shape.
 
+The default coordination shape: **parallelize independent lanes**. When the board has disjoint work, do not serialize it behind one peer or the orchestrator seat. Decompose by worktree/owner, brief each lane, schedule a watchdog wake for each fan-out, and keep the board as the one source of truth. See `patterns/active-fanout.md`.
+
 ## Mesh primitives
 
 You speak to other peers via repowire MCP tools. The wire surface (post-PR-99):
@@ -40,6 +42,7 @@ Where most of your judgment budget goes. Not codifiable as recipes; these are he
 Read these on demand when the situation matches. Treat `patterns/` as a progressive-disclosure procedure library: this index is the trigger list, and the pattern file is the full workflow. Pattern files may include optional frontmatter (`name`, `description`, `triggers`, `risk`, `surfaces`) for future tooling; do not depend on a parser being present.
 
 - `patterns/spawn-brief-iterate.md` — core dispatch loop, default shape for any new work
+- `patterns/active-fanout.md` — default shape for decomposing board items into parallel lanes with watchdog wakes
 - `patterns/two-model-critique.md` — when a single peer proposes an architectural-but-bounded plan (provider hierarchy, routing, build pipeline, framework boundaries), spawn a *different-model* peer in the same worktree to critique before code. ~5-10 min cost, catches blind spots.
 - `patterns/mesh-roundup.md` — polling N peers for status in parallel, compiling impact-first (not by counts)
 - `patterns/release-bundle-decision.md` — given N merged commits, deciding tag-now-or-hold + version + changelog

--- a/repowire/orchestrator/template/patterns/active-fanout.md
+++ b/repowire/orchestrator/template/patterns/active-fanout.md
@@ -1,0 +1,61 @@
+---
+name: active-fanout
+description: Default orchestrator shape for parallelizing independent board lanes.
+triggers: [board-triage, multi-lane-work, project-2, watchdog]
+risk: medium
+surfaces: [mcp, scheduler, dashboard, telegram]
+---
+
+# Pattern: active fan-out
+
+Use this when the board contains multiple independent items or when one item naturally splits into disjoint worktrees, owners, or review lanes. The orchestrator coordinates the shape; peers do the implementation.
+
+## Default shape
+
+1. **Triage the board item.**
+   - If it is user-facing product work, keep it on the product tracker for the repo.
+   - If it is cross-repo orchestration work, keep it on the orchestrator board.
+   - If it is a transient status note, do not create a board item; use session history or a short notify.
+
+2. **Split by ownership.**
+   - One worktree per concern.
+   - One peer owner per implementation lane.
+   - Separate plan/review lanes when the plan can be critiqued independently.
+   - Avoid overlapping write scopes. If two peers would edit the same files, make one a reviewer instead of a parallel implementer.
+
+3. **Brief each lane.**
+   - Include board item title, repository/worktree, success criteria, docs impact, and reporting surface.
+   - Include relevant memory or pattern refs only when they materially change the work.
+   - Ask for plan-before-code when a wrong approach would cost more than about 30 minutes of rework.
+
+4. **Set watchdogs.**
+   - For each fan-out, schedule a self-wake or peer check-in before the work can go stale.
+   - Use `notify` for nudges and routine wakes.
+   - Use `ask` only when the future wake must create a tracked thread that requires closure.
+
+5. **Keep one source of truth.**
+   - The board owns item state.
+   - Peer descriptions expose current focus, not durable history.
+   - Session timelines and reports hold detail.
+   - Memory stores only forward-applicable lessons: "next time X comes up, do Y differently."
+
+6. **Consolidate without churn.**
+   - Update the board at meaningful state changes: Todo -> In Progress -> Done, with explicit blocker notes when needed.
+   - Do not write memory or board updates just because a turn ended.
+   - Prefer a single end-of-lane summary over many small status edits.
+
+## Productized runtime-hook direction
+
+These are orchestrator-scoped defaults for future automation, not global peer behavior:
+
+- **Input triage hook:** classify each user message as immediate reply, board candidate, memory candidate, dispatch command, or schedule request. Default to no write; ask before creating durable state unless the user explicitly named a board/memory action.
+- **Stop consolidation hook:** after orchestrator turns, suggest or stage memory/board/session-summary updates only when there is a durable lesson, a board state transition, or a delegated lane changed status.
+- **Scheduled background child peers:** use schedules to wake the orchestrator or a specific child peer for status, summary, cleanup, or review. Every recurring job needs an owner, cancellation path, and quiet default.
+- **Automatic description/summary jobs:** keep peer descriptions short and current; write longer summaries to session timeline/report surfaces, not memory.
+
+## Anti-patterns
+
+- **Orchestrator implementation drift.** If the work is substantive product implementation, spawn or reuse a project peer.
+- **Serial bottlenecking.** Do not wait for one independent lane before dispatching the next.
+- **Noisy durable writes.** A memory file, board edit, or project note must earn its place.
+- **Unowned background jobs.** Every schedule needs a clear reason, recipient, and cleanup path.

--- a/repowire/orchestrator/workspace.py
+++ b/repowire/orchestrator/workspace.py
@@ -35,6 +35,7 @@ SOURCE_FILE = "AGENTS.md"
 # offers per-file diff prompts for these.
 REPOWIRE_OWNED_FILES = (
     "AGENTS.md",
+    "patterns/active-fanout.md",
     "patterns/mesh-roundup.md",
     "patterns/two-model-critique.md",
     "patterns/release-bundle-decision.md",


### PR DESCRIPTION
## Summary

- Add a shipped orchestrator `active-fanout` pattern for decomposing independent board work into parallel peer lanes.
- Link the pattern from the orchestrator workspace manual and include it in template update tracking.
- Update public orchestrator docs with quiet watchdog scheduling, board/memory discipline, and the corrected product boundary around one-off external shortcuts.

## Notes

This is intentionally a safe guidance slice, not runtime hook automation. The productized direction is scoped to orchestrator behavior: input triage, stop consolidation, scheduled child-peer/background jobs, and short automatic descriptions/summaries should preserve user control and avoid noisy durable writes.

The `no one-off cheats` idea is not productized as generic doctrine. The docs frame one-off external shortcuts as configurable/local policy, not a universal orchestrator rule.

## Validation

- `uv run pytest tests/test_cli_orchestrator.py` passed: 11 tests.
- `git diff --check HEAD~1..HEAD` passed.

`ruff` and `mkdocs` were not available in the current uv environment without syncing dev dependencies, so they were not run here.