### PR TITLE
Attach control events to session bindings

### DIFF
--- a/docs/concepts/message-types.md
+++ b/docs/concepts/message-types.md
@@ -8,6 +8,8 @@ Non-blocking. Returns a `correlation_id` immediately. The recipient closes the t
 
 If the recipient never acks, repowire injects a reminder block at the start of every subsequent prompt on the recipient side until the ask is acked. Tool-call detection is the source of truth — prose `[ack #cid]` mentions in agent output do not close anything, only a real `ack()` MCP call does.
 
+When the daemon can resolve a durable session binding for either side, ask events include nullable `repowire_session_id`, `from_repowire_session_id`, and `to_repowire_session_id` metadata. Peer IDs remain the routing authority.
+
 ## `ack`
 
 Closes an open ask thread.
@@ -17,11 +19,15 @@ Closes an open ask thread.
 
 Replies always reach the original asker regardless of circle — the thread was established at ask-time and the routing is locked then.
 
+Bare ack events and reply notifications carry the same nullable session metadata when a binding is known. Detached or offline peers keep those fields `null`.
+
 ## `notify_peer`
 
 Fire-and-forget. No lifecycle, no response expected. Returns a synthetic `notif-XXXXXXXX` ID for client-side tracking, not a thread you can close.
 
 The special peer name `telegram` routes to the user's phone (if the Telegram bot is running). The dashboard already sees agent turns; you do not need to notify it.
+
+Notify events and newer hook delivery receipts also include nullable session metadata when resolvable. Missing metadata does not change delivery semantics.
 
 ## `broadcast`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -59,6 +59,8 @@ ask(peer_name: str, query: str, reply_to: str | None = None, circle: str | None 
 
 Open a non-blocking ask thread. In normal use, you tell your local agent what you need in natural language, and the agent invokes this MCP tool. Returns a `correlation_id` immediately. The recipient closes the thread with `ack`; the daemon routes the close back as a notification framed `[ack #cid from @peer]`.
 
+Daemon events for asks and acks include nullable `repowire_session_id`, `from_repowire_session_id`, and `to_repowire_session_id` fields when an existing session binding can be resolved. Peer IDs remain the routing authority.
+
 Peer resolution defaults to the caller's circle. Peers whose role bypasses circles (`orchestrator`, `service`, human surfaces) resolve mesh-wide; everything else is scoped to the caller's circle so the daemon's ambiguous-resolve refusal applies. Pass `circle="<name>"` to target a different circle explicitly.
 
 Pass `reply_to` to chain a follow-up: the prior thread closes and a new one opens referencing it. See [misroute refusal](../concepts/message-types.md#misroute-refusal) for what happens when names collide within the resolution scope.
@@ -93,7 +95,9 @@ On the HTTP `/notify` response, `hook_delivery` may be present when the
 recipient is a new enough WebSocket hook. It is a best-effort terminal injection
 receipt with statuses such as `injected`, `rejected`, or `failed`; `null` means
 the hook is older, a non-hook transport handled the notify, or no receipt
-arrived before the daemon returned.
+arrived before the daemon returned. When a session binding is known, `/notify`
+responses and hook receipts may include nullable `repowire_session_id`,
+`from_repowire_session_id`, and `to_repowire_session_id` fields for grouping.
 
 Peer resolution mirrors `ask`: defaults to the caller's circle, except for peers whose role bypasses circles (`orchestrator`, `service`, human surfaces) which resolve mesh-wide. Pass `circle="<name>"` to target a different circle.
 

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -43,9 +43,11 @@ class ApprovalBroker:
         self,
         *,
         emit_event: Callable[[str, dict[str, Any]], str],
+        resolve_repowire_session_id: Callable[[str, str], str | None] | None = None,
         timeout_seconds: float = 60.0,
     ) -> None:
         self._emit_event = emit_event
+        self._resolve_repowire_session_id = resolve_repowire_session_id
         self._timeout_seconds = timeout_seconds
         self._pending: dict[str, _PendingPermission] = {}
         self._lock = asyncio.Lock()
@@ -76,12 +78,14 @@ class ApprovalBroker:
         async with self._lock:
             self._pending[pending.request_id] = pending
 
+        repowire_session_id = self._resolve_session_id(peer_id, session_id)
         self._emit_event(
             "acp_permission_request",
             {
                 "request_id": pending.request_id,
                 "peer_id": peer_id,
                 "session_id": session_id,
+                "repowire_session_id": repowire_session_id,
                 "tool_call": pending.tool_call,
                 "options": normalized_options,
                 "status": "pending",
@@ -150,18 +154,28 @@ class ApprovalBroker:
         decision: PermissionDecision,
     ) -> None:
         status = "timed_out" if decision.timed_out else "decided"
+        repowire_session_id = self._resolve_session_id(pending.peer_id, pending.session_id)
         self._emit_event(
             "acp_permission_decision",
             {
                 "request_id": pending.request_id,
                 "peer_id": pending.peer_id,
                 "session_id": pending.session_id,
+                "repowire_session_id": repowire_session_id,
                 "outcome": decision.outcome,
                 "option_id": decision.option_id,
                 "message": decision.message,
                 "status": status,
             },
         )
+
+    def _resolve_session_id(self, peer_id: str, session_id: str) -> str | None:
+        if self._resolve_repowire_session_id is None:
+            return None
+        try:
+            return self._resolve_repowire_session_id(peer_id, session_id)
+        except Exception:
+            return None
 
 
 def _first_option_id(options: list[dict[str, Any]]) -> str | None:

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -53,13 +53,29 @@ from repowire.daemon.schedule_store import ScheduleStore
 from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.schedules import SQLiteScheduleStore
-from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
+from repowire.daemon.state.session_bindings import (
+    SQLiteSessionBindingStore,
+    resolve_repowire_session_id,
+)
 from repowire.daemon.websocket_transport import WebSocketTransport
 
 logger = logging.getLogger(__name__)
 
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def _make_acp_session_resolver(
+    session_binding_store: SQLiteSessionBindingStore | None,
+):
+    def _resolve(peer_id: str, runtime_session_id: str) -> str | None:
+        return resolve_repowire_session_id(
+            session_binding_store,
+            peer_id=peer_id,
+            runtime_session_id=runtime_session_id,
+        )
+
+    return _resolve
 
 
 class _MCPAuthASGIWrapper:
@@ -249,7 +265,10 @@ def create_app(
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         from repowire.acp import AcpClientManager, ApprovalBroker
-        acp_permission_broker = ApprovalBroker(emit_event=peer_registry.add_event)
+        acp_permission_broker = ApprovalBroker(
+            emit_event=peer_registry.add_event,
+            resolve_repowire_session_id=_make_acp_session_resolver(session_binding_store),
+        )
         app.state.acp_permission_broker = acp_permission_broker
         acp_manager = AcpClientManager(approval_broker=acp_permission_broker)
         app.state.acp_manager = acp_manager
@@ -264,6 +283,7 @@ def create_app(
                 state=app.state,
             ),
             ask_tracker=ask_tracker,
+            session_binding_store=session_binding_store,
         )
         app.state.peer_delivery = peer_delivery
         scheduler = Scheduler(
@@ -546,7 +566,10 @@ def create_test_app(
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         from repowire.acp import AcpClientManager, ApprovalBroker
-        acp_permission_broker = ApprovalBroker(emit_event=registry.add_event)
+        acp_permission_broker = ApprovalBroker(
+            emit_event=registry.add_event,
+            resolve_repowire_session_id=_make_acp_session_resolver(session_binding_store),
+        )
         app.state.acp_permission_broker = acp_permission_broker
         acp_manager = AcpClientManager(approval_broker=acp_permission_broker)
         app.state.acp_manager = acp_manager
@@ -561,6 +584,7 @@ def create_test_app(
                 state=app.state,
             ),
             ask_tracker=ask_tracker,
+            session_binding_store=session_binding_store,
         )
         app.state.peer_delivery = peer_delivery
         scheduler = Scheduler(

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -91,6 +91,8 @@ class Ask:
     to_peer_id: str
     to_peer_name: str
     text: str
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
     reply_to: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     closed: bool = False
@@ -160,6 +162,8 @@ class AskTracker:
         text: str,
         reply_to: str | None = None,
         correlation_id: str | None = None,
+        from_repowire_session_id: str | None = None,
+        to_repowire_session_id: str | None = None,
     ) -> str:
         """Register a new open ask. Returns the correlation_id.
 
@@ -185,6 +189,8 @@ class AskTracker:
                 to_peer_id=to_peer_id,
                 to_peer_name=to_peer_name,
                 text=text,
+                from_repowire_session_id=from_repowire_session_id,
+                to_repowire_session_id=to_repowire_session_id,
                 reply_to=reply_to,
             )
             logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Any, Literal, cast
 from uuid import uuid4
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT, Config
 from repowire.daemon.ask_tracker import AskerIdentity, AskTracker
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
+from repowire.daemon.state.session_bindings import resolve_repowire_session_id
 from repowire.daemon.transport_router import (
     AskCompletion,
     AskEnvelope,
@@ -46,6 +47,9 @@ class NotifyDeliveryResult:
     to_peer_id: str
     to_peer_name: str
     hook_delivery: dict | None = None
+    repowire_session_id: str | None = None
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
 
     @property
     def delivered(self) -> bool:
@@ -67,12 +71,17 @@ class PeerDeliveryService:
         message_router: MessageRouter,
         transport_router: PeerTransportRouter | None = None,
         ask_tracker: AskTracker | None = None,
+        session_binding_store: Any | None = None,
     ) -> None:
         self._config = config
         self._registry = registry
         self._message_router = message_router
         self._transport_router = transport_router
         self._ask_tracker = ask_tracker
+        self._session_binding_store = session_binding_store
+
+    def _session_id_for_peer(self, peer: Any | None) -> str | None:
+        return resolve_repowire_session_id(self._session_binding_store, peer=peer)
 
     async def query(
         self,
@@ -181,6 +190,8 @@ class PeerDeliveryService:
             bypass_circle=bypass_circle,
             circle=circle,
         )
+        from_session_id = self._session_id_for_peer(from_obj)
+        to_session_id = self._session_id_for_peer(target)
         attachment_tuple = tuple(attachments or ())
         transport_result = await self._router().send_notify(
             NotifyEnvelope(
@@ -190,8 +201,23 @@ class PeerDeliveryService:
                 text=text,
                 intended_recipient_name=to_peer,
                 attachments=attachment_tuple,
+                from_repowire_session_id=from_session_id,
+                to_repowire_session_id=to_session_id,
             )
         )
+        hook_delivery = transport_result.hook_delivery
+        if isinstance(hook_delivery, dict):
+            additions = {
+                key: value
+                for key, value in {
+                    "repowire_session_id": transport_result.repowire_session_id,
+                    "from_repowire_session_id": transport_result.from_repowire_session_id,
+                    "to_repowire_session_id": transport_result.to_repowire_session_id,
+                }.items()
+                if value is not None
+            }
+            if additions:
+                hook_delivery = {**hook_delivery, **additions}
         delivery_status = transport_result.status
         delivery_state: Literal["delivered", "queued"] = (
             "queued" if delivery_status == "queued" else "delivered"
@@ -207,7 +233,10 @@ class PeerDeliveryService:
             from_peer_name=from_obj.display_name if from_obj else from_peer,
             to_peer_id=target.peer_id,
             to_peer_name=target.display_name,
-            hook_delivery=transport_result.hook_delivery,
+            hook_delivery=hook_delivery,
+            repowire_session_id=transport_result.repowire_session_id,
+            from_repowire_session_id=transport_result.from_repowire_session_id,
+            to_repowire_session_id=transport_result.to_repowire_session_id,
         )
 
     async def deliver_ask(
@@ -233,6 +262,8 @@ class PeerDeliveryService:
         from_peer_id = from_obj.peer_id if from_obj else from_peer
         from_peer_name = from_obj.display_name if from_obj else from_peer
         completion = on_acp_complete or self._default_acp_completion()
+        from_session_id = self._session_id_for_peer(from_obj)
+        to_session_id = self._session_id_for_peer(target)
 
         await self._router().send_ask(
             AskEnvelope(
@@ -244,6 +275,8 @@ class PeerDeliveryService:
                 reply_to=reply_to,
                 intended_recipient_name=to_peer,
                 attachments=tuple(attachments or ()),
+                from_repowire_session_id=from_session_id,
+                to_repowire_session_id=to_session_id,
             ),
             on_acp_complete=completion,
         )
@@ -470,4 +503,5 @@ def peer_delivery_from_state(
         message_router=getattr(state, "message_router"),
         transport_router=transport_router,
         ask_tracker=getattr(state, "ask_tracker", None),
+        session_binding_store=getattr(state, "session_binding_store", None),
     )

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -972,6 +972,7 @@ class PeerRegistry:
                 message_router=self._router,
             ),
             ask_tracker=self._ask_tracker,
+            session_binding_store=getattr(self, "_session_binding_store", None),
         )
 
     async def query(

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -34,6 +34,7 @@ from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_delivery import peer_delivery_from_state
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
 from repowire.daemon.routes._shared import OkResponse
+from repowire.daemon.state.session_bindings import resolve_repowire_session_id
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer
@@ -164,6 +165,44 @@ async def _capture_asker_identity(
     )
 
 
+def _binding_id_for_peer(state: object, peer: Peer | None) -> str | None:
+    return resolve_repowire_session_id(
+        getattr(state, "session_binding_store", None),
+        peer=peer,
+    )
+
+
+def _emit_ack_event(
+    *,
+    peer_registry: PeerRegistry,
+    ask: object,
+    reason: str,
+    delivered: bool,
+    has_message: bool,
+    has_attachments: bool,
+) -> None:
+    from repowire.daemon.ask_tracker import Ask
+
+    assert isinstance(ask, Ask)
+    peer_registry.add_event(
+        "ack",
+        {
+            "from": ask.to_peer_name,
+            "to": ask.from_peer_name,
+            "from_peer_id": ask.to_peer_id,
+            "to_peer_id": ask.from_peer_id,
+            "correlation_id": ask.correlation_id,
+            "status": reason,
+            "delivered": delivered,
+            "has_message": has_message,
+            "has_attachments": has_attachments,
+            "repowire_session_id": ask.from_repowire_session_id,
+            "from_repowire_session_id": ask.to_repowire_session_id,
+            "to_repowire_session_id": ask.from_repowire_session_id,
+        },
+    )
+
+
 async def _acp_complete(
     *,
     correlation_id: str,
@@ -226,6 +265,14 @@ async def _acp_complete(
                 correlation_id, e,
             )
             await ask_tracker.close(correlation_id, reason="send_failed")
+            _emit_ack_event(
+                peer_registry=peer_registry,
+                ask=ask,
+                reason="send_failed",
+                delivered=False,
+                has_message=True,
+                has_attachments=False,
+            )
             return
         identity = await _capture_asker_identity(peer_registry, ask.from_peer_id)
         stashed = await ask_tracker.set_pending_reply(
@@ -245,9 +292,25 @@ async def _acp_complete(
             correlation_id, e,
         )
         await ask_tracker.close(correlation_id, reason="ack_with_msg")
+        _emit_ack_event(
+            peer_registry=peer_registry,
+            ask=ask,
+            reason="ack_with_msg",
+            delivered=False,
+            has_message=not is_error,
+            has_attachments=False,
+        )
         return
     await ask_tracker.close(
         correlation_id, reason="ack_with_msg" if not is_error else "send_failed",
+    )
+    _emit_ack_event(
+        peer_registry=peer_registry,
+        ask=ask,
+        reason="ack_with_msg" if not is_error else "send_failed",
+        delivered=True,
+        has_message=not is_error,
+        has_attachments=False,
     )
 
 
@@ -280,6 +343,8 @@ async def open_ask(
         )
     from_peer_id = from_peer_obj.peer_id if from_peer_obj else request.from_peer
     from_peer_name = from_peer_obj.display_name if from_peer_obj else request.from_peer
+    from_repowire_session_id = _binding_id_for_peer(state, from_peer_obj)
+    to_repowire_session_id = _binding_id_for_peer(state, peer)
 
     # Enforce circle access BEFORE registering the ask. On the WS path
     # ``deliver_ask`` runs the same check inside ``_resolve_from_peer_unlocked``
@@ -302,6 +367,8 @@ async def open_ask(
             to_peer_name=peer.display_name,
             text=request.text,
             reply_to=request.reply_to,
+            from_repowire_session_id=from_repowire_session_id,
+            to_repowire_session_id=to_repowire_session_id,
         )
     except QuiescedError as e:
         raise HTTPException(
@@ -415,7 +482,12 @@ async def ack_ask(
             f"{request.message or ''}"
         )
         try:
-            await peer_registry.notify(
+            peer_delivery = peer_delivery_from_state(
+                config=state.config,
+                registry=peer_registry,
+                state=state,
+            )
+            await peer_delivery.notify(
                 from_peer=existing.to_peer_id,
                 to_peer=existing.from_peer_id,
                 text=framed,
@@ -430,6 +502,14 @@ async def ack_ask(
                 request.correlation_id, e,
             )
             await ask_tracker.close(request.correlation_id, reason="ack_with_msg")
+            _emit_ack_event(
+                peer_registry=peer_registry,
+                ask=existing,
+                reason="ack_with_msg",
+                delivered=False,
+                has_message=True,
+                has_attachments=bool(request.attachments),
+            )
             return OkResponse()
         except TransportError as e:
             # Asker has no live WS. Leave the ask open so the recipient can
@@ -454,6 +534,14 @@ async def ack_ask(
 
         await ask_tracker.close(request.correlation_id, reason="ack_with_msg")
     else:
+        _emit_ack_event(
+            peer_registry=peer_registry,
+            ask=existing,
+            reason="ack",
+            delivered=False,
+            has_message=False,
+            has_attachments=False,
+        )
         await ask_tracker.close(request.correlation_id, reason="ack")
 
     return OkResponse()

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -90,6 +90,9 @@ class NotifyResponse(BaseModel):
     from_peer_name: str | None = None
     to_peer_id: str | None = None
     to_peer_name: str | None = None
+    repowire_session_id: str | None = None
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
     hook_delivery: dict | None = Field(
         None,
         description=(
@@ -243,6 +246,9 @@ async def notify_peer(
             from_peer_name=delivery.from_peer_name,
             to_peer_id=delivery.to_peer_id,
             to_peer_name=delivery.to_peer_name,
+            repowire_session_id=delivery.repowire_session_id,
+            from_repowire_session_id=delivery.from_repowire_session_id,
+            to_repowire_session_id=delivery.to_repowire_session_id,
             hook_delivery=delivery.hook_delivery,
         )
     except ValueError as e:

--- a/repowire/daemon/state/session_bindings.py
+++ b/repowire/daemon/state/session_bindings.py
@@ -293,3 +293,56 @@ class SQLiteSessionBindingStore:
             "SELECT * FROM session_bindings ORDER BY last_seen_at DESC",
         ).fetchall()
         return [binding for row in rows if (binding := self._row_to_binding(row)) is not None]
+
+
+def resolve_repowire_session_id(
+    store: SQLiteSessionBindingStore | None,
+    *,
+    peer: Any | None = None,
+    peer_id: str | None = None,
+    backend: AgentType | str | None = None,
+    project_path: str | None = None,
+    runtime_session_id: str | None = None,
+) -> str | None:
+    """Best-effort existing binding lookup for control-event annotations.
+
+    This intentionally never creates a binding. Control events should carry a
+    session pointer only when the daemon can resolve an already-observed
+    binding without changing routing or lifecycle state.
+    """
+    if store is None:
+        return None
+
+    if peer is not None:
+        peer_id = peer_id or getattr(peer, "peer_id", None)
+        backend = backend or getattr(peer, "backend", None)
+        project_path = project_path or getattr(peer, "path", None)
+        metadata = getattr(peer, "metadata", None)
+        if runtime_session_id is None and isinstance(metadata, dict):
+            value = metadata.get("hook_session_id") or metadata.get("session_id")
+            if isinstance(value, str) and value:
+                runtime_session_id = value
+
+    if runtime_session_id:
+        binding = store.get_by_runtime_session(
+            runtime_session_id,
+            backend=backend,
+            project_path=project_path,
+        )
+        if binding is not None:
+            return binding.repowire_session_id
+
+    if peer_id:
+        bindings = store.list_by_peer(peer_id)
+        if bindings:
+            return bindings[0].repowire_session_id
+
+    if backend is not None and project_path:
+        bindings = store.list_by_backend_project(
+            backend=backend,
+            project_path=project_path,
+        )
+        if len(bindings) == 1:
+            return bindings[0].repowire_session_id
+
+    return None

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -43,6 +43,8 @@ class AskEnvelope:
     reply_to: str | None = None
     intended_recipient_name: str | None = None
     attachments: tuple[AttachmentRef, ...] = ()
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -55,6 +57,8 @@ class NotifyEnvelope:
     text: str
     intended_recipient_name: str | None = None
     attachments: tuple[AttachmentRef, ...] = ()
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -63,6 +67,9 @@ class NotifyTransportResult:
 
     status: Literal["sent", "queued"]
     hook_delivery: dict[str, Any] | None = None
+    repowire_session_id: str | None = None
+    from_repowire_session_id: str | None = None
+    to_repowire_session_id: str | None = None
 
 
 class AskCompletion(Protocol):
@@ -94,6 +101,9 @@ class WebSocketPeerTransport:
                 "reply_to": envelope.reply_to,
                 "self_target": envelope.from_peer_id == envelope.target.peer_id,
                 "attachments": [a.model_dump(exclude_none=True) for a in envelope.attachments],
+                "repowire_session_id": envelope.to_repowire_session_id,
+                "from_repowire_session_id": envelope.from_repowire_session_id,
+                "to_repowire_session_id": envelope.to_repowire_session_id,
             },
         )
         await self._router.send_ask(
@@ -126,6 +136,9 @@ class WebSocketPeerTransport:
                 "to_peer_id": envelope.target.peer_id,
                 "delivery_status": delivery_status,
                 "attachments": [a.model_dump(exclude_none=True) for a in envelope.attachments],
+                "repowire_session_id": envelope.to_repowire_session_id,
+                "from_repowire_session_id": envelope.from_repowire_session_id,
+                "to_repowire_session_id": envelope.to_repowire_session_id,
             },
         )
         hook_delivery = await self._router.send_notification(
@@ -140,7 +153,13 @@ class WebSocketPeerTransport:
         )
         if not isinstance(hook_delivery, dict):
             hook_delivery = None
-        return NotifyTransportResult(status=delivery_status, hook_delivery=hook_delivery)
+        return NotifyTransportResult(
+            status=delivery_status,
+            hook_delivery=hook_delivery,
+            repowire_session_id=envelope.to_repowire_session_id,
+            from_repowire_session_id=envelope.from_repowire_session_id,
+            to_repowire_session_id=envelope.to_repowire_session_id,
+        )
 
 
 class AcpPeerTransport:
@@ -197,7 +216,12 @@ class AcpPeerTransport:
             text=_text_with_attachment_fallback(envelope.text, envelope.attachments),
             on_complete=_drop_result,
         )
-        return NotifyTransportResult(status="sent")
+        return NotifyTransportResult(
+            status="sent",
+            repowire_session_id=envelope.to_repowire_session_id,
+            from_repowire_session_id=envelope.from_repowire_session_id,
+            to_repowire_session_id=envelope.to_repowire_session_id,
+        )
 
 
 class PeerTransportRouter:
@@ -212,6 +236,7 @@ class PeerTransportRouter:
         acp_manager: Any | None = None,
     ) -> None:
         self._config = config
+        self._registry = registry
         self._ws = WebSocketPeerTransport(registry, message_router)
         self._acp = AcpPeerTransport(acp_manager) if acp_manager is not None else None
 
@@ -231,6 +256,25 @@ class PeerTransportRouter:
         decision = self._acp_decision(envelope.target)
         if decision is not None:
             assert self._acp is not None
+            self._registry.add_event(
+                "ask",
+                {
+                    "from": envelope.from_peer_name,
+                    "to": envelope.target.display_name,
+                    "text": envelope.text,
+                    "from_peer_id": envelope.from_peer_id,
+                    "to_peer_id": envelope.target.peer_id,
+                    "correlation_id": envelope.correlation_id,
+                    "reply_to": envelope.reply_to,
+                    "self_target": envelope.from_peer_id == envelope.target.peer_id,
+                    "attachments": [
+                        a.model_dump(exclude_none=True) for a in envelope.attachments
+                    ],
+                    "repowire_session_id": envelope.to_repowire_session_id,
+                    "from_repowire_session_id": envelope.from_repowire_session_id,
+                    "to_repowire_session_id": envelope.to_repowire_session_id,
+                },
+            )
             await self._acp.send_ask(envelope, on_acp_complete, decision)
             return
         await self._ws.send_ask(envelope)
@@ -239,6 +283,23 @@ class PeerTransportRouter:
         decision = self._acp_decision(envelope.target)
         if decision is not None:
             assert self._acp is not None
+            self._registry.add_event(
+                "notification",
+                {
+                    "from": envelope.from_peer_name,
+                    "to": envelope.target.display_name,
+                    "text": envelope.text,
+                    "from_peer_id": envelope.from_peer_id,
+                    "to_peer_id": envelope.target.peer_id,
+                    "delivery_status": "sent",
+                    "attachments": [
+                        a.model_dump(exclude_none=True) for a in envelope.attachments
+                    ],
+                    "repowire_session_id": envelope.to_repowire_session_id,
+                    "from_repowire_session_id": envelope.from_repowire_session_id,
+                    "to_repowire_session_id": envelope.to_repowire_session_id,
+                },
+            )
             return await self._acp.send_notify(envelope, decision)
         return await self._ws.send_notify(envelope)
 

--- a/tests/test_session_binding_control_events.py
+++ b/tests/test_session_binding_control_events.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon import app as app_mod
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
+
+
+async def _register_peer(
+    client: AsyncClient,
+    *,
+    name: str,
+    path: str,
+    pane_id: str,
+    runtime_session_id: str,
+) -> tuple[str, str]:
+    response = await client.post(
+        "/peers",
+        json={
+            "name": name,
+            "path": path,
+            "circle": "default",
+            "backend": "claude-code",
+            "pane_id": pane_id,
+            "metadata": {"hook_session_id": runtime_session_id},
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return body["peer_id"], body["display_name"]
+
+
+@pytest.mark.asyncio
+async def test_ask_ack_and_notify_events_carry_session_bindings(tmp_path: Path) -> None:
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with app.router.lifespan_context(app):
+        assert isinstance(app.state.session_binding_store, SQLiteSessionBindingStore)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            alice_id, alice_name = await _register_peer(
+                client,
+                name="alice",
+                path="/repo/alice",
+                pane_id="%11",
+                runtime_session_id="runtime-alice",
+            )
+            bob_id, bob_name = await _register_peer(
+                client,
+                name="bob",
+                path="/repo/bob",
+                pane_id="%12",
+                runtime_session_id="runtime-bob",
+            )
+            alice_binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-alice",
+                backend="claude-code",
+                project_path="/repo/alice",
+            )
+            bob_binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-bob",
+                backend="claude-code",
+                project_path="/repo/bob",
+            )
+            assert alice_binding is not None
+            assert bob_binding is not None
+
+            app.state.peer_registry._router.send_ask = AsyncMock()
+            ask_response = await client.post(
+                "/ask",
+                json={
+                    "from_peer": alice_name,
+                    "to_peer": bob_name,
+                    "text": "question",
+                },
+            )
+            assert ask_response.status_code == 200, ask_response.text
+            correlation_id = ask_response.json()["correlation_id"]
+
+            events = app.state.peer_registry.get_events()
+            ask_event = [event for event in events if event["type"] == "ask"][-1]
+            assert ask_event["from_peer_id"] == alice_id
+            assert ask_event["to_peer_id"] == bob_id
+            assert ask_event["repowire_session_id"] == bob_binding.repowire_session_id
+            assert ask_event["from_repowire_session_id"] == alice_binding.repowire_session_id
+            assert ask_event["to_repowire_session_id"] == bob_binding.repowire_session_id
+
+            hook_ack = {
+                "type": "delivery_ack",
+                "delivery_id": "notif-delivery-test",
+                "message_type": "notify",
+                "status": "injected",
+            }
+            app.state.peer_registry._router.send_notification = AsyncMock(
+                return_value=hook_ack,
+            )
+            notify_response = await client.post(
+                "/notify",
+                json={
+                    "from_peer": alice_name,
+                    "to_peer": bob_name,
+                    "text": "FYI",
+                },
+            )
+            assert notify_response.status_code == 200, notify_response.text
+            notify_body = notify_response.json()
+            assert notify_body["repowire_session_id"] == bob_binding.repowire_session_id
+            assert (
+                notify_body["hook_delivery"]["repowire_session_id"]
+                == bob_binding.repowire_session_id
+            )
+            assert (
+                notify_body["hook_delivery"]["from_repowire_session_id"]
+                == alice_binding.repowire_session_id
+            )
+
+            ack_response = await client.post(
+                "/ack",
+                json={
+                    "correlation_id": correlation_id,
+                    "message": "answer",
+                },
+            )
+            assert ack_response.status_code == 200, ack_response.text
+            ack_reply_event = [
+                event for event in app.state.peer_registry.get_events()
+                if event["type"] == "notification"
+            ][-1]
+            assert ack_reply_event["from_peer_id"] == bob_id
+            assert ack_reply_event["to_peer_id"] == alice_id
+            assert (
+                ack_reply_event["repowire_session_id"]
+                == alice_binding.repowire_session_id
+            )
+            assert (
+                ack_reply_event["from_repowire_session_id"]
+                == bob_binding.repowire_session_id
+            )
+            assert (
+                ack_reply_event["to_repowire_session_id"]
+                == alice_binding.repowire_session_id
+            )
+
+            app.state.peer_registry._router.send_ask = AsyncMock()
+            bare_ask_response = await client.post(
+                "/ask",
+                json={
+                    "from_peer": alice_name,
+                    "to_peer": bob_name,
+                    "text": "close only",
+                },
+            )
+            assert bare_ask_response.status_code == 200, bare_ask_response.text
+            bare_ack_response = await client.post(
+                "/ack",
+                json={"correlation_id": bare_ask_response.json()["correlation_id"]},
+            )
+            assert bare_ack_response.status_code == 200, bare_ack_response.text
+            ack_event = [
+                event for event in app.state.peer_registry.get_events()
+                if event["type"] == "ack"
+            ][-1]
+            assert ack_event["repowire_session_id"] == alice_binding.repowire_session_id
+            assert ack_event["from_repowire_session_id"] == bob_binding.repowire_session_id
+            assert ack_event["to_repowire_session_id"] == alice_binding.repowire_session_id
+
+
+@pytest.mark.asyncio
+async def test_detached_sender_leaves_ask_sender_binding_null(tmp_path: Path) -> None:
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            _, bob_name = await _register_peer(
+                client,
+                name="bob",
+                path="/repo/bob",
+                pane_id="%22",
+                runtime_session_id="runtime-bob",
+            )
+            bob_binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-bob",
+                backend="claude-code",
+                project_path="/repo/bob",
+            )
+            assert bob_binding is not None
+
+            app.state.peer_registry._router.send_ask = AsyncMock()
+            response = await client.post(
+                "/ask",
+                json={
+                    "from_peer": "detached-cli",
+                    "to_peer": bob_name,
+                    "text": "offline sender",
+                    "bypass_circle": True,
+                },
+            )
+            assert response.status_code == 200, response.text
+
+            ask_event = [
+                event for event in app.state.peer_registry.get_events()
+                if event["type"] == "ask"
+            ][-1]
+            assert ask_event["from_peer_id"] == "detached-cli"
+            assert ask_event["from_repowire_session_id"] is None
+            assert ask_event["to_repowire_session_id"] == bob_binding.repowire_session_id
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_events_carry_session_binding(tmp_path: Path) -> None:
+    cfg = Config(experiments={"sqlite_state": True})
+    app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            peer_id, _ = await _register_peer(
+                client,
+                name="worker",
+                path="/repo/worker",
+                pane_id="%33",
+                runtime_session_id="runtime-worker",
+            )
+            binding = app.state.session_binding_store.get_by_runtime_session(
+                "runtime-worker",
+                backend="claude-code",
+                project_path="/repo/worker",
+            )
+            assert binding is not None
+            broker = app.state.acp_permission_broker
+
+            task = asyncio.create_task(
+                broker.request_permission(
+                    peer_id=peer_id,
+                    session_id="runtime-worker",
+                    tool_call={"name": "write_file"},
+                    options=[SimpleNamespace(option_id="allow", title="Allow")],
+                )
+            )
+            request_event = await _wait_for_event(
+                app.state.peer_registry,
+                "acp_permission_request",
+            )
+            assert request_event["repowire_session_id"] == binding.repowire_session_id
+
+            response = await client.post(
+                f"/acp/permissions/{request_event['request_id']}/decision",
+                json={"outcome": "allowed", "option_id": "allow"},
+            )
+            assert response.status_code == 200, response.text
+            await asyncio.wait_for(task, timeout=1.0)
+
+            decision_event = await _wait_for_event(
+                app.state.peer_registry,
+                "acp_permission_decision",
+            )
+            assert decision_event["repowire_session_id"] == binding.repowire_session_id
+
+
+async def _wait_for_event(registry, event_type: str) -> dict:
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        matches = [event for event in registry.get_events() if event["type"] == event_type]
+        if matches:
+            return matches[-1]
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {event_type}")

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -26,6 +26,9 @@ export default function ToolsReference() {
           Open a non-blocking ask thread. In normal use, you tell your local agent what you need in natural language, and the agent invokes this MCP tool. Returns a <Mono>correlation_id</Mono> immediately. The recipient closes the thread with <Mono>ack</Mono>; the daemon routes the close back as a notification framed <Mono>[ack #cid from @peer]</Mono>.
         </p>
         <p>
+          Daemon events for asks and acks include nullable <Mono>repowire_session_id</Mono>, <Mono>from_repowire_session_id</Mono>, and <Mono>to_repowire_session_id</Mono> fields when an existing session binding can be resolved. Peer IDs remain the routing authority.
+        </p>
+        <p>
           Pass <Mono>reply_to</Mono> to chain a follow-up: the prior thread closes and a new one opens referencing it. Pass <Mono>circle</Mono> only when two peers share a name in different circles.
         </p>
         <Example>
@@ -55,7 +58,7 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
           Fire-and-forget. No lifecycle, no expected response. Returns a synthetic <Mono>notif-XXXXXXXX</Mono> ID for client-side tracking, not a thread you can close. Use for status pings and announcements.
         </p>
         <p>
-          On the HTTP <Mono>/notify</Mono> response, <Mono>hook_delivery</Mono> may be present when the recipient is a new enough WebSocket hook. It is a best-effort terminal injection receipt with statuses such as <Mono>injected</Mono>, <Mono>rejected</Mono>, or <Mono>failed</Mono>; <Mono>null</Mono> means the hook is older, a non-hook transport handled the notify, or no receipt arrived before the daemon returned.
+          On the HTTP <Mono>/notify</Mono> response, <Mono>hook_delivery</Mono> may be present when the recipient is a new enough WebSocket hook. It is a best-effort terminal injection receipt with statuses such as <Mono>injected</Mono>, <Mono>rejected</Mono>, or <Mono>failed</Mono>; <Mono>null</Mono> means the hook is older, a non-hook transport handled the notify, or no receipt arrived before the daemon returned. When a session binding is known, notify responses and hook receipts may include nullable <Mono>repowire_session_id</Mono>, <Mono>from_repowire_session_id</Mono>, and <Mono>to_repowire_session_id</Mono> fields for grouping.
         </p>
         <p>
           The special peer <Mono>telegram</Mono> routes to the user&rsquo;s phone. The <Mono>dashboard</Mono> already sees agent turns; you do not need to notify it.


### PR DESCRIPTION
## Summary
- attach resolvable repowire_session_id pointers to asks/acks, ACP permission events, and notify delivery receipt metadata
- preserve existing peer-id routing, status codes, reminder behavior, and delivery semantics
- add detached/offline fallback coverage and docs for session-aware control events

## Verification
- worker ran: uv run --extra dev ruff check repowire/ PASS
- worker ran: uv run --extra dev ty check repowire/ PASS
- worker ran: uv run --extra dev pytest PASS
- coordinator reran after removing issues.jsonl and rebasing: uv run --extra dev pytest tests/test_session_binding_control_events.py -q
- coordinator reran focused ruff/ty on touched Python files
- git diff --check origin/main...HEAD
- python3 scripts/pre_pr_hygiene.py

Closes repowire-xhx.