### PR TITLE
Fix Pi self-tool identity drift

### DIFF
--- a/repowire/installers/pi.py
+++ b/repowire/installers/pi.py
@@ -392,6 +392,9 @@ async function handleDaemonMessage(conn: PeerConn, data: Record<string, unknown>
   const msgType = data.type as string;
 
   if (msgType === "connected") {
+    if (typeof data.display_name === "string" && data.display_name) {
+      conn.peerName = data.display_name;
+    }
     if (data.session_id) {
       conn.peerId = data.session_id as string;
       console.debug("[repowire] " + conn.peerName + " connected with peer_id: " + conn.peerId);
@@ -861,7 +864,8 @@ export default async function repowireExtension(pi: ExtensionAPI) {
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const me = callerPeer(ctx);
-      await daemon("/peers/" + encodeURIComponent(me.peerName) + "/description", { description: params.description });
+      const identifier = me.peerId || me.peerName;
+      await daemon("/peers/" + encodeURIComponent(identifier) + "/description", { description: params.description });
       return { content: [{ type: "text", text: "description updated: " + params.description }], details: undefined };
     },
   });

--- a/tests/test_pi_installer.py
+++ b/tests/test_pi_installer.py
@@ -159,6 +159,22 @@ def test_reconnect_with_backoff():
     assert "MAX_RECONNECT_ATTEMPTS" in PLUGIN_CONTENT
 
 
+def test_connected_frame_adopts_daemon_identity():
+    """Pi must use the daemon-assigned identity after WebSocket registration.
+
+    The locally generated session name can differ from the registered display
+    name after reconnect/takeover; self tools must not keep targeting it.
+    """
+    assert 'typeof data.display_name === "string"' in PLUGIN_CONTENT
+    assert "conn.peerName = data.display_name" in PLUGIN_CONTENT
+
+
+def test_set_description_targets_peer_id_when_known():
+    """Self description updates should prefer canonical peer_id over generated name."""
+    assert "const identifier = me.peerId || me.peerName" in PLUGIN_CONTENT
+    assert 'encodeURIComponent(identifier) + "/description"' in PLUGIN_CONTENT
+
+
 def test_signal_handlers_exit():
     """SIGINT/SIGTERM handlers are one-shot and exit, mirroring opencode."""
     assert 'process.once("SIGINT"' in PLUGIN_CONTENT

--- a/tests/test_pi_installer.py
+++ b/tests/test_pi_installer.py
@@ -165,13 +165,13 @@ def test_connected_frame_adopts_daemon_identity():
     The locally generated session name can differ from the registered display
     name after reconnect/takeover; self tools must not keep targeting it.
     """
-    assert 'typeof data.display_name === "string"' in PLUGIN_CONTENT
+    assert 'typeof data.display_name === "string" && data.display_name' in PLUGIN_CONTENT
     assert "conn.peerName = data.display_name" in PLUGIN_CONTENT
 
 
 def test_set_description_targets_peer_id_when_known():
     """Self description updates should prefer canonical peer_id over generated name."""
-    assert "const identifier = me.peerId || me.peerName" in PLUGIN_CONTENT
+    assert PLUGIN_CONTENT.count("const identifier = me.peerId || me.peerName") >= 2
     assert 'encodeURIComponent(identifier) + "/description"' in PLUGIN_CONTENT
 
 


### PR DESCRIPTION
## Summary
- adopt the daemon-assigned Pi display name from the WebSocket connected frame
- make Pi set_description target the canonical peer_id when available instead of a generated session name
- add installer smoke coverage for daemon identity adoption and peer_id-based self description updates

## Tests
- uv run pytest tests/test_pi_installer.py
- uv run ruff check repowire/installers/pi.py tests/test_pi_installer.py
- python3 scripts/pre_pr_hygiene.py

Docs: no public docs update; this is a narrow bug fix to existing Pi self-tool behavior.