### PR TITLE
Persist peer mappings in SQLite state

### DIFF
--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -16,7 +16,7 @@ A live peer has these identity and lifecycle fields:
 - `description` — short task state set by `set_description` and shown in peer lists.
 - `status`, `turn_state`, and `last_seen` — liveness and per-turn observability.
 
-The in-memory `Peer` is the live routing record. The durable `SessionMapping` in `sessions.json` preserves fields that should survive daemon restart, including display name, circle, backend, path, role, description, and the last known agent pid when available.
+The in-memory `Peer` is the live routing record. The durable `SessionMapping` preserves fields that should survive daemon restart, including display name, circle, backend, path, role, description, and the last known agent pid when available. With `experiments.sqlite_state: true`, those mappings live in `~/.repowire/state.db` and legacy `sessions.json` is imported once for downgrade compatibility. With the flag off, `sessions.json` remains the mapping store.
 
 ## Registration and reconnect
 
@@ -42,7 +42,7 @@ Use `peer_id` when exact routing matters. If you use a display name and more tha
 
 `description` is intentionally lightweight: it is task state, not durable truth. Agents should call `set_description("brief task summary")` when starting work and clear or replace it when focus changes.
 
-Because agents can forget to clear it, the daemon bounds stale descriptions with a clear-on-read TTL (`daemon.description_ttl_seconds`, default 900 seconds). There is no polling loop. When a peer is read through `/peers` or peer lookup and its description is older than the TTL, the daemon clears it in memory and in the durable mapping. A description restored from `sessions.json` gets stamped on first read so it has a bounded TTL window rather than living forever.
+Because agents can forget to clear it, the daemon bounds stale descriptions with a clear-on-read TTL (`daemon.description_ttl_seconds`, default 900 seconds). There is no polling loop. When a peer is read through `/peers` or peer lookup and its description is older than the TTL, the daemon clears it in memory and in the durable mapping. A description restored from durable mapping state gets stamped on first read so it has a bounded TTL window rather than living forever.
 
 ## `last_seen` and liveness
 

--- a/docs/concepts/session-binding-contract.md
+++ b/docs/concepts/session-binding-contract.md
@@ -132,8 +132,10 @@ Rules:
 - `repowire/protocol/peers.py` defines live peer identity, backend, path,
   machine, metadata, status, and turn state.
 - `repowire/daemon/peer_registry.py` persists `SessionMapping` in
-  `sessions.json` and owns peer ID reuse, display-name collision handling,
-  role claims, descriptions, pane hijack evidence, and ghost eviction.
+  `sessions.json` when `experiments.sqlite_state` is off and in
+  `StateDatabase` when the flag is on. It owns peer ID reuse, display-name
+  collision handling, role claims, descriptions, pane hijack evidence, and
+  ghost eviction.
 - `repowire/hooks/session_handler.py` registers peers on `SessionStart` with
   backend, path, pane, role, turn state, agent PID, and metadata such as
   `hook_session_id`.
@@ -196,10 +198,9 @@ Rules:
 
 ### PeerRegistry metadata
 
-`SessionMapping` remains the compatibility source for peer reuse until a
-dedicated binding store exists. A future binding store should not remove
-`sessions.json` in the first migration; it should import or mirror enough data
-to support downgrade and existing daemon startup behavior.
+`SessionMapping` remains the compatibility source for peer reuse. It is stored
+in SQLite when `experiments.sqlite_state` is on, with one-time import from
+legacy `sessions.json`; JSON mode remains the downgrade/off-flag path.
 
 Peer metadata may temporarily carry `repowire_session_id`, `runtime_session_id`,
 or source locator hints. Treat metadata as an ingress/compatibility envelope,

--- a/docs/reference/sqlite-state-expansion-plan.md
+++ b/docs/reference/sqlite-state-expansion-plan.md
@@ -9,11 +9,11 @@ Repowire currently has two persistence styles:
 - Experimental SQLite state under `~/.repowire/state.db`, gated by `experiments.sqlite_state`.
 - JSON files under `~/.repowire/`, usually loaded into daemon memory and flushed by lazy repair or explicit mutation paths.
 
-The SQLite path currently covers schedules, session bindings, and dashboard/session events when `experiments.sqlite_state` is enabled. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup.
+The SQLite path currently covers schedules, session bindings, dashboard/session events, and peer session mappings when `experiments.sqlite_state` is enabled. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup. `PeerRegistry` imports legacy `sessions.json` once into `peer_session_mappings` and stops writing new `sessions.json` state.
 
 Other state remains JSON or in-memory:
 
-- `sessions.json`: persistent peer/session mappings inside `PeerRegistry`; still retained for peer identity reuse, daemon restart behavior, and downgrade/backcompat while the binding store hardens.
+- `sessions.json`: persistent peer/session mappings inside `PeerRegistry` only when `experiments.sqlite_state` is false; retained untouched in SQLite mode for downgrade/backcompat.
 - `events.json`: dashboard event ring buffer persistence when `sqlite_state` is disabled; retained untouched for downgrade/backcompat when SQLite event persistence is enabled.
 - `AskTracker`: in-memory ask/ack lifecycle with TTL eviction and in-memory pending ACP reply stashes.
 - Agent transcripts: source-of-truth JSONL files owned by Claude Code or other agent runtimes, parsed on demand for history routes.
@@ -32,7 +32,8 @@ Before:
 Current compatible SQLite slices:
 
 - Schedules stay on the existing experimental SQLite adapter.
-- Peer mappings, asks, query futures, transport state, and raw transcripts keep their current ownership.
+- Peer mappings move to SQLite when `experiments.sqlite_state` is enabled; JSON mode keeps `sessions.json`.
+- Asks, query futures, transport state, and raw transcripts keep their current ownership.
 - Session bindings are stored in SQLite as control/provenance metadata and are used by compatible timeline/transcript and session-control slices when an unambiguous binding exists.
 - Dashboard/session events remain a bounded in-memory deque for route/SSE compatibility; with `sqlite_state` enabled, persistence is backed by SQLite instead of new `events.json` writes.
 - `events.json` remains in place for downgrade/backcompat and one-time import.
@@ -78,9 +79,9 @@ This slice intentionally does not change dashboard API semantics. It only adds a
 
 ## Deferred state
 
-Keep peer identity mappings separate from session bindings for now.
+Keep peer identity mappings separate from session bindings.
 
-Peer mappings affect peer ID reuse, display-name collision handling, circle restoration, role claims, description persistence, pane hijack protection, and clean takeover behavior. The landed binding table does not replace `PeerRegistry.SessionMapping` or `sessions.json`; it records durable workstream/runtime provenance for timeline and control surfaces. Moving peer identity mappings into SQLite should remain a separate review with an explicit downgrade/backcompat plan.
+Peer mappings affect peer ID reuse, display-name collision handling, circle restoration, role claims, description persistence, pane hijack protection, and clean takeover behavior. Their SQLite table is deliberately separate from session bindings: peer mappings record live peer identity state, while session bindings record durable workstream/runtime provenance for timeline and control surfaces.
 
 Defer asks and pending replies.
 
@@ -120,6 +121,12 @@ For the event journal specifically:
 - If SQLite append fails, log and keep the in-memory event path working.
 - If SQLite import fails, start with an empty SQL event table and keep serving from the current in-memory behavior.
 - Avoid eager background migration work. Import during store initialization only, then rely on normal event appends.
+
+For peer mappings specifically:
+
+- Do not write `sessions.json` while `experiments.sqlite_state` is enabled.
+- Leave any existing `sessions.json` file in place so disabling the flag can downgrade to the last JSON-mode snapshot.
+- With the flag disabled, keep the historical JSON load and lazy-repair/shutdown write behavior unchanged.
 
 ## Failure modes
 

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -307,7 +307,7 @@ class ExperimentsConfig(BaseModel):
         default=False,
         description=(
             "Use the experimental SQLite daemon state store for migrated "
-            "domains. Currently used for schedule persistence and session bindings."
+            "domains. Currently used for schedules, peer mappings, and session bindings."
         ),
     )
 

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -243,6 +243,7 @@ def create_app(
             ask_tracker=ask_tracker,
             event_bus=event_bus,
             event_log=event_log,
+            state_db=state_db,
         )
         peer_registry.prune_offline(max_age_hours=cfg.daemon.prune_max_age_hours)
 
@@ -541,6 +542,7 @@ def create_test_app(
         )
 
         event_bus = EventBus()
+        schedules_path = state_dir / "schedules.json"
         registry = PeerRegistry(
             config=cfg,
             message_router=msg_router,
@@ -550,9 +552,8 @@ def create_test_app(
             ask_tracker=ask_tracker,
             event_bus=event_bus,
             event_log=event_log,
+            state_db=state_db,
         )
-
-        schedules_path = state_dir / "schedules.json"
         if cfg.experiments.sqlite_state:
             assert state_db is not None
             schedule_store = SQLiteScheduleStore(

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from repowire.daemon.event_bus import EventBus
     from repowire.daemon.message_router import MessageRouter
     from repowire.daemon.query_tracker import QueryTracker
+    from repowire.daemon.state import StateDatabase
     from repowire.daemon.websocket_transport import WebSocketTransport
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,10 @@ class SessionMapping:
     agent_pid: int | None = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.backend, AgentType):
+            self.backend = AgentType(self.backend)
+        if not isinstance(self.role, PeerRole):
+            self.role = PeerRole(self.role)
         if self.updated_at is None:
             self.updated_at = datetime.now(timezone.utc).isoformat()
 
@@ -134,6 +139,7 @@ class PeerRegistry:
         ask_tracker: AskTracker | None = None,
         event_bus: EventBus | None = None,
         event_log: EventLog | None = None,
+        state_db: StateDatabase | None = None,
     ) -> None:
         self._config = config
         self._router = message_router
@@ -152,6 +158,11 @@ class PeerRegistry:
             Config.get_config_dir() / "sessions.json"
         )
         self._mappings_dirty = False
+        self._state_db = state_db
+        self._sqlite_mappings_enabled = bool(
+            state_db is not None
+            and getattr(getattr(config, "experiments", None), "sqlite_state", False)
+        )
         self._load_mappings()
 
         self._lock = asyncio.Lock()
@@ -168,7 +179,11 @@ class PeerRegistry:
     # ------------------------------------------------------------------
 
     def _load_mappings(self) -> None:
-        """Load session mappings from disk."""
+        """Load session mappings from the configured persistence backend."""
+        if self._sqlite_mappings_enabled:
+            self._import_legacy_mappings_once()
+            self._load_mappings_from_sqlite()
+            return
         if not self._mappings_path.exists():
             return
         try:
@@ -196,11 +211,14 @@ class PeerRegistry:
             logger.error(f"Failed to read session mappings file: {e}")
 
     def _persist_mappings(self) -> None:
-        """Save session mappings to disk atomically (debounced via dirty flag).
+        """Save session mappings to the configured backend.
 
         Called from lazy_repair and shutdown, not on every mutation.
         """
         if not self._mappings_dirty:
+            return
+        if self._sqlite_mappings_enabled:
+            self._persist_mappings_to_sqlite()
             return
         tmp_path = self._mappings_path.with_suffix(".json.tmp")
         try:
@@ -218,6 +236,142 @@ class PeerRegistry:
                 tmp_path.unlink(missing_ok=True)
             except OSError:
                 pass
+
+    def _mapping_to_sql_params(self, mapping: SessionMapping) -> tuple[Any, ...]:
+        backend = (
+            mapping.backend.value
+            if isinstance(mapping.backend, AgentType)
+            else str(mapping.backend)
+        )
+        role = mapping.role.value if isinstance(mapping.role, PeerRole) else str(mapping.role)
+        return (
+            mapping.session_id,
+            mapping.display_name,
+            mapping.circle,
+            backend,
+            mapping.path,
+            role,
+            mapping.updated_at,
+            mapping.description,
+            mapping.agent_pid,
+        )
+
+    @staticmethod
+    def _row_to_mapping(row: Any) -> SessionMapping:
+        return SessionMapping(
+            session_id=row["session_id"],
+            display_name=row["display_name"],
+            circle=row["circle"],
+            backend=AgentType(row["backend"]),
+            path=row["path"],
+            role=PeerRole(row["role"]),
+            updated_at=row["updated_at"],
+            description=row["description"] or "",
+            agent_pid=row["agent_pid"],
+        )
+
+    def _load_mappings_from_sqlite(self) -> None:
+        if self._state_db is None:
+            return
+        rows = self._state_db.conn.execute(
+            "SELECT * FROM peer_session_mappings",
+        ).fetchall()
+        skipped = 0
+        self._mappings.clear()
+        for row in rows:
+            try:
+                mapping = self._row_to_mapping(row)
+            except (TypeError, ValueError, KeyError) as e:
+                skipped += 1
+                logger.warning("Skipping invalid SQLite session mapping row: %s", e)
+                continue
+            if mapping.path and not Path(mapping.path).exists():
+                skipped += 1
+                continue
+            self._mappings[mapping.session_id] = mapping
+        if skipped:
+            logger.info("Skipped %d SQLite session mappings", skipped)
+        logger.info("Loaded %d SQLite session mappings", len(self._mappings))
+
+    def _persist_mappings_to_sqlite(self) -> None:
+        if self._state_db is None:
+            return
+        try:
+            with self._state_db.conn:
+                self._state_db.conn.execute("DELETE FROM peer_session_mappings")
+                self._state_db.conn.executemany(
+                    """
+                    INSERT INTO peer_session_mappings(
+                        session_id, display_name, circle, backend, path, role,
+                        updated_at, description, agent_pid
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [self._mapping_to_sql_params(mapping) for mapping in self._mappings.values()],
+                )
+            self._mappings_dirty = False
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to save SQLite session mappings: %s", e)
+
+    def _import_legacy_mappings_once(self) -> None:
+        """Import legacy sessions.json into SQLite once per source file."""
+        if self._state_db is None or not self._mappings_path.exists():
+            return
+        source_path = str(self._mappings_path)
+        stat = self._mappings_path.stat()
+        imported = self._state_db.conn.execute(
+            "SELECT 1 FROM legacy_imports WHERE source_path = ?",
+            (source_path,),
+        ).fetchone()
+        if imported is not None:
+            return
+
+        row_count = 0
+        status = "ok"
+        error: str | None = None
+        try:
+            data = json.loads(self._mappings_path.read_text())
+            if not isinstance(data, dict):
+                raise ValueError("legacy sessions.json root must be an object")
+            mappings: list[SessionMapping] = []
+            for session_id, mapping_data in data.items():
+                if not isinstance(mapping_data, dict):
+                    continue
+                payload = dict(mapping_data)
+                payload.setdefault("session_id", session_id)
+                mapping = SessionMapping(**payload)
+                mappings.append(mapping)
+            with self._state_db.conn:
+                self._state_db.conn.executemany(
+                    """
+                    INSERT OR IGNORE INTO peer_session_mappings(
+                        session_id, display_name, circle, backend, path, role,
+                        updated_at, description, agent_pid
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [self._mapping_to_sql_params(mapping) for mapping in mappings],
+                )
+                row_count = len(mappings)
+                self._state_db.conn.execute(
+                    """
+                    INSERT INTO legacy_imports(
+                        source_path, source_mtime, source_size, row_count, status, error
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (source_path, stat.st_mtime, stat.st_size, row_count, status, error),
+                )
+        except Exception as e:  # noqa: BLE001
+            status = "error"
+            error = str(e)
+            with self._state_db.conn:
+                self._state_db.conn.execute(
+                    """
+                    INSERT INTO legacy_imports(
+                        source_path, source_mtime, source_size, row_count, status, error
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (source_path, stat.st_mtime, stat.st_size, row_count, status, error),
+                )
+            logger.error("Failed to import legacy session mappings from %s: %s", source_path, e)
 
     # ------------------------------------------------------------------
     # Event tracking

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 class StateDatabase:
@@ -162,6 +162,33 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS peer_session_mappings (
+                    session_id TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL,
+                    circle TEXT NOT NULL,
+                    backend TEXT NOT NULL,
+                    path TEXT,
+                    role TEXT NOT NULL,
+                    updated_at TEXT,
+                    description TEXT NOT NULL DEFAULT '',
+                    agent_pid INTEGER
+                )
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_peer_session_mappings_identity
+                ON peer_session_mappings(display_name, circle, backend)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_peer_session_mappings_path
+                ON peer_session_mappings(backend, path)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
@@ -180,6 +207,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (3, "dashboard event journal"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (4, "peer session mappings for PeerRegistry identity state"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -8,6 +8,7 @@ import pytest
 
 from repowire.config.models import AgentType
 from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.state import StateDatabase
 from repowire.protocol.peers import PeerRole, PeerStatus
 
 
@@ -22,6 +23,20 @@ def _make_registry(tmp_path: Path, mappings: dict | None = None) -> PeerRegistry
     )
 
 
+def _make_sqlite_registry(tmp_path: Path, mappings: dict | None = None) -> PeerRegistry:
+    path = tmp_path / "sessions.json"
+    if mappings:
+        path.write_text(json.dumps(mappings, indent=2))
+    cfg = __import__("repowire.config.models", fromlist=["Config"]).Config()
+    cfg.experiments.sqlite_state = True
+    return PeerRegistry(
+        config=cfg,
+        message_router=__import__("unittest.mock", fromlist=["MagicMock"]).MagicMock(),
+        persistence_path=path,
+        state_db=StateDatabase(tmp_path / "state.db"),
+    )
+
+
 def _ts(hours_ago: float) -> str:
     return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
 
@@ -32,14 +47,14 @@ def test_prune_removes_old_mappings(tmp_path):
             "session_id": "repow-dev-old1",
             "display_name": "old1",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": _ts(100),
         },
         "repow-dev-recent": {
             "session_id": "repow-dev-recent",
             "display_name": "recent",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": _ts(1),
         },
     }
@@ -56,7 +71,7 @@ def test_prune_removes_entries_with_no_timestamp(tmp_path):
             "session_id": "repow-dev-notimestamp",
             "display_name": "notimestamp",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": None,
         },
     }
@@ -77,7 +92,7 @@ def test_prune_persists_to_disk(tmp_path):
             "session_id": "repow-dev-stale",
             "display_name": "stale",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": _ts(200),
         },
     }
@@ -97,7 +112,7 @@ def test_prune_removes_entries_with_bad_timestamp(tmp_path):
             "session_id": "repow-dev-badtimestamp",
             "display_name": "badtimestamp",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": "not-a-valid-iso-timestamp",
         },
     }
@@ -112,7 +127,7 @@ def test_prune_noop_when_nothing_stale(tmp_path):
             "session_id": "repow-dev-fresh",
             "display_name": "fresh",
             "circle": "dev",
-            "backend": AgentType.CLAUDE_CODE,
+            "backend": AgentType.CLAUDE_CODE.value,
             "updated_at": _ts(1),
         },
     }
@@ -668,3 +683,133 @@ async def test_reconnect_updates_agent_pid_on_live_peer_and_mapping(tmp_path):
     assert peer.agent_pid == 20002
     m1 = registry.get_mapping(peer_id)
     assert m1 is not None and m1.agent_pid == 20002
+
+
+def test_sqlite_mode_imports_legacy_sessions_json_once(tmp_path):
+    mappings = {
+        "repow-dev-existing": {
+            "session_id": "repow-dev-existing",
+            "display_name": "proj-claude-code",
+            "circle": "dev",
+            "backend": AgentType.CLAUDE_CODE.value,
+            "path": str(tmp_path),
+            "role": PeerRole.ORCHESTRATOR.value,
+            "updated_at": _ts(1),
+            "description": "legacy role holder",
+            "agent_pid": 4242,
+        },
+    }
+
+    registry = _make_sqlite_registry(tmp_path, mappings)
+
+    mapping = registry.get_mapping("repow-dev-existing")
+    assert mapping is not None
+    assert mapping.display_name == "proj-claude-code"
+    assert mapping.circle == "dev"
+    assert mapping.role == PeerRole.ORCHESTRATOR
+    assert mapping.description == "legacy role holder"
+    assert mapping.agent_pid == 4242
+    row = registry._state_db.conn.execute(
+        "SELECT row_count, status FROM legacy_imports WHERE source_path = ?",
+        (str(tmp_path / "sessions.json"),),
+    ).fetchone()
+    assert row is not None
+    assert row["row_count"] == 1
+    assert row["status"] == "ok"
+
+    # A later downgrade/off-flag write to sessions.json must not be re-imported
+    # after the first audited import.
+    (tmp_path / "sessions.json").write_text(json.dumps({}))
+    restarted = _make_sqlite_registry(tmp_path)
+    assert restarted.get_mapping("repow-dev-existing") is not None
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mode_reuses_peer_id_and_restores_metadata_across_restart(tmp_path):
+    registry = _make_sqlite_registry(tmp_path)
+    workdir = tmp_path / "orchproj"
+    workdir.mkdir()
+
+    peer_id, name = await registry.allocate_and_register(
+        circle="ops",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        role=PeerRole.ORCHESTRATOR,
+        agent_pid=51515,
+        circle_source="tmux",
+    )
+    await registry.update_description(peer_id, "watching sqlite mappings")
+    registry._persist_mappings()
+
+    restarted = _make_sqlite_registry(tmp_path)
+    new_id, new_name = await restarted.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path=str(workdir),
+        role=PeerRole.AGENT,
+        circle_source="fallback",
+    )
+
+    assert new_id == peer_id
+    assert new_name == name
+    peer = await restarted.get_peer(new_id)
+    assert peer is not None
+    assert peer.circle == "ops"
+    assert peer.role == PeerRole.ORCHESTRATOR
+    assert peer.description == "watching sqlite mappings"
+    assert peer.agent_pid == 51515
+
+
+@pytest.mark.asyncio
+async def test_sqlite_mode_syncs_mapping_mutations_without_sessions_json_writes(tmp_path):
+    registry = _make_sqlite_registry(tmp_path)
+    peer_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path=str(tmp_path),
+        agent_pid=10001,
+    )
+    await registry.set_peer_circle(peer_id, "mesh")
+    assert await registry.update_peer_display_name(peer_id, "renamed-codex")
+    await registry.update_description(peer_id, "sqlite-backed")
+    await registry.claim_special_role(peer_id, PeerRole.ORCHESTRATOR)
+    registry._persist_mappings()
+
+    assert not (tmp_path / "sessions.json").exists()
+    restarted = _make_sqlite_registry(tmp_path)
+    mapping = restarted.get_mapping(peer_id)
+    assert mapping is not None
+    assert mapping.circle == "mesh"
+    assert mapping.display_name == "renamed-codex"
+    assert mapping.description == "sqlite-backed"
+    assert mapping.role == PeerRole.ORCHESTRATOR
+    assert mapping.agent_pid == 10001
+
+
+def test_sqlite_mode_prune_persists_to_state_database(tmp_path):
+    registry = _make_sqlite_registry(
+        tmp_path,
+        {
+            "repow-dev-stale": {
+                "session_id": "repow-dev-stale",
+                "display_name": "stale",
+                "circle": "dev",
+                "backend": AgentType.CLAUDE_CODE.value,
+                "updated_at": _ts(200),
+            },
+            "repow-dev-fresh": {
+                "session_id": "repow-dev-fresh",
+                "display_name": "fresh",
+                "circle": "dev",
+                "backend": AgentType.CLAUDE_CODE.value,
+                "updated_at": _ts(1),
+            },
+        },
+    )
+
+    assert registry.prune_offline(max_age_hours=72) == 1
+    registry._persist_mappings()
+
+    restarted = _make_sqlite_registry(tmp_path)
+    assert restarted.get_mapping("repow-dev-stale") is None
+    assert restarted.get_mapping("repow-dev-fresh") is not None

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -28,7 +28,13 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert db.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert db.conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert db.conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
-        assert db.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 3
+        versions = {
+            row[0]
+            for row in db.conn.execute(
+                "SELECT version FROM schema_migrations",
+            ).fetchall()
+        }
+        assert versions == {1, 2, 3, 4}
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -37,13 +43,20 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         }
         assert "session_bindings" in tables
         assert "events" in tables
+        assert "peer_session_mappings" in tables
     finally:
         db.close()
 
     db2 = StateDatabase(db_path)
     try:
         assert db2.conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
-        assert db2.conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 3
+        versions = {
+            row[0]
+            for row in db2.conn.execute(
+                "SELECT version FROM schema_migrations",
+            ).fetchall()
+        }
+        assert versions == {1, 2, 3, 4}
     finally:
         db2.close()
 


### PR DESCRIPTION
## Summary
- add peer_session_mappings to StateDatabase schema v4 after event journal v3
- load/import/persist PeerRegistry SessionMapping through SQLite when experiments.sqlite_state is enabled
- preserve JSON sessions.json behavior when sqlite_state is disabled and leave legacy JSON untouched for downgrade
- update peer identity/session binding/SQLite docs

## Tests
- uv run --extra dev pytest tests/test_session_mapper.py tests/test_claim_role.py tests/test_lazy_repair.py tests/test_sqlite_state_schedules.py tests/test_event_log.py
- uv run --extra dev pytest
- uv run --extra dev ruff check repowire/
- uv run --extra dev ty check repowire/
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers