### PR TITLE
Polish pending asks in Python client

### DIFF
--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -71,7 +71,7 @@ Omit it for the text-only shape; existing callers do not need to change.
 
 ## Listing and inspection
 
-Pull current mesh state. `list_peers` accepts daemon-supported filters; `get_peer` resolves a single peer by name or id. `pending_asks` returns open asks targeting one pane or peer.
+Pull current mesh state. `list_peers` accepts daemon-supported filters; `get_peer` resolves a single peer by name or id. `pending_asks` returns open asks for one pane or peer; pass `direction="outbound"` or `direction="both"` to inspect asks opened by that peer.
 
 ```python
 for peer in await client.list_peers(status="online"):
@@ -80,11 +80,12 @@ for peer in await client.list_peers(status="online"):
 peer = await client.get_peer("project-b")
 
 asks = await client.pending_asks(peer_id=peer.peer_id)
+outbound = await client.pending_asks(peer_id=peer.peer_id, direction="outbound")
 ```
 
 ## Spawning and lifecycle
 
-`spawn` launches a new agent session subject to `daemon.spawn.allowed_commands`. `spawn_config` reports what the daemon will accept without attempting a spawn. `kill_peer` terminates a peer cleanly.
+`spawn` launches a new agent session subject to `daemon.spawn.allowed_commands`. `spawn_config` reports what the daemon will accept without attempting a spawn. Omit `circle` to use the daemon default (`default`), or pass it explicitly for another circle. `kill_peer` terminates a peer cleanly.
 
 ```python
 info = await client.spawn_config()

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -8,7 +8,7 @@ internals or duplicating route-specific request code.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote
 
 import httpx
@@ -38,7 +38,7 @@ class ClientPeer(BaseModel):
     machine: str | None = None
     tmux_session: str | None = None
     backend: str = "claude-code"
-    circle: str = "global"
+    circle: str = "default"
     role: PeerRole = PeerRole.AGENT
     status: str
     last_seen: str | None = None
@@ -70,12 +70,14 @@ class AskResult(BaseModel):
 
 
 class PendingAsk(BaseModel):
-    """Open ask targeting a peer."""
+    """Open ask involving a peer."""
 
     correlation_id: str
     from_peer: str
+    to_peer: str
     text: str
     created_at: str
+    direction: Literal["inbound", "outbound"]
 
 
 class BroadcastResult(BaseModel):
@@ -163,7 +165,6 @@ class AsyncRepowireClient:
         self._auth_headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
         self._client = client or httpx.AsyncClient(
             base_url=self.base_url,
-            headers=self._auth_headers,
             timeout=timeout,
         )
 
@@ -400,9 +401,18 @@ class AsyncRepowireClient:
         *,
         pane_id: str | None = None,
         peer_id: str | None = None,
+        direction: Literal["inbound", "outbound", "both"] = "inbound",
     ) -> list[PendingAsk]:
         """List open asks for exactly one pane_id or peer_id."""
-        params = {k: v for k, v in {"pane_id": pane_id, "peer_id": peer_id}.items() if v}
+        params = {
+            k: v
+            for k, v in {
+                "pane_id": pane_id,
+                "peer_id": peer_id,
+                "direction": direction,
+            }.items()
+            if v
+        }
         data = await self._request("GET", "/asks/pending", params=params)
         return [PendingAsk.model_validate(a) for a in data.get("asks", [])]
 
@@ -487,11 +497,13 @@ class AsyncRepowireClient:
         path: str,
         command: str,
         *,
-        circle: str = "default",
+        circle: str | None = None,
         message: str | None = None,
     ) -> SpawnResult:
         """Spawn a new agent session via the daemon."""
-        payload = {"path": path, "command": command, "circle": circle}
+        payload = {"path": path, "command": command}
+        if circle is not None:
+            payload["circle"] = circle
         if message is not None:
             payload["message"] = message
         return SpawnResult.model_validate(await self._request("POST", "/spawn", json=payload))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from repowire.client import AsyncRepowireClient, ToolCall
+from repowire.client import AsyncRepowireClient, ClientPeer, ToolCall
 from repowire.config.models import Config, DaemonConfig
 from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.deps import cleanup_deps, init_deps
@@ -85,6 +85,19 @@ async def test_health_and_spawn_config(client: AsyncRepowireClient):
     assert spawn_config.allowed_commands == []
 
 
+def test_client_peer_defaults_to_daemon_default_circle():
+    peer = ClientPeer.model_validate(
+        {
+            "peer_id": "peer-1",
+            "name": "alice",
+            "display_name": "alice-claude-code",
+            "status": "online",
+        }
+    )
+
+    assert peer.circle == "default"
+
+
 async def test_peer_lifecycle(client: AsyncRepowireClient):
     registered = await client.register_peer(
         "alice",
@@ -128,6 +141,16 @@ async def test_ask_ack_and_pending(client: AsyncRepowireClient):
     assert len(pending) == 1
     assert pending[0].correlation_id == opened.correlation_id
     assert pending[0].from_peer == alice.display_name
+    assert pending[0].to_peer == bob.display_name
+    assert pending[0].direction == "inbound"
+
+    outbound = await client.pending_asks(peer_id=alice.peer_id, direction="outbound")
+    assert len(outbound) == 1
+    assert outbound[0].correlation_id == opened.correlation_id
+    assert outbound[0].direction == "outbound"
+
+    both = await client.pending_asks(peer_id=alice.peer_id, direction="both")
+    assert [ask.direction for ask in both] == ["outbound"]
 
     await client.ack(opened.correlation_id, from_peer=bob.display_name)
     assert await client.pending_asks(peer_id=bob.peer_id) == []
@@ -251,6 +274,30 @@ async def test_attachment_quota_allows_after_ttl_sweep(
         )
         assert uploaded.size == len(b"fresh upload")
     assert not stale.exists()
+
+
+async def test_owned_client_does_not_duplicate_auth_headers():
+    client = AsyncRepowireClient(auth_token="secret")
+    try:
+        assert "authorization" not in client._client.headers
+    finally:
+        await client.aclose()
+
+
+async def test_spawn_omits_default_circle_for_daemon_default():
+    client = AsyncRepowireClient(client=AsyncMock())
+    client._request = AsyncMock(  # type: ignore[method-assign]
+        return_value={"ok": True, "display_name": "proj-codex", "tmux_session": "default"}
+    )
+
+    result = await client.spawn("/tmp/proj", "codex", message="warm up")
+
+    assert result.display_name == "proj-codex"
+    client._request.assert_awaited_once_with(
+        "POST",
+        "/spawn",
+        json={"path": "/tmp/proj", "command": "codex", "message": "warm up"},
+    )
 
 
 async def test_auth_token_is_sent(tmp_path):

--- a/web/app/docs/reference/client/page.tsx
+++ b/web/app/docs/reference/client/page.tsx
@@ -84,7 +84,7 @@ print(bc)`}
 
       <Section title="Listing and inspection">
         <p>
-          Pull current mesh state. <Mono>list_peers</Mono> accepts daemon-supported filters; <Mono>get_peer</Mono> resolves a single peer by name or id. <Mono>pending_asks</Mono> returns open asks targeting one pane or peer.
+          Pull current mesh state. <Mono>list_peers</Mono> accepts daemon-supported filters; <Mono>get_peer</Mono> resolves a single peer by name or id. <Mono>pending_asks</Mono> returns open asks for one pane or peer; pass <Mono>direction=&quot;outbound&quot;</Mono> or <Mono>direction=&quot;both&quot;</Mono> to inspect asks opened by that peer.
         </p>
         <Code>
 {`for peer in await client.list_peers(status="online"):
@@ -92,13 +92,14 @@ print(bc)`}
 
 peer = await client.get_peer("project-b")
 
-asks = await client.pending_asks(peer_id=peer.peer_id)`}
+asks = await client.pending_asks(peer_id=peer.peer_id)
+outbound = await client.pending_asks(peer_id=peer.peer_id, direction="outbound")`}
         </Code>
       </Section>
 
       <Section title="Spawning and lifecycle">
         <p>
-          <Mono>spawn</Mono> launches a new agent session subject to <Mono>daemon.spawn.allowed_commands</Mono>. <Mono>spawn_config</Mono> reports what the daemon will accept without attempting a spawn. <Mono>kill_peer</Mono> terminates a peer cleanly.
+          <Mono>spawn</Mono> launches a new agent session subject to <Mono>daemon.spawn.allowed_commands</Mono>. <Mono>spawn_config</Mono> reports what the daemon will accept without attempting a spawn. Omit <Mono>circle</Mono> to use the daemon default (<Mono>default</Mono>), or pass it explicitly for another circle. <Mono>kill_peer</Mono> terminates a peer cleanly.
         </p>
         <Code>
 {`info = await client.spawn_config()


### PR DESCRIPTION
## Summary
- align Python client defaults with daemon defaults: `ClientPeer.circle` now defaults to `default`, and `spawn()` omits `circle` unless explicitly provided so the daemon owns its default
- avoid duplicate auth header configuration by sending auth headers per request only, including when a caller injects an `httpx` client
- expose `pending_asks(direction=...)` plus `to_peer`/`direction` on `PendingAsk`; this is kept as client API polish because the daemon already returns these fields and tests cover inbound/outbound/both parsing
- update Python client reference docs and mirrored web docs

## Review notes
- Restored `.beads/issues.jsonl` and root `issues.jsonl` from `origin/main`; no beads/issues churn remains in the PR diff.
- GitHub PR-loop check found no unresolved review threads; Gemini only left a quota warning issue comment.

## Tests
- `uv run --extra dev pytest tests/test_client.py`
- `uv run --extra dev ruff check repowire/client.py tests/test_client.py`
- `uv run --extra dev ty check repowire/client.py`

Issue: repowire-ny2