### PR TITLE
Fix circle provenance adoption

### DIFF
--- a/repowire/client.py
+++ b/repowire/client.py
@@ -253,6 +253,7 @@ class AsyncRepowireClient:
         pane_id: str | None = None,
         backend: str = "claude-code",
         circle: str | None = None,
+        circle_source: str | None = None,
         role: str = "agent",
         metadata: dict[str, Any] | None = None,
     ) -> RegisterPeerResult:
@@ -269,6 +270,7 @@ class AsyncRepowireClient:
             "tmux_session": tmux_session,
             "pane_id": pane_id,
             "circle": circle,
+            "circle_source": circle_source,
         }.items():
             if value is not None:
                 payload[key] = value

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+CircleSource = Literal["tmux", "spawn_hint", "fallback"]
+
 
 def _serialize_attachments(attachments: list | None) -> list[dict[str, Any]]:
     if not attachments:
@@ -436,6 +438,7 @@ class PeerRegistry:
         path: str | None = None,
         role: PeerRole = PeerRole.AGENT,
         agent_pid: int | None = None,
+        circle_source: CircleSource | None = None,
     ) -> str:
         """Find existing mapping or allocate a new session_id. Must hold lock.
 
@@ -456,12 +459,15 @@ class PeerRegistry:
                 return sid
 
         # Cross-circle adoption: when the caller supplied the fallback circle
-        # ("default") but a prior mapping exists for the same (name, backend,
-        # path), reuse it so the peer's prior circle and description survive
-        # restarts where the tmux session name didn't propagate (e.g. claude
-        # --continue). Strictly gated on circle == "default" to avoid
-        # collapsing genuinely separate same-path peers in different circles.
-        if circle == "default" and path:
+        # ("default") because tmux context was missing, but a prior mapping
+        # exists for the same (name, backend, path), reuse it so the peer's
+        # prior circle and description survive restarts where the tmux session
+        # name didn't propagate (e.g. claude --continue). Explicit provenance
+        # matters: a real tmux session named "default" or a spawn hint for
+        # "default" is intentional and must not be remapped to an old
+        # non-default circle.
+        can_cross_circle_adopt = circle_source in (None, "fallback")
+        if circle == "default" and path and can_cross_circle_adopt:
             for sid, mapping in self._mappings.items():
                 if (
                     mapping.display_name == display_name
@@ -531,6 +537,7 @@ class PeerRegistry:
         initial_status: PeerStatus = PeerStatus.ONLINE,
         agent_pid: int | None = None,
         parent_pid: int | None = None,
+        circle_source: CircleSource | None = None,
     ) -> tuple[str, str]:
         """Allocate a peer_id and register the peer atomically.
 
@@ -630,7 +637,7 @@ class PeerRegistry:
                 assigned_name = self._build_display_name(path or "", circle, backend)
                 allocated_id = self._find_or_allocate_mapping(
                     assigned_name, circle, backend, path, role=role,
-                    agent_pid=agent_pid,
+                    agent_pid=agent_pid, circle_source=circle_source,
                 )
                 if pane_id:
                     self._release_pane(pane_id, allocated_id)

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -14,7 +14,11 @@ from repowire import peer_mcp
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_peer_registry
-from repowire.daemon.peer_registry import PaneHijackRejectedError, RoleClaimConflictError
+from repowire.daemon.peer_registry import (
+    CircleSource,
+    PaneHijackRejectedError,
+    RoleClaimConflictError,
+)
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import load_peer_turns, page_turns
@@ -98,6 +102,10 @@ class RegisterPeerRequest(BaseModel):
     pane_id: str | None = Field(None, description="Tmux pane ID")
     backend: AgentType = Field(default=AgentType.CLAUDE_CODE, description="Agent type")
     circle: str | None = Field(None, description="Circle (logical subnet)")
+    circle_source: CircleSource | None = Field(
+        None,
+        description="How the caller resolved circle: tmux, spawn_hint, or fallback",
+    )
     role: PeerRole = Field(default=PeerRole.AGENT, description="Peer role")
     turn_state: TurnState | None = Field(
         None, description="Initial per-turn progress (optional)"
@@ -307,6 +315,7 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
             ),
             agent_pid=request.agent_pid,
             parent_pid=request.parent_pid,
+            circle_source=request.circle_source,
         )
     except PaneHijackRejectedError as exc:
         raise HTTPException(

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from repowire.config.models import AgentType
 from repowire.daemon.deps import get_app_state
+from repowire.daemon.peer_registry import CircleSource
 from repowire.daemon.routes._shared import is_valid_identifier
 from repowire.protocol.peers import PeerRole, PeerStatus, TurnState
 
@@ -91,6 +92,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         path = data.get("path")
         tmux_session = data.get("tmux_session")
         pane_id = data.get("pane_id")
+        circle_source = data.get("circle_source")
+        if circle_source not in (None, "tmux", "spawn_hint", "fallback"):
+            await websocket.send_json({"type": "error", "error": "Invalid circle_source"})
+            await websocket.close(code=4002, reason="Invalid circle_source")
+            return
 
         # Validate display_name
         if not display_name or not is_valid_identifier(display_name):
@@ -158,6 +164,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             machine=os.environ.get("HOSTNAME", "unknown"),
             role=role,
             peer_id=claimed_peer_id,
+            circle_source=cast(CircleSource | None, circle_source),
         )
         session_id = peer_id
 

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -63,6 +63,7 @@ def _register_peer_http(
     circle: str,
     backend: AgentType,
     *,
+    circle_source: str | None = None,
     pane_id: str | None = None,
     metadata: dict | None = None,
     role: str | None = None,
@@ -84,6 +85,8 @@ def _register_peer_http(
         "circle": circle,
         "backend": backend,
     }
+    if circle_source:
+        payload["circle_source"] = circle_source
     if pane_id:
         payload["pane_id"] = pane_id
     if metadata:
@@ -272,11 +275,15 @@ def main(backend: str = "claude-code") -> int:
         # Codex strips tmux env from hook subprocesses, so fall back to the
         # spawn hint before defaulting.
         hint = consume_hint_full(cwd, backend)
-        circle = (
-            tmux_info["session_name"]
-            or (hint["circle"] if hint else None)
-            or "default"
-        )
+        if tmux_info["session_name"]:
+            circle = tmux_info["session_name"]
+            circle_source = "tmux"
+        elif hint:
+            circle = hint["circle"]
+            circle_source = "spawn_hint"
+        else:
+            circle = "default"
+            circle_source = "fallback"
         hint_role = hint.get("role") if hint else None
         # Spawn-seed-drop guard: if the daemon spawned this peer with a seed
         # message, mark turn_state=pending_first_turn so orchestrators can
@@ -308,6 +315,7 @@ def main(backend: str = "claude-code") -> int:
             cwd,
             circle,
             backend_type,
+            circle_source=circle_source,
             pane_id=pane_id,
             metadata=metadata,
             role=hint_role,

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -487,7 +487,9 @@ async def main() -> int:
         logger.error("TMUX_PANE not set")
         return 1
 
-    circle = get_tmux_info()["session_name"] or "default"
+    tmux_session_name = get_tmux_info()["session_name"]
+    circle = tmux_session_name or "default"
+    circle_source = "tmux" if tmux_session_name else "fallback"
     display_name = get_display_name()
     backend_str = os.environ.get("REPOWIRE_BACKEND", "claude-code")
     try:
@@ -542,6 +544,7 @@ async def main() -> int:
                     "backend": backend,
                     "path": path,
                     "pane_id": pane_id,
+                    "circle_source": circle_source,
                 }
                 peer_id = os.environ.get("REPOWIRE_PEER_ID")
                 if peer_id:

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -15,7 +15,7 @@ from repowire.config.models import DEFAULT_DAEMON_URL
 from repowire.hooks._tmux import get_pane_id, get_tmux_info
 from repowire.hooks.utils import get_display_name, read_pane_runtime_metadata
 from repowire.protocol.errors import DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError
-from repowire.spawn_hints import consume_hint
+from repowire.spawn_hints import consume_hint_full
 
 logger = logging.getLogger(__name__)
 
@@ -440,8 +440,18 @@ async def _ensure_registered(*, strict: bool = False) -> None:
 
     # Tmux env is stripped by codex's MCP sandbox, so session_name is None
     # there. Fall back to the spawn hint dropped by the daemon's /spawn route
-    # before defaulting to "default".
-    circle = tmux_info["session_name"] or consume_hint(str(cwd), backend) or "default"
+    # before defaulting to "default". Carry the source so the daemon can
+    # distinguish an explicit tmux session named "default" from a true fallback.
+    hint = consume_hint_full(str(cwd), backend)
+    if tmux_info["session_name"]:
+        circle = tmux_info["session_name"]
+        circle_source = "tmux"
+    elif hint:
+        circle = hint["circle"]
+        circle_source = "spawn_hint"
+    else:
+        circle = "default"
+        circle_source = "fallback"
 
     try:
         body: dict = {
@@ -449,6 +459,7 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             "path": str(cwd),
             "circle": circle,
             "backend": backend,
+            "circle_source": circle_source,
         }
         if pane_id:
             body["pane_id"] = pane_id

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -236,9 +236,10 @@ async def test_ensure_registered_does_not_claim_when_multiple_candidates():
         {"display_name": "agentbox-2-codex", "peer_id": "p2"},
     ]
     posted_name = "agentbox-3-codex"
+    posted_body = {}
 
     async def daemon_router(method, url, body=None, params=None):  # noqa: ARG001
-        del body, params
+        del params
         if method == "GET" and url.startswith("/peers/by-pane/"):
             raise RuntimeError("no pane_id passed in this scenario")
         if method == "GET" and url == "/peers":
@@ -246,6 +247,7 @@ async def test_ensure_registered_does_not_claim_when_multiple_candidates():
         if method == "GET" and url.startswith("/peers/"):
             raise RuntimeError("name lookup miss")
         if method == "POST" and url == "/peers":
+            posted_body.update(body or {})
             return {"peer_id": "p3", "display_name": posted_name}
         raise AssertionError(f"unexpected request: {method} {url}")
 
@@ -262,6 +264,44 @@ async def test_ensure_registered_does_not_claim_when_multiple_candidates():
         "not claim one arbitrarily"
     )
     assert mcp_server._cached_peer_name not in {c["display_name"] for c in candidates}
+    assert posted_body["circle"] == "default"
+    assert posted_body["circle_source"] == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_ensure_registered_marks_explicit_tmux_default_as_tmux():
+    """MCP lazy registration must not let explicit tmux "default" look legacy.
+
+    Without circle_source="tmux", PeerRegistry may cross-adopt an old persisted
+    non-default mapping for the same path/name/backend.
+    """
+    posted_body = {}
+
+    async def daemon_router(method, url, body=None, params=None):  # noqa: ARG001
+        del params
+        if method == "GET" and url.startswith("/peers/by-pane/"):
+            raise RuntimeError("pane lookup miss")
+        if method == "GET" and url == "/peers":
+            return {"peers": []}
+        if method == "GET" and url.startswith("/peers/"):
+            raise RuntimeError("name lookup miss")
+        if method == "POST" and url == "/peers":
+            posted_body.update(body or {})
+            return {"peer_id": "p3", "display_name": "agentbox-codex"}
+        if method == "POST" and url.endswith("/touch"):
+            return {"ok": True}
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    with patch.object(
+            mcp_server, "get_tmux_info", return_value={"pane_id": "%42", "session_name": "default"},
+         ), \
+         patch.object(mcp_server, "get_pane_id", return_value=None), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_router)), \
+         patch.object(mcp_server, "get_display_name", return_value="agentbox"):
+        await mcp_server._ensure_registered()
+
+    assert posted_body["circle"] == "default"
+    assert posted_body["circle_source"] == "tmux"
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -114,6 +114,37 @@ class TestSessionMain:
             call_args = mock_register.call_args
             # First positional arg is now path (cwd), not display_name
             assert call_args[0][0] == str(tmp_path)
+            assert call_args.kwargs["circle_source"] == "tmux"
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=("repow-default-abc12345", "test-claude-code", False),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": None,
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.subprocess.Popen")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    def test_session_start_marks_missing_tmux_default_as_fallback(
+        self, mock_branch, mock_status, mock_popen, mock_tmux, mock_register, mock_fetch, tmp_path,
+    ):
+        with patch("repowire.config.models.CACHE_DIR", tmp_path):
+            result = _run_with_input({
+                "hook_event_name": "SessionStart",
+                "cwd": str(tmp_path),
+                "session_id": "abc12345-rest",
+            })
+            assert result == 0
+            call_args = mock_register.call_args
+            assert call_args[0][1] == "default"
+            assert call_args.kwargs["circle_source"] == "fallback"
 
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -284,6 +284,74 @@ async def test_circle_and_description_persist_across_restart(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_fallback_default_adopts_prior_non_default_circle(tmp_path):
+    """Missing tmux context still restores the prior non-default circle.
+
+    This is the intended compatibility path for restarts such as
+    ``claude --continue`` where registration can only say circle="default"
+    because tmux provenance was unavailable.
+    """
+    registry = _make_registry(tmp_path)
+    workdir = tmp_path / "torale"
+    workdir.mkdir()
+
+    original_id, original_name = await registry.allocate_and_register(
+        circle="5",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        circle_source="tmux",
+    )
+
+    restarted_id, restarted_name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        circle_source="fallback",
+    )
+
+    assert restarted_id == original_id
+    assert restarted_name == original_name
+    peer = await registry.get_peer(restarted_id)
+    assert peer is not None
+    assert peer.circle == "5"
+
+
+@pytest.mark.asyncio
+async def test_explicit_tmux_default_does_not_adopt_prior_non_default_circle(tmp_path):
+    """A real tmux session named "default" must stay in circle "default".
+
+    Regression coverage for the observed bug: ws-hook logged an explicit
+    ``torale-claude-code@default`` registration, but persisted session
+    ``repow-5-043bcace`` for the same path/name/backend remapped it back to
+    circle "5". The tmux provenance makes "default" intentional here.
+    """
+    registry = _make_registry(tmp_path)
+    workdir = tmp_path / "torale"
+    workdir.mkdir()
+
+    old_id, old_name = await registry.allocate_and_register(
+        circle="5",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        circle_source="tmux",
+    )
+    await registry.mark_offline(old_id)
+
+    explicit_default_id, explicit_default_name = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        circle_source="tmux",
+    )
+
+    assert explicit_default_id != old_id
+    assert explicit_default_name == old_name
+    peer = await registry.get_peer(explicit_default_id)
+    assert peer is not None
+    assert peer.circle == "default"
+
+
+@pytest.mark.asyncio
 async def test_role_persists_across_restart_adoption(tmp_path):
     """A restarted daemon must not downgrade an adopted peer's persisted role."""
     path = tmp_path / "sessions.json"

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -618,6 +618,7 @@ class TestMcpRegistration:
                 "path": str(cwd),
                 "circle": "0",
                 "backend": "codex",
+                "circle_source": "tmux",
                 "pane_id": "%1",
             },
         )


### PR DESCRIPTION
## Summary
- carry circle provenance through hook, websocket, MCP, and client registration paths
- prevent explicit tmux session `default` from adopting a stale persisted non-default circle
- preserve fallback default adoption for missing tmux context and restart/continue compatibility

## Verification
- `uv run --extra dev pytest tests/test_session_mapper.py tests/test_session_handler.py tests/test_mcp_peer_identity.py` -> 57 passed
- `uv run --extra dev ruff check <touched files/tests>` -> passed
- `uv run --extra dev ty check <touched source files>` -> passed
- `uv run --extra dev pytest tests/test_routes.py tests/test_websocket.py -k "register_peer or connect"` -> 11 passed
- `python3 scripts/pre_pr_hygiene.py` -> passed

## Docs / Graphify
Pre-PR hygiene flags public/client/hook/architecture surfaces. This patch adds internal provenance metadata for registration and preserves external behavior, so docs are intentionally deferred. Graphify update is useful after this architecture train settles; no generated graphify artifacts are included.

Fixes repowire-01e.