### PR TITLE
Release v0.13.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repowire"
-version = "0.13.33"
+version = "0.13.34"
 description = "Mesh network for AI coding agents - enables Claude Code, Codex, Gemini, and OpenCode sessions to communicate"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1352,7 +1352,7 @@ wheels = [
 
 [[package]]
 name = "repowire"
-version = "0.13.33"
+version = "0.13.34"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cut the v0.13.34 release from current `main`.

Bundled since v0.13.33:
- #243 docs/site visual polish
- #244 localhost HTTP MCP setup polish
- #245 dashboard streaming delta ordering
- #246 orchestrator active fan-out guidance
- #247 attachment metadata for ask/notify/ack
- #248 registry-route split plan
- #249 pre-PR hygiene checklist
- #250 SQLite state expansion plan
- #252 relay Docker hatch build hook copy hotfix

## Changes

- Bump `repowire` version to `0.13.34` in `pyproject.toml`
- Update editable package version in `uv.lock`

## Checks

- `rg -n "0\\.13\\.33|v0\\.13\\.33" -S . --glob '!graphify-out/**' --glob '!site/**' --glob '!dist/**' --glob '!web/node_modules/**'` (no stale references)
- `git diff --check origin/main...HEAD`
- `uv build`
- `uv run python - <<'PY' ... version('repowire') ... PY` → `0.13.34`
- `python3 scripts/pre_pr_hygiene.py`

No changelog file is present in this repo; release notes are captured in this PR body. Do not tag or publish from this PR.
