### PR TITLE
Document peer identity lifecycle invariants

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -3,6 +3,7 @@
 The mental model behind repowire. Read once, refer rarely.
 
 - [Peers and circles](peers-and-circles.md) — what a peer is and how circles scope routing.
+- [Peer identity lifecycle](peer-identity-lifecycle.md) — registration, reconnect, stale fields, and routing observability.
 - [Message types](message-types.md) — `ask`, `ack`, `notify`, `broadcast`.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.

--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -1,0 +1,74 @@
+# Peer identity lifecycle
+
+Peer identity is the daemon contract that lets Repowire route messages without guessing. It is deliberately stronger than a display name: display names are for humans, while `peer_id` is the immutable routing key for a registered peer.
+
+## Identity fields
+
+A live peer has these identity and lifecycle fields:
+
+- `peer_id` — daemon-assigned stable id for routing and ask ownership.
+- `display_name` / `name` — human-facing name. It can collide across circles, so it is not globally unique.
+- `circle` — routing scope. Peers normally message peers in the same circle unless the caller passes an explicit circle or has a role that bypasses circles.
+- `backend` — agent runtime, such as `claude-code`, `codex`, `gemini`, `opencode`, or `pi`.
+- `path` — working directory used for name allocation and reconnect checks.
+- `pane_id` / WebSocket binding — local delivery endpoint for hook-based peers.
+- `role` — `agent` by default; service, human, and orchestrator roles can bypass normal circle visibility.
+- `description` — short task state set by `set_description` and shown in peer lists.
+- `status`, `turn_state`, and `last_seen` — liveness and per-turn observability.
+
+The in-memory `Peer` is the live routing record. The durable `SessionMapping` in `sessions.json` preserves fields that should survive daemon restart, including display name, circle, backend, path, role, description, and the last known agent pid when available.
+
+## Registration and reconnect
+
+On registration, the daemon allocates a `peer_id` and builds a display name from the working directory and backend. If another active peer in the same circle already holds the display name, the daemon suffixes the new name. Offline same-name peers may be pruned so a fresh session can reclaim the name cleanly.
+
+A reconnect may reclaim an existing `peer_id` only when the claim still describes the same peer identity. Today that check is intentionally narrow and v0.13-compatible:
+
+- backend must match;
+- path must match when both the existing peer and the reconnect claim provide one;
+- pane ownership is updated only after that identity check passes.
+
+If the check fails, the stale `peer_id` claim is ignored and the daemon allocates or adopts a different identity. This prevents an old environment variable or stale pane metadata from binding a different session's WebSocket to the wrong peer.
+
+When a new peer claims a pane already held by another peer, the old peer loses that pane binding and is marked offline. Pane lookup should then resolve to the current live owner, not a zombie registration.
+
+## Display-name ambiguity
+
+Display names are scoped and human-facing. A name can exist in multiple circles, so routing code must not silently choose among multiple viable matches.
+
+Use `peer_id` when exact routing matters. If you use a display name and more than one live candidate matches without an explicit `circle=`, the daemon returns a conflict instead of guessing. Passing `circle="name"` narrows the lookup. MCP `list_peers` and `repowire peer describe` expose both display names and peer ids so operators can disambiguate.
+
+## Descriptions and stale task state
+
+`description` is intentionally lightweight: it is task state, not durable truth. Agents should call `set_description("brief task summary")` when starting work and clear or replace it when focus changes.
+
+Because agents can forget to clear it, the daemon bounds stale descriptions with a clear-on-read TTL (`daemon.description_ttl_seconds`, default 900 seconds). There is no polling loop. When a peer is read through `/peers` or peer lookup and its description is older than the TTL, the daemon clears it in memory and in the durable mapping. A description restored from `sessions.json` gets stamped on first read so it has a bounded TTL window rather than living forever.
+
+## `last_seen` and liveness
+
+`last_seen` is the daemon's most recent activity timestamp for the peer. It is refreshed by registration, reconnect, status updates, description updates, role claims, and MCP `touch` calls. MCP tools touch on entry so outbound tool activity counts as liveness even if an inbound WebSocket hook dropped.
+
+`last_seen` is observability, not a unique identity selector. Repowire avoids choosing between ambiguous display-name matches based only on recency because that can misroute work.
+
+## Routing observability
+
+Routing events and logs should make misroutes diagnosable without adding ad hoc logs. For asks and notifications, the daemon records human names and resolved ids in events:
+
+- `from` / `to`
+- `from_peer_id` / `to_peer_id`
+- delivery status where applicable
+- ask `correlation_id`
+
+The WebSocket router also logs the intended recipient name, resolved peer id, frame `to_peer`, and delivered pane id for ask/notify sends. Those fields distinguish a caller typo, an ambiguous display-name lookup, a stale registry entry, and a transport binding problem.
+
+## Compatibility boundary
+
+This contract describes current v0.13 behavior. It does not make every route transport-neutral, persist `last_seen` across restart, or replace peers with sessions as the public API. The session-native architecture remains incremental: sessions are becoming the durable unit of work, while peers remain the live runtime executors.
+
+## See also
+
+- [Peers and circles](peers-and-circles.md)
+- [Message types](message-types.md)
+- [Lazy repair](lazy-repair.md)
+- [MCP tools: `list_peers`](../reference/mcp-tools.md#list_peers)
+- [CLI: `repowire peer describe`](../reference/cli.md#repowire-peer)

--- a/tests/test_circles.py
+++ b/tests/test_circles.py
@@ -330,6 +330,27 @@ class TestAmbiguousDisplayNameNoSilentWinner:
         _, kwargs = mock_message_router.send_notification.call_args
         assert kwargs["to_session_id"] == "sid-b"
 
+    async def test_notify_and_ask_events_record_resolved_peer_ids(
+        self, mock_message_router):
+        """Routing observability stores names plus resolved immutable ids."""
+        pm = PeerRegistry(config=Config(), message_router=mock_message_router)
+        await self._register(pm, "sid-sender", "sender", "teamA")
+        await self._register(pm, "sid-target", "target", "teamA")
+        mock_message_router.send_ask = AsyncMock()
+
+        await pm.notify("sender", "target", "hi")
+        await pm.deliver_ask("sender", "target", "question", correlation_id="ask-ids")
+
+        events = pm.get_events()
+        notify_event, ask_event = events[-2], events[-1]
+        assert notify_event["type"] == "notification"
+        assert ask_event["type"] == "ask"
+        assert notify_event["from_peer_id"] == "sid-sender"
+        assert notify_event["to_peer_id"] == "sid-target"
+        assert ask_event["from_peer_id"] == "sid-sender"
+        assert ask_event["to_peer_id"] == "sid-target"
+        assert ask_event["correlation_id"] == "ask-ids"
+
 
 # ---------------------------------------------------------------------------
 # from_peer circle-preferred lookup (Fix 3 regression)

--- a/tests/test_description_ttl.py
+++ b/tests/test_description_ttl.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from repowire.config.models import Config
+from repowire.config.models import AgentType, Config
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.protocol.peers import Peer, PeerStatus
@@ -134,3 +134,45 @@ async def test_clearing_description_drops_set_at(mock_router):
 
     await registry.update_description("dev", "")
     assert "repow-test-dev" not in registry._description_set_at
+
+
+@pytest.mark.asyncio
+async def test_restored_description_gets_bounded_ttl_window(tmp_path, mock_router):
+    """Descriptions restored from sessions.json are stamped on first read.
+
+    The first read preserves the restored description because the daemon cannot
+    know when it was set, but that read starts a bounded TTL window so the stale
+    task state clears on a later read instead of living forever.
+    """
+    path = tmp_path / "sessions.json"
+    restored_dir = tmp_path / "restored-desc"
+    restored_dir.mkdir()
+    cfg = _make_config(60)
+    registry = PeerRegistry(config=cfg, message_router=mock_router, persistence_path=path)
+    peer_id, _ = await registry.allocate_and_register(
+        circle="team-a",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(restored_dir),
+    )
+    await registry.update_description(peer_id, "old task")
+    registry._persist_mappings()
+
+    restarted = PeerRegistry(config=cfg, message_router=mock_router, persistence_path=path)
+    new_id, _ = await restarted.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(restored_dir),
+    )
+    assert new_id == peer_id
+
+    first_read = await restarted.get_peer(peer_id)
+    assert first_read is not None
+    assert first_read.description == "old task"
+    assert peer_id in restarted._description_set_at
+
+    restarted._description_set_at[peer_id] = (
+        datetime.now(timezone.utc) - timedelta(seconds=120)
+    )
+    second_read = await restarted.get_peer(peer_id)
+    assert second_read is not None
+    assert second_read.description == ""

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -193,6 +193,26 @@ class TestSendAsk:
             '↳ ack("ask-ws") or ack("ask-ws", "reply")'
         )
 
+    async def test_logs_delivery_trace(self, router, transport, caplog):
+        caplog.set_level(logging.INFO, logger="repowire.daemon.message_router")
+        transport.get_connection_pane_id.return_value = "%8"
+
+        await router.send_ask(
+            from_peer="alice",
+            to_session_id="sid-bob",
+            to_peer_name="bob",
+            correlation_id="ask-trace",
+            text="ping?",
+            intended_recipient_name="requested-bob",
+        )
+
+        assert "Ask delivery trace" in caplog.text
+        assert "sender_identity=alice" in caplog.text
+        assert "intended_recipient_name=requested-bob" in caplog.text
+        assert "resolved_peer_id=sid-bob" in caplog.text
+        assert "frame.to_peer=bob" in caplog.text
+        assert "actual_delivered_pane_id=%8" in caplog.text
+
     async def test_includes_reply_to(self, router, transport):
         await router.send_ask(
             from_peer="alice",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -114,6 +114,24 @@ class TestPeers:
         assert r.status_code == 200
         assert r.json()["display_name"] == "panepeer-claude-code"
 
+    async def test_get_peer_ambiguous_display_name_returns_409(self, client):
+        for circle in ("team-a", "team-b"):
+            r = await client.post("/peers", json={
+                "name": "shared",
+                "path": "/tmp/shared",
+                "circle": circle,
+                "backend": "claude-code",
+            })
+            assert r.status_code == 200
+            assert r.json()["display_name"] == "shared-claude-code"
+
+        r = await client.get("/peers/shared-claude-code")
+        assert r.status_code == 409
+        detail = r.json()["detail"]
+        assert "Ambiguous peer name" in detail
+        assert "Specify a circle=" in detail
+        assert "peer_id" in detail
+
     async def test_get_peer_by_name(self, client):
         r = await client.post("/peers", json={
             "name": "mypeer",

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -490,6 +490,12 @@ async def test_reconnect_with_same_peer_id_bypasses_hijack_guard(tmp_path):
         agent_pid=88888,
     )
 
+    peer = await registry.get_peer(peer_id)
+    assert peer is not None and peer.last_seen is not None
+    before_reconnect = peer.last_seen
+    peer.status = PeerStatus.OFFLINE
+    peer.last_seen = before_reconnect - timedelta(seconds=30)
+
     reclaimed_id, reclaimed_name = await registry.allocate_and_register(
         circle="default",
         backend=AgentType.CLAUDE_CODE,
@@ -501,6 +507,11 @@ async def test_reconnect_with_same_peer_id_bypasses_hijack_guard(tmp_path):
     )
     assert reclaimed_id == peer_id
     assert reclaimed_name == name
+    reconnected = await registry.get_peer(peer_id)
+    assert reconnected is not None
+    assert reconnected.status == PeerStatus.ONLINE
+    assert reconnected.last_seen is not None
+    assert reconnected.last_seen > before_reconnect - timedelta(seconds=30)
 
 
 @pytest.mark.asyncio

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -42,6 +42,15 @@ export default function Concepts() {
         </p>
       </Section>
 
+      <Section title="Peer identity lifecycle">
+        <p>
+          The daemon routes by immutable <Mono>peer_id</Mono>, not by display name alone. Display names are human-facing and can collide across circles, so ambiguous name lookups refuse to guess unless you pass an explicit <Mono>circle</Mono> or use a <Mono>peer_id</Mono>.
+        </p>
+        <p>
+          Reconnects may reclaim a peer id only when the claim still matches the registered backend and path. Stale task descriptions are bounded by a clear-on-read TTL, and routing events record resolved peer ids so misroutes can be diagnosed without ad hoc logs.
+        </p>
+      </Section>
+
       <Section title="Message types">
         <p>The daemon routes four message types. Pick by lifecycle, not by content.</p>
         <dl className="mt-4 grid gap-px overflow-hidden border border-border-faint bg-border-faint">


### PR DESCRIPTION
## Summary
- Add a peer identity lifecycle concept doc covering registration, reconnect, ambiguity, description TTL, last_seen, and routing observability.
- Add focused invariant/observability tests for reconnect last_seen refresh, restored-description TTL bounding, ambiguous /peers lookup conflicts, ask delivery trace logging, and resolved peer ids on ask/notify events.
- Mirror the concept at a high level in the shipped web docs concepts page.

## Validation
- uv run --extra dev pytest tests/test_session_mapper.py tests/test_description_ttl.py tests/test_routes.py::TestPeers::test_get_peer_ambiguous_display_name_returns_409 tests/test_message_router.py tests/test_circles.py::TestAmbiguousDisplayNameNoSilentWinner
- uv run --extra dev ruff check tests/test_session_mapper.py tests/test_description_ttl.py tests/test_routes.py tests/test_message_router.py tests/test_circles.py
- python3 scripts/pre_pr_hygiene.py

## Notes
- No product-code behavior changes; /peers and MCP TSV remain backward compatible.
- PEER_IDENTITY_LIFECYCLE_PLAN.md was used for orchestration review and intentionally left out of the commit/PR.
- Graphify update deferred: this slice documents/tests existing behavior and does not change runtime architecture.