### PR TITLE
Expose MCP config scope in dashboard

### DIFF
--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -8,6 +8,7 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 - **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, and broadcasts.
 - **Per-peer chat** — selecting a peer replaces the live log with that peer's selected-session timeline. For Claude Code peers, the chat view merges persisted transcript history with realtime `chat_turn` and `chat_turn_delta` events; other backends contribute realtime events. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
 - **Compose bar** — send a notification or ask to any peer. The dashboard registers as the `dashboard` peer so it shows up in `list_peers` and message routing.
+- **MCP config tab** — supported peers can list, add, and remove MCP servers. The tab labels whether edits affect peer/project config or backend user-global config before showing edit controls.
 - **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL). The outgoing ask carries structured attachment metadata plus a text fallback with the local path so existing agents can still read it.
 - **Attachment chips** — mesh events and per-peer chat render attachment chips with download links when an attachment ID is available.
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -585,8 +585,30 @@ class McpServerResponse(BaseModel):
     env_keys: list[str] = Field(default_factory=list)
 
 
+class McpConfigScopeResponse(BaseModel):
+    backend: str
+    owner: str
+    effective_scope: str
+    label: str
+    description: str
+    supported_scopes: list[str] = Field(default_factory=list)
+    default_scope: str = "user"
+    is_global: bool = False
+    peer_id: str
+    peer_name: str
+    project_path: str | None = None
+    peer_machine: str | None = None
+    self_machine: str
+    same_host: bool
+
+
 class McpListResponse(BaseModel):
     servers: list[McpServerResponse]
+    config_scope: McpConfigScopeResponse | None = None
+
+
+class McpMutationResponse(OkResponse):
+    config_scope: McpConfigScopeResponse | None = None
 
 
 class McpAddRequest(BaseModel):
@@ -609,6 +631,71 @@ async def _resolve_peer_or_404(name: str, circle: str | None) -> Peer:
     return peer
 
 
+def _mcp_scope_metadata(peer: Peer) -> McpConfigScopeResponse:
+    self_machine = socket.gethostname()
+    backend = peer.backend
+    if backend == AgentType.CLAUDE_CODE:
+        scope = {
+            "backend": backend.value,
+            "owner": "peer/project",
+            "effective_scope": "peer_project",
+            "label": "Claude Code peer/project config",
+            "description": (
+                "Claude Code MCP edits can target user/global config or the peer's "
+                "project/worktree via the selected add scope."
+            ),
+            "supported_scopes": ["user", "project"],
+            "default_scope": "user",
+            "is_global": False,
+        }
+    elif backend == AgentType.CODEX:
+        scope = {
+            "backend": backend.value,
+            "owner": "backend",
+            "effective_scope": "backend_global",
+            "label": "Codex global backend config",
+            "description": (
+                "Codex MCP edits target the user-level Codex config shared by "
+                "Codex sessions on this host."
+            ),
+            "supported_scopes": ["user"],
+            "default_scope": "user",
+            "is_global": True,
+        }
+    elif backend == AgentType.GEMINI:
+        scope = {
+            "backend": backend.value,
+            "owner": "backend",
+            "effective_scope": "backend_global",
+            "label": "Gemini global backend config",
+            "description": (
+                "Gemini MCP edits target the user-level Gemini settings shared by "
+                "Gemini sessions on this host."
+            ),
+            "supported_scopes": ["user"],
+            "default_scope": "user",
+            "is_global": True,
+        }
+    else:
+        raise peer_mcp.NotSupportedError(f"MCP config not supported for backend {backend.value}")
+    return McpConfigScopeResponse(
+        **scope,
+        peer_id=peer.peer_id,
+        peer_name=peer.display_name,
+        project_path=peer.path,
+        peer_machine=peer.machine,
+        self_machine=self_machine,
+        same_host=not peer.machine or peer.machine == self_machine,
+    )
+
+
+def _optional_mcp_scope_metadata(peer: Peer) -> dict[str, Any] | None:
+    try:
+        return _mcp_scope_metadata(peer).model_dump()
+    except peer_mcp.PeerMcpError:
+        return None
+
+
 def _enforce_local(peer: Peer) -> None:
     """Reject cross-host operations until ACP transport is wired (issue #183)."""
     self_machine = socket.gethostname()
@@ -623,6 +710,7 @@ def _enforce_local(peer: Peer) -> None:
                 ),
                 "peer_machine": peer.machine,
                 "self_machine": self_machine,
+                "config_scope": _optional_mcp_scope_metadata(peer),
             },
         )
 
@@ -654,13 +742,17 @@ async def list_peer_mcp(
     peer = await _resolve_peer_or_404(name, circle)
     _enforce_local(peer)
     try:
+        config_scope = _mcp_scope_metadata(peer)
         entries = await asyncio.to_thread(peer_mcp.list_servers, peer)
     except peer_mcp.PeerMcpError as e:
         raise _map_peer_mcp_error(e) from e
-    return McpListResponse(servers=[McpServerResponse(**e.to_dict()) for e in entries])
+    return McpListResponse(
+        servers=[McpServerResponse(**e.to_dict()) for e in entries],
+        config_scope=config_scope,
+    )
 
 
-@router.post("/peers/{name}/mcp", response_model=OkResponse)
+@router.post("/peers/{name}/mcp", response_model=McpMutationResponse)
 async def add_peer_mcp(
     name: str,
     request: McpAddRequest,
@@ -671,6 +763,24 @@ async def add_peer_mcp(
     """Add an MCP server to the peer's backend config."""
     peer = await _resolve_peer_or_404(name, circle)
     _enforce_local(peer)
+    try:
+        config_scope = _mcp_scope_metadata(peer)
+    except peer_mcp.PeerMcpError as e:
+        raise _map_peer_mcp_error(e) from e
+    if scope not in config_scope.supported_scopes:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "unsupported_scope",
+                "hint": (
+                    f"Backend {peer.backend.value} supports MCP scopes: "
+                    f"{', '.join(config_scope.supported_scopes)}"
+                ),
+                "requested_scope": scope,
+                "supported_scopes": config_scope.supported_scopes,
+                "config_scope": config_scope.model_dump(),
+            },
+        )
     spec = peer_mcp.McpServerSpec(
         name=request.name,
         type=request.type,
@@ -684,10 +794,10 @@ async def add_peer_mcp(
         await asyncio.to_thread(peer_mcp.add_server, peer, spec)
     except peer_mcp.PeerMcpError as e:
         raise _map_peer_mcp_error(e) from e
-    return OkResponse()
+    return McpMutationResponse(config_scope=config_scope)
 
 
-@router.delete("/peers/{name}/mcp/{server_name}", response_model=OkResponse)
+@router.delete("/peers/{name}/mcp/{server_name}", response_model=McpMutationResponse)
 async def remove_peer_mcp(
     name: str,
     server_name: str,
@@ -698,10 +808,11 @@ async def remove_peer_mcp(
     peer = await _resolve_peer_or_404(name, circle)
     _enforce_local(peer)
     try:
+        config_scope = _mcp_scope_metadata(peer)
         await asyncio.to_thread(peer_mcp.remove_server, peer, server_name)
     except peer_mcp.PeerMcpError as e:
         raise _map_peer_mcp_error(e) from e
-    return OkResponse()
+    return McpMutationResponse(config_scope=config_scope)
 
 
 # Legacy endpoints for backward compatibility

--- a/tests/test_peer_mcp_routes.py
+++ b/tests/test_peer_mcp_routes.py
@@ -95,7 +95,12 @@ class TestMcpRoutes:
 
         r = await client.get(f"/peers/{name}/mcp")
         assert r.status_code == 200
-        assert r.json()["servers"] == []
+        body = r.json()
+        assert body["servers"] == []
+        assert body["config_scope"]["backend"] == "codex"
+        assert body["config_scope"]["effective_scope"] == "backend_global"
+        assert body["config_scope"]["is_global"] is True
+        assert body["config_scope"]["supported_scopes"] == ["user"]
 
         r = await client.post(f"/peers/{name}/mcp", json={
             "name": "repowire",
@@ -103,6 +108,7 @@ class TestMcpRoutes:
             "args": ["mcp"],
         })
         assert r.status_code == 200
+        assert r.json()["config_scope"]["effective_scope"] == "backend_global"
 
         r = await client.get(f"/peers/{name}/mcp")
         assert r.status_code == 200
@@ -119,6 +125,7 @@ class TestMcpRoutes:
         # Remove
         r = await client.delete(f"/peers/{name}/mcp/repowire")
         assert r.status_code == 200
+        assert r.json()["config_scope"]["backend"] == "codex"
 
         # Remove again -> 404
         r = await client.delete(f"/peers/{name}/mcp/repowire")
@@ -137,6 +144,23 @@ class TestMcpRoutes:
         assert r.status_code == 400
         assert "server name" in r.json()["detail"]
         assert not cfg.exists()
+
+    async def test_codex_rejects_project_scope_with_metadata(self, client, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.toml"
+        monkeypatch.setattr(peer_mcp, "CODEX_CONFIG_PATH", cfg)
+
+        name = await _register(client, name="codexscope", backend="codex")
+
+        r = await client.post(f"/peers/{name}/mcp?scope=project", json={
+            "name": "repowire",
+            "command": "repowire",
+        })
+        assert r.status_code == 409
+        detail = r.json()["detail"]
+        assert detail["error"] == "unsupported_scope"
+        assert detail["requested_scope"] == "project"
+        assert detail["supported_scopes"] == ["user"]
+        assert detail["config_scope"]["effective_scope"] == "backend_global"
 
     async def test_unsupported_backend_returns_501(self, client):
         name = await _register(client, name="pipeer", backend="claude-code")

--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -511,3 +511,107 @@ describe("PeerView session protection", () => {
     expect(screen.queryByText("racing event")).not.toBeInTheDocument();
   });
 });
+
+describe("PeerView MCP config scope", () => {
+  it("labels Codex MCP edits as global backend config before adding", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/peers/alice/mcp")) {
+        return new Response(
+          JSON.stringify({
+            servers: [],
+            config_scope: {
+              backend: "codex",
+              owner: "backend",
+              effective_scope: "backend_global",
+              label: "Codex global backend config",
+              description: "Codex MCP edits target the user-level Codex config shared by Codex sessions on this host.",
+              supported_scopes: ["user"],
+              default_scope: "user",
+              is_global: true,
+              peer_id: PEER.peer_id,
+              peer_name: "alice",
+              project_path: "/tmp/alice",
+              peer_machine: "host",
+              self_machine: "host",
+              same_host: true,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <PeerView
+        peer={{ ...PEER, backend: "codex" }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "mcp" }));
+
+    expect(await screen.findByText("Codex global backend config")).toBeInTheDocument();
+    fireEvent.click(await screen.findByText("+ add server"));
+
+    expect(screen.getByText("editing Codex global backend config")).toBeInTheDocument();
+    expect(screen.getByText("scope: user")).toBeInTheDocument();
+    expect(screen.queryByText("project scope")).not.toBeInTheDocument();
+  });
+
+  it("shows cross-host scope metadata without crashing", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/peers/alice/mcp")) {
+        return new Response(
+          JSON.stringify({
+            detail: {
+              error: "cross_host",
+              peer_machine: "remote-host",
+              self_machine: "local-host",
+              config_scope: {
+                backend: "gemini",
+                owner: "backend",
+                effective_scope: "backend_global",
+                label: "Gemini global backend config",
+                description: "Gemini MCP edits target the user-level Gemini settings shared by Gemini sessions on this host.",
+                supported_scopes: ["user"],
+                default_scope: "user",
+                is_global: true,
+                peer_id: PEER.peer_id,
+                peer_name: "alice",
+                project_path: "/tmp/alice",
+                peer_machine: "remote-host",
+                self_machine: "local-host",
+                same_host: false,
+              },
+            },
+          }),
+          { status: 409 },
+        );
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <PeerView
+        peer={{ ...PEER, backend: "gemini", machine: "remote-host" }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "mcp" }));
+
+    expect(await screen.findByText("Gemini global backend config")).toBeInTheDocument();
+    expect(screen.getByText("remote host")).toBeInTheDocument();
+  });
+});

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -959,32 +959,96 @@ interface McpServerEntry {
   env_keys: string[];
 }
 
+interface McpConfigScope {
+  backend: string;
+  owner: string;
+  effective_scope: string;
+  label: string;
+  description: string;
+  supported_scopes: string[];
+  default_scope: string;
+  is_global: boolean;
+  peer_id: string;
+  peer_name: string;
+  project_path: string | null;
+  peer_machine: string | null;
+  self_machine: string;
+  same_host: boolean;
+}
+
+function fallbackMcpScope(peer: Peer): McpConfigScope {
+  const backend = peer.backend || "unknown";
+  const isGlobal = backend === "codex" || backend === "gemini";
+  return {
+    backend,
+    owner: isGlobal ? "backend" : "peer/project",
+    effective_scope: isGlobal ? "backend_global" : "peer_project",
+    label: isGlobal ? `${backend} global backend config` : `${backend} peer/project config`,
+    description: isGlobal
+      ? `${backend} MCP edits target the user-level backend config shared by sessions on this host.`
+      : `${backend} MCP edits target this peer and may support project/worktree scope.`,
+    supported_scopes: backend === "claude-code" ? ["user", "project"] : ["user"],
+    default_scope: "user",
+    is_global: isGlobal,
+    peer_id: peer.peer_id,
+    peer_name: peer.display_name || peer.name,
+    project_path: peer.path || null,
+    peer_machine: peer.machine || null,
+    self_machine: "",
+    same_host: true,
+  };
+}
+
+function McpScopeBanner({ scope }: { scope: McpConfigScope }) {
+  return (
+    <div className="mb-3 rounded border border-border-faint bg-surface-container-low px-3 py-2 font-mono text-xs text-outline">
+      <div className="font-semibold text-on-surface-variant">{scope.label}</div>
+      <div className="mt-1">{scope.description}</div>
+      <div className="mt-1 text-[10px] uppercase tracking-wider">
+        owner: {scope.owner} · scope: {scope.effective_scope}
+        {scope.project_path ? ` · worktree: ${scope.project_path}` : ""}
+      </div>
+    </div>
+  );
+}
+
 function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
   const [servers, setServers] = useState<McpServerEntry[] | null>(null);
+  const [configScope, setConfigScope] = useState<McpConfigScope | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [crossHost, setCrossHost] = useState(false);
   const [unsupported, setUnsupported] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
+  const peerScopeFallback = useMemo(() => fallbackMcpScope(peer), [peer]);
 
   useEffect(() => {
     let cancelled = false;
-    setServers(null);
-    setError(null);
-    setCrossHost(false);
-    setUnsupported(false);
     (async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setServers(null);
+      setConfigScope(null);
+      setError(null);
+      setCrossHost(false);
+      setUnsupported(false);
       try {
         const r = await fetch(`${apiBase}/peers/${encodeURIComponent(peer.name)}/mcp`);
         if (r.status === 409) {
           const body = await r.json().catch(() => ({}));
           if (body?.detail?.error === "cross_host") {
-            if (!cancelled) setCrossHost(true);
+            if (!cancelled) {
+              setConfigScope(body.detail.config_scope || peerScopeFallback);
+              setCrossHost(true);
+            }
             return;
           }
         }
         if (r.status === 501) {
-          if (!cancelled) setUnsupported(true);
+          if (!cancelled) {
+            setConfigScope(peerScopeFallback);
+            setUnsupported(true);
+          }
           return;
         }
         if (!r.ok) {
@@ -993,7 +1057,10 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
           return;
         }
         const data = await r.json();
-        if (!cancelled) setServers(data.servers || []);
+        if (!cancelled) {
+          setConfigScope(data.config_scope || peerScopeFallback);
+          setServers(data.servers || []);
+        }
       } catch (e) {
         if (!cancelled) setError(String(e));
       }
@@ -1001,7 +1068,7 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
     return () => {
       cancelled = true;
     };
-  }, [peer.name, apiBase, refreshTick]);
+  }, [peer.name, apiBase, refreshTick, peerScopeFallback]);
 
   async function handleRemove(name: string) {
     if (!confirm(`Remove MCP server "${name}"?`)) return;
@@ -1020,6 +1087,7 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
   if (crossHost) {
     return (
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-6">
+        {configScope && <McpScopeBanner scope={configScope} />}
         <div className="rounded border border-border-faint bg-surface-container-low p-4 font-mono text-xs text-outline">
           <div className="mb-1 font-semibold text-on-surface-variant">remote host</div>
           Per-peer MCP config is same-host only in v1. Peer runs on{" "}
@@ -1032,6 +1100,7 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
   if (unsupported) {
     return (
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-6">
+        {configScope && <McpScopeBanner scope={configScope} />}
         <div className="rounded border border-border-faint bg-surface-container-low p-4 font-mono text-xs text-outline">
           Backend <span className="text-on-surface">{peer.backend}</span> does not support MCP config in v1.
         </div>
@@ -1041,6 +1110,8 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+      {configScope && <McpScopeBanner scope={configScope} />}
+
       {error && (
         <div className="mb-3 rounded border border-error/30 bg-error/10 px-3 py-2 font-mono text-xs text-on-surface">
           {error}
@@ -1103,6 +1174,7 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
           <AddMcpForm
             peer={peer}
             apiBase={apiBase}
+            configScope={configScope || peerScopeFallback}
             onCancel={() => setShowAdd(false)}
             onAdded={() => {
               setShowAdd(false);
@@ -1126,12 +1198,14 @@ function McpPanel({ peer, apiBase }: { peer: Peer; apiBase: string }) {
 function AddMcpForm({
   peer,
   apiBase,
+  configScope,
   onCancel,
   onAdded,
   onError,
 }: {
   peer: Peer;
   apiBase: string;
+  configScope: McpConfigScope;
   onCancel: () => void;
   onAdded: () => void;
   onError: (msg: string) => void;
@@ -1148,6 +1222,9 @@ function AddMcpForm({
   async function submit() {
     if (!name.trim()) {
       onError("server name is required");
+      return;
+    }
+    if (configScope.is_global && !confirm(`Add "${name.trim()}" to ${configScope.label}? This backend config is shared beyond this peer.`)) {
       return;
     }
     const env: Record<string, string> = {};
@@ -1190,6 +1267,9 @@ function AddMcpForm({
 
   return (
     <div className="space-y-2 rounded border border-border-faint bg-surface-container-low p-3 font-mono text-xs">
+      <div className="rounded border border-border-faint bg-surface px-2 py-1 text-[10px] uppercase tracking-wider text-outline">
+        editing {configScope.label}
+      </div>
       <input
         placeholder="name"
         value={name}
@@ -1206,7 +1286,7 @@ function AddMcpForm({
           <option value="http">http</option>
           <option value="sse">sse</option>
         </select>
-        {peer.backend === "claude-code" && (
+        {configScope.supported_scopes.length > 1 ? (
           <select
             value={scope}
             onChange={(e) => setScope(e.target.value as typeof scope)}
@@ -1215,6 +1295,10 @@ function AddMcpForm({
             <option value="user">user scope</option>
             <option value="project">project scope</option>
           </select>
+        ) : (
+          <div className="border border-border-faint bg-surface px-2 py-1 text-outline">
+            scope: {configScope.default_scope}
+          </div>
         )}
       </div>
       {type === "stdio" ? (


### PR DESCRIPTION
## Summary
- add MCP config scope metadata to peer MCP list/mutation responses
- show dashboard MCP scope labels and global-backend edit confirmation
- document the dashboard MCP tab scope labeling

## Verification
- uv run pytest tests/test_peer_mcp_routes.py -q
- uv run ruff check repowire/daemon/routes/peers.py tests/test_peer_mcp_routes.py
- uv run ty check repowire/daemon/routes/peers.py
- cd web && npm run test -- PeerView.test.tsx --run
- cd web && npm run lint -- app/dashboard/components/PeerView.tsx app/dashboard/components/PeerView.test.tsx
- git diff --check

Closes repowire-w67.6 / GH #211.