### PR TITLE
Add SQLite session binding store

### DIFF
--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -272,7 +272,7 @@ class ExperimentsConfig(BaseModel):
         default=False,
         description=(
             "Use the experimental SQLite daemon state store for migrated "
-            "domains. Currently limited to schedule persistence."
+            "domains. Currently used for schedule persistence and session bindings."
         ),
     )
 

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -52,6 +52,7 @@ from repowire.daemon.schedule_store import ScheduleStore
 from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.schedules import SQLiteScheduleStore
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 from repowire.daemon.websocket_transport import WebSocketTransport
 
 logger = logging.getLogger(__name__)
@@ -224,10 +225,12 @@ def create_app(
                 db=state_db,
                 legacy_path=schedules_path,
             )
+            session_binding_store = SQLiteSessionBindingStore(state_db)
         else:
             schedule_store = ScheduleStore(
                 persistence_path=schedules_path,
             )
+            session_binding_store = None
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -243,6 +246,7 @@ def create_app(
         )
         app.state.schedule_store = schedule_store
         app.state.state_db = state_db
+        app.state.session_binding_store = session_binding_store
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(emit_event=peer_registry.add_event)
         app.state.acp_permission_broker = acp_permission_broker
@@ -510,10 +514,21 @@ def create_test_app(
             event_log=event_log,
         )
 
-        schedule_store = ScheduleStore(
-            persistence_path=(persistence_path.parent if persistence_path else Path("/tmp"))
-            / "schedules.json",
-        )
+        state_db: StateDatabase | None = None
+        state_dir = persistence_path.parent if persistence_path else Path("/tmp")
+        schedules_path = state_dir / "schedules.json"
+        if cfg.experiments.sqlite_state:
+            state_db = StateDatabase(state_dir / "state.db")
+            schedule_store = SQLiteScheduleStore(
+                db=state_db,
+                legacy_path=schedules_path,
+            )
+            session_binding_store = SQLiteSessionBindingStore(state_db)
+        else:
+            schedule_store = ScheduleStore(
+                persistence_path=schedules_path,
+            )
+            session_binding_store = None
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -526,6 +541,8 @@ def create_test_app(
         rq_dir = persistence_path.parent if persistence_path else Path.home() / ".repowire"
         app.state.review_queue_store = ReviewQueueStore(rq_dir / "review_queue.json")
         app.state.schedule_store = schedule_store
+        app.state.state_db = state_db
+        app.state.session_binding_store = session_binding_store
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(emit_event=registry.add_event)
         app.state.acp_permission_broker = acp_permission_broker
@@ -576,6 +593,8 @@ def create_test_app(
 
         await acp_manager.close()
         await scheduler.stop()
+        if state_db is not None:
+            state_db.close()
         event_log.save()
         await registry.stop()
         cleanup_deps()

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -19,6 +20,17 @@ from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerStatus, TurnState
 
 router = APIRouter(tags=["messages"])
+logger = logging.getLogger(__name__)
+
+
+def _metadata_source_uri(metadata: dict | None) -> str | None:
+    if not metadata:
+        return None
+    for key in ("runtime_source_uri", "source_uri", "transcript_source_uri"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 class QueryRequest(BaseModel):
@@ -460,16 +472,54 @@ async def ingest_chat_turn(
 ) -> OkResponse:
     """Ingest a chat turn from the stop hook for dashboard display."""
     peer_registry = get_peer_registry()
+    resolved_peer = None
     data = request.model_dump(exclude={"pane_id"})
 
     if not request.peer_id and request.pane_id:
         peer = await peer_registry.get_peer_by_pane(request.pane_id)
         if peer:
+            resolved_peer = peer
             data["peer_id"] = peer.peer_id
             data["peer"] = peer.display_name  # canonicalize to registered name
+    elif request.peer_id:
+        try:
+            resolved_peer = await peer_registry.get_peer(request.peer_id)
+        except ValueError:
+            resolved_peer = None
+    else:
+        try:
+            resolved_peer = await peer_registry.get_peer(request.peer)
+        except ValueError:
+            resolved_peer = None
 
     if request.turn_id and request.role == "assistant":
         _mark_turn_finalized(request.turn_id, request.session_id)
+
+    state = get_app_state()
+    binding_store = getattr(state, "session_binding_store", None)
+    if binding_store is not None and resolved_peer is not None:
+        try:
+            binding_store.upsert_observation(
+                peer_id=resolved_peer.peer_id,
+                backend=resolved_peer.backend,
+                project_path=resolved_peer.path,
+                runtime_session_id=request.session_id,
+                runtime_source_uri=_metadata_source_uri(resolved_peer.metadata),
+                provenance={
+                    "source_kind": "runtime_transcript"
+                    if request.session_id else "runtime_unavailable",
+                    "backend": resolved_peer.backend.value,
+                    "runtime_session_id": request.session_id,
+                    "source_event_id": request.turn_id,
+                    "observed_by_peer_id": resolved_peer.peer_id,
+                },
+                metadata={
+                    "last_turn_id": request.turn_id,
+                    "last_role": request.role,
+                },
+            )
+        except Exception:
+            logger.warning("Failed to persist session binding for chat turn", exc_info=True)
 
     peer_registry.add_event("chat_turn", data)
     return OkResponse()

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import socket
 from typing import Any
@@ -13,7 +14,7 @@ from pydantic import BaseModel, Field, field_validator
 from repowire import peer_mcp
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
-from repowire.daemon.deps import get_peer_registry
+from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_registry import (
     CircleSource,
     PaneHijackRejectedError,
@@ -25,6 +26,29 @@ from repowire.session.history import load_peer_history, page_turns
 from repowire.session.timeline import TimelineItem, build_session_timeline
 
 router = APIRouter(tags=["peers"])
+logger = logging.getLogger(__name__)
+
+
+def _metadata_source_uri(metadata: dict[str, Any] | None) -> str | None:
+    if not metadata:
+        return None
+    for key in ("runtime_source_uri", "source_uri", "transcript_source_uri"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _binding_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    if not metadata:
+        return {}
+    allowed_keys = (
+        "hook_session_id",
+        "runtime_source_uri",
+        "source_uri",
+        "transcript_source_uri",
+    )
+    return {key: metadata[key] for key in allowed_keys if metadata.get(key) is not None}
 
 
 class PeerInfo(BaseModel):
@@ -323,6 +347,26 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
             status_code=status.HTTP_409_CONFLICT,
             detail=str(exc),
         ) from exc
+    binding_store = getattr(get_app_state(), "session_binding_store", None)
+    if binding_store is not None:
+        try:
+            binding_store.upsert_observation(
+                peer_id=peer_id,
+                backend=request.backend,
+                project_path=request.path,
+                runtime_session_id=request.metadata.get("hook_session_id"),
+                runtime_source_uri=_metadata_source_uri(request.metadata),
+                provenance={
+                    "source_kind": "runtime_hook",
+                    "backend": request.backend.value,
+                    "runtime_session_id": request.metadata.get("hook_session_id"),
+                    "observed_by_peer_id": peer_id,
+                },
+                status="active",
+                metadata=_binding_metadata(request.metadata),
+            )
+        except Exception:
+            logger.warning("Failed to persist session binding for peer registration", exc_info=True)
     return peer_id, display_name
 
 

--- a/repowire/daemon/state/__init__.py
+++ b/repowire/daemon/state/__init__.py
@@ -1,5 +1,6 @@
 """SQLite-backed daemon state primitives."""
 
 from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
 
-__all__ = ["StateDatabase"]
+__all__ = ["SessionBinding", "SQLiteSessionBindingStore", "StateDatabase"]

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 class StateDatabase:
@@ -83,10 +83,61 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS session_bindings (
+                    repowire_session_id TEXT PRIMARY KEY,
+                    peer_id TEXT,
+                    current_executor_peer_id TEXT,
+                    backend TEXT NOT NULL,
+                    project_path TEXT NOT NULL,
+                    runtime_session_id TEXT,
+                    runtime_source_uri TEXT,
+                    source_cursor TEXT,
+                    provenance TEXT NOT NULL DEFAULT '{}',
+                    resume_capability TEXT NOT NULL DEFAULT '{}',
+                    status TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                )
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_bindings_peer
+                ON session_bindings(peer_id)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_bindings_runtime
+                ON session_bindings(backend, runtime_session_id)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_bindings_backend_project
+                ON session_bindings(backend, project_path)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_session_bindings_source_uri
+                ON session_bindings(runtime_source_uri)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
-                (SCHEMA_VERSION, "initial daemon state schema with schedules"),
+                (1, "initial daemon state schema with schedules"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (2, "session bindings for runtime provenance metadata"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/session_bindings.py
+++ b/repowire/daemon/state/session_bindings.py
@@ -1,0 +1,295 @@
+"""SQLite-backed session binding metadata store."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from repowire.config.models import AgentType
+from repowire.daemon.state.database import StateDatabase
+
+BindingStatus = Literal["active", "detached", "resumable", "archived", "lost", "superseded"]
+
+
+@dataclass
+class SessionBinding:
+    """Durable binding between a Repowire workstream and runtime session metadata."""
+
+    repowire_session_id: str
+    peer_id: str | None
+    current_executor_peer_id: str | None
+    backend: str
+    project_path: str
+    runtime_session_id: str | None = None
+    runtime_source_uri: str | None = None
+    source_cursor: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    resume_capability: dict[str, Any] = field(default_factory=dict)
+    status: BindingStatus = "active"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+    last_seen_at: str = ""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def _backend_value(backend: AgentType | str) -> str:
+    return backend.value if isinstance(backend, AgentType) else str(backend)
+
+
+def _merge_dicts(existing: dict[str, Any], updates: dict[str, Any] | None) -> dict[str, Any]:
+    if not updates:
+        return dict(existing)
+    merged = dict(existing)
+    merged.update({k: v for k, v in updates.items() if v is not None})
+    return merged
+
+
+class SQLiteSessionBindingStore:
+    """Repository for runtime session binding/provenance metadata.
+
+    The store intentionally persists only identifiers, source locators, cursors,
+    and small metadata envelopes. Raw runtime transcript bodies stay in the
+    backend-owned source files/databases.
+    """
+
+    def __init__(self, db: StateDatabase) -> None:
+        self._db = db
+        self._conn = db.conn
+
+    @staticmethod
+    def _row_to_binding(row: sqlite3.Row | None) -> SessionBinding | None:
+        if row is None:
+            return None
+        return SessionBinding(
+            repowire_session_id=row["repowire_session_id"],
+            peer_id=row["peer_id"],
+            current_executor_peer_id=row["current_executor_peer_id"],
+            backend=row["backend"],
+            project_path=row["project_path"],
+            runtime_session_id=row["runtime_session_id"],
+            runtime_source_uri=row["runtime_source_uri"],
+            source_cursor=_json_loads(row["source_cursor"]),
+            provenance=_json_loads(row["provenance"]),
+            resume_capability=_json_loads(row["resume_capability"]),
+            status=row["status"],
+            metadata=_json_loads(row["metadata"]),
+            created_at=row["created_at"],
+            last_seen_at=row["last_seen_at"],
+        )
+
+    def _find_existing(
+        self,
+        *,
+        peer_id: str | None,
+        backend: str,
+        project_path: str,
+        runtime_session_id: str | None,
+        runtime_source_uri: str | None,
+    ) -> SessionBinding | None:
+        if runtime_source_uri:
+            found = self.get_by_source_uri(runtime_source_uri)
+            if found is not None:
+                return found
+        if runtime_session_id:
+            found = self.get_by_runtime_session(
+                runtime_session_id,
+                backend=backend,
+                project_path=project_path or None,
+            )
+            if found is not None:
+                return found
+        if peer_id:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM session_bindings
+                WHERE peer_id = ? AND backend = ? AND project_path = ?
+                  AND runtime_session_id IS NULL AND runtime_source_uri IS NULL
+                ORDER BY last_seen_at DESC
+                LIMIT 1
+                """,
+                (peer_id, backend, project_path),
+            ).fetchone()
+            return self._row_to_binding(rows)
+        return None
+
+    def upsert_observation(
+        self,
+        *,
+        peer_id: str | None,
+        backend: AgentType | str,
+        project_path: str | None,
+        runtime_session_id: str | None = None,
+        runtime_source_uri: str | None = None,
+        source_cursor: dict[str, Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+        resume_capability: dict[str, Any] | None = None,
+        status: BindingStatus = "active",
+        metadata: dict[str, Any] | None = None,
+        observed_at: str | None = None,
+    ) -> SessionBinding:
+        """Create or update the binding matching an observed runtime edge."""
+        normalized_backend = _backend_value(backend)
+        normalized_path = project_path or ""
+        now = observed_at or _now()
+        existing = self._find_existing(
+            peer_id=peer_id,
+            backend=normalized_backend,
+            project_path=normalized_path,
+            runtime_session_id=runtime_session_id,
+            runtime_source_uri=runtime_source_uri,
+        )
+
+        if existing is None:
+            binding = SessionBinding(
+                repowire_session_id=f"rw-session-{uuid4().hex[:12]}",
+                peer_id=peer_id,
+                current_executor_peer_id=peer_id,
+                backend=normalized_backend,
+                project_path=normalized_path,
+                runtime_session_id=runtime_session_id,
+                runtime_source_uri=runtime_source_uri,
+                source_cursor=source_cursor or {},
+                provenance=provenance or {},
+                resume_capability=resume_capability or {},
+                status=status,
+                metadata=metadata or {},
+                created_at=now,
+                last_seen_at=now,
+            )
+        else:
+            binding = SessionBinding(
+                repowire_session_id=existing.repowire_session_id,
+                peer_id=peer_id or existing.peer_id,
+                current_executor_peer_id=peer_id or existing.current_executor_peer_id,
+                backend=normalized_backend,
+                project_path=normalized_path or existing.project_path,
+                runtime_session_id=runtime_session_id or existing.runtime_session_id,
+                runtime_source_uri=runtime_source_uri or existing.runtime_source_uri,
+                source_cursor=_merge_dicts(existing.source_cursor, source_cursor),
+                provenance=_merge_dicts(existing.provenance, provenance),
+                resume_capability=_merge_dicts(existing.resume_capability, resume_capability),
+                status=status or existing.status,
+                metadata=_merge_dicts(existing.metadata, metadata),
+                created_at=existing.created_at,
+                last_seen_at=now,
+            )
+
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO session_bindings(
+                    repowire_session_id, peer_id, current_executor_peer_id, backend,
+                    project_path, runtime_session_id, runtime_source_uri, source_cursor,
+                    provenance, resume_capability, status, metadata, created_at, last_seen_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    binding.repowire_session_id,
+                    binding.peer_id,
+                    binding.current_executor_peer_id,
+                    binding.backend,
+                    binding.project_path,
+                    binding.runtime_session_id,
+                    binding.runtime_source_uri,
+                    _json_dumps(binding.source_cursor),
+                    _json_dumps(binding.provenance),
+                    _json_dumps(binding.resume_capability),
+                    binding.status,
+                    _json_dumps(binding.metadata),
+                    binding.created_at,
+                    binding.last_seen_at,
+                ),
+            )
+        return binding
+
+    def get(self, repowire_session_id: str) -> SessionBinding | None:
+        row = self._conn.execute(
+            "SELECT * FROM session_bindings WHERE repowire_session_id = ?",
+            (repowire_session_id,),
+        ).fetchone()
+        return self._row_to_binding(row)
+
+    def list_by_peer(self, peer_id: str) -> list[SessionBinding]:
+        rows = self._conn.execute(
+            "SELECT * FROM session_bindings WHERE peer_id = ? ORDER BY last_seen_at DESC",
+            (peer_id,),
+        ).fetchall()
+        return [binding for row in rows if (binding := self._row_to_binding(row)) is not None]
+
+    def get_by_runtime_session(
+        self,
+        runtime_session_id: str,
+        *,
+        backend: AgentType | str | None = None,
+        project_path: str | None = None,
+    ) -> SessionBinding | None:
+        clauses = ["runtime_session_id = ?"]
+        params: list[str] = [runtime_session_id]
+        if backend is not None:
+            clauses.append("backend = ?")
+            params.append(_backend_value(backend))
+        if project_path is not None:
+            clauses.append("project_path = ?")
+            params.append(project_path)
+        row = self._conn.execute(
+            f"""
+            SELECT * FROM session_bindings
+            WHERE {' AND '.join(clauses)}
+            ORDER BY last_seen_at DESC
+            LIMIT 1
+            """,
+            params,
+        ).fetchone()
+        return self._row_to_binding(row)
+
+    def list_by_backend_project(
+        self,
+        *,
+        backend: AgentType | str,
+        project_path: str,
+    ) -> list[SessionBinding]:
+        rows = self._conn.execute(
+            """
+            SELECT * FROM session_bindings
+            WHERE backend = ? AND project_path = ?
+            ORDER BY last_seen_at DESC
+            """,
+            (_backend_value(backend), project_path),
+        ).fetchall()
+        return [binding for row in rows if (binding := self._row_to_binding(row)) is not None]
+
+    def get_by_source_uri(self, runtime_source_uri: str) -> SessionBinding | None:
+        row = self._conn.execute(
+            """
+            SELECT * FROM session_bindings
+            WHERE runtime_source_uri = ?
+            ORDER BY last_seen_at DESC
+            LIMIT 1
+            """,
+            (runtime_source_uri,),
+        ).fetchone()
+        return self._row_to_binding(row)
+
+    def list_all(self) -> list[SessionBinding]:
+        rows = self._conn.execute(
+            "SELECT * FROM session_bindings ORDER BY last_seen_at DESC",
+        ).fetchall()
+        return [binding for row in rows if (binding := self._row_to_binding(row)) is not None]

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -7,10 +7,13 @@ from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from httpx import ASGITransport, AsyncClient
+
 from repowire.config.models import Config
 from repowire.daemon.schedule_store import Schedule, ScheduleStore
 from repowire.daemon.state.database import SCHEMA_VERSION, StateDatabase
 from repowire.daemon.state.schedules import SQLiteScheduleStore
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 
 
 def _ts(seconds_from_now: float = 60.0) -> datetime:
@@ -25,14 +28,21 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert db.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert db.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
-        assert db.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 1
+        assert db.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 2
+        tables = {
+            row[0]
+            for row in db.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'",
+            ).fetchall()
+        }
+        assert "session_bindings" in tables
     finally:
         db.close()
 
     db2 = StateDatabase(db_path)
     try:
         assert db2.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
-        assert db2.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 1
+        assert db2.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 2
     finally:
         db2.close()
 
@@ -149,6 +159,57 @@ def test_sqlite_schedule_store_imports_existing_legacy_shape(tmp_path: Path) -> 
         db.close()
 
 
+def test_sqlite_session_binding_store_upsert_and_lookup_fields(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteSessionBindingStore(db)
+        binding = store.upsert_observation(
+            peer_id="repow-default-a1",
+            backend="claude-code",
+            project_path="/repo",
+            runtime_session_id="hook-session-1",
+            runtime_source_uri="claude-jsonl:repo/hook-session-1.jsonl",
+            source_cursor={"line_offset": 7},
+            provenance={"source_kind": "runtime_transcript"},
+            metadata={"hook_session_id": "hook-session-1"},
+        )
+
+        updated = store.upsert_observation(
+            peer_id="repow-default-a1",
+            backend="claude-code",
+            project_path="/repo",
+            runtime_session_id="hook-session-1",
+            metadata={"last_turn_id": "turn-9"},
+        )
+
+        assert updated.repowire_session_id == binding.repowire_session_id
+        assert updated.current_executor_peer_id == "repow-default-a1"
+        assert updated.runtime_source_uri == "claude-jsonl:repo/hook-session-1.jsonl"
+        assert updated.source_cursor == {"line_offset": 7}
+        assert updated.metadata["hook_session_id"] == "hook-session-1"
+        assert updated.metadata["last_turn_id"] == "turn-9"
+        assert store.get(binding.repowire_session_id) is not None
+        assert store.list_by_peer("repow-default-a1")[0].runtime_session_id == "hook-session-1"
+        assert (
+            store.get_by_runtime_session(
+                "hook-session-1",
+                backend="claude-code",
+                project_path="/repo",
+            )
+            is not None
+        )
+        assert (
+            store.list_by_backend_project(backend="claude-code", project_path="/repo")[0]
+            .repowire_session_id
+            == binding.repowire_session_id
+        )
+        by_source = store.get_by_source_uri("claude-jsonl:repo/hook-session-1.jsonl")
+        assert by_source is not None
+        assert by_source.repowire_session_id == binding.repowire_session_id
+    finally:
+        db.close()
+
+
 async def test_create_app_uses_sqlite_schedule_store_and_imports_legacy_json(
     monkeypatch,
     tmp_path: Path,
@@ -182,3 +243,62 @@ async def test_create_app_uses_sqlite_schedule_store_and_imports_legacy_json(
         assert reopened.conn.execute("SELECT row_count FROM legacy_imports").fetchone()[0] == 1
     finally:
         reopened.close()
+
+
+async def test_test_app_wires_session_binding_store_and_observes_hooks(tmp_path: Path) -> None:
+    from repowire.daemon import app as app_mod
+
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with app.router.lifespan_context(app):
+        assert isinstance(app.state.session_binding_store, SQLiteSessionBindingStore)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            reg = await client.post(
+                "/peers",
+                json={
+                    "name": "worker",
+                    "path": "/repo",
+                    "circle": "default",
+                    "backend": "claude-code",
+                    "pane_id": "%77",
+                    "metadata": {
+                        "hook_session_id": "hook-session-1",
+                        "runtime_source_uri": "claude-jsonl:repo/hook-session-1.jsonl",
+                    },
+                },
+            )
+            assert reg.status_code == 200
+            peer_id = reg.json()["peer_id"]
+
+            binding = app.state.session_binding_store.get_by_runtime_session(
+                "hook-session-1",
+                backend="claude-code",
+                project_path="/repo",
+            )
+            assert binding is not None
+            assert binding.peer_id == peer_id
+            assert binding.metadata["hook_session_id"] == "hook-session-1"
+
+            chat = await client.post(
+                "/events/chat",
+                json={
+                    "peer": "worker-claude-code",
+                    "role": "assistant",
+                    "text": "done",
+                    "session_id": "hook-session-1",
+                    "turn_id": "turn-1",
+                    "pane_id": "%77",
+                },
+            )
+            assert chat.status_code == 200
+
+            updated = app.state.session_binding_store.get_by_runtime_session(
+                "hook-session-1",
+                backend="claude-code",
+                project_path="/repo",
+            )
+            assert updated is not None
+            assert updated.repowire_session_id == binding.repowire_session_id
+            assert updated.metadata["last_turn_id"] == "turn-1"
+            assert updated.provenance["source_event_id"] == "turn-1"


### PR DESCRIPTION
## Summary
- add session_bindings to the existing experimental StateDatabase schema
- add SQLiteSessionBindingStore for runtime session binding/provenance metadata, without storing raw transcript bodies
- wire app/test app state when experiments.sqlite_state is enabled
- capture safe binding observations from peer registration metadata and chat-turn ingest while keeping timeline/transcript route behavior unchanged

## Verification
- uv run --extra dev ruff check repowire/ PASS
- uv run --extra dev ty check repowire/ PASS
- uv run --extra dev pytest PASS (1188 passed)
- local focused rerun after ledger-clean amend: uv run --extra dev pytest tests/test_sqlite_state_schedules.py -q (9 passed)
- local focused ruff/ty on touched files passed
- python3 scripts/pre_pr_hygiene.py passed after removing root issues.jsonl from the product commit

## Notes
- This does not migrate timeline/transcript lookup to bindings; that remains repowire-0p4.
- This does not persist raw runtime history. It stores identifiers, source locators, cursors, provenance, and small metadata envelopes only.

Closes repowire-2rc.