### PR TITLE
Add dashboard session controls

### DIFF
--- a/docs/surfaces/dashboard.md
+++ b/docs/surfaces/dashboard.md
@@ -7,7 +7,8 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 - **Peer overview** — every peer's status (`online` / `busy` / `offline`), description, project path, circle, backend.
 - **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, and broadcasts.
 - **Per-peer chat** — selecting a peer replaces the live log with that peer's selected-session timeline. For Claude Code, Codex, and Codex ACP peers, the chat view merges supported persisted local history with realtime `chat_turn` and `chat_turn_delta` events; backends without a supported local history source contribute realtime events and report that degraded state in the timeline response. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
-- **Compose bar** — send a notification or ask to any peer. The dashboard registers as the `dashboard` peer so it shows up in `list_peers` and message routing.
+- **Compose bar** — send a plain-text ask to any peer. The dashboard registers as the `dashboard` peer so it shows up in `list_peers` and message routing. This remains the default path for conversational requests and attachments.
+- **Session controls** — when the selected chat has a Repowire session binding, a compact command surface can inspect resume capability and send fire-and-forget notifications to the active executor with `POST /sessions/{repowire_session_id}/controls/notify`. Sessions without an active executor, without a selected binding, or with unsupported resume metadata show disabled controls with the daemon-provided capability message.
 - **Spawn and backend controls** — spawn a peer or switch a peer backend using the runtime profiles from `daemon.spawn.commands` and the roots from `daemon.spawn.allowed_paths`.
 - **MCP config tab** — supported peers can list, add, and remove MCP servers. The tab labels whether edits affect peer/project config or backend user-global config before showing edit controls.
 - **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL). The outgoing ask carries structured attachment metadata plus a text fallback with the local path so existing agents can still read it.
@@ -19,13 +20,15 @@ The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemi
 
 ACP-routed permission prompts emit `acp_permission_request` and `acp_permission_decision` events into the same daemon event stream. Human control surfaces can resolve a pending prompt with `POST /acp/permissions/{request_id}/decision`; if no decision arrives before the broker timeout, the daemon records a timed-out decision and denies by default. This v0.13 slice exposes the event/route contract only; the dashboard approval UI remains planned work.
 
-## Roadmap: session timeline
+## Session command direction
 
 The v0.13 dashboard direction is a timeline-centered view. The current slice merges supported persisted history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.
 
 `GET /peers/{name}/timeline` is the first daemon-side session timeline read model. It returns normalized items with explicit `session_id`, `turn_id`, `source` (`history` or `realtime`), and `kind` (`turn` or `delta_group`) by merging supported local history turns with the daemon's buffered realtime `chat_turn` and `chat_turn_delta` events. The response also includes `history_status`, `history_backend`, and `history_message` so callers can distinguish loaded history from unsupported or unavailable backend history. When a session binding is available, history lookup resolves through that binding's runtime session/source locator and reports `history_source`, `repowire_session_id`, `binding_status`, and `runtime_session_id`; otherwise it falls back to the peer/path discovery used by earlier v0.13 slices. Claude Code history is loaded from project transcripts, Codex and Codex ACP history is loaded from rollout JSONLs matched by runtime cwd or binding source locator, and Gemini/OpenCode/Pi currently report unsupported local history while retaining realtime timeline events. This route is additive; existing `/events` and dashboard SSE behavior are unchanged.
 
 `GET /peers/{name}/transcript` uses the same binding-backed history resolution and fallback behavior, while preserving its existing paginated transcript fields.
+
+`POST /sessions/{repowire_session_id}/controls/resume` is used by the dashboard as a dry-run capability probe. It reports whether the selected binding already has an active executor, has backend resume metadata available for future callers, or is unsupported/unavailable. In this v0.13 slice the dashboard only executes active-executor notify controls; backend-specific resume execution, scheduling controls, approval handling, and plan-mode decisions remain roadmap items for the shared session command surface.
 
 ## Mobile
 

--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -615,3 +615,180 @@ describe("PeerView MCP config scope", () => {
     expect(screen.getByText("remote host")).toBeInTheDocument();
   });
 });
+
+describe("PeerView session controls", () => {
+  it("notifies the active session through the session control endpoint", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/spawn/config")) return new Promise<Response>(() => {});
+      if (url.includes("/transcript")) {
+        return new Response(JSON.stringify({ turns: [], next_before: null }), { status: 200 });
+      }
+      if (url.includes("/controls/resume")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            repowire_session_id: "session-a",
+            session_status: "active",
+            status: "active_executor",
+            capability: "active_executor",
+            message: "Session already has an active executor; send controls to that peer.",
+            backend: "codex",
+            executor_peer_id: PEER.peer_id,
+            executor_peer_name: "alice",
+            resume_capability: {},
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/controls/notify")) {
+        return new Response(
+          JSON.stringify({ ok: true, delivery_state: "delivered", reason: "sent" }),
+          { status: 200 },
+        );
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <PeerView
+        peer={{ ...PEER, backend: "codex", metadata: { hook_session_id: "session-a" } }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("active executor")).toBeInTheDocument();
+    const input = screen.getByPlaceholderText("notify active alice session...");
+    fireEvent.change(input, { target: { value: "status please" } });
+    fireEvent.click(screen.getByLabelText("Notify active session"));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((call) => String(call[0]).includes("/sessions/session-a/controls/notify"))).toBe(true);
+    });
+    const notifyCall = fetchMock.mock.calls.find((call) => String(call[0]).includes("/controls/notify"));
+    expect(notifyCall?.[1]).toMatchObject({ method: "POST" });
+    expect(JSON.parse(String((notifyCall?.[1] as RequestInit).body))).toMatchObject({
+      from_peer: "dashboard",
+      text: "status please",
+      bypass_circle: true,
+    });
+    expect(await screen.findByText("delivered to active session")).toBeInTheDocument();
+  });
+
+  it("keeps the plain ask composer on /ask alongside session controls", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/spawn/config")) return new Promise<Response>(() => {});
+      if (url.includes("/transcript")) {
+        return new Response(JSON.stringify({ turns: [], next_before: null }), { status: 200 });
+      }
+      if (url.includes("/controls/resume")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            repowire_session_id: "session-a",
+            session_status: "active",
+            status: "active_executor",
+            capability: "active_executor",
+            message: "Session already has an active executor.",
+            backend: "codex",
+            resume_capability: {},
+          }),
+          { status: 200 },
+        );
+      }
+      if (url === "/ask") {
+        return new Response(JSON.stringify({ correlation_id: "ask-12345678" }), { status: 200 });
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <PeerView
+        peer={{ ...PEER, metadata: { hook_session_id: "session-a" } }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    const askComposer = screen.getByTestId("compose-textarea");
+    fireEvent.change(askComposer, { target: { value: "normal ask" } });
+    fireEvent.click(screen.getByLabelText("Ask peer"));
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((call) => String(call[0]) === "/ask")).toBe(true);
+    });
+    const askCall = fetchMock.mock.calls.find((call) => String(call[0]) === "/ask");
+    expect(JSON.parse(String((askCall?.[1] as RequestInit).body))).toMatchObject({
+      from_peer: "dashboard",
+      to_peer: "alice",
+      bypass_circle: true,
+    });
+  });
+
+  it("shows unsupported and no-session controls as disabled states", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/spawn/config")) return new Promise<Response>(() => {});
+      if (url.includes("/transcript")) {
+        return new Response(JSON.stringify({ turns: [], next_before: null }), { status: 200 });
+      }
+      if (url.includes("/controls/resume")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            repowire_session_id: "session-a",
+            session_status: "detached",
+            status: "unsupported",
+            capability: "unsupported",
+            message: "No compatible backend resume capability is recorded for this session.",
+            backend: "opencode",
+            resume_capability: {},
+          }),
+          { status: 200 },
+        );
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(
+      <PeerView
+        peer={{ ...PEER, backend: "opencode", metadata: { hook_session_id: "session-a" } }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("resume unsupported")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("session notify unavailable")).toBeDisabled();
+    expect(screen.getByLabelText("Notify active session")).toBeDisabled();
+    expect(await screen.findByText(/no messages with alice/i)).toBeInTheDocument();
+
+    await act(async () => {
+      rerender(
+        <PeerView
+          peer={{ ...PEER, peer_id: "peer-no-session", metadata: {} }}
+          events={[]}
+          apiBase=""
+          onClose={() => {}}
+          onSent={() => {}}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("no session selected")).toBeInTheDocument();
+    expect(screen.getByText("Controls appear after a session is selected from live or persisted history.")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("session notify unavailable")).toBeDisabled();
+  });
+});

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { AlertCircle, Check, Clock, Copy, Paperclip, RefreshCw, Send, X } from "lucide-react";
+import { AlertCircle, Bell, Check, Clock, Copy, Paperclip, RefreshCw, RotateCcw, Send, X } from "lucide-react";
 import { cn, shortPath, statusDot } from "../lib/utils";
 import { registerSnapshotProvider, useFrozenThread, useIsPeerProtected } from "../lib/protection";
 import { clearDraft, setDraftFile, setDraftText, useDraftFile, useDraftText } from "../lib/drafts";
@@ -27,6 +27,27 @@ interface PendingAsk {
   reply?: string;
   reply_from?: string;
   attachments?: AttachmentRef[];
+}
+
+interface SessionResumeControlResponse {
+  ok: boolean;
+  repowire_session_id: string;
+  session_status: string;
+  status: "active_executor" | "resume_available" | "unsupported" | "binding_unavailable";
+  capability: "active_executor" | "supported" | "unsupported" | "unavailable";
+  message: string;
+  backend: string;
+  runtime_session_id?: string | null;
+  runtime_source_uri?: string | null;
+  executor_peer_id?: string | null;
+  executor_peer_name?: string | null;
+  resume_capability: Record<string, unknown>;
+}
+
+interface SessionNotifyControlResponse {
+  ok: boolean;
+  delivery_state: "delivered" | "queued";
+  reason: string;
 }
 
 const ACK_FRAME_RE = /^\[ack #([^\]\s]+) from @([^\]\s]+)\]\s?([\s\S]*)$/;
@@ -354,6 +375,12 @@ export function PeerView({
             <div ref={bottomRef} />
           </div>
 
+          <SessionCommandPanel
+            peer={peer}
+            apiBase={apiBase}
+            activeSessionId={activeSessionId}
+            onSent={onSent}
+          />
           <ComposeBar peer={peer} apiBase={apiBase} events={events} onSent={onSent} />
         </>
       ) : activeTab === "history" ? (
@@ -592,6 +619,214 @@ function HistoryTurn({ turn, peer }: { turn: TranscriptTurn; peer: Peer }) {
         )}
       </div>
       {!isUser && turn.tool_calls.length > 0 && <ToolCallBlock toolCalls={turn.tool_calls} />}
+    </div>
+  );
+}
+
+function SessionCommandPanel({
+  peer,
+  apiBase,
+  activeSessionId,
+  onSent,
+}: {
+  peer: Peer;
+  apiBase: string;
+  activeSessionId: string | null;
+  onSent?: () => void;
+}) {
+  const [resumeState, setResumeState] = useState<SessionResumeControlResponse | null>(null);
+  const [loadingCapability, setLoadingCapability] = useState(false);
+  const [capabilityError, setCapabilityError] = useState<string | null>(null);
+  const [notifyText, setNotifyText] = useState("");
+  const [notifyPending, setNotifyPending] = useState(false);
+  const [notifyStatus, setNotifyStatus] = useState<string | null>(null);
+  const [notifyError, setNotifyError] = useState<string | null>(null);
+
+  const loadCapability = useCallback(async () => {
+    if (!activeSessionId) {
+      setResumeState(null);
+      setCapabilityError(null);
+      setLoadingCapability(false);
+      return;
+    }
+    setLoadingCapability(true);
+    setCapabilityError(null);
+    try {
+      const res = await fetch(
+        `${apiBase}/sessions/${encodeURIComponent(activeSessionId)}/controls/resume`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ from_peer: "dashboard", dry_run: true }),
+        },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const detail = data?.detail;
+        setResumeState(null);
+        setCapabilityError(
+          typeof detail === "string"
+            ? detail
+            : detail?.message || detail?.error || `Error ${res.status}`,
+        );
+        return;
+      }
+      setResumeState(data as SessionResumeControlResponse);
+    } catch (e) {
+      setResumeState(null);
+      setCapabilityError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      setLoadingCapability(false);
+    }
+  }, [activeSessionId, apiBase]);
+
+  useEffect(() => {
+    setNotifyText("");
+    setNotifyStatus(null);
+    setNotifyError(null);
+    void loadCapability();
+  }, [loadCapability]);
+
+  const canNotifySession = Boolean(activeSessionId && resumeState?.capability === "active_executor");
+  const resumeLabel = !activeSessionId
+    ? "no session selected"
+    : loadingCapability
+    ? "checking session..."
+    : resumeState?.capability === "active_executor"
+    ? "active executor"
+    : resumeState?.capability === "supported"
+    ? "resume metadata ready"
+    : resumeState
+    ? "resume unsupported"
+    : "session controls unavailable";
+  const controlMessage = !activeSessionId
+    ? "Controls appear after a session is selected from live or persisted history."
+    : resumeState?.message || capabilityError || "Session capability is loading.";
+
+  async function submitNotify() {
+    const text = notifyText.trim();
+    if (!activeSessionId || !text || notifyPending || !canNotifySession) return;
+    setNotifyPending(true);
+    setNotifyStatus(null);
+    setNotifyError(null);
+    try {
+      const res = await fetch(
+        `${apiBase}/sessions/${encodeURIComponent(activeSessionId)}/controls/notify`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            from_peer: "dashboard",
+            text,
+            attachments: [],
+            bypass_circle: true,
+          }),
+        },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const detail = data?.detail;
+        setNotifyError(
+          typeof detail === "string"
+            ? detail
+            : detail?.message || detail?.error || `Error ${res.status}`,
+        );
+        return;
+      }
+      const body = data as SessionNotifyControlResponse;
+      setNotifyText("");
+      setNotifyStatus(body.delivery_state === "queued" ? "queued for active session" : "delivered to active session");
+      onSent?.();
+    } catch (e) {
+      setNotifyError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      setNotifyPending(false);
+    }
+  }
+
+  return (
+    <div className="border-t border-border-faint bg-surface px-3 py-2 md:px-4">
+      <div className="rounded border border-border-faint bg-surface-container-low p-2.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-outline">
+            session controls
+          </span>
+          <span
+            className={cn(
+              "inline-flex items-center rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em]",
+              canNotifySession
+                ? "border-primary/40 bg-primary/10 text-primary"
+                : "border-border-faint text-outline",
+            )}
+          >
+            {resumeLabel}
+          </span>
+          <button
+            type="button"
+            onClick={loadCapability}
+            disabled={!activeSessionId || loadingCapability}
+            title="Refresh session capability"
+            aria-label="Refresh session capability"
+            className="ml-auto flex h-7 w-7 items-center justify-center rounded text-outline hover:bg-surface-container-high hover:text-on-surface disabled:opacity-40"
+          >
+            <RotateCcw className={cn("h-3.5 w-3.5", loadingCapability && "animate-spin")} />
+          </button>
+        </div>
+        <div className="mt-1.5 line-clamp-2 font-mono text-[11px] leading-4 text-outline">
+          {controlMessage}
+        </div>
+
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {[
+            "Please send a quick status update.",
+            "Checkpoint your current diff and next step.",
+            "Continue with the active task and report blockers.",
+          ].map((template) => (
+            <button
+              key={template}
+              type="button"
+              onClick={() => setNotifyText(template)}
+              disabled={!canNotifySession}
+              className="rounded border border-border-faint px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-outline hover:bg-surface-container-high hover:text-on-surface disabled:opacity-40"
+            >
+              {template.split(" ").slice(0, 2).join(" ")}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-2 flex items-end gap-2">
+          <textarea
+            value={notifyText}
+            onChange={(event) => setNotifyText(event.target.value)}
+            disabled={!canNotifySession || notifyPending}
+            rows={1}
+            placeholder={canNotifySession ? `notify active ${peerLabel(peer)} session...` : "session notify unavailable"}
+            className="max-h-20 min-h-8 flex-1 resize-none rounded border border-border-faint bg-surface-container-lowest px-2.5 py-1.5 font-mono text-xs text-on-surface outline-none placeholder:text-outline focus:border-primary focus:ring-1 focus:ring-primary disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={submitNotify}
+            disabled={!canNotifySession || !notifyText.trim() || notifyPending}
+            aria-label="Notify active session"
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded transition-[filter,transform] active:scale-[0.98]",
+              canNotifySession && notifyText.trim()
+                ? "bg-primary text-on-primary hover:brightness-110"
+                : "bg-surface-container-high text-outline",
+            )}
+          >
+            {notifyPending ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Bell className="h-4 w-4" />}
+          </button>
+        </div>
+        {(notifyStatus || notifyError) && (
+          <div className={cn("mt-2 flex items-center gap-2 font-mono text-xs", notifyError ? "text-error" : "text-primary")}>
+            {notifyError ? <AlertCircle className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
+            <span>{notifyError || notifyStatus}</span>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -144,7 +144,9 @@ function DashboardInner() {
   }, [fetchEvents, fetchPeers]);
 
   useEffect(() => {
-    void Promise.all([fetchPeers(), fetchEvents()]);
+    queueMicrotask(() => {
+      void Promise.all([fetchPeers(), fetchEvents()]);
+    });
   }, [fetchEvents, fetchPeers]);
 
   const selectedPeer = useMemo(


### PR DESCRIPTION
## Summary
- Add a compact session command panel above the existing ask composer
- Probe `/sessions/{repowire_session_id}/controls/resume` and enable active-session notify through `/controls/notify`
- Keep the plain `/ask` composer as the default path and document the dashboard session-control behavior

## Verification
- `npm ci` in `web/`
- `npm test -- PeerView.test.tsx` in `web/` (18 tests passed)
- `npm run lint` in `web/`
- `npm run build` in `web/`
- `python3 scripts/pre_pr_hygiene.py` (advisory only; dashboard docs updated)

## Notes
No backend routes changed; this uses the existing session-control API surface.