### PR TITLE
Guard pre-PR hygiene against Beads ledger churn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,7 @@ Before opening a PR, run the advisory pre-PR hygiene check:
 python3 scripts/pre_pr_hygiene.py
 ```
 
-This is a lightweight opt-in checklist, not a mandatory hook. It compares the branch with `origin/main`, includes staged and unstaged changes, and points at README, reference docs, mirrored web docs, `CLAUDE.md` / `AGENTS.md`, and graphify follow-ups that may need review. Keep the final decision product-repo focused and document intentional deferrals in the PR handoff.
+This is a lightweight opt-in checklist, not a mandatory hook. It compares the branch with `origin/main`, includes staged and unstaged changes, points at README, reference docs, mirrored web docs, `CLAUDE.md` / `AGENTS.md`, and graphify follow-ups that may need review, and fails if Beads JSONL ledger churn (`.beads/issues.jsonl` or root `issues.jsonl`) is present. Use `--restore-beads-ledgers` for local-only ledger churn. Keep the final decision product-repo focused and document intentional deferrals in the PR handoff.
 
 See `docs/pre-pr-hygiene.md` for the tool-surface matrix.
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ python3 scripts/pre_pr_hygiene.py
 ```
 
 It is an opt-in prompt for docs, README, agent-instruction, and graphify follow-ups, not a
-mandatory hook.
+mandatory hook. It also flags Beads JSONL ledger churn before it can leak into PR diffs.
 
 ## License
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -10,4 +10,5 @@ python3 scripts/pre_pr_hygiene.py
 
 The checklist is not a mandatory hook. It points contributors at README, reference docs, mirrored
 web docs, `CLAUDE.md` / `AGENTS.md`, and graphify reminders when the changed paths suggest a
-product-surface or architecture update.
+product-surface or architecture update. It also flags Beads JSONL ledger churn; use
+`--restore-beads-ledgers` to back up and restore local-only ledger diffs before opening a PR.

--- a/docs/pre-pr-hygiene.md
+++ b/docs/pre-pr-hygiene.md
@@ -8,9 +8,21 @@ python3 scripts/pre_pr_hygiene.py
 ```
 
 The script compares your branch with `origin/main`, includes staged and unstaged changes, and
-prints the documentation and repo-instruction surfaces that deserve review. It is intentionally
-not a mandatory hook. Use judgement, keep the PR focused, and explain any intentional docs deferral
-in the handoff.
+prints the documentation and repo-instruction surfaces that deserve review. It also fails fast when
+tracked Beads JSONL ledgers (`.beads/issues.jsonl` or root `issues.jsonl`) appear in the committed,
+staged, or unstaged diff, because those files are mutable issue state and should not ride along in
+feature PRs.
+
+To clean local-only ledger churn before opening a PR, run:
+
+```bash
+python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers
+```
+
+That command backs up the local ledger contents under `.beads/backup/pre-pr-hygiene/` and restores
+the tracked files from git. Committed ledger changes are reported only; amend or rebase those out.
+The docs checklist remains advisory and is not a mandatory hook. Use judgement, keep the PR focused,
+and explain any intentional docs deferral in the handoff.
 
 ## Tool-Surface Matrix
 

--- a/scripts/pre_pr_hygiene.py
+++ b/scripts/pre_pr_hygiene.py
@@ -8,9 +8,11 @@ import fnmatch
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 DEFAULT_BASE = "origin/main"
+BEADS_LEDGER_PATHS = (".beads/issues.jsonl", "issues.jsonl")
 
 
 @dataclass(frozen=True)
@@ -147,13 +149,48 @@ def run_git(args: list[str]) -> str:
         raise SystemExit(exc.returncode) from exc
 
 
+def merge_base(base: str) -> str:
+    return run_git(["merge-base", base, "HEAD"]).strip()
+
+
+def diff_names(args: list[str]) -> set[str]:
+    return set(run_git(["diff", "--name-only", *args]).splitlines())
+
+
 def changed_files(base: str) -> list[str]:
-    merge_base = run_git(["merge-base", base, "HEAD"]).strip()
-    names = set(run_git(["diff", "--name-only", f"{merge_base}...HEAD"]).splitlines())
-    names.update(run_git(["diff", "--name-only"]).splitlines())
-    names.update(run_git(["diff", "--name-only", "--cached"]).splitlines())
+    base_commit = merge_base(base)
+    names = diff_names([f"{base_commit}...HEAD"])
+    names.update(diff_names([]))
+    names.update(diff_names(["--cached"]))
     names.update(run_git(["ls-files", "--others", "--exclude-standard"]).splitlines())
     return sorted(name for name in names if name)
+
+
+def beads_ledger_changes(base: str) -> tuple[list[str], list[str]]:
+    base_commit = merge_base(base)
+    committed = sorted(
+        path for path in diff_names([f"{base_commit}...HEAD"]) if path in BEADS_LEDGER_PATHS
+    )
+    local = diff_names([])
+    local.update(diff_names(["--cached"]))
+    local.update(run_git(["ls-files", "--others", "--exclude-standard"]).splitlines())
+    return committed, sorted(path for path in local if path in BEADS_LEDGER_PATHS)
+
+
+def backup_and_restore_beads_ledgers(paths: list[str]) -> None:
+    if not paths:
+        return
+
+    backup_dir = Path(".beads/backup/pre-pr-hygiene")
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    for path in paths:
+        source = Path(path)
+        if source.exists():
+            backup_path = backup_dir / f"{timestamp}__{path.replace('/', '__')}"
+            backup_path.write_bytes(source.read_bytes())
+
+    run_git(["restore", "--staged", "--worktree", "--", *paths])
 
 
 def matches(path: str, patterns: tuple[str, ...]) -> bool:
@@ -196,11 +233,24 @@ def main() -> int:
         default=DEFAULT_BASE,
         help=f"Base ref to compare against. Defaults to {DEFAULT_BASE}.",
     )
+    parser.add_argument(
+        "--restore-beads-ledgers",
+        action="store_true",
+        help=(
+            "Restore local Beads JSONL ledger churn after saving a backup under "
+            ".beads/backup/pre-pr-hygiene/. Committed ledger changes are only reported."
+        ),
+    )
     args = parser.parse_args()
 
     if not Path(".git").exists():
         sys.stderr.write("Run this from the Repowire repo root.\n")
         return 2
+
+    committed_ledgers, local_ledgers = beads_ledger_changes(args.base)
+    if args.restore_beads_ledgers and local_ledgers:
+        backup_and_restore_beads_ledgers(local_ledgers)
+        committed_ledgers, local_ledgers = beads_ledger_changes(args.base)
 
     files = changed_files(args.base)
     if not files:
@@ -209,6 +259,27 @@ def main() -> int:
 
     print(f"Pre-PR hygiene checklist against {args.base}")
     print("This is advisory; use judgement and explain intentional deferrals in the PR.")
+
+    if committed_ledgers or local_ledgers:
+        print("\n## Beads ledger safety")
+        print(
+            "Mutable Beads JSONL ledgers must not ride along in feature PRs. "
+            "They are generated issue state, not product changes."
+        )
+        if committed_ledgers:
+            print("Committed ledger changes found:")
+            for path in committed_ledgers:
+                print(f"  - {path}")
+            print("Rebase or amend these out before opening the PR.")
+        if local_ledgers:
+            print("Local ledger churn found:")
+            for path in local_ledgers:
+                print(f"  - {path}")
+            print(
+                "Run `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` "
+                "to back up and restore these files."
+            )
+
     print("\nChanged files:")
     for path in files:
         print(f"  - {path}")
@@ -224,6 +295,11 @@ def main() -> int:
     print("  - Run relevant tests/lint/type checks for the touched area.")
     print("  - If docs are intentionally deferred, file a Beads follow-up and mention it.")
     print("  - Keep generated graphify JSON/cache out of hand-written docs.")
+
+    if committed_ledgers or local_ledgers:
+        print("  - Remove Beads JSONL ledger churn before opening the PR.")
+        return 1
+
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a Beads ledger safety check to pre-PR hygiene for .beads/issues.jsonl and root issues.jsonl
- add --restore-beads-ledgers to back up and restore local-only ledger churn
- document the guard in contributor/pre-PR hygiene docs

## Test plan
- python3 -m py_compile scripts/pre_pr_hygiene.py
- uv run ruff check scripts/pre_pr_hygiene.py
- python3 scripts/pre_pr_hygiene.py --base origin/main
- manual: append to issues.jsonl/.beads/issues.jsonl, verify hygiene exits 1, then --restore-beads-ledgers restores cleanly

Closes #169