### PR TITLE
Clarify session binding cleanup boundary

### DIFF
--- a/docs/concepts/session-binding-contract.md
+++ b/docs/concepts/session-binding-contract.md
@@ -1,9 +1,11 @@
 # Session binding contract
 
-Status: architecture contract for the v0.13 session-native train. This document
-defines the boundary future implementation slices should preserve; it does not
-claim the persistence table, route rewrites, dashboard controls, approvals, or
-resume flows are shipped.
+Status: architecture contract for the v0.13 session-native train, updated after
+the compatible SQLite binding-store, binding lookup, and session-control slices
+landed. This document defines the boundary current and future implementation
+slices should preserve; it does not claim dashboard controls, approval UI,
+backend-specific resume execution, or full transport-neutral routing are
+shipped.
 
 ## Problem
 
@@ -140,8 +142,9 @@ Rules:
 - `repowire/session/history.py` discovers and replays backend-owned history for
   Claude Code and Codex by project path and runtime metadata.
 - `repowire/daemon/routes/peers.py` exposes `/peers/{name}/timeline` and
-  `/peers/{name}/transcript`, scoped today by peer/path/backend plus optional
-  runtime `session_id`.
+  `/peers/{name}/transcript`, resolving through an unambiguous session binding
+  when available and otherwise preserving peer/path/backend compatibility plus
+  optional runtime `session_id` filtering.
 - `repowire/daemon/routes/messages.py` ingests live `chat_turn` and
   `chat_turn_delta` events using runtime `session_id` and `turn_id` for
   dashboard reconciliation.
@@ -151,9 +154,12 @@ Rules:
 - `repowire/daemon/peer_delivery.py` coordinates ask/notify delivery and
   already exposes explicit delivered/queued outcomes for some paths.
 - `repowire/daemon/state/database.py` is the experimental daemon SQLite wrapper
-  currently used by schedules. The existing
+  currently used by schedules and session bindings. The existing
   `docs/reference/sqlite-state-expansion-plan.md` recommends expanding SQLite
   carefully and keeping raw transcripts outside SQLite.
+- `repowire/daemon/state/session_bindings.py` persists binding metadata,
+  source locators, cursors, provenance, resume capability, and lifecycle
+  status without storing raw runtime transcript bodies.
 
 ## Migration path
 
@@ -262,20 +268,19 @@ routes harden.
 ## SQLite fit
 
 Session bindings fit the daemon-owned SQLite boundary better than raw
-transcripts because they are control/provenance state. A future implementation
-can add a binding table under the existing `StateDatabase` lifecycle, gated the
-same way other experimental state is gated.
+transcripts because they are control/provenance state. The current binding table
+lives under the existing `StateDatabase` lifecycle and remains distinct from
+`PeerRegistry.SessionMapping` so peer identity restart behavior and downgrade
+compatibility are preserved.
 
-Do not add the binding table opportunistically while changing timeline,
-delivery, or dashboard behavior. The persistence slice should define a store
-interface, migration tests, JSON downgrade/backcompat behavior, and failure
-policy separately.
+Do not use the binding table as a reason to remove peer/path compatibility,
+rewrite delivery semantics, or persist raw runtime transcript bodies. Further
+SQLite expansion should define store interfaces, migration tests, JSON
+downgrade/backcompat behavior, and failure policy separately.
 
 ## Non-goals for this contract
 
-- No full persistence table is required by this document.
 - No dashboard UI changes.
-- No route behavior changes.
 - No changes to ask reminder, pending reply, TTL, or approval semantics.
 - No model switching or production-ready ACP claim.
 - No background polling. Binding repair should follow the existing lazy-repair

--- a/docs/reference/sqlite-state-expansion-plan.md
+++ b/docs/reference/sqlite-state-expansion-plan.md
@@ -1,6 +1,6 @@
 # SQLite state expansion plan
 
-Status: architecture recommendation for v0.13.x review. Do not implement schema migration from this document without a follow-up implementation review.
+Status: architecture recommendation for v0.13.x review, updated after the session-binding slices landed. Do not implement additional schema migration from this document without a follow-up implementation review.
 
 ## Current state
 
@@ -9,17 +9,17 @@ Repowire currently has two persistence styles:
 - Experimental SQLite state under `~/.repowire/state.db`, gated by `experiments.sqlite_state`.
 - JSON files under `~/.repowire/`, usually loaded into daemon memory and flushed by lazy repair or explicit mutation paths.
 
-The SQLite path is currently limited to schedules. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat.
+The SQLite path currently covers schedules and session bindings. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies.
 
 Other state remains JSON or in-memory:
 
-- `sessions.json`: persistent peer/session mappings inside `PeerRegistry`.
+- `sessions.json`: persistent peer/session mappings inside `PeerRegistry`; still retained for peer identity reuse, daemon restart behavior, and downgrade/backcompat while the binding store hardens.
 - `events.json`: dashboard event ring buffer persisted from `PeerRegistry`.
 - `AskTracker`: in-memory ask/ack lifecycle with TTL eviction and in-memory pending ACP reply stashes.
 - Agent transcripts: source-of-truth JSONL files owned by Claude Code or other agent runtimes, parsed on demand for history routes.
 - `review_queue.json`: small low-frequency review queue state.
 
-## Before and after
+## Before and current
 
 Before:
 
@@ -29,13 +29,13 @@ Before:
 - Peer mappings are restored from `sessions.json`.
 - Open asks and pending replies are lost on daemon restart.
 
-After the recommended first slice:
+Current compatible SQLite slices:
 
 - Schedules stay on the existing experimental SQLite adapter.
-- Dashboard/session events are appended to SQLite as an event journal behind `experiments.sqlite_state`.
-- The in-memory event deque and SSE wakeups remain the live delivery path.
-- `events.json` remains in place for downgrade and is imported once into SQLite when the event table is empty.
 - Peer mappings, asks, query futures, transport state, and raw transcripts keep their current ownership.
+- Session bindings are stored in SQLite as control/provenance metadata and are used by compatible timeline/transcript and session-control slices when an unambiguous binding exists.
+- Dashboard/session events remain a 500-item in-memory deque plus `events.json`.
+- `events.json` remains in place for downgrade/backcompat.
 
 ## Recommendation
 
@@ -61,9 +61,9 @@ Indexes should support newest-first timeline reads and session-scoped dashboard 
 - `(peer_id, timestamp)`
 - `(type, timestamp)` if route usage needs it
 
-Keep payload JSON as the compatibility envelope in the first slice. Typed columns should be limited to query keys that are already stable.
+Keep payload JSON as the compatibility envelope in the event-journal slice. Typed columns should be limited to query keys that are already stable.
 
-## First safe v0.13 slice
+## Next safe v0.13 slice
 
 Implement a `SQLiteEventStore` behind `experiments.sqlite_state`:
 
@@ -78,9 +78,9 @@ This slice intentionally does not change dashboard API semantics. It only adds a
 
 ## Deferred state
 
-Defer peer/session mappings.
+Keep peer identity mappings separate from session bindings for now.
 
-Peer mappings affect peer ID reuse, display-name collision handling, circle restoration, role claims, description persistence, pane hijack protection, and clean takeover behavior. They are a good SQLite candidate, but moving them first would couple the database migration to routing-sensitive behavior. Move them only after the event journal proves the database lifecycle and after a dedicated mapping-store interface exists.
+Peer mappings affect peer ID reuse, display-name collision handling, circle restoration, role claims, description persistence, pane hijack protection, and clean takeover behavior. The landed binding table does not replace `PeerRegistry.SessionMapping` or `sessions.json`; it records durable workstream/runtime provenance for timeline and control surfaces. Moving peer identity mappings into SQLite should remain a separate review with an explicit downgrade/backcompat plan.
 
 Defer asks and pending replies.
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -559,7 +559,7 @@ def _timeline_item_response(item: TimelineItem) -> SessionTimelineItem:
 
 
 def _resolve_history_binding(peer: Peer, session_id: str | None) -> SessionBinding | None:
-    """Return an unambiguous binding for compatibility history routes."""
+    """Return an unambiguous binding for peer compatibility history routes."""
     binding_store = getattr(get_app_state(), "session_binding_store", None)
     if binding_store is None:
         return None
@@ -609,6 +609,8 @@ def _load_history_for_peer(
             metadata={**peer.metadata, **binding.metadata},
         )
         return history, binding
+    # Keep peer/path discovery as the downgrade-compatible route behavior when
+    # no binding is available or the observed bindings are ambiguous.
     return load_peer_history(peer.path, peer.backend, peer.metadata), None
 
 


### PR DESCRIPTION
## Summary
- Update the session binding contract to reflect landed SQLite binding-store, lookup, and session-control slices
- Refresh the SQLite expansion plan so session bindings are current state and the event journal is the next SQLite candidate
- Clarify that peer/path transcript discovery remains the downgrade-compatible fallback when bindings are absent or ambiguous

## Scope
This is intentionally a docs/comment cleanup. It preserves sessions.json/SessionMapping peer identity compatibility, source-owned transcript parsing, and peer_path history fallback behavior. No obsolete product path was safe to remove in this slice.

## Verification
- uv run pytest tests/test_session_mapper.py tests/test_transcript_history_routes.py tests/test_session_timeline_routes.py tests/test_session_controls_routes.py tests/test_sqlite_state_schedules.py (52 passed, worker)
- uv run ruff check repowire/daemon/routes/peers.py repowire/daemon/state/session_bindings.py (passed, worker)
- uv run ty check repowire/daemon/routes/peers.py repowire/daemon/state/session_bindings.py (passed, worker)
- uv run pytest tests/test_transcript_history_routes.py tests/test_session_timeline_routes.py tests/test_session_controls_routes.py (20 passed, coordinator)
- uv run ruff check repowire/daemon/routes/peers.py (passed, coordinator)
- uv run ty check repowire/daemon/routes/peers.py (passed, coordinator)
- python3 scripts/pre_pr_hygiene.py (advisory only; graphify/architecture review considered)
- git diff --check

## Follow-up
Observed post-restart stale peer listings were cleaned operationally. Current audit did not find a cleanup-scoped product fix; file a separate repro Bead if it recurs with live evidence.