### PR TITLE
Fix relay Docker Hatch build hook copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 
 # Dependency cache layer
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md hatch_build.py ./
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-install-project --no-dev
 
 # App code layer

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,7 +16,7 @@ ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 
 # Dependency cache layer
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md hatch_build.py ./
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-install-project --no-dev
 
 # App code layer


### PR DESCRIPTION
## Summary
- copy `hatch_build.py` with the Python project metadata in the relay Docker image so Hatch custom hooks can load during `uv sync`
- apply the same fix to `deploy/Dockerfile` for the mirrored relay image path

## Validation
- `rg -n "COPY pyproject\.toml uv\.lock README\.md hatch_build\.py \.\/|uv sync --frozen" Dockerfile deploy/Dockerfile`
- `docker build --progress=plain -t repowire-relay-hatch-hotfix:local .` passed; final `uv sync --frozen --no-dev` built `repowire @ file:///app` without the missing `hatch_build.py` error
- `docker build --progress=plain -f deploy/Dockerfile -t repowire-relay-hatch-hotfix-deploy:local .` passed from cache with the corrected metadata layer
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/pre_pr_hygiene.py`

Fixes main Deploy Relay failure: `OSError: Build script does not exist: hatch_build.py`.

Docs impact: none; Docker packaging hotfix only.

Changed files: `Dockerfile`, `deploy/Dockerfile`. No Beads churn included.