### PR TITLE
Fix orchestrator role reclaim after restart

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -150,6 +150,14 @@ Update the free-form description visible in `list_peers`. Call this at the start
 set_description("rebuilding docs slice B")
 ```
 
+### `claim_orchestrator_role`
+
+```python
+claim_orchestrator_role(force: bool = False) -> str
+```
+
+Self-repair tool for the orchestrator workspace. Use it after a daemon restart when `list_peers(include_self=True)` shows the orchestrator session as `role=agent`. It targets the caller's current peer id, persists `role=orchestrator` into the session mapping, and refuses non-orchestrator workspace/session names. Pass `force=True` only when an existing fresh orchestrator holder in the same circle should be demoted.
+
 ### `orchestrator_status`
 
 ```python

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -401,7 +401,6 @@ class PeerRegistry:
                     break
 
             if blocker is None:
-                self._prune_name_from_mappings(candidate, circle, backend)
                 return candidate
 
             sid, peer = blocker

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -58,13 +58,20 @@ def _cache_identity(result: dict) -> None:
     global _cached_peer_id, _cached_peer_name, _cached_my_circle, _cached_my_role
     if result.get("peer_id"):
         _cached_peer_id = result["peer_id"]
-    name = result.get("display_name") or result.get("name")
+    name = result.get("display_name") or result.get("peer_name") or result.get("name")
     if name:
         _cached_peer_name = name
     if result.get("circle"):
         _cached_my_circle = result.get("circle")
     if result.get("role"):
         _cached_my_role = result.get("role")
+
+
+def _orchestrator_self_claim_allowed(peer: dict) -> bool:
+    """Return whether this peer is eligible to reclaim the orchestrator role."""
+    display_name = str(peer.get("display_name") or peer.get("name") or "").lower()
+    path_name = Path(str(peer.get("path") or "")).name.lower()
+    return display_name == "orchestrator" or path_name == "orchestrator"
 
 
 async def _resolve_circle_for_send(
@@ -810,6 +817,54 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
             {"description": description},
         )
         return f"description updated: {description}"
+
+    @mcp.tool()
+    async def claim_orchestrator_role(force: bool = False) -> str:
+        """[Repowire mesh] Reclaim this session's role=orchestrator.
+
+        Use from the orchestrator workspace after a daemon restart if list_peers
+        shows this session as role=agent. This is self-only: it targets the
+        caller's current peer_id and cannot claim the role for another peer.
+
+        Args:
+            force: Demote an existing fresh orchestrator holder in this circle.
+
+        Returns:
+            Confirmation message
+        """
+        _ensure_http_admin_tool_allowed("claim_orchestrator_role")
+        await _ensure_registered(strict=True)
+        name, circle, _role = await _get_my_identity()
+        identifier = _cached_peer_id or name
+        if not identifier:
+            raise RuntimeError("Cannot resolve current peer identity")
+
+        current = await daemon_request("GET", f"/peers/{quote(identifier, safe='')}")
+        _cache_identity(current)
+        if not _orchestrator_self_claim_allowed(current):
+            raise PermissionError(
+                "claim_orchestrator_role can only be used by the orchestrator "
+                "workspace/session"
+            )
+
+        target = _cached_peer_id or identifier
+        result = await daemon_request(
+            "POST",
+            "/peers/claim-role",
+            {
+                "role": "orchestrator",
+                "peer_name": target,
+                "circle": current.get("circle") or circle,
+                "force": force,
+            },
+        )
+        _cache_identity(result)
+        holders = result.get("previous_holders") or []
+        suffix = f"; demoted {len(holders)} previous holder(s)" if holders else ""
+        return (
+            f"claimed role=orchestrator for {result.get('peer_name') or target} "
+            f"in circle {result.get('circle')}{suffix}"
+        )
 
     @mcp.tool()
     async def spawn_peer(

--- a/tests/test_claim_role.py
+++ b/tests/test_claim_role.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -18,6 +18,7 @@ from repowire.daemon.peer_registry import PeerRegistry, RoleClaimConflictError
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.routes import peers
 from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.mcp import server as mcp_server
 from repowire.protocol.peers import PeerRole, PeerStatus
 
 
@@ -232,3 +233,88 @@ def test_cli_claim_role_reports_live_holder_conflict(monkeypatch: pytest.MonkeyP
     assert result.exit_code == 1
     assert "Cannot claim role" in result.output
     assert "Use --force" in result.output
+
+
+@pytest.mark.asyncio
+async def test_mcp_self_claim_reclaims_orchestrator_after_restart(
+    client: tuple[AsyncClient, PeerRegistry],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http_client, registry = client
+    orch_dir = registry._mappings_path.parent / "orchestrator"
+    orch_dir.mkdir()
+    active_id = await _register(registry, path=str(orch_dir), circle="default")
+    mcp_server.reset_mcp_context()
+    mcp_server._registered = True
+    mcp_server._cached_peer_id = active_id
+    mcp_server._cached_peer_name = "orchestrator-codex"
+    mcp_server._cached_my_circle = "default"
+    mcp_server._cached_my_role = "agent"
+
+    async def local_daemon_request(
+        method: str,
+        path: str,
+        body: dict | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        response = await http_client.request(method, path, json=body, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    monkeypatch.setattr(mcp_server, "daemon_request", local_daemon_request)
+    monkeypatch.setattr(mcp_server, "_touch_last_seen", AsyncMock())
+    claim = mcp_server.create_mcp_server()._tool_manager._tools["claim_orchestrator_role"].fn
+
+    result = await claim()
+
+    assert "claimed role=orchestrator" in result
+    peer = await registry.get_peer(active_id)
+    assert peer is not None
+    assert peer.role == PeerRole.ORCHESTRATOR
+    assert registry.get_mapping(active_id).role == PeerRole.ORCHESTRATOR
+
+    # Simulate daemon restart: persisted mapping must restore the reclaimed role.
+    registry._persist_mappings()
+    restarted = _make_registry(registry._mappings_path.parent)
+    peer_id, _name = await restarted.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path=str(orch_dir),
+        role=PeerRole.AGENT,
+        machine="m",
+    )
+    restarted_peer = await restarted.get_peer(peer_id)
+    assert restarted_peer is not None
+    assert restarted_peer.role == PeerRole.ORCHESTRATOR
+
+
+@pytest.mark.asyncio
+async def test_mcp_self_claim_rejects_non_orchestrator_session(
+    client: tuple[AsyncClient, PeerRegistry],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http_client, _registry = client
+    active_id = await _register(_registry, path="/tmp/project", circle="default")
+    mcp_server.reset_mcp_context()
+    mcp_server._registered = True
+    mcp_server._cached_peer_id = active_id
+    mcp_server._cached_peer_name = "project-codex"
+    mcp_server._cached_my_circle = "default"
+    mcp_server._cached_my_role = "agent"
+
+    async def local_daemon_request(
+        method: str,
+        path: str,
+        body: dict | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        response = await http_client.request(method, path, json=body, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    monkeypatch.setattr(mcp_server, "daemon_request", local_daemon_request)
+    monkeypatch.setattr(mcp_server, "_touch_last_seen", AsyncMock())
+    claim = mcp_server.create_mcp_server()._tool_manager._tools["claim_orchestrator_role"].fn
+
+    with pytest.raises(PermissionError, match="orchestrator workspace"):
+        await claim()

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -456,7 +456,8 @@ class TestMcpToolDescriptions:
         mcp = create_mcp_server()
         mesh_tools = ["list_peers", "ask", "ack", "notify_peer", "broadcast",
                        "spawn_peer", "kill_peer", "whoami", "set_description",
-                       "schedule_create", "schedule_self", "schedule_cron",
+                       "claim_orchestrator_role", "schedule_create", "schedule_self",
+                       "schedule_cron",
                        "schedule_list", "schedule_delete"]
         for name in mesh_tools:
             tool = mcp._tool_manager._tools.get(name)


### PR DESCRIPTION
## Summary
- add a self-only MCP `claim_orchestrator_role` repair tool for orchestrator sessions
- preserve mapping-only same-name/circle/backend records so restart adoption can reuse persisted roles
- document the MCP repair tool and add regression coverage for restart reclaim plus non-orchestrator rejection

## Subtle Registry Fix
`_build_display_name()` no longer prunes mapping-only same-name/circle/backend records when no live peer blocks the name. That lets `_find_or_allocate_mapping()` reuse the persisted orchestrator mapping after daemon restart instead of recreating it as `role=agent`. Offline live peer clean-takeover behavior remains covered.

## Verification
- `uv run --extra dev pytest tests/test_claim_role.py tests/test_spawn.py::TestMcpToolDescriptions tests/test_session_mapper.py tests/test_acp_broker_client.py::test_pending_reply_rebinds_on_new_peer_id_after_clean_takeover` -> 35 passed
- `uv run --extra dev ruff check repowire/daemon/peer_registry.py repowire/mcp/server.py tests/test_claim_role.py tests/test_spawn.py docs/reference/mcp-tools.md` -> passed
- `uv run --extra dev ty check repowire/daemon/peer_registry.py repowire/mcp/server.py` -> passed
- `python3 scripts/pre_pr_hygiene.py` -> passed
- `git diff --check` -> passed

## Docs / Graphify
Updated `docs/reference/mcp-tools.md` for the new MCP tool. Broader architecture docs and Graphify are deferred because this is a narrow repair surface, not a new routing model.

Fixes repowire-90k.