### PR TITLE
Extend notify response semantics

### DIFF
--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Literal, cast
 from uuid import uuid4
 
@@ -26,6 +27,32 @@ from repowire.daemon.transport_router import (
 from repowire.protocol.messages import AttachmentRef
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NotifyDeliveryResult:
+    """Structured notify outcome for HTTP clients.
+
+    ``status`` is the legacy compact value returned by older call sites.
+    ``delivery_state`` and ``reason`` make the same outcome explicit so
+    clients do not need to infer BUSY queueing or transport success.
+    """
+
+    status: Literal["sent", "queued"]
+    delivery_state: Literal["delivered", "queued"]
+    reason: Literal["transport_delivered", "recipient_busy"]
+    from_peer_id: str | None
+    from_peer_name: str
+    to_peer_id: str
+    to_peer_name: str
+
+    @property
+    def delivered(self) -> bool:
+        return self.delivery_state == "delivered"
+
+    @property
+    def queued(self) -> bool:
+        return self.delivery_state == "queued"
 
 
 class PeerDeliveryService:
@@ -126,6 +153,27 @@ class PeerDeliveryService:
         attachments: list[AttachmentRef] | tuple[AttachmentRef, ...] | None = None,
     ) -> Literal["sent", "queued"]:
         """Send a fire-and-forget notification using ACP-before-WS routing."""
+        result = await self.notify_result(
+            from_peer=from_peer,
+            to_peer=to_peer,
+            text=text,
+            bypass_circle=bypass_circle,
+            circle=circle,
+            attachments=attachments,
+        )
+        return result.status
+
+    async def notify_result(
+        self,
+        *,
+        from_peer: str,
+        to_peer: str,
+        text: str,
+        bypass_circle: bool = False,
+        circle: str | None = None,
+        attachments: list[AttachmentRef] | tuple[AttachmentRef, ...] | None = None,
+    ) -> NotifyDeliveryResult:
+        """Send a notification and return an explicit delivery outcome."""
         from_obj, target = await self._registry.check_access(
             from_peer=from_peer,
             to_peer=to_peer,
@@ -133,7 +181,7 @@ class PeerDeliveryService:
             circle=circle,
         )
         attachment_tuple = tuple(attachments or ())
-        return await self._router().send_notify(
+        delivery_status = await self._router().send_notify(
             NotifyEnvelope(
                 from_peer_id=from_obj.peer_id if from_obj else None,
                 from_peer_name=from_obj.display_name if from_obj else from_peer,
@@ -142,6 +190,21 @@ class PeerDeliveryService:
                 intended_recipient_name=to_peer,
                 attachments=attachment_tuple,
             )
+        )
+        delivery_state: Literal["delivered", "queued"] = (
+            "queued" if delivery_status == "queued" else "delivered"
+        )
+        reason: Literal["transport_delivered", "recipient_busy"] = (
+            "recipient_busy" if delivery_status == "queued" else "transport_delivered"
+        )
+        return NotifyDeliveryResult(
+            status=delivery_status,
+            delivery_state=delivery_state,
+            reason=reason,
+            from_peer_id=from_obj.peer_id if from_obj else None,
+            from_peer_name=from_obj.display_name if from_obj else from_peer,
+            to_peer_id=target.peer_id,
+            to_peer_name=target.display_name,
         )
 
     async def deliver_ask(

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -7,7 +7,7 @@ import json
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT
@@ -59,7 +59,9 @@ class NotifyResponse(BaseModel):
 
     ``status`` reflects the recipient's state at send-time: ``sent`` means
     ONLINE (immediate paste), ``queued`` means BUSY (ws-hook holds the paste
-    until the current turn ends). Wire format otherwise unchanged.
+    until the current turn ends). ``delivery_state`` is the explicit client
+    semantic: ``delivered`` for transport handoff, ``queued`` for BUSY
+    handoff.
 
     Notify is fire-and-forget: daemon-side success means the frame was handed
     to the recipient WebSocket, not that the agent received or processed it.
@@ -68,6 +70,14 @@ class NotifyResponse(BaseModel):
 
     ok: bool = True
     status: Literal["sent", "queued"] = "sent"
+    delivery_state: Literal["delivered", "queued"] = "delivered"
+    delivered: bool = True
+    queued: bool = False
+    reason: Literal["transport_delivered", "recipient_busy"] = "transport_delivered"
+    from_peer_id: str | None = None
+    from_peer_name: str | None = None
+    to_peer_id: str | None = None
+    to_peer_name: str | None = None
 
 
 class BroadcastRequest(BaseModel):
@@ -165,7 +175,7 @@ async def query_peer(
 async def notify_peer(
     request: NotifyRequest,
     _: str | None = Depends(require_auth),
-) -> NotifyResponse:
+) -> NotifyResponse | JSONResponse:
     """Send a notification to a peer (fire-and-forget).
 
     Routing is transport-agnostic:
@@ -196,7 +206,7 @@ async def notify_peer(
             registry=peer_registry,
             state=state,
         )
-        delivery_status = await peer_delivery.notify(
+        delivery = await peer_delivery.notify_result(
             from_peer=request.from_peer,
             to_peer=request.to_peer,
             text=request.text,
@@ -204,23 +214,62 @@ async def notify_peer(
             circle=request.circle,
             attachments=request.attachments,
         )
-        return NotifyResponse(status=delivery_status)
+        return NotifyResponse(
+            status=delivery.status,
+            delivery_state=delivery.delivery_state,
+            delivered=delivery.delivered,
+            queued=delivery.queued,
+            reason=delivery.reason,
+            from_peer_id=delivery.from_peer_id,
+            from_peer_name=delivery.from_peer_name,
+            to_peer_id=delivery.to_peer_id,
+            to_peer_name=delivery.to_peer_name,
+        )
     except ValueError as e:
         msg = str(e)
         if msg.startswith("Ambiguous peer name"):
             code = status.HTTP_409_CONFLICT
+            error_status = "ambiguous_peer"
+            delivery_state = "failed"
+            reason = "ambiguous_peer"
         elif msg.startswith("Unknown peer"):
             code = status.HTTP_404_NOT_FOUND
+            error_status = "not_found"
+            delivery_state = "unknown_peer"
+            reason = "unknown_peer"
         else:
             code = status.HTTP_403_FORBIDDEN
-        raise HTTPException(
+            error_status = "forbidden"
+            delivery_state = "failed"
+            reason = "forbidden"
+        return JSONResponse(
             status_code=code,
-            detail=msg,
+            content={
+                "ok": False,
+                "status": error_status,
+                "delivery_state": delivery_state,
+                "delivered": False,
+                "queued": False,
+                "reason": reason,
+                "detail": msg,
+                "from_peer_name": request.from_peer,
+                "to_peer_name": request.to_peer,
+            },
         )
     except TransportError as e:
-        raise HTTPException(
+        return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Peer {request.to_peer} has no live connection: {e}",
+            content={
+                "ok": False,
+                "status": "unavailable",
+                "delivery_state": "no_live_transport",
+                "delivered": False,
+                "queued": False,
+                "reason": "no_live_transport",
+                "detail": f"Peer {request.to_peer} has no live connection: {e}",
+                "from_peer_name": request.from_peer,
+                "to_peer_name": request.to_peer,
+            },
         )
     except Exception as e:
         raise HTTPException(

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -456,7 +456,14 @@ async def test_public_notify_route_does_not_503_for_acp_peer(
             assert r.status_code == 200, (
                 f"/notify 503'd for ACP peer (regression of repowire#206): {r.text}"
             )
-            assert r.json()["status"] == "sent"
+            body = r.json()
+            assert body["status"] == "sent"
+            assert body["delivery_state"] == "delivered"
+            assert body["delivered"] is True
+            assert body["queued"] is False
+            assert body["reason"] == "transport_delivered"
+            assert body["from_peer_name"] == asker
+            assert body["to_peer_name"] == answerer
     finally:
         await asyncio.sleep(0)
         await manager.close()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -896,6 +896,14 @@ class TestNotify:
             "text": "hello",
         })
         assert r.status_code == 404
+        body = r.json()
+        assert body["detail"] == "Unknown peer: nonexistent"
+        assert body["ok"] is False
+        assert body["status"] == "not_found"
+        assert body["delivery_state"] == "unknown_peer"
+        assert body["reason"] == "unknown_peer"
+        assert body["delivered"] is False
+        assert body["queued"] is False
 
     async def test_notify_ambiguous_peer_returns_409(self, client):
         """When two peers share a display_name across circles, /notify must
@@ -920,7 +928,43 @@ class TestNotify:
             "text": "hello",
         })
         assert r.status_code == 409
-        assert "Ambiguous peer name" in r.json()["detail"]
+        body = r.json()
+        assert "Ambiguous peer name" in body["detail"]
+        assert body["ok"] is False
+        assert body["status"] == "ambiguous_peer"
+        assert body["delivery_state"] == "failed"
+        assert body["reason"] == "ambiguous_peer"
+        assert body["delivered"] is False
+        assert body["queued"] is False
+
+    async def test_notify_cross_circle_forbidden_returns_403_shape(self, client):
+        registry = get_peer_registry()
+        _sender_id, sender_name = await registry.allocate_and_register(
+            circle="alpha",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/alpha-sender",
+        )
+        _recipient_id, recipient_name = await registry.allocate_and_register(
+            circle="beta",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/beta-recipient",
+        )
+
+        r = await client.post("/notify", json={
+            "from_peer": sender_name,
+            "to_peer": recipient_name,
+            "text": "hello",
+        })
+
+        assert r.status_code == 403
+        body = r.json()
+        assert "Circle boundary" in body["detail"]
+        assert body["ok"] is False
+        assert body["status"] == "forbidden"
+        assert body["delivery_state"] == "failed"
+        assert body["reason"] == "forbidden"
+        assert body["delivered"] is False
+        assert body["queued"] is False
 
     async def test_notify_online_recipient_returns_sent(self, client, monkeypatch):
         from unittest.mock import AsyncMock
@@ -953,6 +997,14 @@ class TestNotify:
         body = r.json()
         assert body["ok"] is True
         assert body["status"] == "sent"
+        assert body["delivery_state"] == "delivered"
+        assert body["delivered"] is True
+        assert body["queued"] is False
+        assert body["reason"] == "transport_delivered"
+        assert body["from_peer_id"] == _sender_id
+        assert body["from_peer_name"] == sender_name
+        assert body["to_peer_id"] == recipient_id
+        assert body["to_peer_name"] == recipient_name
 
     async def test_notify_carries_attachments_to_event_and_wire(self, client, monkeypatch):
         from unittest.mock import AsyncMock
@@ -1019,6 +1071,52 @@ class TestNotify:
         body = r.json()
         assert body["ok"] is True
         assert body["status"] == "queued"
+        assert body["delivery_state"] == "queued"
+        assert body["delivered"] is False
+        assert body["queued"] is True
+        assert body["reason"] == "recipient_busy"
+        assert body["from_peer_id"] == _sender_id
+        assert body["from_peer_name"] == sender_name
+        assert body["to_peer_id"] == recipient_id
+        assert body["to_peer_name"] == recipient_name
+
+    async def test_notify_no_live_transport_returns_503_shape(self, client, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from repowire.daemon.websocket_transport import TransportError
+
+        registry = get_peer_registry()
+        _sender_id, sender_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/sender3",
+        )
+        _recipient_id, recipient_name = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CLAUDE_CODE,
+            path="/tmp/recipient3",
+        )
+        monkeypatch.setattr(
+            registry._router,
+            "send_notification",
+            AsyncMock(side_effect=TransportError("No connection")),
+        )
+
+        r = await client.post("/notify", json={
+            "from_peer": sender_name,
+            "to_peer": recipient_name,
+            "text": "hello",
+        })
+
+        assert r.status_code == 503
+        body = r.json()
+        assert "no live connection" in body["detail"]
+        assert body["ok"] is False
+        assert body["status"] == "unavailable"
+        assert body["delivery_state"] == "no_live_transport"
+        assert body["reason"] == "no_live_transport"
+        assert body["delivered"] is False
+        assert body["queued"] is False
 
 
 # -- Broadcast --


### PR DESCRIPTION
## Summary
- add structured notify delivery outcomes while preserving existing HTTP status codes
- expose delivered/queued/reason and peer identity fields for successful /notify calls
- return structured error bodies for unknown, ambiguous, forbidden, and no-live-transport cases

## Verification
- `uv run --extra dev pytest tests/test_routes.py::TestNotify tests/test_acp_broker_client.py::test_public_notify_route_does_not_503_for_acp_peer` -> 8 passed
- `uv run --extra dev ruff check repowire/daemon/peer_delivery.py repowire/daemon/routes/messages.py tests/test_routes.py tests/test_acp_broker_client.py` -> passed
- `uv run --extra dev ty check repowire/daemon/peer_delivery.py repowire/daemon/routes/messages.py` -> passed
- `python3 scripts/pre_pr_hygiene.py` -> passed

## Docs / Graphify
Pre-PR hygiene flags architecture docs because /notify semantics changed. This is a narrow response-shape addition and preserves route status contracts; docs/Graphify are deferred until the architecture cleanup train settles.

Fixes repowire-ivl.