### PR TITLE
Fix Claude channel auth token wiring

### DIFF
--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -4,7 +4,7 @@
 
 ## What gets installed
 
-Hooks and MCP entries land in `~/.claude/settings.json`. Repowire owns these keys; user-defined hooks in the same file are preserved.
+Hooks land in `~/.claude/settings.json`. The normal Repowire MCP server is added by the Claude CLI. In experimental channel mode, the channel server entry is written to `~/.claude.json`.
 
 ### Hooks
 
@@ -23,7 +23,7 @@ The hooks shell out to the `repowire` CLI: `repowire hook session`, `repowire ho
 
 ### MCP server
 
-The repowire MCP server is added under `mcpServers.repowire` in the same settings file. It runs as `repowire mcp` over stdio.
+The normal Repowire MCP server is added as `repowire`. It runs as `repowire mcp` over stdio and provides the stable tool surface: `ask`, `ack`, `notify_peer`, `broadcast`, peer listing, schedules, and related commands.
 
 ## Plugins and skills
 
@@ -44,13 +44,15 @@ repowire setup --experimental-channels
 
 Replaces tmux-injection delivery with direct MCP-channel delivery. When a message arrives, Claude sees a `<channel source="repowire">` tag in its context instead of a `[ask #cid from @peer] ...` line injected into the terminal.
 
+Channel setup adds a separate `repowire-channel` MCP server entry in `~/.claude.json`. The normal `repowire` MCP server remains installed; use its stable tools, including `ack`, for ask lifecycle and parity with the default transport. The channel server itself only handles channel delivery and legacy query replies.
+
 Requirements:
 
 - Claude Code v2.1.80 or newer.
 - claude.ai login (not API/Console key auth).
 - [bun](https://bun.sh) on `PATH`.
 
-The channel transport only replaces the SessionStart / UserPromptSubmit / Notification hooks. The `Stop` and `StopFailure` hooks are kept so the dashboard still sees chat turns and status repair still runs.
+The channel transport only replaces the SessionStart / UserPromptSubmit / Notification hooks. The `Stop` and `StopFailure` hooks are kept so the dashboard still sees chat turns and status repair still runs. If the daemon has `daemon.auth_token` configured, setup passes it to the channel server as `REPOWIRE_AUTH_TOKEN` so the WebSocket registration can authenticate.
 
 If `repowire setup --experimental-channels` declines to install:
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -49,7 +49,7 @@ OpenCode does not expose the same hook shape, so Repowire installs a TypeScript 
 
 ### Channel / ACP transport
 
-`repowire setup --experimental-channels` installs Claude Code's experimental channel/ACP transport. Messages arrive as `<channel source="repowire">` tags, while replies route through a channel reply tool. This requires Claude Code support, claude.ai login, and `bun`. Treat this path as experimental; hooks + MCP remain the default.
+`repowire setup --experimental-channels` installs Claude Code's experimental channel/ACP transport. Messages arrive as `<channel source="repowire">` tags, while legacy query replies route through a channel reply tool. The normal `repowire mcp` server remains installed for stable tools such as `ask`, `ack`, `notify_peer`, schedules, and peer listing. This requires Claude Code support, claude.ai login, and `bun`. Treat this path as experimental; hooks + MCP remain the default.
 
 ### Relay
 

--- a/docs/troubleshooting/channel-auth.md
+++ b/docs/troubleshooting/channel-auth.md
@@ -16,12 +16,13 @@ The channel server starts but immediately exits with an auth error.
 
 - Run `claude /status` and confirm you're signed in via claude.ai, not via API key. If it shows an API key, sign out and back in with `claude /login`.
 - Tokens can rotate. Re-running `claude /login` refreshes them; the channel server picks up the new token on next start.
+- If the daemon is configured with `daemon.auth_token`, re-run `repowire setup --experimental-channels` so the `repowire-channel` entry includes `REPOWIRE_AUTH_TOKEN`.
 
 ## Messages not arriving
 
 The channel server is running but messages never reach Claude:
 
-- Confirm the MCP server entry in `~/.claude/settings.json` points at the channel server, not the regular stdio MCP server. `repowire setup --experimental-channels` writes the right entry; if you've hand-edited it, re-run setup.
+- Confirm the `repowire-channel` MCP server entry in `~/.claude.json` points at the channel server. The normal `repowire` MCP server should still be present separately for tools such as `ack`, `ask`, and `notify_peer`.
 - Restart the Claude Code session. The channel server connects once at session start; if it disconnected, a restart re-establishes the WebSocket.
 
 ## Switching back to default transport

--- a/repowire/channel/server.ts
+++ b/repowire/channel/server.ts
@@ -21,6 +21,7 @@ import WebSocket from "ws";
 // -- Config --
 
 const DAEMON_URL = process.env.REPOWIRE_DAEMON_URL ?? "ws://127.0.0.1:8377";
+const AUTH_TOKEN = process.env.REPOWIRE_AUTH_TOKEN ?? "";
 // Proposed name for initial connect; daemon assigns the canonical display_name
 const PROPOSED_NAME = process.env.REPOWIRE_DISPLAY_NAME ?? "channel";
 const CIRCLE = process.env.REPOWIRE_CIRCLE ?? "default";
@@ -60,6 +61,7 @@ function connectDaemon(mcp: Server): void {
         circle: CIRCLE,
         backend: "claude-code",
         path: PROJECT_PATH,
+        ...(AUTH_TOKEN ? { auth_token: AUTH_TOKEN } : {}),
       })
     );
   });

--- a/repowire/installers/claude_code.py
+++ b/repowire/installers/claude_code.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from repowire.config.models import load_config
+
 CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
 CLAUDE_JSON = Path.home() / ".claude.json"
 
@@ -237,10 +239,15 @@ def install_channel() -> tuple[bool, str]:
         config = {}
     config.setdefault("mcpServers", {})
 
-    config["mcpServers"]["repowire-channel"] = {
+    channel_entry: dict[str, object] = {
         "command": "bun",
         "args": [str(server_path)],
     }
+    auth_token = load_config().daemon.auth_token
+    if auth_token:
+        channel_entry["env"] = {"REPOWIRE_AUTH_TOKEN": auth_token}
+
+    config["mcpServers"]["repowire-channel"] = channel_entry
 
     CLAUDE_JSON.write_text(json.dumps(config, indent=2))
 

--- a/tests/test_claude_code_installer.py
+++ b/tests/test_claude_code_installer.py
@@ -24,6 +24,14 @@ def _retarget(tmp_path, monkeypatch):
     claude_json = tmp_path / ".claude.json"
     monkeypatch.setattr(cc_mod, "CLAUDE_SETTINGS", settings)
     monkeypatch.setattr(cc_mod, "CLAUDE_JSON", claude_json)
+
+    class Daemon:
+        auth_token = None
+
+    class Config:
+        daemon = Daemon()
+
+    monkeypatch.setattr(cc_mod, "load_config", lambda: Config())
     return settings, claude_json
 
 
@@ -196,6 +204,29 @@ def test_install_channel_on_empty_writes_mcp_entry(tmp_path, monkeypatch):
     assert data["mcpServers"]["repowire-channel"] == {
         "command": "bun",
         "args": [str(server)],
+    }
+
+
+def test_install_channel_passes_daemon_auth_token_to_channel_env(tmp_path, monkeypatch):
+    _, claude_json = _retarget(tmp_path, monkeypatch)
+    server = _stub_channel_prereqs(monkeypatch, tmp_path)
+
+    class Daemon:
+        auth_token = "secret-token"
+
+    class Config:
+        daemon = Daemon()
+
+    monkeypatch.setattr(cc_mod, "load_config", lambda: Config())
+
+    ok, _msg = cc_mod.install_channel()
+    assert ok is True
+
+    data = _read(claude_json)
+    assert data["mcpServers"]["repowire-channel"] == {
+        "command": "bun",
+        "args": [str(server)],
+        "env": {"REPOWIRE_AUTH_TOKEN": "secret-token"},
     }
 
 


### PR DESCRIPTION
## Summary
- pass `daemon.auth_token` into the experimental `repowire-channel` MCP entry as `REPOWIRE_AUTH_TOKEN`
- send that token in the channel WebSocket connect frame so authenticated daemons accept channel peers
- clarify channel docs: channel entry lives in `~/.claude.json`, normal `repowire mcp` remains the stable ask/ack/list/schedule tool surface

## Verification
- `uv run pytest tests/test_claude_code_installer.py` (24 passed)
- `uv run ruff check repowire/installers/claude_code.py tests/test_claude_code_installer.py`
- `bunx tsc --noEmit ... server.ts` passed after `bun install` in `repowire/channel`; generated `node_modules`/`bun.lock` were removed afterward and are not committed
- `git diff --check`
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`

Follow-up note: this fixes the narrow authenticated-channel smoke blocker. Broader channel/MCP parity remains intentionally out of scope.

Refs #163.