### PR TITLE
Add session timeline read model

### DIFF
--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -20,6 +20,8 @@ The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemi
 
 The v0.13 dashboard direction is a timeline-centered view. The current slice merges Claude transcript history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.
 
+`GET /peers/{name}/timeline` is the first daemon-side session timeline read model. It returns normalized items with explicit `session_id`, `turn_id`, `source` (`history` or `realtime`), and `kind` (`turn` or `delta_group`) by merging Claude transcript turns with the daemon's buffered realtime `chat_turn` and `chat_turn_delta` events. This route is additive; existing `/peers/{name}/transcript`, `/events`, and dashboard SSE behavior are unchanged.
+
 ## Mobile
 
 The dashboard is mobile-responsive: hamburger menu for the peer list, touch-friendly compose bar, sticky bottom switcher between peer roster and mesh log. You don't need the Telegram or Slack bot to drive the mesh from a phone — though those surfaces are often more convenient than the mobile dashboard.

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -22,6 +22,7 @@ from repowire.daemon.peer_registry import (
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import load_peer_turns, page_turns
+from repowire.session.timeline import TimelineItem, build_session_timeline
 
 router = APIRouter(tags=["peers"])
 
@@ -452,6 +453,89 @@ class TranscriptTurn(BaseModel):
 class TranscriptResponse(BaseModel):
     turns: list[TranscriptTurn]
     next_before: str | None = None
+
+
+class SessionTimelineItem(BaseModel):
+    id: str
+    kind: str
+    source: str
+    timestamp: str
+    session_id: str
+    turn_id: str
+    role: str
+    text: str
+    tool_calls: list[dict[str, str]] = Field(default_factory=list)
+    peer_id: str | None = None
+    peer: str | None = None
+    event_ids: list[str] = Field(default_factory=list)
+
+
+class SessionTimelineResponse(BaseModel):
+    peer_id: str
+    peer_name: str
+    session_id: str | None = None
+    items: list[SessionTimelineItem]
+
+
+def _timeline_item_response(item: TimelineItem) -> SessionTimelineItem:
+    return SessionTimelineItem(
+        id=item.id,
+        kind=item.kind,
+        source=item.source,
+        timestamp=item.timestamp,
+        session_id=item.session_id,
+        turn_id=item.turn_id,
+        role=item.role,
+        text=item.text,
+        tool_calls=item.tool_calls,
+        peer_id=item.peer_id,
+        peer=item.peer,
+        event_ids=item.event_ids,
+    )
+
+
+@router.get("/peers/{name}/timeline", response_model=SessionTimelineResponse)
+async def get_peer_timeline(
+    name: str,
+    limit: int = Query(100, ge=1, le=500, description="Max timeline items to return"),
+    session_id: str | None = Query(
+        None,
+        description="Optional hook/runtime transcript session id used for timeline scoping.",
+    ),
+    circle: str | None = Query(None),
+    _: str | None = Depends(require_auth),
+) -> SessionTimelineResponse:
+    """Merged session timeline for dashboard/control callers.
+
+    v0.13-compatible slice: persisted Claude transcript turns and buffered
+    realtime ``chat_turn``/``chat_turn_delta`` events are normalized to one
+    session/turn identity model. Existing transcript and event endpoints remain
+    unchanged.
+    """
+    peer_registry = get_peer_registry()
+    peer = await peer_registry.get_peer(name, circle=circle)
+    if peer is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Peer not found: {name}",
+        )
+
+    history_turns = await asyncio.to_thread(load_peer_turns, peer.path, peer.backend)
+    items = build_session_timeline(
+        history_turns=history_turns,
+        events=peer_registry.get_events(),
+        peer_id=peer.peer_id,
+        peer_names={peer.display_name, peer.peer_id, name},
+        session_id=session_id,
+    )
+    if len(items) > limit:
+        items = items[-limit:]
+    return SessionTimelineResponse(
+        peer_id=peer.peer_id,
+        peer_name=peer.display_name,
+        session_id=session_id,
+        items=[_timeline_item_response(item) for item in items],
+    )
 
 
 @router.get("/peers/{name}/transcript", response_model=TranscriptResponse)

--- a/repowire/session/timeline.py
+++ b/repowire/session/timeline.py
@@ -1,0 +1,208 @@
+"""Session-scoped timeline assembly for dashboard/control surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from repowire.session.history import Turn
+
+TimelineSource = Literal["history", "realtime"]
+TimelineKind = Literal["turn", "delta_group"]
+
+
+@dataclass
+class TimelineItem:
+    """One normalized session timeline item.
+
+    ``session_id`` and ``turn_id`` are the stable reconciliation identity.
+    ``peer_id`` is the live transport owner when known, so later control
+    commands can target a durable session first and resolve the current peer
+    separately.
+    """
+
+    id: str
+    kind: TimelineKind
+    source: TimelineSource
+    timestamp: str
+    session_id: str
+    turn_id: str
+    role: str
+    text: str
+    tool_calls: list[dict[str, str]] = field(default_factory=list)
+    peer_id: str | None = None
+    peer: str | None = None
+    event_ids: list[str] = field(default_factory=list)
+
+
+def timeline_key(session_id: str | None, turn_id: str | None) -> str | None:
+    """Return the stable session/turn reconciliation key."""
+    if not turn_id:
+        return None
+    return f"{session_id or 'legacy'}:{turn_id}"
+
+
+def _event_belongs_to_peer(
+    event: dict[str, Any],
+    *,
+    peer_id: str | None,
+    peer_names: set[str],
+) -> bool:
+    event_peer_id = event.get("peer_id")
+    if event_peer_id and peer_id:
+        return event_peer_id == peer_id
+    event_peer = event.get("peer")
+    return isinstance(event_peer, str) and event_peer in peer_names
+
+
+def _history_item(turn: Turn) -> TimelineItem:
+    return TimelineItem(
+        id=f"history:{turn.session_id}:{turn.turn_id}",
+        kind="turn",
+        source="history",
+        timestamp=turn.timestamp,
+        session_id=turn.session_id,
+        turn_id=turn.turn_id,
+        role=turn.role,
+        text=turn.text,
+        tool_calls=turn.tool_calls,
+    )
+
+
+def _chat_turn_item(event: dict[str, Any]) -> TimelineItem | None:
+    turn_id = event.get("turn_id")
+    if not isinstance(turn_id, str) or not turn_id:
+        return None
+    session_id = event.get("session_id") or "legacy"
+    return TimelineItem(
+        id=str(event.get("id") or f"event:{session_id}:{turn_id}"),
+        kind="turn",
+        source="realtime",
+        timestamp=str(event.get("timestamp") or ""),
+        session_id=str(session_id),
+        turn_id=turn_id,
+        role=str(event.get("role") or ""),
+        text=str(event.get("text") or ""),
+        tool_calls=list(event.get("tool_calls") or []),
+        peer_id=event.get("peer_id"),
+        peer=event.get("peer"),
+        event_ids=[str(event["id"])] if event.get("id") else [],
+    )
+
+
+def _coalesce_delta_groups(
+    events: list[dict[str, Any]],
+    *,
+    hidden_keys: set[str],
+) -> list[TimelineItem]:
+    groups: dict[str, TimelineItem] = {}
+    group_events: dict[str, list[dict[str, Any]]] = {}
+
+    for event in events:
+        if event.get("type") != "chat_turn_delta":
+            continue
+        turn_id = event.get("turn_id")
+        if not isinstance(turn_id, str) or not turn_id:
+            continue
+        session_id = str(event.get("session_id") or "legacy")
+        key = timeline_key(session_id, turn_id)
+        if key and key in hidden_keys:
+            continue
+        group_key = key or str(event.get("id") or turn_id)
+        group_events.setdefault(group_key, []).append(event)
+        if group_key not in groups:
+            groups[group_key] = TimelineItem(
+                id=f"delta:{session_id}:{turn_id}",
+                kind="delta_group",
+                source="realtime",
+                timestamp=str(event.get("timestamp") or ""),
+                session_id=session_id,
+                turn_id=turn_id,
+                role="assistant",
+                text="",
+                peer_id=event.get("peer_id"),
+                peer=event.get("peer"),
+            )
+        elif str(event.get("timestamp") or "") > groups[group_key].timestamp:
+            groups[group_key].timestamp = str(event.get("timestamp") or "")
+
+    out: list[TimelineItem] = []
+    for group_key, item in groups.items():
+        ordered = sorted(
+            group_events[group_key],
+            key=lambda ev: (
+                ev.get("chunk_index")
+                if isinstance(ev.get("chunk_index"), int)
+                else 2**31 - 1,
+                str(ev.get("timestamp") or ""),
+            ),
+        )
+        text_parts: list[str] = []
+        for event in ordered:
+            if event.get("id"):
+                item.event_ids.append(str(event["id"]))
+            if event.get("kind") == "tool_use" and isinstance(event.get("tool_call"), dict):
+                item.tool_calls.append(event["tool_call"])
+            elif event.get("kind") in (None, "text"):
+                text = str(event.get("text") or "")
+                if text:
+                    text_parts.append(text)
+        item.text = "\n\n".join(text_parts)
+        if item.text or item.tool_calls:
+            out.append(item)
+    return out
+
+
+def build_session_timeline(
+    *,
+    history_turns: list[Turn],
+    events: list[dict[str, Any]],
+    peer_id: str | None,
+    peer_names: set[str],
+    session_id: str | None = None,
+) -> list[TimelineItem]:
+    """Merge persisted turns and realtime chat events into one timeline.
+
+    Realtime final ``chat_turn`` items win over persisted turns with the same
+    ``session_id``/``turn_id``. Streaming deltas are grouped by the same key
+    and hidden once either a persisted or realtime final turn exists.
+    """
+    history_items = [
+        _history_item(turn)
+        for turn in history_turns
+        if session_id is None or turn.session_id == session_id
+    ]
+    history_keys = {
+        key
+        for item in history_items
+        if (key := timeline_key(item.session_id, item.turn_id)) is not None
+    }
+
+    peer_events = [
+        event
+        for event in events
+        if event.get("type") in {"chat_turn", "chat_turn_delta"}
+        and _event_belongs_to_peer(event, peer_id=peer_id, peer_names=peer_names)
+        and (session_id is None or (event.get("session_id") or "legacy") == session_id)
+    ]
+
+    realtime_turns = [
+        item for event in peer_events if event.get("type") == "chat_turn"
+        if (item := _chat_turn_item(event)) is not None
+    ]
+    realtime_keys = {
+        key
+        for item in realtime_turns
+        if (key := timeline_key(item.session_id, item.turn_id)) is not None
+    }
+
+    items: list[TimelineItem] = []
+    items.extend(realtime_turns)
+    items.extend(
+        item
+        for item in history_items
+        if timeline_key(item.session_id, item.turn_id) not in realtime_keys
+    )
+    items.extend(_coalesce_delta_groups(peer_events, hidden_keys=history_keys | realtime_keys))
+    items.sort(key=lambda item: (item.timestamp, item.session_id, item.turn_id, item.source))
+    return items

--- a/tests/test_session_timeline.py
+++ b/tests/test_session_timeline.py
@@ -1,0 +1,126 @@
+"""Tests for session timeline assembly."""
+
+from __future__ import annotations
+
+from repowire.session.history import Turn
+from repowire.session.timeline import build_session_timeline
+
+
+def _turn(text: str, *, turn_id: str, ts: str = "2026-01-01T00:00:00Z") -> Turn:
+    return Turn(
+        role="assistant",
+        text=text,
+        timestamp=ts,
+        session_id="s1",
+        turn_id=turn_id,
+        tool_calls=[],
+    )
+
+
+def test_realtime_final_replaces_matching_history_turn() -> None:
+    items = build_session_timeline(
+        history_turns=[_turn("history", turn_id="t1")],
+        events=[
+            {
+                "id": "e1",
+                "type": "chat_turn",
+                "timestamp": "2026-01-01T00:00:01Z",
+                "peer_id": "peer-1",
+                "peer": "worker",
+                "role": "assistant",
+                "text": "live",
+                "session_id": "s1",
+                "turn_id": "t1",
+            }
+        ],
+        peer_id="peer-1",
+        peer_names={"worker"},
+    )
+
+    assert [(item.source, item.text) for item in items] == [("realtime", "live")]
+    assert items[0].session_id == "s1"
+    assert items[0].turn_id == "t1"
+
+
+def test_deltas_coalesce_until_final_turn_exists() -> None:
+    events = [
+        {
+            "id": "d2",
+            "type": "chat_turn_delta",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "peer_id": "peer-1",
+            "peer": "worker",
+            "session_id": "s1",
+            "turn_id": "t2",
+            "chunk_index": 1,
+            "kind": "text",
+            "text": "second",
+        },
+        {
+            "id": "d1",
+            "type": "chat_turn_delta",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "peer_id": "peer-1",
+            "peer": "worker",
+            "session_id": "s1",
+            "turn_id": "t2",
+            "chunk_index": 0,
+            "kind": "text",
+            "text": "first",
+        },
+    ]
+    items = build_session_timeline(
+        history_turns=[],
+        events=events,
+        peer_id="peer-1",
+        peer_names={"worker"},
+    )
+    assert len(items) == 1
+    assert items[0].kind == "delta_group"
+    assert items[0].text == "first\n\nsecond"
+    assert items[0].event_ids == ["d1", "d2"]
+
+    finalized = build_session_timeline(
+        history_turns=[_turn("final", turn_id="t2", ts="2026-01-01T00:00:03Z")],
+        events=events,
+        peer_id="peer-1",
+        peer_names={"worker"},
+    )
+    assert [(item.kind, item.text) for item in finalized] == [("turn", "final")]
+
+
+def test_session_filter_applies_to_history_and_events() -> None:
+    history = [
+        _turn("keep history", turn_id="t1"),
+        Turn(
+            role="assistant",
+            text="drop history",
+            timestamp="2026-01-01T00:00:00Z",
+            session_id="s2",
+            turn_id="t2",
+            tool_calls=[],
+        ),
+    ]
+    events = [
+        {
+            "id": "e1",
+            "type": "chat_turn",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "peer_id": "peer-1",
+            "peer": "worker",
+            "role": "assistant",
+            "text": "drop event",
+            "session_id": "s2",
+            "turn_id": "t3",
+        }
+    ]
+
+    items = build_session_timeline(
+        history_turns=history,
+        events=events,
+        peer_id="peer-1",
+        peer_names={"worker"},
+        session_id="s1",
+    )
+
+    assert [item.text for item in items] == ["keep history"]

--- a/tests/test_session_timeline_routes.py
+++ b/tests/test_session_timeline_routes.py
@@ -1,0 +1,213 @@
+"""Route tests for GET /peers/{name}/timeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.session.history import _encode_cwd
+
+
+def _make_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=tracker,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+    app = FastAPI()
+    app.include_router(peers.router)
+    return app, registry
+
+
+def _write_session(projects_root: Path, peer_path: str, entries: list[dict]) -> None:
+    session_dir = projects_root / _encode_cwd(peer_path)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    out = session_dir / "session.jsonl"
+    with open(out, "a") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+@pytest.mark.anyio
+async def test_timeline_merges_history_and_realtime_events(tmp_path: Path) -> None:
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        peer_id, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        _write_session(
+            projects_root,
+            peer_path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "sessionId": "s1",
+                    "message": {"content": "prompt"},
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "assistant-turn",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "sessionId": "s1",
+                    "message": {"content": [{"type": "text", "text": "history final"}]},
+                },
+            ],
+        )
+        registry.add_event(
+            "chat_turn",
+            {
+                "peer": name,
+                "peer_id": peer_id,
+                "role": "assistant",
+                "text": "live final",
+                "session_id": "s1",
+                "turn_id": "assistant-turn",
+            },
+        )
+        registry.add_event(
+            "chat_turn_delta",
+            {
+                "peer": name,
+                "peer_id": peer_id,
+                "role": "assistant",
+                "session_id": "s1",
+                "turn_id": "streaming-turn",
+                "chunk_index": 0,
+                "kind": "text",
+                "text": "streaming",
+            },
+        )
+
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                res = await ac.get(f"/peers/{name}/timeline")
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["peer_id"] == peer_id
+        assert body["peer_name"] == name
+        assert [(item["source"], item["kind"], item["text"]) for item in body["items"]] == [
+            ("history", "turn", "prompt"),
+            ("realtime", "turn", "live final"),
+            ("realtime", "delta_group", "streaming"),
+        ]
+        assert body["items"][1]["session_id"] == "s1"
+        assert body["items"][1]["turn_id"] == "assistant-turn"
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_timeline_session_filter_and_limit(tmp_path: Path) -> None:
+    app, registry = _make_app(tmp_path)
+    projects_root = tmp_path / "projects"
+    peer_path = "/peer/work"
+    try:
+        peer_id, name = await registry.allocate_and_register(
+            circle="global",
+            backend=AgentType.CLAUDE_CODE,
+            path=peer_path,
+            pane_id=None,
+            tmux_session=None,
+            metadata={},
+            machine="test",
+        )
+        _write_session(
+            projects_root,
+            peer_path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "sessionId": "s1",
+                    "message": {"content": "old keep"},
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "sessionId": "s1",
+                    "message": {"content": "new keep"},
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "sessionId": "s2",
+                    "message": {"content": "drop"},
+                },
+            ],
+        )
+        registry.add_event(
+            "chat_turn",
+            {
+                "peer": name,
+                "peer_id": peer_id,
+                "role": "assistant",
+                "text": "live keep",
+                "session_id": "s1",
+                "turn_id": "live-turn",
+            },
+        )
+
+        with patch("repowire.session.history._claude_projects_dir", return_value=projects_root):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                res = await ac.get(
+                    f"/peers/{name}/timeline",
+                    params={"session_id": "s1", "limit": 2},
+                )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["session_id"] == "s1"
+        assert [item["text"] for item in body["items"]] == ["new keep", "live keep"]
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_timeline_unknown_peer_returns_404(tmp_path: Path) -> None:
+    app, _ = _make_app(tmp_path)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+            res = await ac.get("/peers/ghost/timeline")
+        assert res.status_code == 404
+    finally:
+        cleanup_deps()


### PR DESCRIPTION
## Summary
- add a session timeline assembly helper for history + realtime chat events
- expose additive GET /peers/{name}/timeline with stable session_id/turn_id fields
- document the dashboard timeline route note

## Verification
- uv run pytest tests/test_session_timeline.py tests/test_session_timeline_routes.py -q
- uv run ruff check repowire/session/timeline.py repowire/daemon/routes/peers.py tests/test_session_timeline.py tests/test_session_timeline_routes.py
- uv run ty check repowire/session/timeline.py repowire/daemon/routes/peers.py
- git diff --check

Closes repowire-w67.2 / GH #210.