### PR TITLE
Add session-targeted control routes

### DIFF
--- a/docs/concepts/control-surfaces.md
+++ b/docs/concepts/control-surfaces.md
@@ -15,3 +15,22 @@ When an agent wants to reach the human, the move is `notify_peer("telegram", "..
 ## What surfaces don't do
 
 Control surfaces are clients of the routing API, not part of it. The daemon is the single source of truth for peer state and message routing. A surface that crashes does not lose mesh state; reopening it picks back up from the daemon.
+
+## Session-targeted controls
+
+The first session-native control API targets durable `repowire_session_id`
+bindings rather than display names:
+
+- `POST /sessions/{repowire_session_id}/controls/notify` resolves the binding
+  to its current active executor and sends through the existing notify delivery
+  path. If no active executor is attached, it returns
+  `session_executor_unavailable` instead of guessing from path or display name.
+- `POST /sessions/{repowire_session_id}/controls/resume` reports the current
+  resume capability for the binding. Active sessions return
+  `status=active_executor`; detached sessions return `status=resume_available`
+  only when backend resume metadata is already recorded, otherwise
+  `status=unsupported`.
+
+These routes require the SQLite session binding store. Existing peer-targeted
+`ask`, `notify_peer`, and dashboard routes remain compatible and continue to
+route by peer identity.

--- a/docs/concepts/session-binding-contract.md
+++ b/docs/concepts/session-binding-contract.md
@@ -248,6 +248,17 @@ If a session has no reliable runtime source locator, resume should fail with a
 clear capability error rather than guessing from display name or current
 working directory alone.
 
+Current compatible slice:
+
+- `POST /sessions/{repowire_session_id}/controls/notify` resolves an active
+  executor from the binding and uses the existing notify delivery path.
+- `POST /sessions/{repowire_session_id}/controls/resume` reports
+  `active_executor`, `resume_available`, or `unsupported` capability status.
+  It does not execute backend-specific resume yet.
+
+Peer-targeted controls remain the compatibility surface while session-targeted
+routes harden.
+
 ## SQLite fit
 
 Session bindings fit the daemon-owned SQLite boundary better than raw

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -28,6 +28,7 @@ The daemon is the single routing hub. It does not care whether a peer arrived th
 | Peer state | `repowire/daemon/peer_registry.py` | Registration, liveness, circles, roles, lazy repair |
 | Message routing | `repowire/daemon/peer_delivery.py`, `repowire/daemon/transport_router.py`, `repowire/daemon/message_router.py`, `repowire/daemon/websocket_transport.py` | Delivery orchestration, ACP-before-WebSocket transport selection, and wire delivery over connected peers |
 | Ask lifecycle | `repowire/daemon/ask_tracker.py`, `repowire/daemon/routes/asks.py` | Open ask state, pending reminders, close/ack handling |
+| Session controls | `repowire/daemon/session_controls.py`, `repowire/daemon/routes/sessions.py` | Session-binding resolution and session-targeted control capability routes |
 | Schedules | `repowire/daemon/scheduler.py`, `repowire/daemon/schedule_store.py`, `repowire/daemon/routes/schedules.py` | One-shot and recurring cron deliveries |
 | Hooks | `repowire/hooks/` | Runtime event adapters, tmux injection, transcript/chat extraction |
 | MCP server | `repowire/mcp/server.py` | Agent-facing tools over stdio |
@@ -66,7 +67,8 @@ The current stable surface is peer-oriented, but the v0.13 architecture train is
 - Peers remain runtime executors.
 - Ask/notify delivery now goes through a delivery service plus transport router; WebSocket hooks, experimental ACP, relay, and future transports continue moving toward transport-neutral routing.
 - The dashboard currently shows a selected peer/session timeline, merging Claude transcript history where available with realtime events.
-- Broader composer actions, scheduling, approval handling, resume, and backend/model controls move toward a shared session command surface.
+- The first session-targeted control routes resolve `repowire_session_id` bindings to an active executor or explicit resume capability status.
+- Broader composer actions, scheduling, approval handling, and backend/model controls move toward the same shared session command surface.
 
 This is a roadmap. Current routes and tools still expose peers, circles, asks, notifications, and schedules. The ask/notify delivery-service and transport-router extraction has landed, but ACP remains experimental and not every route/control path is transport-neutral yet.
 

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -45,6 +45,7 @@ from repowire.daemon.routes import (
     peers,
     reviews,
     schedules,
+    sessions,
     websocket,
 )
 from repowire.daemon.routes import spawn as spawn_routes
@@ -409,6 +410,7 @@ def create_app(
     app.include_router(attachments.router)
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
+    app.include_router(sessions.router)
 
     _mount_http_mcp(app, _config or load_config())
 
@@ -616,6 +618,7 @@ def create_test_app(
     app.include_router(attachments.router)
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
+    app.include_router(sessions.router)
 
     _mount_http_mcp(app, config or Config())
 

--- a/repowire/daemon/routes/sessions.py
+++ b/repowire/daemon/routes/sessions.py
@@ -1,0 +1,212 @@
+"""Session-targeted control endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state
+from repowire.daemon.peer_delivery import peer_delivery_from_state
+from repowire.daemon.session_controls import (
+    SessionBindingStoreUnavailableError,
+    resolve_session_binding,
+    resume_capability_for,
+)
+from repowire.daemon.websocket_transport import TransportError
+from repowire.protocol.messages import AttachmentRef
+
+router = APIRouter(tags=["sessions"])
+
+
+class SessionNotifyRequest(BaseModel):
+    """Fire-and-forget control message targeted by Repowire session ID."""
+
+    from_peer: str = Field(default="dashboard", description="Sending peer or surface")
+    text: str = Field(..., description="Notification/control text")
+    attachments: list[AttachmentRef] = Field(default_factory=list)
+    bypass_circle: bool = Field(
+        default=True,
+        description="Dashboard/API callers default to bypassing circle checks",
+    )
+
+
+class SessionNotifyResponse(BaseModel):
+    """Response for a session-targeted notify control."""
+
+    ok: bool = True
+    repowire_session_id: str
+    session_status: str
+    capability: Literal["active_executor"]
+    executor_peer_id: str
+    executor_peer_name: str
+    delivery_state: Literal["delivered", "queued"]
+    delivered: bool
+    queued: bool
+    reason: str
+    hook_delivery: dict | None = None
+
+
+class SessionResumeRequest(BaseModel):
+    """Inspect or request the compatible resume path for a Repowire session."""
+
+    from_peer: str = Field(default="dashboard", description="Caller peer or surface")
+    dry_run: bool = Field(
+        default=True,
+        description="Reserved for future backend resume execution; currently always inspect-only",
+    )
+
+
+class SessionResumeResponse(BaseModel):
+    """Current resume capability for a session binding."""
+
+    ok: bool = True
+    repowire_session_id: str
+    session_status: str
+    status: Literal[
+        "active_executor",
+        "resume_available",
+        "unsupported",
+        "binding_unavailable",
+    ]
+    capability: Literal["active_executor", "supported", "unsupported", "unavailable"]
+    message: str
+    backend: str
+    runtime_session_id: str | None = None
+    runtime_source_uri: str | None = None
+    executor_peer_id: str | None = None
+    executor_peer_name: str | None = None
+    resume_capability: dict = Field(default_factory=dict)
+
+
+@router.post(
+    "/sessions/{repowire_session_id}/controls/notify",
+    response_model=SessionNotifyResponse,
+)
+async def notify_session(
+    repowire_session_id: str,
+    request: SessionNotifyRequest,
+    _auth: str | None = Depends(require_auth),
+) -> SessionNotifyResponse:
+    """Send a notify/control message to the active executor for a session."""
+    state = get_app_state()
+    resolution = await _resolve_or_http(state, repowire_session_id)
+    if not resolution.has_active_executor or resolution.executor is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "session_executor_unavailable",
+                "repowire_session_id": repowire_session_id,
+                "session_status": resolution.binding.status,
+                "executor_peer_id": resolution.executor_peer_id,
+                "capability": "unsupported",
+            },
+        )
+
+    try:
+        delivery = await peer_delivery_from_state(
+            config=state.config,
+            registry=state.peer_registry,
+            state=state,
+        ).notify_result(
+            from_peer=request.from_peer,
+            to_peer=resolution.executor.peer_id,
+            text=request.text,
+            bypass_circle=request.bypass_circle,
+            attachments=request.attachments,
+        )
+    except TransportError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "error": "transport_unavailable",
+                "repowire_session_id": repowire_session_id,
+                "executor_peer_id": resolution.executor.peer_id,
+                "message": str(exc),
+            },
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "session_delivery_rejected",
+                "repowire_session_id": repowire_session_id,
+                "message": str(exc),
+            },
+        ) from exc
+
+    return SessionNotifyResponse(
+        repowire_session_id=repowire_session_id,
+        session_status=resolution.binding.status,
+        capability="active_executor",
+        executor_peer_id=resolution.executor.peer_id,
+        executor_peer_name=resolution.executor.display_name,
+        delivery_state=delivery.delivery_state,
+        delivered=delivery.delivered,
+        queued=delivery.queued,
+        reason=delivery.reason,
+        hook_delivery=delivery.hook_delivery,
+    )
+
+
+@router.post(
+    "/sessions/{repowire_session_id}/controls/resume",
+    response_model=SessionResumeResponse,
+)
+async def resume_session(
+    repowire_session_id: str,
+    request: SessionResumeRequest,
+    _auth: str | None = Depends(require_auth),
+) -> SessionResumeResponse:
+    """Return the compatible resume capability for a session binding.
+
+    This v0.13 slice is API-first: active sessions resolve to their current
+    executor, and detached sessions expose recorded backend capability metadata
+    or a clear unsupported status. Backend-specific resume execution can be
+    layered onto this contract without changing peer-targeted ask/notify APIs.
+    """
+    state = get_app_state()
+    resolution = await _resolve_or_http(state, repowire_session_id)
+    resume_status, capability, message = resume_capability_for(resolution)
+    executor = resolution.executor if resolution.has_active_executor else None
+    binding = resolution.binding
+    return SessionResumeResponse(
+        repowire_session_id=repowire_session_id,
+        session_status=binding.status,
+        status=resume_status,
+        capability=capability,
+        message=message,
+        backend=binding.backend,
+        runtime_session_id=binding.runtime_session_id,
+        runtime_source_uri=binding.runtime_source_uri,
+        executor_peer_id=executor.peer_id if executor else resolution.executor_peer_id,
+        executor_peer_name=executor.display_name if executor else None,
+        resume_capability=binding.resume_capability,
+    )
+
+
+async def _resolve_or_http(state: object, repowire_session_id: str):
+    try:
+        resolution = await resolve_session_binding(
+            state=state,
+            repowire_session_id=repowire_session_id,
+        )
+    except SessionBindingStoreUnavailableError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "session_bindings_unavailable",
+                "message": str(exc),
+            },
+        ) from exc
+    if resolution is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "session_not_found",
+                "repowire_session_id": repowire_session_id,
+            },
+        )
+    return resolution

--- a/repowire/daemon/session_controls.py
+++ b/repowire/daemon/session_controls.py
@@ -1,0 +1,108 @@
+"""Session-targeted control resolution over durable session bindings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
+from repowire.protocol.peers import Peer, PeerStatus
+
+Capability = Literal["active_executor", "supported", "unsupported", "unavailable"]
+ResumeStatus = Literal[
+    "active_executor",
+    "resume_available",
+    "unsupported",
+    "binding_unavailable",
+]
+
+
+class SessionBindingStoreUnavailableError(RuntimeError):
+    """Raised when session bindings are not configured for this daemon."""
+
+
+@dataclass(frozen=True)
+class SessionResolution:
+    """Resolved binding plus the current live executor, when attached."""
+
+    binding: SessionBinding
+    executor: Peer | None
+
+    @property
+    def executor_peer_id(self) -> str | None:
+        return self.binding.current_executor_peer_id or self.binding.peer_id
+
+    @property
+    def has_active_executor(self) -> bool:
+        return self.executor is not None and self.executor.status != PeerStatus.OFFLINE
+
+
+def get_session_binding_store(state: object) -> SQLiteSessionBindingStore:
+    """Return the configured session binding store or raise a typed error."""
+    store = getattr(state, "session_binding_store", None)
+    if store is None:
+        raise SessionBindingStoreUnavailableError(
+            "Session bindings require experiments.sqlite_state"
+        )
+    return store
+
+
+async def resolve_session_binding(
+    *,
+    state: object,
+    repowire_session_id: str,
+) -> SessionResolution | None:
+    """Resolve a Repowire session binding to its current executor peer."""
+    store = get_session_binding_store(state)
+    binding = store.get(repowire_session_id)
+    if binding is None:
+        return None
+
+    executor_id = binding.current_executor_peer_id or binding.peer_id
+    executor: Peer | None = None
+    if executor_id:
+        registry = getattr(state, "peer_registry")
+        try:
+            executor = await registry.get_peer(executor_id)
+        except ValueError:
+            executor = None
+    return SessionResolution(binding=binding, executor=executor)
+
+
+def resume_capability_for(resolution: SessionResolution) -> tuple[ResumeStatus, Capability, str]:
+    """Return the compatible resume status for a resolved session binding."""
+    binding = resolution.binding
+    if resolution.has_active_executor:
+        return (
+            "active_executor",
+            "active_executor",
+            "Session already has an active executor; send controls to that peer.",
+        )
+
+    if binding.status in {"archived", "lost", "superseded"}:
+        return (
+            "unsupported",
+            "unavailable",
+            f"Session binding status is {binding.status}; resume is not available.",
+        )
+
+    capability = binding.resume_capability or {}
+    if _capability_supported(capability):
+        return (
+            "resume_available",
+            "supported",
+            "Backend resume metadata is present; callers can use this capability record.",
+        )
+
+    return (
+        "unsupported",
+        "unsupported",
+        "No compatible backend resume capability is recorded for this session.",
+    )
+
+
+def _capability_supported(capability: dict[str, Any]) -> bool:
+    if capability.get("supported") is True or capability.get("can_resume") is True:
+        return True
+    status = capability.get("status")
+    return isinstance(status, str) and status in {"supported", "available", "resume_available"}

--- a/tests/test_session_controls_routes.py
+++ b/tests/test_session_controls_routes.py
@@ -1,0 +1,184 @@
+"""HTTP tests for session-targeted control routes."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon import app as app_mod
+from repowire.daemon.peer_delivery import NotifyDeliveryResult
+
+pytestmark = pytest.mark.anyio
+
+
+async def _register_bound_peer(client: AsyncClient) -> str:
+    response = await client.post(
+        "/peers",
+        json={
+            "name": "worker",
+            "path": "/repo",
+            "circle": "default",
+            "backend": "claude-code",
+            "metadata": {
+                "hook_session_id": "runtime-active-1",
+                "runtime_source_uri": "claude-jsonl:repo/runtime-active-1.jsonl",
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["peer_id"]
+
+
+class _FakePeerDelivery:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def notify_result(self, **kwargs):
+        self.calls.append(kwargs)
+        return NotifyDeliveryResult(
+            status="sent",
+            delivery_state="delivered",
+            reason="transport_delivered",
+            from_peer_id=None,
+            from_peer_name=kwargs["from_peer"],
+            to_peer_id=kwargs["to_peer"],
+            to_peer_name="worker-claude-code",
+        )
+
+
+async def test_session_resume_returns_active_executor(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            peer_id = await _register_bound_peer(client)
+            binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-active-1",
+                backend="claude-code",
+                project_path="/repo",
+            )
+            assert binding is not None
+
+            response = await client.post(
+                f"/sessions/{binding.repowire_session_id}/controls/resume",
+                json={},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "active_executor"
+    assert body["capability"] == "active_executor"
+    assert body["executor_peer_id"] == peer_id
+    assert body["runtime_session_id"] == "runtime-active-1"
+
+
+async def test_session_resume_reports_supported_backend_capability(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        binding = app.state.session_binding_store.upsert_observation(
+            peer_id=None,
+            backend="codex",
+            project_path="/repo",
+            runtime_session_id="codex-runtime-1",
+            runtime_source_uri="codex-rollout:repo/codex-runtime-1.jsonl",
+            resume_capability={
+                "supported": True,
+                "strategy": "codex_resume",
+                "runtime_session_id_arg": "codex-runtime-1",
+            },
+            status="resumable",
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/sessions/{binding.repowire_session_id}/controls/resume",
+                json={},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "resume_available"
+    assert body["capability"] == "supported"
+    assert body["backend"] == "codex"
+    assert body["resume_capability"]["strategy"] == "codex_resume"
+
+
+async def test_session_resume_reports_unsupported_fallback(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        binding = app.state.session_binding_store.upsert_observation(
+            peer_id=None,
+            backend="gemini",
+            project_path="/repo",
+            runtime_session_id="gemini-runtime-1",
+            status="detached",
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                f"/sessions/{binding.repowire_session_id}/controls/resume",
+                json={},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "unsupported"
+    assert body["capability"] == "unsupported"
+    assert "No compatible backend resume capability" in body["message"]
+
+
+async def test_session_notify_targets_active_executor(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        fake_delivery = _FakePeerDelivery()
+        app.state.peer_delivery = fake_delivery
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            peer_id = await _register_bound_peer(client)
+            binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-active-1",
+                backend="claude-code",
+                project_path="/repo",
+            )
+            assert binding is not None
+            response = await client.post(
+                f"/sessions/{binding.repowire_session_id}/controls/notify",
+                json={"from_peer": "dashboard", "text": "continue this work"},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["capability"] == "active_executor"
+    assert body["executor_peer_id"] == peer_id
+    assert body["delivery_state"] == "delivered"
+    assert fake_delivery.calls == [
+        {
+            "from_peer": "dashboard",
+            "to_peer": peer_id,
+            "text": "continue this work",
+            "bypass_circle": True,
+            "attachments": [],
+        }
+    ]
+
+
+async def test_session_controls_require_binding_store(tmp_path):
+    cfg = Config(experiments={"sqlite_state": False})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post("/sessions/rw-session-missing/controls/resume", json={})
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "session_bindings_unavailable"


### PR DESCRIPTION
## Summary
- add a narrow session-targeted control/resume route surface over session bindings
- resolve active executor/capability state without changing existing peer-targeted ask/notify surfaces
- document session controls in architecture/control docs

## Verification
- uv run --extra dev pytest tests/test_session_controls_routes.py -q
- uv run --extra dev ruff check repowire/daemon/session_controls.py repowire/daemon/routes/sessions.py repowire/daemon/app.py tests/test_session_controls_routes.py
- uv run --extra dev ty check repowire/daemon/session_controls.py repowire/daemon/routes/sessions.py repowire/daemon/app.py
- git diff --check origin/main...HEAD
- python3 scripts/pre_pr_hygiene.py

Closes repowire-5hc.