### PR TITLE
Add pre-PR hygiene checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,16 @@ Feature work that changes public behavior must update public docs in the same PR
 
 When adding features, explicitly check docs impact before closing the issue. If docs are intentionally deferred, file a Beads follow-up and say why in the PR handoff.
 
+Before opening a PR, run the advisory pre-PR hygiene check:
+
+```bash
+python3 scripts/pre_pr_hygiene.py
+```
+
+This is a lightweight opt-in checklist, not a mandatory hook. It compares the branch with `origin/main`, includes staged and unstaged changes, and points at README, reference docs, mirrored web docs, `CLAUDE.md` / `AGENTS.md`, and graphify follow-ups that may need review. Keep the final decision product-repo focused and document intentional deferrals in the PR handoff.
+
+See `docs/pre-pr-hygiene.md` for the tool-surface matrix.
+
 Third-party extension context:
 
 - Vercel Labs `skills` (`npx skills add ...`) installs reusable `SKILL.md` packages across agents. Repowire does not install these today.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ git commit -m "short description of what and why"
 git push origin your-branch-name
 ```
 
+Before opening the PR, run the advisory repo-hygiene checklist:
+```bash
+python3 scripts/pre_pr_hygiene.py
+```
+
+This is not a mandatory hook. It compares your branch with `origin/main` and reminds you which
+public surfaces to check: README, reference docs, mirrored web docs, `CLAUDE.md` / `AGENTS.md`,
+and graphify for architecture-level changes. See [`docs/pre-pr-hygiene.md`](docs/pre-pr-hygiene.md)
+for the tool-surface matrix.
+
 ## Where to Find Things
 
 `CLAUDE.md` has the full architecture overview, worth reading before diving in. Here's a quick map of the main areas:

--- a/README.md
+++ b/README.md
@@ -248,7 +248,15 @@ uv tool uninstall repowire
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR, run the advisory repo-hygiene
+checklist:
+
+```bash
+python3 scripts/pre_pr_hygiene.py
+```
+
+It is an opt-in prompt for docs, README, agent-instruction, and graphify follow-ups, not a
+mandatory hook.
 
 ## License
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,3 +1,13 @@
 # Contributing
 
 See [`CONTRIBUTING.md`](https://github.com/prassanna-ravishankar/repowire/blob/main/CONTRIBUTING.md) in the repository for the contribution workflow, code-quality gates, and release process.
+
+Before opening a PR from a checkout, run the advisory hygiene checklist:
+
+```bash
+python3 scripts/pre_pr_hygiene.py
+```
+
+The checklist is not a mandatory hook. It points contributors at README, reference docs, mirrored
+web docs, `CLAUDE.md` / `AGENTS.md`, and graphify reminders when the changed paths suggest a
+product-surface or architecture update.

--- a/docs/pre-pr-hygiene.md
+++ b/docs/pre-pr-hygiene.md
@@ -1,0 +1,35 @@
+# Pre-PR Hygiene
+
+Repowire changes often touch more than one public surface. Before opening a PR, run the
+advisory checklist:
+
+```bash
+python3 scripts/pre_pr_hygiene.py
+```
+
+The script compares your branch with `origin/main`, includes staged and unstaged changes, and
+prints the documentation and repo-instruction surfaces that deserve review. It is intentionally
+not a mandatory hook. Use judgement, keep the PR focused, and explain any intentional docs deferral
+in the handoff.
+
+## Tool-Surface Matrix
+
+| Change area | Code paths that usually trigger review | Public surfaces to check |
+| --- | --- | --- |
+| CLI and setup | `repowire/cli.py`, `repowire/config/`, `repowire/spawn.py`, `install.sh`, `repowire.yaml.example` | `README.md`, `docs/reference/cli.md`, `web/app/docs/reference/cli/page.tsx`, `CLAUDE.md`, `AGENTS.md` |
+| MCP and Python client | `repowire/mcp/`, `repowire/peer_mcp.py`, `repowire/client.py`, `repowire/protocol/` | `docs/reference/mcp-tools.md`, `docs/reference/python-client.md`, mirrored web docs, `README.md` when the surface changes materially |
+| Agent runtimes and hooks | `repowire/hooks/`, `repowire/installers/`, `repowire/channel/`, `repowire/acp/` | `docs/agents/`, hook/channel troubleshooting docs, `CLAUDE.md`, `AGENTS.md` |
+| Dashboard and human surfaces | `web/app/dashboard/`, `repowire/telegram/`, `repowire/slack/`, attachments routes, relay code | `docs/surfaces/`, `docs/relay/`, `web/app/docs/`, `README.md`, browser-generated screenshots under `images/` when UI changes materially |
+| Daemon routing and architecture | `repowire/daemon/`, `repowire/session/`, routing/lifecycle/scheduling state | `docs/reference/architecture.md`, `docs/concepts/`, `docs/patterns/`, `CLAUDE.md`, `AGENTS.md` |
+
+## Graphify Reminder
+
+For architecture-level changes, especially daemon routing, peer state, hook lifecycle, transport,
+or session model changes, run the incremental graph update:
+
+```bash
+/graphify . --update
+```
+
+Use `graphify-out/GRAPH_REPORT.md` as a navigation aid for the PR summary when helpful. Do not
+paste large generated JSON or cache artifacts into README or hand-written docs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,5 +158,6 @@ nav:
   - About:
       - about/index.md
       - Versioning: about/versioning.md
+      - Pre-PR hygiene: pre-pr-hygiene.md
       - License: about/license.md
       - Contributing: about/contributing.md

--- a/scripts/pre_pr_hygiene.py
+++ b/scripts/pre_pr_hygiene.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Opt-in pre-PR hygiene checklist for Repowire contributors."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_BASE = "origin/main"
+
+
+@dataclass(frozen=True)
+class Rule:
+    name: str
+    patterns: tuple[str, ...]
+    check: tuple[str, ...]
+    reason: str
+    graphify: bool = False
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        name="CLI and setup surface",
+        patterns=(
+            "repowire/cli.py",
+            "repowire/config/**",
+            "repowire/spawn.py",
+            "repowire/spawn_hints.py",
+            "repowire/service/**",
+            "install.sh",
+            "repowire.yaml.example",
+        ),
+        check=(
+            "README.md",
+            "docs/reference/cli.md",
+            "web/app/docs/reference/cli/page.tsx",
+            "CLAUDE.md",
+            "AGENTS.md",
+        ),
+        reason="commands, flags, config defaults, setup, and spawn output are user-visible.",
+    ),
+    Rule(
+        name="MCP and Python client surface",
+        patterns=(
+            "repowire/mcp/**",
+            "repowire/peer_mcp.py",
+            "repowire/client.py",
+            "repowire/protocol/**",
+            "docs/reference/mcp-tools.md",
+            "docs/reference/python-client.md",
+        ),
+        check=(
+            "README.md",
+            "docs/reference/mcp-tools.md",
+            "docs/reference/python-client.md",
+            "web/app/docs/reference/tools/page.tsx",
+            "web/app/docs/reference/client/page.tsx",
+            "CLAUDE.md",
+            "AGENTS.md",
+        ),
+        reason=(
+            "tool names, signatures, defaults, return shapes, and routing semantics are public API."
+        ),
+    ),
+    Rule(
+        name="Agent runtime and hook behavior",
+        patterns=(
+            "repowire/hooks/**",
+            "repowire/installers/**",
+            "repowire/channel/**",
+            "repowire/acp/**",
+            "repowire/orchestrator/template/AGENTS.md",
+        ),
+        check=(
+            "README.md",
+            "docs/agents/**",
+            "docs/troubleshooting/hooks.md",
+            "docs/troubleshooting/channel-auth.md",
+            "CLAUDE.md",
+            "AGENTS.md",
+        ),
+        reason=(
+            "per-runtime install, hook, channel, and troubleshooting behavior needs to "
+            "stay aligned."
+        ),
+        graphify=True,
+    ),
+    Rule(
+        name="Dashboard and human control surfaces",
+        patterns=(
+            "web/app/dashboard/**",
+            "web/app/docs/**",
+            "web/components/**",
+            "repowire/telegram/**",
+            "repowire/slack/**",
+            "repowire/daemon/routes/attachments.py",
+            "repowire/relay/**",
+            "repowire/daemon/relay_client.py",
+        ),
+        check=(
+            "README.md",
+            "docs/surfaces/**",
+            "docs/relay/**",
+            "web/app/docs/**",
+            "images/**",
+            "CLAUDE.md",
+            "AGENTS.md",
+        ),
+        reason="dashboard, Telegram, Slack, relay, and attachment behavior are product surfaces.",
+    ),
+    Rule(
+        name="Daemon routing and architecture",
+        patterns=(
+            "repowire/daemon/**",
+            "repowire/session/**",
+            "repowire/peer_describe.py",
+            "docs/reference/architecture.md",
+            "docs/concepts/**",
+            "docs/patterns/**",
+        ),
+        check=(
+            "README.md",
+            "docs/reference/architecture.md",
+            "docs/concepts/**",
+            "docs/patterns/**",
+            "CLAUDE.md",
+            "AGENTS.md",
+        ),
+        reason=(
+            "routing, lifecycle, scheduling, peer state, and session framing affect "
+            "architecture docs."
+        ),
+        graphify=True,
+    ),
+)
+
+
+def run_git(args: list[str]) -> str:
+    try:
+        return subprocess.check_output(["git", *args], text=True, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.stderr)
+        raise SystemExit(exc.returncode) from exc
+
+
+def changed_files(base: str) -> list[str]:
+    merge_base = run_git(["merge-base", base, "HEAD"]).strip()
+    names = set(run_git(["diff", "--name-only", f"{merge_base}...HEAD"]).splitlines())
+    names.update(run_git(["diff", "--name-only"]).splitlines())
+    names.update(run_git(["diff", "--name-only", "--cached"]).splitlines())
+    names.update(run_git(["ls-files", "--others", "--exclude-standard"]).splitlines())
+    return sorted(name for name in names if name)
+
+
+def matches(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def touched_docs(files: list[str], patterns: tuple[str, ...]) -> list[str]:
+    return [path for path in files if matches(path, patterns)]
+
+
+def print_rule(rule: Rule, files: list[str]) -> bool:
+    hits = [path for path in files if matches(path, rule.patterns)]
+    if not hits:
+        return False
+
+    docs = touched_docs(files, rule.check)
+    print(f"\n## {rule.name}")
+    print(f"Reason: {rule.reason}")
+    print("Changed paths:")
+    for path in hits:
+        print(f"  - {path}")
+
+    print("Review these surfaces:")
+    for pattern in rule.check:
+        marker = "x" if any(matches(path, (pattern,)) for path in docs) else " "
+        print(f"  [{marker}] {pattern}")
+
+    if rule.graphify:
+        print("Graphify: consider `/graphify . --update` for this architecture-level change.")
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print an opt-in pre-PR docs and architecture hygiene checklist."
+    )
+    parser.add_argument(
+        "--base",
+        default=DEFAULT_BASE,
+        help=f"Base ref to compare against. Defaults to {DEFAULT_BASE}.",
+    )
+    args = parser.parse_args()
+
+    if not Path(".git").exists():
+        sys.stderr.write("Run this from the Repowire repo root.\n")
+        return 2
+
+    files = changed_files(args.base)
+    if not files:
+        print("No changed files detected.")
+        return 0
+
+    print(f"Pre-PR hygiene checklist against {args.base}")
+    print("This is advisory; use judgement and explain intentional deferrals in the PR.")
+    print("\nChanged files:")
+    for path in files:
+        print(f"  - {path}")
+
+    matched = False
+    for rule in RULES:
+        matched = print_rule(rule, files) or matched
+
+    if not matched:
+        print("\nNo product-surface hygiene rules matched these paths.")
+
+    print("\nBefore opening the PR:")
+    print("  - Run relevant tests/lint/type checks for the touched area.")
+    print("  - If docs are intentionally deferred, file a Beads follow-up and mention it.")
+    print("  - Keep generated graphify JSON/cache out of hand-written docs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add an opt-in `scripts/pre_pr_hygiene.py` checklist that compares a branch to `origin/main` and includes staged, unstaged, and untracked files
- add a repo-level pre-PR hygiene doc with the tool-surface matrix and graphify reminder for architecture changes
- link the advisory workflow from README, CONTRIBUTING, CLAUDE/AGENTS instructions, and published docs nav

## Changed files

- `scripts/pre_pr_hygiene.py`
- `docs/pre-pr-hygiene.md`
- `README.md`
- `CONTRIBUTING.md`
- `CLAUDE.md` / `AGENTS.md` symlinked instructions
- `docs/about/contributing.md`
- `mkdocs.yml`

## Checks

- `python3 scripts/pre_pr_hygiene.py`
- `python3 -m py_compile scripts/pre_pr_hygiene.py`
- `uv run --extra dev ruff check scripts/pre_pr_hygiene.py`
- `uv run --extra docs mkdocs build --strict` (passes; emits upstream MkDocs 2.0 warning from Material for MkDocs)

## Notes

- no `.beads` or `uv.lock` churn
