### PR TITLE
Fix runtime and transport liveness split

### DIFF
--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -41,6 +41,8 @@ This is why `spawn_peer(..., message=...)` is effectively required for Codex pee
 
 `UserPromptSubmit` marks the peer `busy` with `turn_state=working`. `Stop` marks it `online` with `turn_state=idle`. If Codex misses the terminal hook after a user interrupt, the daemon's demand-driven lazy repair can reset a stale `busy`/`working` peer after `daemon.stale_busy_timeout_seconds`; this is a fallback for stale state, not guaranteed cancel detection.
 
+Codex can also drop the background WebSocket hook while the TUI pane remains alive. Repowire treats that as transport loss, not proof that the runtime is dead: status stays runtime-driven when pane/process evidence still exists, but inbound ask/notify delivery fails loudly until the WebSocket hook reconnects.
+
 ## Verifying
 
 ```bash

--- a/docs/concepts/lazy-repair.md
+++ b/docs/concepts/lazy-repair.md
@@ -8,7 +8,7 @@ The practical consequence: a fully idle mesh consumes near-zero CPU. Peers do no
 
 The mesh is a routing hub, not a monitoring system. If you want certainty about a peer's state, address the peer — its `Stop` hook will refresh `last_seen` on its way out, and the next MCP call from anywhere will run `lazy_repair()` and reconcile.
 
-The corollary: `list_peers` results are *eventually consistent*. A peer that crashed without a clean `Stop` may still show `online` for up to a minute until the next lazy repair sees the stale `last_seen` and demotes it.
+The corollary: `list_peers` results are *eventually consistent*. A peer that crashed without a clean `Stop` may still show `online` for up to a minute until the next lazy repair sees missing runtime evidence or stale `last_seen` and demotes it. A peer whose WebSocket hook disconnected but whose tmux pane or agent process is still present may remain `online`/`busy`; delivery over that missing inbound transport still fails explicitly.
 
 ## What this rules out
 

--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -48,6 +48,8 @@ Because agents can forget to clear it, the daemon bounds stale descriptions with
 
 `last_seen` is the daemon's most recent activity timestamp for the peer. It is refreshed by registration, reconnect, status updates, description updates, role claims, and MCP `touch` calls. MCP tools touch on entry so outbound tool activity counts as liveness even if an inbound WebSocket hook dropped.
 
+Runtime/session liveness is separate from transport/socket liveness. A hook-based peer may have a live tmux pane and agent process while its background WebSocket sidecar is disconnected; in that state the peer can remain `online` or `busy`, but ask/notify delivery over the WebSocket still fails explicitly because inbound transport is unavailable. Lazy repair only demotes disconnected pane-backed peers when runtime evidence is also missing: the recorded agent PID is not alive and tmux no longer shows the pane. Fresh HTTP pane pre-registration starts `offline` until a WebSocket connection or hook/MCP touch proves runtime activity.
+
 `last_seen` is observability, not a unique identity selector. Repowire avoids choosing between ambiguous display-name matches based only on recency because that can misroute work.
 
 ## Routing observability

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import time
 from collections import deque
 from dataclasses import asdict, dataclass
@@ -527,6 +528,7 @@ class PeerRegistry:
         role: PeerRole = PeerRole.AGENT,
         peer_id: str | None = None,
         turn_state: TurnState | None = None,
+        initial_status: PeerStatus = PeerStatus.ONLINE,
         agent_pid: int | None = None,
         parent_pid: int | None = None,
     ) -> tuple[str, str]:
@@ -565,11 +567,11 @@ class PeerRegistry:
                     )
                 else:
                     old_status = existing.status
-                    existing.status = PeerStatus.ONLINE
+                    existing.status = initial_status
                     existing.last_seen = datetime.now(timezone.utc)
                     if turn_state is not None:
                         existing.turn_state = turn_state
-                    self._emit_status_change(existing, old_status, PeerStatus.ONLINE)
+                    self._emit_status_change(existing, old_status, initial_status)
                     if pane_id:
                         self._release_pane(pane_id, peer_id)
                         existing.pane_id = pane_id
@@ -657,7 +659,7 @@ class PeerRegistry:
                     circle=effective_circle,
                     backend=backend,
                     role=effective_role,
-                    status=PeerStatus.ONLINE,
+                    status=initial_status,
                     last_seen=datetime.now(timezone.utc),
                     pane_id=pane_id,
                     tmux_session=tmux_session,
@@ -669,7 +671,12 @@ class PeerRegistry:
                     agent_pid=effective_agent_pid,
                 )
                 self._peers[allocated_id] = peer
-                logger.info(f"Peer registered: {assigned_name} ({allocated_id})")
+                logger.info(
+                    "Peer registered: %s (%s, status=%s)",
+                    assigned_name,
+                    allocated_id,
+                    initial_status.value,
+                )
                 result_peer_id = allocated_id
                 result_name = assigned_name
                 should_redeliver = True
@@ -1674,10 +1681,16 @@ class PeerRegistry:
             self._persist_mappings()
 
     async def _demote_disconnected_peers(self) -> int:
-        """Mark ONLINE/BUSY peers without a WebSocket connection as OFFLINE.
+        """Mark ONLINE/BUSY transport-owned peers without a WebSocket as OFFLINE.
 
         Catches ghost peers that registered via HTTP but whose ws-hook
         never connected (e.g. pane died before ws-hook could start).
+
+        Pane-backed runtimes are preserved only when the daemon can still see
+        runtime evidence (the recorded agent PID is alive or tmux still has
+        the pane). A dropped ws-hook alone only means inbound transport is
+        unavailable; absence of both socket and runtime evidence is a dead
+        peer and should go OFFLINE.
 
         Peers carrying ``metadata["acp"]`` are exempt while the
         ``experiments.acp_broker_client`` flag is on: brokered ACP peers are
@@ -1693,19 +1706,70 @@ class PeerRegistry:
             else False
         )
         async with self._lock:
-            ghosts = [
+            candidates = [
                 p for p in self._peers.values()
                 if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
                 and not self._transport.is_connected(p.peer_id)
+                and not p.pane_id
                 and not (acp_flag and p.metadata and p.metadata.get("acp"))
             ]
+            pane_candidates = [
+                p for p in self._peers.values()
+                if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+                and not self._transport.is_connected(p.peer_id)
+                and p.pane_id
+                and not (acp_flag and p.metadata and p.metadata.get("acp"))
+            ]
+
+        checks = await asyncio.gather(
+            *(
+                asyncio.to_thread(self._has_runtime_evidence, peer)
+                for peer in pane_candidates
+            ),
+            return_exceptions=True,
+        )
+        for peer, has_evidence in zip(pane_candidates, checks, strict=True):
+            if has_evidence is True:
+                continue
+            candidates.append(peer)
+
         count = 0
-        for peer in ghosts:
+        for peer in candidates:
             await self.mark_offline(peer.peer_id)
             count += 1
         if count:
-            logger.info("demoted %d ghost peers (no WebSocket)", count)
+            logger.info("demoted %d ghost peers (no WebSocket/runtime evidence)", count)
         return count
+
+    @staticmethod
+    def _has_runtime_evidence(peer: Peer) -> bool:
+        """Best-effort runtime proof for a disconnected pane-backed peer.
+
+        This is demand-driven lazy repair, not polling. It intentionally
+        checks only local process/tmux evidence and does not attempt any
+        WebSocket recovery.
+        """
+        if peer.agent_pid is not None:
+            try:
+                os.kill(peer.agent_pid, 0)
+                return True
+            except PermissionError:
+                return True
+            except OSError:
+                pass
+
+        if not peer.pane_id:
+            return False
+        try:
+            result = subprocess.run(
+                ["tmux", "display-message", "-t", peer.pane_id, "-p", "#{pane_pid}"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (FileNotFoundError, OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0 and bool(result.stdout.strip())
 
     async def _demote_unsafe_connected_peers(self) -> int:
         """Mark connected tmux peers OFFLINE if their pane is no longer safe."""
@@ -1940,18 +2004,19 @@ class PeerRegistry:
 
         async with self._lock:
             targets = [
-                (p.peer_id, p.backend, p.circle)
+                p
                 for p in self._peers.values()
                 if p.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
             ]
 
-        async def check_peer(
-            peer_id: str, backend, circle: str,
-        ) -> tuple[str, str | None] | None:
+        async def check_peer(peer: Peer) -> tuple[str, str | None] | None:
             """Returns (peer_id, circle) if alive, None if dead."""
+            peer_id = peer.peer_id
+            circle = peer.circle
             if not transport.is_connected(peer_id):
-                return None
-            if backend == AgentType.OPENCODE:
+                has_evidence = await asyncio.to_thread(self._has_runtime_evidence, peer)
+                return (peer_id, circle) if has_evidence else None
+            if peer.backend == AgentType.OPENCODE:
                 return (peer_id, circle)
             try:
                 pong = await transport.ping(peer_id, timeout=5.0)
@@ -1961,14 +2026,14 @@ class PeerRegistry:
                 return None
 
         results = await asyncio.gather(
-            *(check_peer(pid, backend, circle) for pid, backend, circle in targets),
+            *(check_peer(peer) for peer in targets),
             return_exceptions=True,
         )
 
         alive_peers = [r for r in results if isinstance(r, tuple)]
-        dead_peer_ids = {t[0] for t in targets} - {r[0] for r in alive_peers}
+        dead_peer_ids = {p.peer_id for p in targets} - {r[0] for r in alive_peers}
 
-        targets_map = {pid: c for pid, _, c in targets}
+        targets_map = {p.peer_id: p.circle for p in targets}
         for peer_id, new_circle in alive_peers:
             current = targets_map.get(peer_id)
             if current and new_circle and new_circle != current:

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -300,6 +300,11 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
             machine=request.machine or socket.gethostname(),
             role=request.role,
             turn_state=request.turn_state,
+            initial_status=(
+                PeerStatus.OFFLINE
+                if request.pane_id and request.metadata.get("hook_session_id")
+                else PeerStatus.ONLINE
+            ),
             agent_pid=request.agent_pid,
             parent_pid=request.parent_pid,
         )

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -214,7 +214,6 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             removed = await transport.disconnect(session_id, websocket)
             if removed:
                 await query_tracker.cancel_queries_to_peer(session_id)
-                await peer_registry.update_peer_status(session_id, PeerStatus.OFFLINE)
 
 
 async def _handle_message(

--- a/tests/test_lazy_repair.py
+++ b/tests/test_lazy_repair.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
 import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -161,6 +163,89 @@ class TestLazyRepairDebounce:
         assert result.status == PeerStatus.OFFLINE
         transport.ping.assert_awaited_once_with(peer.peer_id, timeout=1.0)
 
+    async def test_disconnected_pane_peer_with_live_runtime_stays_live(self):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.is_connected = MagicMock(return_value=False)
+        qt = MagicMock()
+        qt.cancel_queries_to_peer = AsyncMock(return_value=0)
+        manager = _make_manager(transport=transport, query_tracker=qt)
+
+        peer = _make_peer(
+            pane_id="%5",
+            status=PeerStatus.BUSY,
+        )
+        peer.agent_pid = os.getpid()
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.BUSY
+            live.agent_pid = os.getpid()
+
+        await manager.lazy_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result.status == PeerStatus.BUSY
+        qt.cancel_queries_to_peer.assert_not_called()
+
+    async def test_disconnected_pane_peer_without_runtime_evidence_is_demoted(
+        self, monkeypatch,
+    ):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.is_connected = MagicMock(return_value=False)
+        qt = MagicMock()
+        qt.cancel_queries_to_peer = AsyncMock(return_value=0)
+        manager = _make_manager(transport=transport, query_tracker=qt)
+
+        peer = _make_peer(pane_id="%5", status=PeerStatus.ONLINE)
+        peer.agent_pid = 999_999_999
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.agent_pid = 999_999_999
+
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.os.kill",
+            lambda _pid, _sig: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+
+        await manager.lazy_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result.status == PeerStatus.OFFLINE
+        qt.cancel_queries_to_peer.assert_awaited_once_with(peer.peer_id)
+
+    async def test_disconnected_pane_peer_with_stale_pid_and_live_pane_stays_live(
+        self, monkeypatch,
+    ):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.is_connected = MagicMock(return_value=False)
+        qt = MagicMock()
+        qt.cancel_queries_to_peer = AsyncMock(return_value=0)
+        manager = _make_manager(transport=transport, query_tracker=qt)
+
+        peer = _make_peer(pane_id="%5", status=PeerStatus.ONLINE)
+        peer.agent_pid = 999_999_999
+        await manager.register_peer(peer)
+        async with manager._lock:
+            manager._peers[peer.peer_id].agent_pid = 999_999_999
+
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.os.kill",
+            lambda _pid, _sig: (_ for _ in ()).throw(ProcessLookupError()),
+        )
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.subprocess.run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                args=["tmux"], returncode=0, stdout="123\n", stderr="",
+            ),
+        )
+
+        await manager.lazy_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result.status == PeerStatus.ONLINE
+        qt.cancel_queries_to_peer.assert_not_called()
+
     async def test_stale_busy_working_peer_repairs_to_idle(self):
         manager = _make_manager(stale_busy_timeout_seconds=60)
         old_seen = datetime.now(timezone.utc) - timedelta(seconds=61)
@@ -301,7 +386,7 @@ class TestLazyRepairReaper:
 
 class TestActiveRepairLiveness:
     async def test_no_ws_marks_offline(self):
-        """Peer with no WebSocket connection is marked OFFLINE."""
+        """Peer with no WebSocket or runtime evidence is marked OFFLINE."""
         transport = MagicMock(spec=WebSocketTransport)
         transport.is_connected = MagicMock(return_value=False)
         qt = MagicMock()
@@ -315,6 +400,28 @@ class TestActiveRepairLiveness:
 
         result = await manager.get_peer(peer.peer_id)
         assert result.status == PeerStatus.OFFLINE
+
+    async def test_no_ws_with_live_pane_runtime_stays_online(self):
+        """Active repair separates inbound transport loss from runtime liveness."""
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.is_connected = MagicMock(return_value=False)
+        transport.ping = AsyncMock(side_effect=AssertionError("should not ping without WS"))
+        qt = MagicMock()
+        qt.cancel_queries_to_peer = AsyncMock(return_value=0)
+        manager = _make_manager(transport=transport, query_tracker=qt)
+
+        peer = _make_peer(pane_id="%5", status=PeerStatus.ONLINE)
+        peer.agent_pid = os.getpid()
+        await manager.register_peer(peer)
+        async with manager._lock:
+            manager._peers[peer.peer_id].agent_pid = os.getpid()
+
+        await manager.active_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result.status == PeerStatus.ONLINE
+        transport.ping.assert_not_awaited()
+        qt.cancel_queries_to_peer.assert_not_called()
 
     async def test_pong_alive_stays_online(self):
         """Peer that responds to ping stays ONLINE."""

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,6 +1,8 @@
 """Tests for the WebSocket endpoint."""
 
+import asyncio
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -167,6 +169,107 @@ class TestWebSocketConnect:
                 peers_list = r.json()["peers"]
                 names = [p["display_name"] for p in peers_list]
                 assert assigned_name in names
+
+        cleanup_deps()
+
+    async def test_disconnect_does_not_mark_pane_runtime_offline(self, tmp_path):
+        """A dropped ws-hook socket is transport loss, not proof the pane died."""
+        app = _make_app(tmp_path)
+
+        t = ASGITransport(app=app)
+        async with AsyncClient(transport=t, base_url="http://test") as c:
+            reg = await c.post("/peers", json={
+                "name": "codexpeer",
+                "path": "/tmp/codexpeer",
+                "circle": "default",
+                "backend": "codex",
+                "pane_id": "%codex",
+                "agent_pid": os.getpid(),
+                "metadata": {"hook_session_id": "codex-session"},
+            })
+            peer_id = reg.json()["peer_id"]
+
+        async with AsyncClient(
+            transport=ASGIWebSocketTransport(app), base_url="http://test"
+        ) as client:
+            async with aconnect_ws("/ws", client) as ws:
+                await ws.send_json({
+                    "type": "connect",
+                    "display_name": "codexpeer",
+                    "circle": "default",
+                    "backend": "codex",
+                    "path": "/tmp/codexpeer",
+                    "pane_id": "%codex",
+                    "peer_id": peer_id,
+                })
+                resp = json.loads(await ws.receive_text())
+                assert resp["type"] == "connected"
+                assigned_name = resp["display_name"]
+                await ws.send_json({
+                    "type": "status",
+                    "status": "busy",
+                    "turn_state": "working",
+                })
+
+            await asyncio.sleep(0.1)
+
+            t = ASGITransport(app=app)
+            async with AsyncClient(transport=t, base_url="http://test") as c:
+                r = await c.get(f"/peers/{assigned_name}")
+                body = r.json()
+                assert body["status"] == "busy"
+                assert body["turn_state"] == "working"
+
+                r = await c.post("/notify", json={
+                    "from_peer": "cli",
+                    "to_peer": assigned_name,
+                    "text": "still explicit",
+                })
+                assert r.status_code == 503
+                assert "no live connection" in r.json()["detail"]
+
+        cleanup_deps()
+
+    async def test_ws_connect_revives_http_pane_preregistration(self, tmp_path):
+        app = _make_app(tmp_path)
+
+        t = ASGITransport(app=app)
+        async with AsyncClient(transport=t, base_url="http://test") as c:
+            reg = await c.post("/peers", json={
+                "name": "prepeer",
+                "path": "/tmp/prepeer",
+                "circle": "default",
+                "backend": "codex",
+                "pane_id": "%pre",
+                "metadata": {"hook_session_id": "pre-session"},
+            })
+            assert reg.status_code == 200
+            peer_id = reg.json()["peer_id"]
+            assigned_name = reg.json()["display_name"]
+
+            r = await c.get(f"/peers/{peer_id}")
+            assert r.json()["status"] == "offline"
+
+        async with AsyncClient(
+            transport=ASGIWebSocketTransport(app), base_url="http://test"
+        ) as client, aconnect_ws("/ws", client) as ws:
+            await ws.send_json({
+                "type": "connect",
+                "display_name": "prepeer",
+                "circle": "default",
+                "backend": "codex",
+                "path": "/tmp/prepeer",
+                "pane_id": "%pre",
+                "peer_id": peer_id,
+            })
+            resp = json.loads(await ws.receive_text())
+            assert resp["type"] == "connected"
+            assert resp["session_id"] == peer_id
+
+            t = ASGITransport(app=app)
+            async with AsyncClient(transport=t, base_url="http://test") as c:
+                r = await c.get(f"/peers/{assigned_name}")
+                assert r.json()["status"] == "online"
 
         cleanup_deps()
 


### PR DESCRIPTION
## Summary
- separate runtime/session liveness from WebSocket transport availability for pane-backed peers
- start HTTP pane pre-registration offline until WebSocket/session proof, avoiding false-online startup records
- keep live Codex pane runtimes online/busy across ws-hook disconnects while delivery still fails explicitly when no inbound transport exists
- add lazy/active repair runtime-evidence checks using agent PID or tmux pane presence

## Verification
- `uv run pytest tests/test_lazy_repair.py tests/test_websocket.py tests/test_routes.py::TestNotify tests/test_ask_routes.py`
- `uv run ruff check repowire/daemon/peer_registry.py repowire/daemon/routes/peers.py repowire/daemon/routes/websocket.py tests/test_lazy_repair.py tests/test_websocket.py`
- `uv run ty check repowire/daemon/peer_registry.py repowire/daemon/routes/peers.py repowire/daemon/routes/websocket.py`
- `python3 scripts/pre_pr_hygiene.py`

## Notes
- Closes Beads `repowire-fxa` and `repowire-pve`.
- This intentionally preserves public status names; the internal architecture now treats status as runtime-facing while transport availability is checked at delivery time.
- `repowire-ivl` richer `/notify` response shape remains separate.