### PR TITLE
Route ACP permissions through approval broker

### DIFF
--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -16,6 +16,8 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 
 The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemini session extracts the response and tool calls from the transcript or runtime output, then posts them to `POST /events/chat` on the daemon. Claude Code can also stream block-level `chat_turn_delta` events while a turn is in progress. The dashboard streams events over Server-Sent Events and merges them with Claude transcript history for the selected peer/session. OpenCode bridges the same realtime shape via its plugin.
 
+ACP-routed permission prompts emit `acp_permission_request` and `acp_permission_decision` events into the same daemon event stream. Human control surfaces can resolve a pending prompt with `POST /acp/permissions/{request_id}/decision`; if no decision arrives before the broker timeout, the daemon records a timed-out decision and denies by default. This v0.13 slice exposes the event/route contract only; the dashboard approval UI remains planned work.
+
 ## Roadmap: session timeline
 
 The v0.13 dashboard direction is a timeline-centered view. The current slice merges Claude transcript history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.

--- a/repowire/acp/__init__.py
+++ b/repowire/acp/__init__.py
@@ -22,6 +22,7 @@ from repowire.acp.broker import (
 from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
 from repowire.acp.manager import AcpClientManager, AcpPeerSpec
 from repowire.acp.models import AcpPeerConfig
+from repowire.acp.permissions import ApprovalBroker, PermissionDecision
 
 __all__ = [
     "AcpAckCallback",
@@ -32,6 +33,8 @@ __all__ = [
     "AcpPeerSpec",
     "AcpPromptResult",
     "AcpRouteDecision",
+    "ApprovalBroker",
+    "PermissionDecision",
     "decide_acp_route",
     "deliver_ask_via_acp",
     "maybe_decide_acp_route",

--- a/repowire/acp/client.py
+++ b/repowire/acp/client.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from repowire.acp.models import AcpPeerConfig
+from repowire.acp.permissions import ApprovalBroker, PermissionDecision
 from repowire.acp.transport import spawn_acp_subprocess
 
 if TYPE_CHECKING:
@@ -54,7 +55,11 @@ _ACP_INSTALL_HINT = (
 )
 
 
-def _make_recorder() -> Any:
+def _make_recorder(
+    *,
+    peer_id: str | None = None,
+    approval_broker: ApprovalBroker | None = None,
+) -> Any:
     """Build a fresh ``acp.Client`` instance that records updates for one peer.
 
     Defined as a factory rather than a top-level class so the ``acp`` import
@@ -73,8 +78,8 @@ def _make_recorder() -> Any:
     class _BrokerRecorder(acp.Client):
         """Records ``session/update`` notifications for the broker.
 
-        Auto-allows permission requests for phase-3. Later phases will surface
-        permission UX to the dashboard or telegram peer.
+        Permission requests are routed through the daemon-side approval broker.
+        When no broker is configured, requests fail closed.
         """
 
         def __init__(self) -> None:
@@ -92,8 +97,19 @@ def _make_recorder() -> Any:
             tool_call: Any,
             **_: Any,
         ) -> Any:
-            del session_id, tool_call
-            chosen = options[0] if options else None
+            if approval_broker is None or peer_id is None:
+                return acp.RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+            decision = await approval_broker.request_permission(
+                peer_id=peer_id,
+                session_id=session_id,
+                tool_call=tool_call,
+                options=options,
+            )
+            if decision.outcome != "allowed":
+                return acp.RequestPermissionResponse(
+                    outcome=DeniedOutcome(outcome="cancelled"),
+                )
+            chosen = _select_allowed_option(options, decision)
             if chosen is None:
                 return acp.RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
             return acp.RequestPermissionResponse(
@@ -132,10 +148,17 @@ class AcpClient:
     or via ``AcpClientManager`` which handles the lifetime.
     """
 
-    def __init__(self, config: AcpPeerConfig, *, fallback_cwd: str | None = None) -> None:
+    def __init__(
+        self,
+        config: AcpPeerConfig,
+        *,
+        fallback_cwd: str | None = None,
+        peer_id: str | None = None,
+        approval_broker: ApprovalBroker | None = None,
+    ) -> None:
         self._config = config
         self._fallback_cwd = fallback_cwd
-        self._recorder = _make_recorder()
+        self._recorder = _make_recorder(peer_id=peer_id, approval_broker=approval_broker)
         self._connection: ClientSideConnection | None = None
         self._session_id: str | None = None
         self._exit_stack: Any = None
@@ -358,3 +381,13 @@ def _assemble_agent_text(updates: list[Any]) -> str:
         if text:
             parts.append(text)
     return "".join(parts)
+
+
+def _select_allowed_option(options: list[Any], decision: PermissionDecision) -> Any | None:
+    """Return the ACP option selected by a broker decision."""
+    if not decision.option_id:
+        return options[0] if options else None
+    for option in options:
+        if getattr(option, "option_id", None) == decision.option_id:
+            return option
+    return None

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
 from repowire.acp.models import AcpPeerConfig
+from repowire.acp.permissions import ApprovalBroker
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +38,11 @@ class AcpClientManager:
     safe to call from the daemon lifespan shutdown hook.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, approval_broker: ApprovalBroker | None = None) -> None:
         self._clients: dict[str, AcpClient] = {}
         self._lock = asyncio.Lock()
         self._closed = False
+        self._approval_broker = approval_broker
 
     async def get_or_create(self, spec: AcpPeerSpec) -> AcpClient:
         """Return the live ``AcpClient`` for ``spec.peer_id``, starting it if needed."""
@@ -49,7 +51,12 @@ class AcpClientManager:
         async with self._lock:
             client = self._clients.get(spec.peer_id)
             if client is None:
-                client = AcpClient(spec.config, fallback_cwd=spec.fallback_cwd)
+                client = AcpClient(
+                    spec.config,
+                    fallback_cwd=spec.fallback_cwd,
+                    peer_id=spec.peer_id,
+                    approval_broker=self._approval_broker,
+                )
                 self._clients[spec.peer_id] = client
         return client
 

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -1,0 +1,198 @@
+"""Human approval broker for ACP permission requests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from uuid import uuid4
+
+PermissionOutcome = Literal["allowed", "denied", "cancelled"]
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """Resolved ACP permission decision."""
+
+    outcome: PermissionOutcome
+    option_id: str | None = None
+    message: str | None = None
+    timed_out: bool = False
+
+
+@dataclass
+class _PendingPermission:
+    request_id: str
+    peer_id: str
+    session_id: str
+    tool_call: dict[str, Any]
+    options: list[dict[str, Any]]
+    future: asyncio.Future[PermissionDecision] = field(repr=False)
+
+
+class ApprovalBroker:
+    """Small in-process broker for ACP tool permission decisions.
+
+    The broker emits dashboard event-log records for visibility, waits for a
+    human decision submitted through the daemon, and defaults to deny when the
+    decision does not arrive before the timeout.
+    """
+
+    def __init__(
+        self,
+        *,
+        emit_event: Callable[[str, dict[str, Any]], str],
+        timeout_seconds: float = 60.0,
+    ) -> None:
+        self._emit_event = emit_event
+        self._timeout_seconds = timeout_seconds
+        self._pending: dict[str, _PendingPermission] = {}
+        self._lock = asyncio.Lock()
+
+    async def request_permission(
+        self,
+        *,
+        peer_id: str,
+        session_id: str,
+        tool_call: Any,
+        options: list[Any],
+    ) -> PermissionDecision:
+        """Emit a permission request and wait for a decision.
+
+        Timeout intentionally defaults to deny. This is safer than preserving
+        the prior auto-allow fallback, and keeps the ACP subprocess unblocked.
+        """
+        loop = asyncio.get_running_loop()
+        normalized_options = [_normalize_option(option) for option in options]
+        pending = _PendingPermission(
+            request_id=f"acpperm-{uuid4().hex[:12]}",
+            peer_id=peer_id,
+            session_id=session_id,
+            tool_call=_normalize_payload(tool_call),
+            options=normalized_options,
+            future=loop.create_future(),
+        )
+        async with self._lock:
+            self._pending[pending.request_id] = pending
+
+        self._emit_event(
+            "acp_permission_request",
+            {
+                "request_id": pending.request_id,
+                "peer_id": peer_id,
+                "session_id": session_id,
+                "tool_call": pending.tool_call,
+                "options": normalized_options,
+                "status": "pending",
+                "timeout_seconds": self._timeout_seconds,
+            },
+        )
+
+        try:
+            decision = await asyncio.wait_for(pending.future, timeout=self._timeout_seconds)
+        except asyncio.TimeoutError:
+            decision = PermissionDecision(
+                outcome="denied",
+                message="permission request timed out",
+                timed_out=True,
+            )
+        finally:
+            async with self._lock:
+                self._pending.pop(pending.request_id, None)
+
+        self._emit_decision_event(pending, decision)
+        return decision
+
+    async def decide(
+        self,
+        request_id: str,
+        *,
+        outcome: PermissionOutcome,
+        option_id: str | None = None,
+        message: str | None = None,
+    ) -> PermissionDecision | None:
+        """Resolve a pending request.
+
+        Returns ``None`` when the request is unknown or already resolved.
+        """
+        async with self._lock:
+            pending = self._pending.get(request_id)
+            if pending is None or pending.future.done():
+                return None
+            if outcome == "allowed":
+                option_id = option_id or _first_option_id(pending.options)
+            decision = PermissionDecision(
+                outcome=outcome,
+                option_id=option_id,
+                message=message,
+            )
+            pending.future.set_result(decision)
+            return decision
+
+    async def get_pending(self, request_id: str) -> dict[str, Any] | None:
+        """Return a pending request snapshot for validation/UI callers."""
+        async with self._lock:
+            pending = self._pending.get(request_id)
+            if pending is None:
+                return None
+            return {
+                "request_id": pending.request_id,
+                "peer_id": pending.peer_id,
+                "session_id": pending.session_id,
+                "tool_call": pending.tool_call,
+                "options": list(pending.options),
+            }
+
+    def _emit_decision_event(
+        self,
+        pending: _PendingPermission,
+        decision: PermissionDecision,
+    ) -> None:
+        status = "timed_out" if decision.timed_out else "decided"
+        self._emit_event(
+            "acp_permission_decision",
+            {
+                "request_id": pending.request_id,
+                "peer_id": pending.peer_id,
+                "session_id": pending.session_id,
+                "outcome": decision.outcome,
+                "option_id": decision.option_id,
+                "message": decision.message,
+                "status": status,
+            },
+        )
+
+
+def _first_option_id(options: list[dict[str, Any]]) -> str | None:
+    for option in options:
+        option_id = option.get("option_id")
+        if isinstance(option_id, str) and option_id:
+            return option_id
+    return None
+
+
+def _normalize_option(option: Any) -> dict[str, Any]:
+    payload = _normalize_payload(option)
+    option_id = payload.get("option_id") or getattr(option, "option_id", None)
+    if option_id is not None:
+        payload["option_id"] = str(option_id)
+    return payload
+
+
+def _normalize_payload(value: Any) -> dict[str, Any]:
+    """Best-effort compact serialization for ACP SDK models."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump(mode="json", exclude_none=True)
+        if isinstance(dumped, dict):
+            return dumped
+    out: dict[str, Any] = {}
+    for name in ("tool_call_id", "name", "title", "kind", "option_id", "description"):
+        attr = getattr(value, name, None)
+        if attr is not None:
+            out[name] = attr
+    return out or {"repr": repr(value)}

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -36,6 +36,7 @@ from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.relay_client import RelayClient
 from repowire.daemon.review_queue_store import ReviewQueueStore
 from repowire.daemon.routes import (
+    acp_permissions,
     asks,
     attachments,
     health,
@@ -242,8 +243,10 @@ def create_app(
         )
         app.state.schedule_store = schedule_store
         app.state.state_db = state_db
-        from repowire.acp import AcpClientManager
-        acp_manager = AcpClientManager()
+        from repowire.acp import AcpClientManager, ApprovalBroker
+        acp_permission_broker = ApprovalBroker(emit_event=peer_registry.add_event)
+        app.state.acp_permission_broker = acp_permission_broker
+        acp_manager = AcpClientManager(approval_broker=acp_permission_broker)
         app.state.acp_manager = acp_manager
         from repowire.daemon.transport_router import transport_router_from_state
         peer_delivery = PeerDeliveryService(
@@ -392,6 +395,7 @@ def create_app(
 
     # Include routers
     app.include_router(health.router)
+    app.include_router(acp_permissions.router)
     app.include_router(peers.router)
     app.include_router(messages.router)
     app.include_router(asks.router)
@@ -522,8 +526,10 @@ def create_test_app(
         rq_dir = persistence_path.parent if persistence_path else Path.home() / ".repowire"
         app.state.review_queue_store = ReviewQueueStore(rq_dir / "review_queue.json")
         app.state.schedule_store = schedule_store
-        from repowire.acp import AcpClientManager
-        acp_manager = AcpClientManager()
+        from repowire.acp import AcpClientManager, ApprovalBroker
+        acp_permission_broker = ApprovalBroker(emit_event=registry.add_event)
+        app.state.acp_permission_broker = acp_permission_broker
+        acp_manager = AcpClientManager(approval_broker=acp_permission_broker)
         app.state.acp_manager = acp_manager
         from repowire.daemon.transport_router import transport_router_from_state
         peer_delivery = PeerDeliveryService(
@@ -581,6 +587,7 @@ def create_test_app(
     )
 
     app.include_router(health.router)
+    app.include_router(acp_permissions.router)
     app.include_router(peers.router)
     app.include_router(messages.router)
     app.include_router(asks.router)

--- a/repowire/daemon/deps.py
+++ b/repowire/daemon/deps.py
@@ -19,6 +19,7 @@ class AppState(Protocol):
     ask_tracker: Any
     peer_registry: PeerRegistry
     peer_delivery: PeerDeliveryService
+    acp_permission_broker: Any
     config: Config
     schedule_store: Any
     scheduler: Any

--- a/repowire/daemon/routes/acp_permissions.py
+++ b/repowire/daemon/routes/acp_permissions.py
@@ -1,0 +1,95 @@
+"""ACP permission approval endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state
+
+router = APIRouter(tags=["acp"])
+
+
+class AcpPermissionDecisionRequest(BaseModel):
+    """Human decision for a pending ACP permission request."""
+
+    outcome: Literal["allowed", "denied", "cancelled"] = Field(
+        ..., description="Permission decision."
+    )
+    option_id: str | None = Field(
+        None,
+        description="ACP option_id to select when outcome is allowed.",
+    )
+    message: str | None = Field(
+        None,
+        description="Optional human-readable decision note.",
+    )
+
+
+class AcpPermissionDecisionResponse(BaseModel):
+    ok: bool = True
+    request_id: str
+    outcome: Literal["allowed", "denied", "cancelled"]
+    option_id: str | None = None
+
+
+@router.post(
+    "/acp/permissions/{request_id}/decision",
+    response_model=AcpPermissionDecisionResponse,
+)
+async def decide_acp_permission(
+    request_id: str,
+    body: AcpPermissionDecisionRequest,
+    _: str | None = Depends(require_auth),
+) -> AcpPermissionDecisionResponse:
+    """Resolve a pending brokered ACP permission request."""
+    state = get_app_state()
+    broker = getattr(state, "acp_permission_broker", None)
+    if broker is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ACP permission broker not initialized",
+        )
+
+    pending = await broker.get_pending(request_id)
+    if pending is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ACP permission request not found: {request_id}",
+        )
+    if body.outcome == "allowed":
+        valid_options = {
+            option.get("option_id")
+            for option in pending["options"]
+            if isinstance(option.get("option_id"), str)
+        }
+        if body.option_id is not None and body.option_id not in valid_options:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown ACP permission option_id: {body.option_id}",
+            )
+        if body.option_id is None and not valid_options:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Allowed ACP permission decision requires an option_id",
+            )
+
+    decision = await broker.decide(
+        request_id,
+        outcome=body.outcome,
+        option_id=body.option_id,
+        message=body.message,
+    )
+    if decision is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ACP permission request not found: {request_id}",
+        )
+    return AcpPermissionDecisionResponse(
+        request_id=request_id,
+        outcome=decision.outcome,
+        option_id=decision.option_id,
+    )

--- a/tests/test_acp_permissions.py
+++ b/tests/test_acp_permissions.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.acp import ApprovalBroker
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import acp_permissions
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+@pytest.mark.asyncio
+async def test_approval_broker_timeout_emits_default_deny_events() -> None:
+    events: list[dict] = []
+
+    def _emit(event_type: str, data: dict) -> str:
+        events.append({"type": event_type, **data})
+        return f"evt-{len(events)}"
+
+    broker = ApprovalBroker(emit_event=_emit, timeout_seconds=0.01)
+
+    decision = await broker.request_permission(
+        peer_id="peer-1",
+        session_id="session-1",
+        tool_call={"name": "shell", "tool_call_id": "call-1"},
+        options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+    )
+
+    assert decision.outcome == "denied"
+    assert decision.timed_out is True
+    assert events[0]["type"] == "acp_permission_request"
+    assert events[0]["peer_id"] == "peer-1"
+    assert events[0]["session_id"] == "session-1"
+    assert events[0]["tool_call"]["name"] == "shell"
+    assert events[0]["options"] == [{"option_id": "opt-allow", "title": "Allow"}]
+    assert events[0]["status"] == "pending"
+    assert events[1]["type"] == "acp_permission_decision"
+    assert events[1]["request_id"] == events[0]["request_id"]
+    assert events[1]["outcome"] == "denied"
+    assert events[1]["status"] == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_permission_decision_route_resolves_pending_request(tmp_path: Path) -> None:
+    app, broker, registry = _make_permission_app(tmp_path)
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1",
+                session_id="session-1",
+                tool_call={"name": "write_file"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow write")],
+            )
+        )
+        request_event = await _wait_for_event(registry, "acp_permission_request")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as http:
+            response = await http.post(
+                f"/acp/permissions/{request_event['request_id']}/decision",
+                json={
+                    "outcome": "allowed",
+                    "option_id": "opt-allow",
+                    "message": "approved by test",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "ok": True,
+            "request_id": request_event["request_id"],
+            "outcome": "allowed",
+            "option_id": "opt-allow",
+        }
+
+        decision = await asyncio.wait_for(task, timeout=1.0)
+        assert decision.outcome == "allowed"
+        assert decision.option_id == "opt-allow"
+
+        decision_event = await _wait_for_event(registry, "acp_permission_decision")
+        assert decision_event["request_id"] == request_event["request_id"]
+        assert decision_event["peer_id"] == "peer-1"
+        assert decision_event["session_id"] == "session-1"
+        assert decision_event["outcome"] == "allowed"
+        assert decision_event["option_id"] == "opt-allow"
+        assert decision_event["status"] == "decided"
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_permission_decision_route_rejects_unknown_option(tmp_path: Path) -> None:
+    app, broker, registry = _make_permission_app(tmp_path)
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1",
+                session_id="session-1",
+                tool_call={"name": "write_file"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow write")],
+            )
+        )
+        request_event = await _wait_for_event(registry, "acp_permission_request")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as http:
+            response = await http.post(
+                f"/acp/permissions/{request_event['request_id']}/decision",
+                json={"outcome": "allowed", "option_id": "wrong-option"},
+            )
+
+        assert response.status_code == 400
+        await broker.decide(request_event["request_id"], outcome="cancelled")
+        await task
+    finally:
+        cleanup_deps()
+
+
+def _make_permission_app(tmp_path: Path) -> tuple[FastAPI, ApprovalBroker, PeerRegistry]:
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+
+    broker = ApprovalBroker(emit_event=registry.add_event, timeout_seconds=5.0)
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+        acp_permission_broker=broker,
+    )
+    init_deps(cfg, registry, state)
+
+    app = FastAPI()
+    app.include_router(acp_permissions.router)
+    return app, broker, registry
+
+
+async def _wait_for_event(registry: PeerRegistry, event_type: str) -> dict:
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        matches = [event for event in registry.get_events() if event["type"] == event_type]
+        if matches:
+            return matches[-1]
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {event_type}")


### PR DESCRIPTION
## Summary
- add an in-process ACP ApprovalBroker that emits permission request/decision events and denies on timeout
- route ACP client permission callbacks through the broker instead of auto-selecting the first option
- add authenticated POST /acp/permissions/{request_id}/decision plus focused broker/route tests and a dashboard surface note

## Verification
- uv run pytest tests/test_acp_permissions.py -q
- uv run pytest tests/test_acp_broker_client.py tests/test_transport_router.py tests/test_acp_permissions.py -q
- uv run ruff check repowire/acp/permissions.py repowire/acp/client.py repowire/acp/manager.py repowire/daemon/app.py repowire/daemon/deps.py repowire/daemon/routes/acp_permissions.py tests/test_acp_permissions.py
- uv run ty check repowire/acp/permissions.py repowire/acp/client.py repowire/acp/manager.py repowire/daemon/app.py repowire/daemon/deps.py repowire/daemon/routes/acp_permissions.py
- git diff --check origin/main...HEAD
- python3 scripts/pre_pr_hygiene.py

## Notes
- No dashboard approval UI or MCP tool in this slice. The new route/event contract is additive; UI/control surfaces can build on it later.
- No timeline extension in this slice; ACP permission events are visible in the daemon event stream.
- Closes repowire-w67.3 / GH #216.