### PR TITLE
Persist event log in SQLite state

### DIFF
--- a/docs/reference/sqlite-state-expansion-plan.md
+++ b/docs/reference/sqlite-state-expansion-plan.md
@@ -1,6 +1,6 @@
 # SQLite state expansion plan
 
-Status: architecture recommendation for v0.13.x review, updated after the session-binding slices landed. Do not implement additional schema migration from this document without a follow-up implementation review.
+Status: architecture recommendation for v0.13.x review, updated after the event-journal slice landed. Do not implement additional schema migration from this document without a follow-up implementation review.
 
 ## Current state
 
@@ -9,12 +9,12 @@ Repowire currently has two persistence styles:
 - Experimental SQLite state under `~/.repowire/state.db`, gated by `experiments.sqlite_state`.
 - JSON files under `~/.repowire/`, usually loaded into daemon memory and flushed by lazy repair or explicit mutation paths.
 
-The SQLite path currently covers schedules and session bindings. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies.
+The SQLite path currently covers schedules, session bindings, and dashboard/session events when `experiments.sqlite_state` is enabled. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup.
 
 Other state remains JSON or in-memory:
 
 - `sessions.json`: persistent peer/session mappings inside `PeerRegistry`; still retained for peer identity reuse, daemon restart behavior, and downgrade/backcompat while the binding store hardens.
-- `events.json`: dashboard event ring buffer persisted from `PeerRegistry`.
+- `events.json`: dashboard event ring buffer persistence when `sqlite_state` is disabled; retained untouched for downgrade/backcompat when SQLite event persistence is enabled.
 - `AskTracker`: in-memory ask/ack lifecycle with TTL eviction and in-memory pending ACP reply stashes.
 - Agent transcripts: source-of-truth JSONL files owned by Claude Code or other agent runtimes, parsed on demand for history routes.
 - `review_queue.json`: small low-frequency review queue state.
@@ -34,8 +34,8 @@ Current compatible SQLite slices:
 - Schedules stay on the existing experimental SQLite adapter.
 - Peer mappings, asks, query futures, transport state, and raw transcripts keep their current ownership.
 - Session bindings are stored in SQLite as control/provenance metadata and are used by compatible timeline/transcript and session-control slices when an unambiguous binding exists.
-- Dashboard/session events remain a 500-item in-memory deque plus `events.json`.
-- `events.json` remains in place for downgrade/backcompat.
+- Dashboard/session events remain a bounded in-memory deque for route/SSE compatibility; with `sqlite_state` enabled, persistence is backed by SQLite instead of new `events.json` writes.
+- `events.json` remains in place for downgrade/backcompat and one-time import.
 
 ## Recommendation
 
@@ -63,9 +63,9 @@ Indexes should support newest-first timeline reads and session-scoped dashboard 
 
 Keep payload JSON as the compatibility envelope in the event-journal slice. Typed columns should be limited to query keys that are already stable.
 
-## Next safe v0.13 slice
+## Event journal slice
 
-Implement a `SQLiteEventStore` behind `experiments.sqlite_state`:
+Implemented behind `experiments.sqlite_state`:
 
 1. Add the event table in the daemon state migration.
 2. Import legacy `events.json` once if the SQL event table is empty.

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -52,6 +52,7 @@ from repowire.daemon.routes import spawn as spawn_routes
 from repowire.daemon.schedule_store import ScheduleStore
 from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.state import StateDatabase
+from repowire.daemon.state.events import SQLiteEventStore
 from repowire.daemon.state.schedules import SQLiteScheduleStore
 from repowire.daemon.state.session_bindings import (
     SQLiteSessionBindingStore,
@@ -216,7 +217,18 @@ def create_app(
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
         ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
-        event_log = EventLog(Path.home() / ".repowire" / "events.json")
+        state_db: StateDatabase | None = None
+        state_dir = Path.home() / ".repowire"
+        events_path = state_dir / "events.json"
+        schedules_path = state_dir / "schedules.json"
+        event_store: SQLiteEventStore | None = None
+        if cfg.experiments.sqlite_state:
+            state_db = StateDatabase(state_dir / "state.db")
+            event_store = SQLiteEventStore(
+                db=state_db,
+                legacy_path=events_path,
+            )
+        event_log = EventLog(events_path, store=event_store)
         message_router = MessageRouter(
             transport=transport,
             query_tracker=query_tracker,
@@ -234,10 +246,8 @@ def create_app(
         )
         peer_registry.prune_offline(max_age_hours=cfg.daemon.prune_max_age_hours)
 
-        state_db: StateDatabase | None = None
-        schedules_path = Path.home() / ".repowire" / "schedules.json"
         if cfg.experiments.sqlite_state:
-            state_db = StateDatabase(Path.home() / ".repowire" / "state.db")
+            assert state_db is not None
             schedule_store = SQLiteScheduleStore(
                 db=state_db,
                 legacy_path=schedules_path,
@@ -382,9 +392,9 @@ def create_app(
             await relay_client.stop()
         await acp_manager.close()
         await scheduler.stop()
+        event_log.save()
         if state_db is not None:
             state_db.close()
-        event_log.save()
         peer_registry._persist_mappings()
         await peer_registry.stop()
         cleanup_deps()
@@ -514,11 +524,17 @@ def create_test_app(
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
         ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
-        event_path = (
-            (persistence_path.parent if persistence_path else Path("/tmp"))
-            / "events.json"
-        )
-        event_log = EventLog(event_path)
+        state_db: StateDatabase | None = None
+        state_dir = persistence_path.parent if persistence_path else Path("/tmp")
+        event_path = state_dir / "events.json"
+        event_store: SQLiteEventStore | None = None
+        if cfg.experiments.sqlite_state:
+            state_db = StateDatabase(state_dir / "state.db")
+            event_store = SQLiteEventStore(
+                db=state_db,
+                legacy_path=event_path,
+            )
+        event_log = EventLog(event_path, store=event_store)
         msg_router = message_router or MessageRouter(
             transport=transport,
             query_tracker=query_tracker,
@@ -536,11 +552,9 @@ def create_test_app(
             event_log=event_log,
         )
 
-        state_db: StateDatabase | None = None
-        state_dir = persistence_path.parent if persistence_path else Path("/tmp")
         schedules_path = state_dir / "schedules.json"
         if cfg.experiments.sqlite_state:
-            state_db = StateDatabase(state_dir / "state.db")
+            assert state_db is not None
             schedule_store = SQLiteScheduleStore(
                 db=state_db,
                 legacy_path=schedules_path,
@@ -619,9 +633,9 @@ def create_test_app(
 
         await acp_manager.close()
         await scheduler.stop()
+        event_log.save()
         if state_db is not None:
             state_db.close()
-        event_log.save()
         await registry.stop()
         cleanup_deps()
 

--- a/repowire/daemon/event_log.py
+++ b/repowire/daemon/event_log.py
@@ -12,6 +12,7 @@ from typing import Any
 from uuid import uuid4
 
 from repowire.config.models import Config
+from repowire.daemon.state.events import SQLiteEventStore
 
 logger = logging.getLogger(__name__)
 
@@ -19,15 +20,28 @@ logger = logging.getLogger(__name__)
 class EventLog:
     """Bounded daemon event log with debounced disk persistence."""
 
-    def __init__(self, path: Path | None = None, max_events: int = 500) -> None:
+    def __init__(
+        self,
+        path: Path | None = None,
+        max_events: int = 500,
+        store: SQLiteEventStore | None = None,
+    ) -> None:
         self.path = path or (Config.get_config_dir() / "events.json")
         self.events: deque[dict[str, Any]] = deque(maxlen=max_events)
         self.dirty = False
         self.subscribers: set[asyncio.Event] = set()
+        self.store = store
         self.load()
 
     def load(self) -> None:
         """Load persisted events from disk."""
+        if self.store is not None:
+            try:
+                self.events.clear()
+                self.events.extend(self.store.load_recent(self.events.maxlen or 500))
+            except Exception:
+                logger.warning("Failed to load events from SQLite state", exc_info=True)
+            return
         try:
             if self.path.exists():
                 data = json.loads(self.path.read_text())
@@ -35,10 +49,13 @@ class EventLog:
                 for event in data[-100:]:
                     self.events.append(event)
         except Exception:
-            logger.warning("Failed to load events from %s", self.path)
+            logger.warning("Failed to load events from %s", self.path, exc_info=True)
 
     def save(self) -> None:
         """Persist events to disk when dirty."""
+        if self.store is not None:
+            self.dirty = False
+            return
         if not self.dirty:
             return
         try:
@@ -51,15 +68,20 @@ class EventLog:
     def add_event(self, event_type: str, data: dict[str, Any]) -> str:
         """Add an event to the history. Returns event ID."""
         event_id = str(uuid4())
-        self.events.append(
-            {
-                "id": event_id,
-                "type": event_type,
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                **data,
-            }
-        )
-        self.dirty = True
+        event = {
+            "id": event_id,
+            "type": event_type,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **data,
+        }
+        self.events.append(event)
+        if self.store is None:
+            self.dirty = True
+        else:
+            try:
+                self.store.append(event)
+            except Exception:
+                logger.warning("Failed to append event to SQLite state", exc_info=True)
         for sub in self.subscribers:
             sub.set()
         return event_id
@@ -89,7 +111,13 @@ class EventLog:
         for event in self.events:
             if event["id"] == event_id:
                 event.update(updates)
-                self.dirty = True
+                if self.store is None:
+                    self.dirty = True
+                else:
+                    try:
+                        self.store.update(event)
+                    except Exception:
+                        logger.warning("Failed to update event in SQLite state", exc_info=True)
                 return True
         return False
 

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 class StateDatabase:
@@ -127,6 +127,41 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    type TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    peer_id TEXT,
+                    peer_name TEXT,
+                    session_id TEXT,
+                    turn_id TEXT,
+                    payload_json TEXT NOT NULL
+                )
+                """,
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp)",
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_events_session_timestamp
+                ON events(session_id, timestamp)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_events_peer_timestamp
+                ON events(peer_id, timestamp)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_events_type_timestamp
+                ON events(type, timestamp)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
@@ -138,6 +173,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (2, "session bindings for runtime provenance metadata"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (3, "dashboard event journal"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/events.py
+++ b/repowire/daemon/state/events.py
@@ -1,0 +1,152 @@
+"""SQLite-backed dashboard event persistence."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from repowire.daemon.state.database import StateDatabase
+
+logger = logging.getLogger(__name__)
+
+
+class SQLiteEventStore:
+    """EventLog persistence adapter backed by the daemon state DB."""
+
+    def __init__(self, db: StateDatabase, legacy_path: Path | None = None) -> None:
+        self._db = db
+        self._conn = db.conn
+        if legacy_path is not None:
+            self._import_legacy_if_empty(legacy_path)
+
+    def _import_legacy_if_empty(self, legacy_path: Path) -> None:
+        already_recorded = self._conn.execute(
+            "SELECT 1 FROM legacy_imports WHERE source_path = ?",
+            (str(legacy_path),),
+        ).fetchone()
+        if already_recorded is not None:
+            return
+        if not legacy_path.exists():
+            return
+        try:
+            raw_data = json.loads(legacy_path.read_text())
+            if not isinstance(raw_data, list):
+                raise TypeError("top-level events JSON must be a list")
+            events = [event for event in raw_data if isinstance(event, dict)]
+            if len(events) != len(raw_data):
+                raise TypeError("all event entries must be objects")
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.error("Corrupt legacy events file (%s); skipping SQLite import", e)
+            with self._conn:
+                self._record_import(legacy_path, 0, "error", type(e).__name__)
+            return
+        imported = 0
+        with self._conn:
+            for event in events:
+                if self._insert_event(event):
+                    imported += 1
+            self._record_import(legacy_path, imported, "ok", None)
+        logger.info("Imported %d legacy events into SQLite state", imported)
+
+    def _record_import(
+        self,
+        legacy_path: Path,
+        row_count: int,
+        status: str,
+        error: str | None,
+    ) -> None:
+        try:
+            st = legacy_path.stat()
+            source_mtime = st.st_mtime
+            source_size = st.st_size
+        except OSError:
+            source_mtime = None
+            source_size = None
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO legacy_imports(
+                source_path, source_mtime, source_size, row_count, status, error
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (str(legacy_path), source_mtime, source_size, row_count, status, error),
+        )
+
+    @staticmethod
+    def _columns_for_event(
+        event: dict[str, Any],
+    ) -> tuple[
+        str,
+        str,
+        str,
+        str | None,
+        str | None,
+        str | None,
+        str | None,
+        str,
+    ]:
+        event_id = str(event["id"])
+        event_type = str(event["type"])
+        timestamp = str(event["timestamp"])
+        peer_id = event.get("peer_id")
+        peer_name = event.get("peer") or event.get("from_peer") or event.get("to_peer")
+        session_id = event.get("session_id") or event.get("repowire_session_id")
+        turn_id = event.get("turn_id")
+        payload_json = json.dumps(event, separators=(",", ":"), sort_keys=True)
+        return (
+            event_id,
+            event_type,
+            timestamp,
+            str(peer_id) if peer_id is not None else None,
+            str(peer_name) if peer_name is not None else None,
+            str(session_id) if session_id is not None else None,
+            str(turn_id) if turn_id is not None else None,
+            payload_json,
+        )
+
+    def _insert_event(self, event: dict[str, Any]) -> bool:
+        if not all(key in event for key in ("id", "type", "timestamp")):
+            logger.warning("Skipping malformed event row during SQLite import")
+            return False
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO events(
+                event_id, type, timestamp, peer_id, peer_name, session_id,
+                turn_id, payload_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            self._columns_for_event(event),
+        )
+        return True
+
+    def append(self, event: dict[str, Any]) -> None:
+        with self._conn:
+            self._insert_event(event)
+
+    def update(self, event: dict[str, Any]) -> None:
+        self.append(event)
+
+    def load_recent(self, limit: int) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT payload_json FROM events
+            ORDER BY timestamp DESC, rowid DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        events: list[dict[str, Any]] = []
+        for row in reversed(rows):
+            try:
+                event = json.loads(row["payload_json"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Skipping corrupt SQLite event payload")
+                continue
+            if isinstance(event, dict):
+                events.append(event)
+        return events
+
+    def count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM events").fetchone()
+        return int(row[0]) if row is not None else 0

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -5,8 +5,11 @@ import json
 
 import pytest
 
+from repowire.config.models import Config
 from repowire.daemon.app import create_test_app
 from repowire.daemon.event_log import EventLog
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.events import SQLiteEventStore
 
 
 def test_add_event_assigns_id_timestamp_and_marks_dirty(tmp_path):
@@ -100,3 +103,168 @@ async def test_create_test_app_persists_events_on_shutdown(tmp_path):
     data = json.loads((tmp_path / "events.json").read_text())
     assert len(data) == 1
     assert data[0]["type"] == "shutdown"
+
+
+def test_sqlite_event_store_imports_legacy_events_once(tmp_path):
+    legacy_path = tmp_path / "events.json"
+    legacy_path.write_text(json.dumps([
+        {
+            "id": "event-1",
+            "type": "chat_turn",
+            "timestamp": "2026-05-22T09:00:00+00:00",
+            "peer": "alice",
+            "text": "hello",
+        },
+    ]))
+
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteEventStore(db, legacy_path=legacy_path)
+        assert store.count() == 1
+        assert store.load_recent(500)[0]["text"] == "hello"
+        row = db.conn.execute(
+            "SELECT row_count, status FROM legacy_imports WHERE source_path = ?",
+            (str(legacy_path),),
+        ).fetchone()
+        assert row["row_count"] == 1
+        assert row["status"] == "ok"
+
+        store.append({
+            "id": "event-2",
+            "type": "notification",
+            "timestamp": "2026-05-22T09:01:00+00:00",
+        })
+        SQLiteEventStore(db, legacy_path=legacy_path)
+        assert store.count() == 2
+    finally:
+        db.close()
+
+
+def test_sqlite_event_store_import_guard_uses_legacy_import_audit(tmp_path):
+    legacy_path = tmp_path / "events.json"
+    legacy_path.write_text(json.dumps([
+        {
+            "id": "legacy-event",
+            "type": "chat_turn",
+            "timestamp": "2026-05-22T09:00:00+00:00",
+        },
+    ]))
+
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        existing_store = SQLiteEventStore(db)
+        existing_store.append({
+            "id": "sqlite-event",
+            "type": "notification",
+            "timestamp": "2026-05-22T09:01:00+00:00",
+        })
+
+        imported_store = SQLiteEventStore(db, legacy_path=legacy_path)
+        assert imported_store.count() == 2
+        assert {event["id"] for event in imported_store.load_recent(10)} == {
+            "legacy-event",
+            "sqlite-event",
+        }
+        row = db.conn.execute(
+            "SELECT row_count, status FROM legacy_imports WHERE source_path = ?",
+            (str(legacy_path),),
+        ).fetchone()
+        assert row["row_count"] == 1
+        assert row["status"] == "ok"
+    finally:
+        db.close()
+
+
+def test_sqlite_event_store_records_corrupt_legacy_import(tmp_path):
+    legacy_path = tmp_path / "events.json"
+    legacy_path.write_text("{not json")
+
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteEventStore(db, legacy_path=legacy_path)
+        assert store.count() == 0
+        row = db.conn.execute(
+            "SELECT row_count, status, error FROM legacy_imports WHERE source_path = ?",
+            (str(legacy_path),),
+        ).fetchone()
+        assert row["row_count"] == 0
+        assert row["status"] == "error"
+        assert row["error"] == "JSONDecodeError"
+    finally:
+        db.close()
+
+
+def test_sqlite_event_store_load_recent_preserves_equal_timestamp_insert_order(tmp_path):
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteEventStore(db)
+        timestamp = "2026-05-22T09:00:00+00:00"
+        for event_id in ("event-1", "event-2", "event-3"):
+            store.append({
+                "id": event_id,
+                "type": "chat_turn",
+                "timestamp": timestamp,
+            })
+
+        assert [event["id"] for event in store.load_recent(2)] == ["event-2", "event-3"]
+    finally:
+        db.close()
+
+
+def test_sqlite_event_log_loads_bounded_recent_window_and_updates(tmp_path):
+    legacy_path = tmp_path / "events.json"
+    legacy_path.write_text(json.dumps([
+        {
+            "id": f"event-{i}",
+            "type": "chat_turn",
+            "timestamp": f"2026-05-22T09:0{i}:00+00:00",
+            "text": f"message {i}",
+        }
+        for i in range(4)
+    ]))
+
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteEventStore(db, legacy_path=legacy_path)
+        log = EventLog(legacy_path, max_events=2, store=store)
+        assert [event["id"] for event in log.get_events()] == ["event-2", "event-3"]
+        assert log.update_event("event-3", {"status": "done"}) is True
+
+        reloaded = EventLog(legacy_path, max_events=4, store=store)
+        assert reloaded.get_events()[-1]["status"] == "done"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_create_test_app_uses_sqlite_event_log_without_json_write(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+
+    async with app.router.lifespan_context(app):
+        app.state.event_log.add_event("shutdown", {"text": "persist me"})
+        assert app.state.event_log.dirty is False
+
+    assert not (tmp_path / "events.json").exists()
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        row = db.conn.execute("SELECT payload_json FROM events").fetchone()
+        assert row is not None
+        assert json.loads(row["payload_json"])["text"] == "persist me"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_event_log_seeds_memory_after_restart(tmp_path):
+    cfg = Config(experiments={"sqlite_state": True})
+    app = create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with app.router.lifespan_context(app):
+        event_id = app.state.event_log.add_event("restart", {"text": "survive"})
+
+    restarted = create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
+    async with restarted.router.lifespan_context(restarted):
+        events = restarted.state.event_log.get_events()
+        assert len(events) == 1
+        assert events[0]["id"] == event_id
+        assert events[0]["text"] == "survive"

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -28,7 +28,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert db.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert db.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
-        assert db.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 2
+        assert db.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 3
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -36,13 +36,14 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
             ).fetchall()
         }
         assert "session_bindings" in tables
+        assert "events" in tables
     finally:
         db.close()
 
     db2 = StateDatabase(db_path)
     try:
         assert db2.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
-        assert db2.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 2
+        assert db2.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 3
     finally:
         db2.close()
 


### PR DESCRIPTION
## Summary
- add SQLite event table/store under experiments.sqlite_state
- keep EventLog in-memory/SSE semantics while persisting add/update through state.db
- import legacy events.json once and stop writing events.json in SQLite mode
- update SQLite state expansion docs

## Tests
- uv run pytest tests/test_event_log.py tests/test_sqlite_state_schedules.py
- uv run pytest tests/test_event_log.py tests/test_sse_stream.py tests/test_routes.py::TestEvents tests/test_transport_router.py tests/test_sqlite_state_schedules.py
- uv run ruff check repowire/daemon/app.py repowire/daemon/event_log.py repowire/daemon/state/database.py repowire/daemon/state/events.py tests/test_event_log.py tests/test_sqlite_state_schedules.py
- uv run ty check repowire/daemon/app.py repowire/daemon/event_log.py repowire/daemon/state/database.py repowire/daemon/state/events.py
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers