### PR TITLE
Add attachment metadata to message surfaces

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -54,7 +54,7 @@ Lifecycle/admin tools such as spawn, kill, and schedule mutation are disabled fo
 ### `ask`
 
 ```python
-ask(peer_name: str, query: str, reply_to: str | None = None, circle: str | None = None) -> str
+ask(peer_name: str, query: str, reply_to: str | None = None, circle: str | None = None, attachments: list[dict] | None = None) -> str
 ```
 
 Open a non-blocking ask thread. Returns a `correlation_id` immediately. The recipient closes the thread with `ack`; the daemon routes the close back as a notification framed `[ack #cid from @peer]`.
@@ -71,7 +71,7 @@ ask("project-b", "What API endpoints do you expose?")
 ### `ack`
 
 ```python
-ack(correlation_id: str, message: str | None = None) -> str
+ack(correlation_id: str, message: str | None = None, attachments: list[dict] | None = None) -> str
 ```
 
 Close an open ask. Bare `ack(cid)` signals "seen, no action needed." A reply `ack(cid, message)` closes the thread and delivers the message back to the original asker. Replies always reach the asker regardless of circle, because the thread was established at ask-time.
@@ -84,7 +84,7 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")
 ### `notify_peer`
 
 ```python
-notify_peer(peer_name: str, message: str, circle: str | None = None) -> str
+notify_peer(peer_name: str, message: str, circle: str | None = None, attachments: list[dict] | None = None) -> str
 ```
 
 Fire-and-forget. No lifecycle, no expected response. Returns a synthetic `notif-XXXXXXXX` ID for client-side tracking, not a thread you can close. Use for status pings and announcements.
@@ -96,6 +96,11 @@ The special peer `telegram` routes to the user's phone. The `dashboard` already 
 ```python
 notify_peer("telegram", "deploy finished, green across CI")
 ```
+
+`ask`, reply `ack`, and `notify_peer` accept optional attachment metadata
+objects (`id`, `path`, `filename`, `size`, `content_type`). Text-only calls are
+unchanged; surfaces should still include a local path in text when targeting an
+older transport that may ignore the structured field.
 
 ### `broadcast`
 

--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -65,6 +65,10 @@ bc = await client.broadcast(
 print(bc)
 ```
 
+`ask`, `ack`, and `notify` also accept an optional `attachments=[...]` list using
+daemon attachment metadata (`id`, `path`, `filename`, `size`, `content_type`).
+Omit it for the text-only shape; existing callers do not need to change.
+
 ## Listing and inspection
 
 Pull current mesh state. `list_peers` accepts daemon-supported filters; `get_peer` resolves a single peer by name or id. `pending_asks` returns open asks targeting one pane or peer.

--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -8,7 +8,8 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 - **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, and broadcasts.
 - **Per-peer chat** — selecting a peer replaces the live log with that peer's selected-session timeline. For Claude Code peers, the chat view merges persisted transcript history with realtime `chat_turn` and `chat_turn_delta` events; other backends contribute realtime events. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
 - **Compose bar** — send a notification or ask to any peer. The dashboard registers as the `dashboard` peer so it shows up in `list_peers` and message routing.
-- **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL) and the resulting path is included in the notification so the recipient agent can read it.
+- **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL). The outgoing ask carries structured attachment metadata plus a text fallback with the local path so existing agents can still read it.
+- **Attachment chips** — mesh events and per-peer chat render attachment chips with download links when an attachment ID is available.
 
 ## Where chat turns come from
 

--- a/docs/surfaces/telegram.md
+++ b/docs/surfaces/telegram.md
@@ -48,7 +48,9 @@ notify_peer("telegram", "deploy finished, green across CI")
 
 ## Attachments
 
-The bot downloads photos sent in Telegram, uploads them to the daemon via `POST /attachments`, and includes the resulting local path in the outgoing ask. The recipient agent can then read the image via its multimodal tool — Claude's `Read` tool, for instance, accepts the local path directly.
+The bot downloads photos sent in Telegram, uploads them to the daemon via `POST /attachments`, and sends both the attachment metadata and a text fallback with the resulting local path in the outgoing ask. The recipient agent can then read the image via its multimodal tool — Claude's `Read` tool, for instance, accepts the local path directly.
+
+When messages arrive from Repowire with attachment metadata, the bot sends local image files as Telegram photos and other local files as documents when it can access the daemon-local path. If the file is not local to the bot, it falls back to a download link.
 
 Attachments live in `~/.repowire/attachments/` with a 24-hour TTL.
 

--- a/repowire/channel/server.ts
+++ b/repowire/channel/server.ts
@@ -34,6 +34,19 @@ let displayName: string = PROPOSED_NAME;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 const pendingCorrelations = new Map<string, string>(); // correlation_id -> from_peer
 
+function attachmentText(attachments: unknown): string {
+  if (!Array.isArray(attachments) || attachments.length === 0) return "";
+  const lines = ["", "Attachments:"];
+  for (const item of attachments) {
+    if (!item || typeof item !== "object") continue;
+    const att = item as Record<string, unknown>;
+    const label = att.filename ?? att.path ?? att.id ?? "attachment";
+    const target = att.path ?? (att.id ? `/attachments/${att.id}` : "");
+    lines.push(target ? `- ${label}: ${target}` : `- ${label}`);
+  }
+  return lines.length > 2 ? lines.join("\n") : "";
+}
+
 function connectDaemon(mcp: Server): void {
   const url = `${DAEMON_URL.replace("http://", "ws://").replace("https://", "wss://")}/ws`;
 
@@ -95,7 +108,7 @@ function connectDaemon(mcp: Server): void {
       await mcp.notification({
         method: "notifications/claude/channel",
         params: {
-          content: msg.text ?? "",
+          content: `${msg.text ?? ""}${attachmentText(msg.attachments)}`,
           meta,
         },
       });

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 
 from repowire.config.models import DEFAULT_DAEMON_URL
 from repowire.protocol.errors import DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError
+from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerRole
 
 
@@ -132,6 +133,7 @@ class AttachmentInfo(BaseModel):
     path: str
     filename: str
     size: int
+    content_type: str | None = None
 
 
 class OrchestratorStatus(BaseModel):
@@ -348,6 +350,7 @@ class AsyncRepowireClient:
         text: str,
         *,
         from_peer: str,
+        attachments: list[AttachmentRef | dict[str, Any]] | None = None,
         reply_to: str | None = None,
         bypass_circle: bool = False,
         circle: str | None = None,
@@ -361,15 +364,35 @@ class AsyncRepowireClient:
         }
         if reply_to is not None:
             payload["reply_to"] = reply_to
+        if attachments:
+            payload["attachments"] = [
+                a.model_dump(exclude_none=True) if isinstance(a, AttachmentRef) else a
+                for a in attachments
+            ]
         if circle is not None:
             payload["circle"] = circle
         return AskResult.model_validate(await self._request("POST", "/ask", json=payload))
 
-    async def ack(self, correlation_id: str, *, from_peer: str, message: str | None = None) -> None:
+    async def ack(
+        self,
+        correlation_id: str,
+        *,
+        from_peer: str,
+        message: str | None = None,
+        attachments: list[AttachmentRef | dict[str, Any]] | None = None,
+    ) -> None:
         """Close an ask, optionally delivering a reply message."""
-        payload = {"correlation_id": correlation_id, "from_peer": from_peer}
+        payload: dict[str, Any] = {
+            "correlation_id": correlation_id,
+            "from_peer": from_peer,
+        }
         if message is not None:
             payload["message"] = message
+        if attachments:
+            payload["attachments"] = [
+                a.model_dump(exclude_none=True) if isinstance(a, AttachmentRef) else a
+                for a in attachments
+            ]
         await self._request("POST", "/ack", json=payload)
 
     async def pending_asks(
@@ -389,6 +412,7 @@ class AsyncRepowireClient:
         text: str,
         *,
         from_peer: str,
+        attachments: list[AttachmentRef | dict[str, Any]] | None = None,
         bypass_circle: bool = False,
         circle: str | None = None,
     ) -> None:
@@ -401,6 +425,11 @@ class AsyncRepowireClient:
         }
         if circle is not None:
             payload["circle"] = circle
+        if attachments:
+            payload["attachments"] = [
+                a.model_dump(exclude_none=True) if isinstance(a, AttachmentRef) else a
+                for a in attachments
+            ]
         await self._request("POST", "/notify", json=payload)
 
     async def broadcast(

--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -10,8 +10,20 @@ from typing import Any
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.websocket_transport import TransportError, WebSocketTransport
+from repowire.protocol.messages import AttachmentRef
 
 logger = logging.getLogger(__name__)
+
+
+def _dump_attachments(
+    attachments: list[AttachmentRef] | list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    if not attachments:
+        return []
+    return [
+        a.model_dump(exclude_none=True) if isinstance(a, AttachmentRef) else a
+        for a in attachments
+    ]
 
 
 class MessageRouter:
@@ -100,6 +112,7 @@ class MessageRouter:
         to_peer_name: str,
         text: str,
         intended_recipient_name: str | None = None,
+        attachments: list[AttachmentRef] | list[dict[str, Any]] | None = None,
     ) -> None:
         """Send a plain FYI notification (fire-and-forget, no lifecycle).
 
@@ -115,6 +128,8 @@ class MessageRouter:
             "to_peer": to_peer_name,
             "text": text,
         }
+        if attachments:
+            message["attachments"] = _dump_attachments(attachments)
         logger.info(
             "Notify delivery trace: sender_identity=%s intended_recipient_name=%s "
             "resolved_peer_id=%s frame.to_peer=%s actual_delivered_pane_id=%s",
@@ -136,6 +151,7 @@ class MessageRouter:
         text: str,
         reply_to: str | None = None,
         intended_recipient_name: str | None = None,
+        attachments: list[AttachmentRef] | list[dict[str, Any]] | None = None,
     ) -> None:
         """Send a first-class ask wire message.
 
@@ -159,6 +175,8 @@ class MessageRouter:
             "to_peer": to_peer_name,
             "text": hinted_text,
         }
+        if attachments:
+            message["attachments"] = _dump_attachments(attachments)
         if reply_to is not None:
             message["reply_to"] = reply_to
         logger.info(

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -35,6 +35,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _serialize_attachments(attachments: list | None) -> list[dict[str, Any]]:
+    if not attachments:
+        return []
+    return [
+        item.model_dump(exclude_none=True) if hasattr(item, "model_dump") else item
+        for item in attachments
+    ]
+
+
 def normalize_identity_path(raw: str) -> str:
     """Canonical path form for asker identity matching.
 
@@ -1038,6 +1047,7 @@ class PeerRegistry:
         text: str,
         bypass_circle: bool = False,
         circle: str | None = None,
+        attachments: list | None = None,
     ) -> Literal["sent", "queued"]:
         """Send a notification to a peer (fire-and-forget).
 
@@ -1074,6 +1084,7 @@ class PeerRegistry:
                 "from": from_peer_name, "to": peer_name, "text": text,
                 "from_peer_id": from_peer_id, "to_peer_id": peer_id,
                 "delivery_status": delivery_status,
+                "attachments": _serialize_attachments(attachments),
             },
         )
 
@@ -1083,6 +1094,7 @@ class PeerRegistry:
             to_peer_name=peer_name,
             text=text,
             intended_recipient_name=to_peer,
+            attachments=attachments,
         )
         return delivery_status
 
@@ -1095,6 +1107,7 @@ class PeerRegistry:
         reply_to: str | None = None,
         bypass_circle: bool = False,
         circle: str | None = None,
+        attachments: list | None = None,
     ) -> None:
         """Inject an ask to a peer as a type=ask wire frame.
 
@@ -1125,6 +1138,7 @@ class PeerRegistry:
                 "correlation_id": correlation_id,
                 "reply_to": reply_to,
                 "self_target": from_peer_id == peer_id,
+                "attachments": _serialize_attachments(attachments),
             },
         )
 
@@ -1136,6 +1150,7 @@ class PeerRegistry:
             text=text,
             reply_to=reply_to,
             intended_recipient_name=to_peer,
+            attachments=attachments,
         )
 
     async def broadcast(

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -35,6 +35,7 @@ from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
 from repowire.daemon.routes._shared import OkResponse
 from repowire.daemon.transport_router import AskEnvelope, transport_router_from_state
 from repowire.daemon.websocket_transport import TransportError
+from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,10 @@ class AskRequest(BaseModel):
     from_peer: str = Field(..., description="Display name of the sender")
     to_peer: str = Field(..., description="Display name of the recipient")
     text: str = Field(..., description="Ask content")
+    attachments: list[AttachmentRef] = Field(
+        default_factory=list,
+        description="Optional daemon attachment metadata to carry with the ask",
+    )
     reply_to: str | None = Field(
         None,
         description="If set, closes the referenced ask AND opens this new one",
@@ -67,6 +72,10 @@ class AckRequest(BaseModel):
 
     correlation_id: str
     message: str | None = None
+    attachments: list[AttachmentRef] = Field(
+        default_factory=list,
+        description="Optional daemon attachment metadata to carry with an ack reply",
+    )
     from_peer: str | None = Field(
         None,
         description=(
@@ -330,6 +339,7 @@ async def open_ask(
                 correlation_id=cid,
                 reply_to=request.reply_to,
                 intended_recipient_name=request.to_peer,
+                attachments=tuple(request.attachments),
             ),
             on_acp_complete=_on_acp_complete,
         )
@@ -388,7 +398,7 @@ async def ack_ask(
             status_code=404,
             detail=f"No open ask with correlation_id: {request.correlation_id}",
         )
-    if existing.closed and request.message:
+    if existing.closed and (request.message or request.attachments):
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail=(
@@ -400,16 +410,20 @@ async def ack_ask(
         # Idempotent bare re-ack: already closed, nothing to do.
         return OkResponse()
 
-    if request.message:
+    if request.message or request.attachments:
         # bypass_circle=True: ack closes a thread already established at
         # ask-time; circle gate doesn't reapply.
-        framed = f"[ack #{request.correlation_id} from @{existing.to_peer_name}] {request.message}"
+        framed = (
+            f"[ack #{request.correlation_id} from @{existing.to_peer_name}] "
+            f"{request.message or ''}"
+        )
         try:
             await peer_registry.notify(
                 from_peer=existing.to_peer_id,
                 to_peer=existing.from_peer_id,
                 text=framed,
                 bypass_circle=True,
+                attachments=request.attachments,
             )
         except ValueError as e:
             # Asker peer no longer in registry. Close as best-effort and

--- a/repowire/daemon/routes/attachments.py
+++ b/repowire/daemon/routes/attachments.py
@@ -58,7 +58,7 @@ async def upload_attachment(
     file: UploadFile,
     _: str | None = Depends(require_auth),
 ) -> dict:
-    """Upload a file attachment. Returns {id, path, filename, size}."""
+    """Upload a file attachment. Returns metadata for mesh message references."""
     if file.size and file.size > MAX_FILE_SIZE:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -113,6 +113,7 @@ async def upload_attachment(
         "path": str(dest),
         "filename": file.filename or dest.name,
         "size": size,
+        "content_type": file.content_type,
     }
 
 

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -18,6 +18,7 @@ from repowire.daemon.transport_router import (
     NotifyEnvelope,
     transport_router_from_state,
 )
+from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerStatus, TurnState
 
 router = APIRouter(tags=["messages"])
@@ -48,6 +49,10 @@ class NotifyRequest(BaseModel):
     from_peer: str = Field(..., description="Name of the sending peer")
     to_peer: str = Field(..., description="Name of the target peer")
     text: str = Field(..., description="Notification text")
+    attachments: list[AttachmentRef] = Field(
+        default_factory=list,
+        description="Optional daemon attachment metadata to carry with the message",
+    )
     bypass_circle: bool = Field(default=False, description="Bypass circle restrictions (CLI mode)")
     circle: str | None = Field(None, description="Circle to scope target peer lookup")
 
@@ -227,6 +232,7 @@ async def notify_peer(
                 target=target,
                 text=request.text,
                 intended_recipient_name=request.to_peer,
+                attachments=tuple(request.attachments),
             )
         )
         return NotifyResponse(status=delivery_status)

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -16,7 +16,19 @@ from repowire.acp import AcpRouteDecision, deliver_ask_via_acp, maybe_decide_acp
 from repowire.config.models import Config
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
+from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer, PeerStatus
+
+
+def _text_with_attachment_fallback(text: str, attachments: tuple[AttachmentRef, ...]) -> str:
+    if not attachments:
+        return text
+    lines = ["", "Attachments:"]
+    for attachment in attachments:
+        label = attachment.filename or attachment.path or attachment.id or "attachment"
+        target = attachment.path or (f"/attachments/{attachment.id}" if attachment.id else "")
+        lines.append(f"- {label}: {target}" if target else f"- {label}")
+    return text + "\n".join(lines)
 
 
 @dataclass(frozen=True)
@@ -30,6 +42,7 @@ class AskEnvelope:
     correlation_id: str
     reply_to: str | None = None
     intended_recipient_name: str | None = None
+    attachments: tuple[AttachmentRef, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -41,6 +54,7 @@ class NotifyEnvelope:
     target: Peer
     text: str
     intended_recipient_name: str | None = None
+    attachments: tuple[AttachmentRef, ...] = ()
 
 
 class AskCompletion(Protocol):
@@ -71,6 +85,7 @@ class WebSocketPeerTransport:
                 "correlation_id": envelope.correlation_id,
                 "reply_to": envelope.reply_to,
                 "self_target": envelope.from_peer_id == envelope.target.peer_id,
+                "attachments": [a.model_dump(exclude_none=True) for a in envelope.attachments],
             },
         )
         await self._router.send_ask(
@@ -83,6 +98,7 @@ class WebSocketPeerTransport:
             intended_recipient_name=(
                 envelope.intended_recipient_name or envelope.target.display_name
             ),
+            attachments=list(envelope.attachments),
         )
 
     async def send_notify(
@@ -101,6 +117,7 @@ class WebSocketPeerTransport:
                 "from_peer_id": envelope.from_peer_id,
                 "to_peer_id": envelope.target.peer_id,
                 "delivery_status": delivery_status,
+                "attachments": [a.model_dump(exclude_none=True) for a in envelope.attachments],
             },
         )
         await self._router.send_notification(
@@ -111,6 +128,7 @@ class WebSocketPeerTransport:
             intended_recipient_name=(
                 envelope.intended_recipient_name or envelope.target.display_name
             ),
+            attachments=list(envelope.attachments),
         )
         return delivery_status
 
@@ -140,7 +158,7 @@ class AcpPeerTransport:
             manager=self._manager,
             spec=decision.spec,
             correlation_id=envelope.correlation_id,
-            text=envelope.text,
+            text=_text_with_attachment_fallback(envelope.text, envelope.attachments),
             on_complete=on_complete,
         )
 
@@ -166,7 +184,7 @@ class AcpPeerTransport:
             manager=self._manager,
             spec=decision.spec,
             correlation_id=cid,
-            text=envelope.text,
+            text=_text_with_attachment_fallback(envelope.text, envelope.attachments),
             on_complete=_drop_result,
         )
         return "sent"

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import time
+from typing import cast
 
 try:
     import websockets
@@ -48,6 +49,23 @@ _consecutive_ping_unsafe = 0
 _CONSECUTIVE_PANE_UNSAFE_PINGS = 3
 _RECONNECT_WARNING_ATTEMPTS = 50
 _MAX_RECONNECT_DELAY_SECONDS = 30
+
+
+def _format_attachment_lines(attachments: object) -> str:
+    """Render attachment metadata into agent-readable fallback text."""
+    if not isinstance(attachments, list) or not attachments:
+        return ""
+    lines = ["", "Attachments:"]
+    for item in attachments:
+        if not isinstance(item, dict):
+            continue
+        attachment = cast(dict[str, object], item)
+        attachment_id = attachment.get("id")
+        path = attachment.get("path")
+        label = attachment.get("filename") or path or attachment_id or "attachment"
+        target = path or (f"/attachments/{attachment_id}" if attachment_id else "")
+        lines.append(f"- {label}: {target}" if target else f"- {label}")
+    return "\n".join(lines) if len(lines) > 2 else ""
 
 
 class PaneUnsafeError(RuntimeError):
@@ -377,7 +395,7 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         correlation_id = data.get("correlation_id", "")
         from_peer = data.get("from_peer", "unknown")
         to_peer = data.get("to_peer", "")
-        text = data.get("text", "")
+        text = data.get("text", "") + _format_attachment_lines(data.get("attachments"))
         # `to_peer` is included so a recipient can spot misroutes when two
         # peers share a display_name across circles (issue #136). Older
         # daemons may omit it — keep the legacy frame in that case.
@@ -396,7 +414,7 @@ async def handle_message(data: dict, pane_id: str, websocket=None) -> None:
         try:
             from_peer = data.get("from_peer", "unknown")
             to_peer = data.get("to_peer", "")
-            text = data.get("text", "")
+            text = data.get("text", "") + _format_attachment_lines(data.get("attachments"))
             to_label = f" → @{to_peer}" if to_peer else ""
             if await asyncio.to_thread(
                 _tmux_send_keys, pane_id, f"@{from_peer}{to_label}: {text}",

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -567,39 +567,22 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         query: str,
         reply_to: str | None = None,
         circle: str | None = None,
+        attachments: list[dict] | None = None,
     ) -> str:
         """[Repowire mesh] Open a non-blocking ask thread with a peer.
 
-        Use ask when you need a tracked thread that the recipient must close
-        with `ack`, such as a worker status check or reviewer checkpoint. Use
-        notify_peer for fire-and-forget updates, reminders, and nudges.
-        Asking yourself is valid for deliberate loopback checks, but use
-        notify_peer or schedule_self(kind="notify") for self-wakes/reminders
-        that do not need tracked closure.
-
-        Returns immediately with a correlation_id. The peer receives the
-        ask, and when they respond they call `ack(correlation_id)` (bare
-        close, "seen, no action") or `ack(correlation_id, message)` (close
-        with reply content delivered back to you as a notification framed
-        `[ack #correlation_id from @peer] message`).
-
-        To chain a follow-up: call `ask(peer_name, query, reply_to=corr_id)`.
-        That closes the prior thread AND opens a new one referencing it.
-
-        Ask is not a synchronous wait or delivery receipt. The MCP surface is
-        non-blocking by design; watch notifications for the eventual ack.
-
-        Do not use SendMessage to reach repowire peers. SendMessage is a
-        Claude Code harness tool for same-session teammates only.
+        Use for tracked work that the recipient must close with `ack`. The
+        call returns a correlation_id immediately; it is not a synchronous
+        wait or delivery receipt. Use notify_peer for fire-and-forget nudges.
+        Chain follow-ups with `reply_to`, which closes the prior thread and
+        opens a new one. Do not use SendMessage for mesh peers.
 
         Args:
             peer_name: Display name or peer_id of the peer to ask.
             query: The question or request to send
             reply_to: If set, closes that prior ask before opening this one
-            circle: Circle to scope the lookup. Defaults to your own circle,
-                    with fallback to peers whose role bypasses circles
-                    (service, orchestrator, human). Pass explicitly to target
-                    a peer in a different circle.
+            circle: Optional target lookup circle.
+            attachments: Optional daemon attachment metadata objects.
 
         Returns:
             correlation_id for tracking this ask thread
@@ -617,13 +600,19 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
             body["reply_to"] = reply_to
         if effective_circle is not None:
             body["circle"] = effective_circle
+        if attachments:
+            body["attachments"] = attachments
         result = await daemon_request("POST", "/ask", body)
         if result.get("error"):
             raise Exception(result["error"])
         return result.get("correlation_id", "")
 
     @mcp.tool()
-    async def ack(correlation_id: str, message: str | None = None) -> str:
+    async def ack(
+        correlation_id: str,
+        message: str | None = None,
+        attachments: list[dict] | None = None,
+    ) -> str:
         """[Repowire mesh] Close an open ask thread.
 
         Bare ack: `ack(corr_id)` — closes the thread, signals "seen, no
@@ -639,6 +628,8 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         Args:
             correlation_id: The ask's correlation_id
             message: Optional reply content. Omit for bare close.
+            attachments: Optional daemon attachment metadata objects to send
+                    with a reply.
 
         Returns:
             Confirmation message
@@ -651,11 +642,20 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         }
         if message is not None:
             body["message"] = message
+        if attachments:
+            body["attachments"] = attachments
         await daemon_request("POST", "/ack", body)
-        return f"acked #{correlation_id}" + (" with reply" if message else "")
+        return f"acked #{correlation_id}" + (
+            " with reply" if (message or attachments) else ""
+        )
 
     @mcp.tool()
-    async def notify_peer(peer_name: str, message: str, circle: str | None = None) -> str:
+    async def notify_peer(
+        peer_name: str,
+        message: str,
+        circle: str | None = None,
+        attachments: list[dict] | None = None,
+    ) -> str:
         """[Repowire mesh] Send a fire-and-forget notification to a peer in another project.
 
         Use for status updates, announcements, replies to notifications,
@@ -676,6 +676,8 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
                     with fallback to peers whose role bypasses circles
                     (service, orchestrator, human). Pass explicitly to target
                     a peer in a different circle.
+            attachments: Optional daemon attachment metadata objects. Existing
+                    text-only callers can omit this.
 
         Returns:
             Correlation ID (format: notif-XXXXXXXX) for tracking.
@@ -692,6 +694,8 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         }
         if effective_circle is not None:
             body["circle"] = effective_circle
+        if attachments:
+            body["attachments"] = attachments
         await daemon_request("POST", "/notify", body)
         return correlation_id
 

--- a/repowire/protocol/messages.py
+++ b/repowire/protocol/messages.py
@@ -10,6 +10,16 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 
 
+class AttachmentRef(BaseModel):
+    """Attachment metadata carried alongside mesh message text."""
+
+    id: str | None = Field(None, description="Daemon attachment ID, if uploaded")
+    path: str | None = Field(None, description="Daemon-local file path, if available")
+    filename: str | None = Field(None, description="Original or display filename")
+    size: int | None = Field(None, description="Size in bytes, if known")
+    content_type: str | None = Field(None, description="MIME type, if known")
+
+
 class MessageType(str, Enum):
     """Type of message in the mesh."""
 

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -19,7 +19,7 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import quote, urlparse, urlunparse
 
 import httpx
@@ -69,6 +69,7 @@ class PendingRetry:
     text: str
     expires_at: float
     mode: Literal["ask", "notify"] = "ask"
+    attachments: list[dict[str, Any]] | None = None
 
     def is_active(self, now: float) -> bool:
         return now < self.expires_at
@@ -320,10 +321,12 @@ class TelegramPeer:
         t = msg.get("type", "")
         who = msg.get("from_peer", "?")
         text = msg.get("text", "")
+        attachments = msg.get("attachments", [])
 
         if t == "notify":
             self._touch_recent(who)
             await self._tg_send(f"*@{_esc(who)}*\n{_esc(text)}")
+            await self._tg_send_attachments(attachments)
         elif t == "query":
             self._touch_recent(who)
             await self._tg_send(f"❓ *@{_esc(who)}*\n{_esc(text)}")
@@ -336,9 +339,11 @@ class TelegramPeer:
                 f"❓ *@{_esc(who)}* `[ask #{_esc(short_cid)}]`\n{_esc(text)}",
                 markup=markup,
             )
+            await self._tg_send_attachments(attachments)
         elif t == "broadcast":
             self._touch_recent(who)
             await self._tg_send(f"📢 *@{_esc(who)}*\n{_esc(text)}")
+            await self._tg_send_attachments(attachments)
         elif t == "ping" and self._ws:
             await self._ws.send(json.dumps({"type": "pong"}))
 
@@ -550,6 +555,7 @@ class TelegramPeer:
                 retry.text,
                 message_id=message_id,
                 mode=retry.mode,
+                attachments=retry.attachments,
             )
             return
 
@@ -605,7 +611,12 @@ class TelegramPeer:
             msg = caption or "Photo attached"
             msg += f"\n[Attachment: {att['path']}]"
 
-            await self._ask(self._reply_target, msg, message_id=message_id)
+            await self._ask(
+                self._reply_target,
+                msg,
+                message_id=message_id,
+                attachments=[att],
+            )
         except Exception as e:
             await self._tg_send(f"Error: {_esc(str(e))}")
 
@@ -717,11 +728,27 @@ class TelegramPeer:
 
         await self._tg_send("\n".join(lines), markup=_kb(rows))
 
-    async def _ask(self, peer: str, message: str, message_id: int | None = None) -> None:
-        await self._send_peer_message(peer, message, message_id=message_id, mode="ask")
+    async def _ask(
+        self,
+        peer: str,
+        message: str,
+        message_id: int | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        await self._send_peer_message(
+            peer, message, message_id=message_id, mode="ask", attachments=attachments,
+        )
 
-    async def _notify(self, peer: str, message: str, message_id: int | None = None) -> None:
-        await self._send_peer_message(peer, message, message_id=message_id, mode="notify")
+    async def _notify(
+        self,
+        peer: str,
+        message: str,
+        message_id: int | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        await self._send_peer_message(
+            peer, message, message_id=message_id, mode="notify", attachments=attachments,
+        )
 
     async def _send_peer_message(
         self,
@@ -730,16 +757,20 @@ class TelegramPeer:
         message_id: int | None = None,
         *,
         mode: Literal["ask", "notify"],
+        attachments: list[dict[str, Any]] | None = None,
     ) -> None:
         endpoint = "ask" if mode == "ask" else "notify"
+        body: dict[str, Any] = {
+            "from_peer": self._display_name,
+            "to_peer": peer,
+            "text": message,
+        }
+        if attachments:
+            body["attachments"] = attachments
         try:
             r = await self._http.post(
                 f"{self._daemon_url}/{endpoint}",
-                json={
-                    "from_peer": self._display_name,
-                    "to_peer": peer,
-                    "text": message,
-                },
+                json=body,
             )
             if r.status_code == 200:
                 if message_id:
@@ -754,6 +785,7 @@ class TelegramPeer:
                     text=message,
                     expires_at=time.monotonic() + RETRY_WINDOW_S,
                     mode=mode,
+                    attachments=attachments,
                 )
                 await self._tg_send(
                     f"✗ Couldn't reach *@{_esc(peer)}*: {_esc(str(detail))}\n"
@@ -764,6 +796,7 @@ class TelegramPeer:
                 text=message,
                 expires_at=time.monotonic() + RETRY_WINDOW_S,
                 mode=mode,
+                attachments=attachments,
             )
             await self._tg_send(
                 f"⚠️ Daemon unreachable: {_esc(str(e))}\n"
@@ -800,6 +833,44 @@ class TelegramPeer:
             await self._http.post(f"{self._bot_path}/sendMessage", json=payload)
         except Exception:
             logger.warning("Telegram send failed", exc_info=True)
+
+    async def _tg_send_attachments(self, attachments: object) -> None:
+        if not isinstance(attachments, list):
+            return
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            attachment_data = cast(dict[str, Any], attachment)
+            path = attachment_data.get("path")
+            attachment_id = attachment_data.get("id")
+            filename = attachment_data.get("filename") or (
+                Path(path).name if isinstance(path, str) else "attachment"
+            )
+            content_type = str(attachment_data.get("content_type") or "")
+            try:
+                if isinstance(path, str) and Path(path).exists():
+                    method = "sendPhoto" if content_type.startswith("image/") else "sendDocument"
+                    field = "photo" if method == "sendPhoto" else "document"
+                    with open(path, "rb") as fh:
+                        await self._http.post(
+                            f"{self._bot_path}/{method}",
+                            data={"chat_id": self._chat_id},
+                            files={
+                                field: (
+                                    filename,
+                                    fh,
+                                    content_type or "application/octet-stream",
+                                )
+                            },
+                        )
+                    continue
+                if attachment_id:
+                    await self._tg_send(
+                        f"📎 {_esc(str(filename))}\n"
+                        f"{_esc(self._daemon_url + '/attachments/' + str(attachment_id))}"
+                    )
+            except Exception:
+                logger.warning("Telegram attachment send failed", exc_info=True)
 
     async def _current_reply_keyboard(self) -> dict:
         """Build the persistent keyboard from fresh peer data."""

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -187,6 +187,30 @@ class TestAsk:
         assert event["to_peer_id"] == bob["peer_id"]
         assert event["self_target"] is False
 
+    async def test_ask_carries_attachments_to_event_and_wire(self, env):
+        client, registry, _, msg_router = env
+        alice = await _register_peer_info(client, "alice")
+        bob = await _register_peer_info(client, "bob")
+
+        r = await client.post("/ask", json={
+            "from_peer": alice["peer_id"],
+            "to_peer": bob["peer_id"],
+            "text": "see image",
+            "attachments": [{
+                "id": "att123",
+                "path": "/tmp/att123.png",
+                "filename": "diagram.png",
+                "size": 123,
+                "content_type": "image/png",
+            }],
+        })
+
+        assert r.status_code == 200
+        kwargs = msg_router.send_ask.await_args.kwargs
+        assert kwargs["attachments"][0].id == "att123"
+        event = registry.get_events()[-1]
+        assert event["attachments"][0]["filename"] == "diagram.png"
+
     async def test_self_ask_succeeds_with_diagnostic_event_marker(self, env):
         client, registry, at, msg_router = env
         alice = await _register_peer_info(client, "alice")
@@ -239,6 +263,34 @@ class TestAck:
         ask = await at.get(cid)
         assert ask.closed
         assert ask.close_reason == "ack_with_msg"
+
+    async def test_ack_reply_carries_attachments(self, env):
+        client, registry, at, msg_router = env
+        alice = await _register_peer_info(client, "alice")
+        bob = await _register_peer_info(client, "bob")
+        r = await client.post("/ask", json={
+            "from_peer": alice["peer_id"], "to_peer": bob["peer_id"], "text": "?",
+        })
+        cid = r.json()["correlation_id"]
+
+        r = await client.post("/ack", json={
+            "correlation_id": cid,
+            "from_peer": bob["display_name"],
+            "message": "attached",
+            "attachments": [{
+                "id": "att123",
+                "path": "/tmp/att123.png",
+                "filename": "diagram.png",
+            }],
+        })
+
+        assert r.status_code == 200
+        ask = await at.get(cid)
+        assert ask.closed
+        kwargs = msg_router.send_notification.await_args.kwargs
+        assert kwargs["attachments"][0].id == "att123"
+        event = registry.get_events()[-1]
+        assert event["attachments"][0]["filename"] == "diagram.png"
 
     async def test_ack_reply_uses_stored_peer_ids_not_reported_from_peer(self, env):
         client, registry, at, msg_router = env

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,6 +133,40 @@ async def test_ask_ack_and_pending(client: AsyncRepowireClient):
     assert await client.pending_asks(peer_id=bob.peer_id) == []
 
 
+async def test_ask_notify_ack_accept_attachments(client: AsyncRepowireClient):
+    alice = await client.register_peer("alice", path="/tmp/alice", circle="default")
+    bob = await client.register_peer("bob", path="/tmp/bob", circle="default")
+    attachment = {
+        "id": "att123",
+        "path": "/tmp/att123.png",
+        "filename": "diagram.png",
+        "content_type": "image/png",
+    }
+
+    opened = await client.ask(
+        bob.display_name,
+        "see image",
+        from_peer=alice.display_name,
+        attachments=[attachment],
+    )
+    await client.ack(
+        opened.correlation_id,
+        from_peer=bob.display_name,
+        message="reply",
+        attachments=[attachment],
+    )
+    await client.notify(
+        bob.display_name,
+        "heads up",
+        from_peer=alice.display_name,
+        attachments=[attachment],
+    )
+
+    events = await client.events()
+    assert events[0].attachments[0]["filename"] == "diagram.png"
+    assert events[-1].attachments[0]["id"] == "att123"
+
+
 async def test_notify_broadcast_events_and_chat_ingest(client: AsyncRepowireClient):
     alice = await client.register_peer("alice", path="/tmp/alice", circle="default")
     bob = await client.register_peer("bob", path="/tmp/bob", circle="default")

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -39,6 +39,27 @@ class TestSendNotification:
         assert msg["to_peer"] == "recipient"
         assert msg["text"] == "hello"
 
+    async def test_sends_attachments_to_transport(self, router, transport):
+        await router.send_notification(
+            "sender",
+            "sid-1",
+            "recipient",
+            "hello",
+            attachments=[{
+                "id": "att-1",
+                "path": "/tmp/a.png",
+                "filename": "a.png",
+                "content_type": "image/png",
+            }],
+        )
+        msg = transport.send.call_args[0][1]
+        assert msg["attachments"] == [{
+            "id": "att-1",
+            "path": "/tmp/a.png",
+            "filename": "a.png",
+            "content_type": "image/png",
+        }]
+
     async def test_transport_error_propagates(self, router, transport):
         transport.send.side_effect = TransportError("disconnected")
         with pytest.raises(TransportError):
@@ -183,3 +204,21 @@ class TestSendAsk:
         )
         msg = transport.send.call_args[0][1]
         assert msg["reply_to"] == "ask-prior"
+
+    async def test_includes_attachments(self, router, transport):
+        await router.send_ask(
+            from_peer="alice",
+            to_session_id="sid-bob",
+            to_peer_name="bob",
+            correlation_id="ask-new",
+            text="see file",
+            attachments=[{
+                "id": "att-1",
+                "path": "/tmp/a.png",
+                "filename": "a.png",
+                "content_type": "image/png",
+            }],
+        )
+        msg = transport.send.call_args[0][1]
+        assert msg["attachments"][0]["id"] == "att-1"
+        assert msg["attachments"][0]["path"] == "/tmp/a.png"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -936,6 +936,41 @@ class TestNotify:
         assert body["ok"] is True
         assert body["status"] == "sent"
 
+    async def test_notify_carries_attachments_to_event_and_wire(self, client, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        registry = get_peer_registry()
+        _sender_id, sender_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/sender-att",
+        )
+        _recipient_id, recipient_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/recipient-att",
+        )
+        monkeypatch.setattr(
+            registry._router, "send_notification", AsyncMock(return_value=None),
+        )
+
+        r = await client.post("/notify", json={
+            "from_peer": sender_name,
+            "to_peer": recipient_name,
+            "text": "see file",
+            "attachments": [{
+                "id": "att123",
+                "path": "/tmp/att123.png",
+                "filename": "diagram.png",
+            }],
+        })
+
+        assert r.status_code == 200
+        kwargs = registry._router.send_notification.await_args.kwargs
+        assert kwargs["attachments"][0].id == "att123"
+        event = registry.get_events()[-1]
+        assert event["attachments"][0]["filename"] == "diagram.png"
+
     async def test_notify_busy_recipient_returns_queued(self, client, monkeypatch):
         from unittest.mock import AsyncMock
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -262,6 +262,27 @@ async def test_send_peer_message_uses_daemon_assigned_service_name(
     assert post.await_args.kwargs["json"]["to_peer"] == "agent"
 
 
+@pytest.mark.asyncio
+async def test_send_peer_message_includes_attachments(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = AsyncMock()
+    post.return_value = SimpleNamespace(status_code=200)
+    monkeypatch.setattr(telegram_bot._http, "post", post)
+
+    await telegram_bot._ask(
+        "agent",
+        "see image",
+        attachments=[{
+            "id": "att123",
+            "path": "/tmp/att123.png",
+            "filename": "diagram.png",
+        }],
+    )
+
+    assert post.await_args.kwargs["json"]["attachments"][0]["id"] == "att123"
+
+
 # -- PendingRetry TTL --
 
 

--- a/web/app/dashboard/components/MeshFeed.test.tsx
+++ b/web/app/dashboard/components/MeshFeed.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MeshFeed } from "./MeshFeed";
+import type { Event, Peer } from "../types";
+
+const PEER: Peer = {
+  peer_id: "peer-1",
+  name: "alice",
+  display_name: "alice",
+  status: "online",
+  machine: "host",
+  path: "/tmp/alice",
+  circle: "default",
+};
+
+describe("MeshFeed", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("uses apiBase for attachment download links", () => {
+    const event: Event = {
+      id: "event-1",
+      type: "notification",
+      timestamp: "2025-01-01T00:00:00Z",
+      from: "alice",
+      to: "bob",
+      text: "see file",
+      attachments: [{
+        id: "att-123",
+        filename: "diagram.png",
+      }],
+    };
+
+    render(
+      <MeshFeed
+        events={[event]}
+        peers={[PEER]}
+        apiBase="http://daemon.test"
+        onPickPeer={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /diagram\.png/i })).toHaveAttribute(
+      "href",
+      "http://daemon.test/attachments/att-123",
+    );
+  });
+});

--- a/web/app/dashboard/components/MeshFeed.tsx
+++ b/web/app/dashboard/components/MeshFeed.tsx
@@ -1,10 +1,21 @@
 import { useEffect, useMemo, useRef } from "react";
+import { Paperclip } from "lucide-react";
 import { cn } from "../lib/utils";
-import type { Event, Peer } from "../types";
+import type { AttachmentRef, Event, Peer } from "../types";
 import { peerLabel } from "../types";
 import { formatTime } from "./status";
 
-export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers: Peer[]; onPickPeer: (peer: Peer) => void }) {
+export function MeshFeed({
+  events,
+  peers,
+  apiBase,
+  onPickPeer,
+}: {
+  events: Event[];
+  peers: Peer[];
+  apiBase: string;
+  onPickPeer: (peer: Peer) => void;
+}) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const feedEvents = useMemo(
     () =>
@@ -45,7 +56,12 @@ export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers
           </div>
         ) : (
           feedEvents.map((event) => (
-            <EventRow key={event.id} event={event} onPickPeer={pickPeerByName} />
+            <EventRow
+              key={event.id}
+              event={event}
+              apiBase={apiBase}
+              onPickPeer={pickPeerByName}
+            />
           ))
         )}
         <div ref={bottomRef} />
@@ -54,7 +70,15 @@ export function MeshFeed({ events, peers, onPickPeer }: { events: Event[]; peers
   );
 }
 
-function EventRow({ event, onPickPeer }: { event: Event; onPickPeer: (name?: string) => void }) {
+function EventRow({
+  event,
+  apiBase,
+  onPickPeer,
+}: {
+  event: Event;
+  apiBase: string;
+  onPickPeer: (name?: string) => void;
+}) {
   const route = event.type === "broadcast" ? "=>" : event.type === "response" ? "↳" : "->";
   const color =
     event.status === "error"
@@ -93,7 +117,39 @@ function EventRow({ event, onPickPeer }: { event: Event; onPickPeer: (name?: str
       </div>
       <span className={cn("mt-0.5 block min-w-0 break-words [overflow-wrap:anywhere] md:mt-0", event.status === "error" ? "text-error" : "text-on-surface-variant")}>
         {event.text}
+        <AttachmentChips attachments={event.attachments} apiBase={apiBase} />
       </span>
     </div>
+  );
+}
+
+function AttachmentChips({
+  attachments,
+  apiBase,
+}: {
+  attachments?: AttachmentRef[];
+  apiBase: string;
+}) {
+  if (!attachments || attachments.length === 0) return null;
+  return (
+    <span className="mt-1 flex flex-wrap gap-1.5">
+      {attachments.map((attachment, index) => {
+        const label = attachment.filename || attachment.path?.split("/").pop() || attachment.id || "attachment";
+        const href = attachment.id ? `${apiBase}/attachments/${encodeURIComponent(attachment.id)}` : undefined;
+        const chip = (
+          <span className="inline-flex max-w-56 items-center gap-1 truncate border border-border-faint bg-surface-container-low px-1.5 py-0.5 text-[10px] text-outline">
+            <Paperclip className="h-3 w-3 shrink-0" aria-hidden="true" />
+            <span className="truncate">{label}</span>
+          </span>
+        );
+        return href ? (
+          <a key={`${attachment.id}-${index}`} href={href} className="hover:text-on-surface">
+            {chip}
+          </a>
+        ) : (
+          <span key={`${label}-${index}`}>{chip}</span>
+        );
+      })}
+    </span>
   );
 }

--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -290,6 +290,37 @@ describe("PeerView session protection", () => {
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it("uses apiBase for thread attachment download links", () => {
+    const event: Event = {
+      id: "att-event",
+      type: "notification",
+      timestamp: "2025-01-01T00:00:00Z",
+      from: "alice",
+      to: "dashboard",
+      from_peer_id: PEER.peer_id,
+      text: "attached",
+      attachments: [{
+        id: "att-123",
+        filename: "diagram.png",
+      }],
+    };
+
+    render(
+      <PeerView
+        peer={PEER}
+        events={[event]}
+        apiBase="http://daemon.test"
+        onClose={() => {}}
+        onSent={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: /diagram\.png/i })).toHaveAttribute(
+      "href",
+      "http://daemon.test/attachments/att-123",
+    );
+  });
+
   it("auto-scrolls on new events when not protected", () => {
     const initial: Event[] = [chatTurn("e1", "hello", "2025-01-01T00:00:00Z")];
     const { rerender } = render(

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -5,7 +5,7 @@ import { AlertCircle, Check, Clock, Copy, Paperclip, RefreshCw, Send, X } from "
 import { cn, shortPath, statusDot } from "../lib/utils";
 import { registerSnapshotProvider, useFrozenThread, useIsPeerProtected } from "../lib/protection";
 import { clearDraft, setDraftFile, setDraftText, useDraftFile, useDraftText } from "../lib/drafts";
-import type { Event, Peer } from "../types";
+import type { AttachmentRef, Event, Peer } from "../types";
 import { peerLabel } from "../types";
 import { formatTime, StatusLabel } from "./status";
 
@@ -26,6 +26,7 @@ interface PendingAsk {
   state: "pending" | "delivered" | "timed_out";
   reply?: string;
   reply_from?: string;
+  attachments?: AttachmentRef[];
 }
 
 const ACK_FRAME_RE = /^\[ack #([^\]\s]+) from @([^\]\s]+)\]\s?([\s\S]*)$/;
@@ -341,7 +342,12 @@ export function PeerView({
                 ) : event.type === "history_turn" ? (
                   <HistoryTurn key={event.id} turn={event} peer={peer} />
                 ) : (
-                  <ThreadItem key={event.id} event={event as Event} peer={peer} />
+                  <ThreadItem
+                    key={event.id}
+                    event={event as Event}
+                    peer={peer}
+                    apiBase={apiBase}
+                  />
                 )
               )
             )}
@@ -359,7 +365,15 @@ export function PeerView({
   );
 }
 
-function ThreadItem({ event, peer }: { event: Event; peer: Peer }) {
+function ThreadItem({
+  event,
+  peer,
+  apiBase,
+}: {
+  event: Event;
+  peer: Peer;
+  apiBase: string;
+}) {
   if (event.type === "chat_turn") {
     const isUser = event.role === "user";
     return (
@@ -374,14 +388,15 @@ function ThreadItem({ event, peer }: { event: Event; peer: Peer }) {
               ? "border-r-2 border-primary bg-primary/10"
               : "border-l-2 border-primary/70 bg-surface-container-high"
           )}
-        >
-          {isUser ? (
-            <p className="whitespace-pre-wrap break-words">{event.text}</p>
+      >
+        {isUser ? (
+          <p className="whitespace-pre-wrap break-words">{event.text}</p>
           ) : (
             <div className="prose prose-invert prose-sm max-w-none break-words [&_pre]:overflow-x-auto">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{event.text}</ReactMarkdown>
             </div>
           )}
+          <AttachmentChips attachments={event.attachments} apiBase={apiBase} />
         </div>
         {!isUser && event.tool_calls && event.tool_calls.length > 0 && (
           <ToolCallBlock toolCalls={event.tool_calls} />
@@ -406,6 +421,41 @@ function ThreadItem({ event, peer }: { event: Event; peer: Peer }) {
       <span className="shrink-0 tabular-nums">{formatTime(event.timestamp)}</span>
       <span className="text-on-surface-variant">{label}</span>
       <span className="truncate">{event.text}</span>
+      <AttachmentChips attachments={event.attachments} apiBase={apiBase} compact />
+    </div>
+  );
+}
+
+function AttachmentChips({
+  attachments,
+  apiBase,
+  compact = false,
+}: {
+  attachments?: AttachmentRef[];
+  apiBase: string;
+  compact?: boolean;
+}) {
+  if (!attachments || attachments.length === 0) return null;
+  return (
+    <div className={cn("mt-2 flex flex-wrap gap-1.5", compact && "mt-0")}>
+      {attachments.map((attachment, index) => {
+        const label = attachment.filename || attachment.path?.split("/").pop() || attachment.id || "attachment";
+        const href = attachment.id ? `${apiBase}/attachments/${encodeURIComponent(attachment.id)}` : undefined;
+        const chip = (
+          <span className="inline-flex max-w-64 items-center gap-1.5 truncate rounded border border-border-faint bg-surface-container-low px-2 py-1 font-mono text-[11px] text-on-surface-variant">
+            <Paperclip className="h-3 w-3 shrink-0 text-outline" aria-hidden="true" />
+            <span className="truncate">{label}</span>
+            {attachment.size ? <span className="shrink-0 text-outline">{Math.ceil(attachment.size / 1024)}KB</span> : null}
+          </span>
+        );
+        return href ? (
+          <a key={`${attachment.id}-${index}`} href={href} className="hover:brightness-110">
+            {chip}
+          </a>
+        ) : (
+          <span key={`${label}-${index}`}>{chip}</span>
+        );
+      })}
     </div>
   );
 }
@@ -630,7 +680,7 @@ function ComposeBar({
   const dismissAsk = (cid: string) =>
     setPendingAsks((prev) => prev.filter((a) => a.correlation_id !== cid));
 
-  const uploadFile = async (upload: File): Promise<string | null> => {
+  const uploadFile = async (upload: File): Promise<AttachmentRef | null> => {
     const formData = new FormData();
     formData.append("file", upload);
     try {
@@ -641,7 +691,7 @@ function ComposeBar({
       });
       if (!res.ok) return null;
       const data = await res.json();
-      return data.path as string;
+      return data as AttachmentRef;
     } catch {
       return null;
     }
@@ -654,14 +704,20 @@ function ComposeBar({
 
     try {
       let msg = text.trim();
+      let attachments: AttachmentRef[] = [];
       const hint = "\n(from @dashboard - reply naturally, dashboard sees your response automatically)";
       if (file) {
-        const path = await uploadFile(file);
-        if (!path) {
+        const attachment = await uploadFile(file);
+        if (!attachment) {
           setError("Failed to upload file");
           return;
         }
-        msg = msg ? `${msg}\n[Attachment: ${path}]` : `[Attachment: ${path}]`;
+        attachments = [attachment];
+        if (attachment.path) {
+          msg = msg
+            ? `${msg}\n[Attachment: ${attachment.path}]`
+            : `[Attachment: ${attachment.path}]`;
+        }
       }
 
       const res = await fetch(`${apiBase}/ask`, {
@@ -671,6 +727,7 @@ function ComposeBar({
           from_peer: "dashboard",
           to_peer: peer.name,
           text: msg + hint,
+          attachments,
           bypass_circle: true,
         }),
       });
@@ -687,6 +744,7 @@ function ComposeBar({
             preview,
             sent_at: Date.now(),
             state: "pending",
+            attachments,
           },
         ]);
         clearDraft(peer.peer_id);
@@ -840,6 +898,9 @@ function ComposeBar({
                   {a.reply}
                 </div>
               )}
+              <div className="pl-5">
+                <AttachmentChips attachments={a.attachments} apiBase={apiBase} compact />
+              </div>
             </div>
           ))}
         </div>

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -255,7 +255,12 @@ function DashboardInner() {
               onSent={refreshData}
             />
           ) : (
-            <MeshFeed events={events} peers={visiblePeers} onPickPeer={selectPeer} />
+            <MeshFeed
+              events={events}
+              peers={visiblePeers}
+              apiBase={API_BASE}
+              onPickPeer={selectPeer}
+            />
           )}
         </main>
 

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -33,6 +33,14 @@ export interface OrchestratorStatus {
   stale_after?: string | null;
 }
 
+export interface AttachmentRef {
+  id?: string | null;
+  path?: string | null;
+  filename?: string | null;
+  size?: number | null;
+  content_type?: string | null;
+}
+
 /** Human-readable label: display_name is daemon-assigned and human-friendly. */
 export function peerLabel(peer: Peer): string {
   return peer.display_name || peer.name;
@@ -55,6 +63,7 @@ export interface Event {
   from_peer_id?: string;
   to_peer_id?: string;
   text: string;
+  attachments?: AttachmentRef[];
   status?: "pending" | "success" | "error" | "blocked";
   peer?: string;
   peer_id?: string;


### PR DESCRIPTION
## Summary
- Add optional attachment metadata to ask, notify, and ack request/transport surfaces while preserving text-only compatibility.
- Carry attachments through daemon events, WebSocket frames, MCP, and the Python client.
- Render dashboard attachment chips/download links and Telegram native photos/documents when local files are available, with link/path fallbacks.
- Keep existing path text fallbacks for older transports and agent readability.

## Validation
- `uv run pytest tests/test_message_router.py tests/test_ask_routes.py tests/test_routes.py::TestNotify tests/test_telegram_bot.py tests/test_client.py`
- `uv run ruff check repowire/protocol/messages.py repowire/daemon/message_router.py repowire/daemon/transport_router.py repowire/daemon/routes/asks.py repowire/daemon/routes/messages.py repowire/daemon/routes/attachments.py repowire/daemon/peer_registry.py repowire/client.py repowire/mcp/server.py repowire/hooks/websocket_hook.py repowire/telegram/bot.py tests/test_message_router.py tests/test_ask_routes.py tests/test_routes.py tests/test_telegram_bot.py tests/test_client.py`
- `uv run ty check repowire/daemon/routes/asks.py repowire/daemon/routes/messages.py repowire/daemon/message_router.py repowire/daemon/transport_router.py repowire/client.py repowire/mcp/server.py repowire/telegram/bot.py repowire/protocol/messages.py`
- `cd web && npx tsc --noEmit && npm test -- --run components/PeerView.test.tsx`

## Notes
- Draft PR: schema shape and Telegram remote-host fallback semantics should get reviewer attention.
- No `.beads` or `uv.lock` churn included.
