### PR TITLE
docs: define mesh command UX contract

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -5,6 +5,7 @@ The mental model behind repowire. Read once, refer rarely.
 - [Peers and circles](peers-and-circles.md) — what a peer is and how circles scope routing.
 - [Peer identity lifecycle](peer-identity-lifecycle.md) — registration, reconnect, stale fields, and routing observability.
 - [Message types](message-types.md) — `ask`, `ack`, `notify`, `broadcast`.
+- [Mesh command UX contract](mesh-command-ux.md) — command ids, JSON and human rendering, and agent-facing invocation rules.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.
 - [Orchestrator pattern](orchestrator.md) — a peer whose job is coordinating other peers.

--- a/docs/concepts/mesh-command-ux.md
+++ b/docs/concepts/mesh-command-ux.md
@@ -1,0 +1,160 @@
+# Mesh command UX contract
+
+This contract defines the user-facing command layer Repowire should expose for
+mesh and session operations. It is a design contract, not a new daemon job
+store. Current implementations may be CLI commands, MCP tools, dashboard
+actions, Telegram or Slack commands, or future Claude Code plugin commands.
+
+The command layer must keep two renderings for every command:
+
+- **Human rendering**: compact text or UI for a person steering the mesh.
+- **JSON rendering**: stable structured output for agents, plugins, tests, and
+  scripts.
+
+## Command set
+
+| Command | Purpose | Backing surface today |
+| --- | --- | --- |
+| `status` | Summarize daemon reachability, installed transports, online peers, and current peer identity. | `repowire status`, `GET /health`, `GET /peers`, `whoami` |
+| `peers` | List addressable peers with id, name, circle, role, status, turn state, backend, and description. | `repowire peer list`, MCP `list_peers`, `GET /peers` |
+| `pending-asks` | Show open inbound and outbound ask threads for a peer or session. | `GET /asks/pending?direction=both`, `repowire peer describe` |
+| `ask` | Open a tracked, non-blocking ask thread that the recipient must close with `ack`. | MCP `ask`, `POST /ask` |
+| `notify` | Send a fire-and-forget message with no expected response. | MCP `notify_peer`, `POST /notify` |
+| `schedule` | Create, list, or delete one-shot and recurring future mesh messages. | `repowire schedule`, MCP schedule tools, `/schedules` |
+| `timeline` | Read a peer or session timeline from realtime events plus available transcript history. | `/events`, `/peers/{id}/timeline`, session timeline routes |
+| `result` | Read the latest visible outcome for a thread, schedule delivery, or session turn. | ask tracker state, events, session timeline |
+| `doctor` | Diagnose setup, transport, daemon, relay, and state-store health. | `repowire doctor`, `repowire.doctor` |
+
+Optional review controls can be layered on top of the same rendering rules, but
+they are not part of the minimum command set for this contract.
+
+## Invocation boundaries
+
+Commands must name their routing scope explicitly when there is any chance of
+ambiguity:
+
+- Use `peer_id` for exact routing. Display names are human-facing and can
+  collide across circles.
+- Use `circle` when addressing a display name outside the caller's default
+  circle.
+- Use `repowire_session_id` only for session-scoped commands. If the session has
+  no live executor, commands must report that state instead of silently falling
+  back to a peer.
+- Human surfaces may accept short slash forms such as `/peers` or `/ask`, but
+  the resolved command must still map to one command id from the table above.
+
+Agents must not use `SendMessage` for Repowire peers. `SendMessage` is only for
+same-session harness teammates. Mesh peers are reached with Repowire commands:
+`ask` for tracked work, `notify` for fire-and-forget updates, and `ack` to close
+an inbound ask.
+
+## Ask, ack, and notify rules
+
+The command UX must preserve the lifecycle distinction:
+
+- `ask` is non-blocking and returns a `correlation_id` immediately. The returned
+  id is not a delivery receipt.
+- A recipient closes an ask with bare `ack(correlation_id)` when no substantive
+  reply is needed.
+- A recipient replies with `ack(correlation_id, message)`. The reply is the
+  close operation and is delivered back to the original asker.
+- Follow-ups use `ask(reply_to=correlation_id, ...)`, which closes the prior
+  thread and opens a new tracked thread.
+- `notify` is fire-and-forget. It may return a local notification id for
+  observability, but that id is not an ask thread and cannot be acked.
+- `schedule --kind ask` opens an ask thread when the schedule fires.
+  `schedule --kind notify` delivers a fire-and-forget notification.
+
+## JSON rendering
+
+Every command that returns data should support this envelope:
+
+```json
+{
+  "command": "peers",
+  "status": "ok",
+  "schema_version": 1,
+  "target": {
+    "peer_id": "repow-5-abd4d21e",
+    "peer_name": "project-a-codex",
+    "circle": "default",
+    "repowire_session_id": "rws-..."
+  },
+  "data": {},
+  "warnings": [],
+  "next_actions": []
+}
+```
+
+Required fields:
+
+- `command`: one command id from the command set.
+- `status`: `ok`, `empty`, `partial`, or `error`.
+- `schema_version`: integer, starting at `1`.
+- `data`: command-specific object or list.
+
+Optional fields:
+
+- `target`: resolved peer or session identity.
+- `warnings`: non-fatal issues, such as stale peer state or partial transcript
+  history.
+- `next_actions`: short machine-readable hints such as `ack`, `retry`,
+  `choose-circle`, `start-daemon`, or `run-doctor`.
+
+Command-specific `data` objects should prefer existing daemon field names:
+`peer_id`, `display_name`, `circle`, `role`, `status`, `turn_state`, `backend`,
+`description`, `correlation_id`, `schedule_id`, `kind`, `fire_at`, `cron`,
+`repowire_session_id`, and `event_id`.
+
+## Human rendering
+
+Human output should be brief and scannable:
+
+- `status`: one daemon line, one install/transport line, one peer-count line,
+  and current identity when known.
+- `peers`: table columns `name`, `status`, `turn`, `circle`, `role`, `backend`,
+  `description`; include `peer_id` on demand or when names are ambiguous.
+- `pending-asks`: group inbound and outbound separately; include age,
+  `correlation_id`, from/to peer, and a one-line text preview.
+- `ask`: print the new `correlation_id` and make clear that the command is
+  non-blocking.
+- `notify`: print the notification id only as observability, not as a thread to
+  wait on.
+- `schedule`: print schedule id, kind, target, and next fire time; list mode
+  should group one-shot and recurring entries when possible.
+- `timeline`: show newest relevant turns/events first by default, with source
+  labels for realtime event, transcript history, schedule, or ask.
+- `result`: show the latest known answer, completion, or failure. If durable
+  tracked work is not available, say which existing source was inspected.
+- `doctor`: keep the existing ok/warn/fail/skip hierarchy and add suggested next
+  actions only when they are concrete.
+
+## Timeline and result boundaries
+
+`timeline` and `result` are views over existing peer, ask, schedule, event, and
+session-history data. They must not imply a daemon-backed job lifecycle unless
+the tracked-work design is implemented separately.
+
+Until durable tracked work exists:
+
+- `result` for an ask can report open, acked, or missing ask state.
+- `result` for a schedule can report configured, deleted, last delivery event,
+  or unknown.
+- `result` for a session can report the latest visible chat turn or event, not a
+  guaranteed task completion record.
+
+## Doctor and health boundaries
+
+`doctor` may report current daemon, hook, MCP, plugin, relay, scheduler, and
+state-store diagnostics. ACP/channel broker readiness, last broker error,
+permission relay health, and degradation matrices belong to the ACP/channel
+health work. This command contract can reserve fields for them, but should not
+claim those states are implemented.
+
+## Plugin packaging boundary
+
+Future Claude Code plugin packaging may ship these commands as slash commands,
+skills, hooks, MCP bootstrap, or documentation. Packaging must consume this
+contract rather than redefine command semantics. Repowire setup remains the core
+daemon and multi-runtime install path; a plugin is a convenience package, not a
+replacement for setup.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Repowire is not a standalone chat UI in this flow. You ask your local agent in n
 ## What to read next
 
 - [Quickstart](quickstart/index.md) walks through install, setup, and the first cross-repo ask.
-- [Concepts](concepts/index.md) covers peers, circles, message types, and the orchestrator pattern.
+- [Concepts](concepts/index.md) covers peers, circles, message types, the mesh command UX contract, and the orchestrator pattern.
 - [Control surfaces](surfaces/index.md) explains dashboard, Telegram, Slack, and relay control paths.
 - [Patterns](patterns/index.md) covers multi-repo asks, mobile dispatch, worktree isolation, scheduled wake-ups, and orchestrator coordination.
 - [MCP tools reference](reference/mcp-tools.md) is the source of truth for the agent API.

--- a/tests/test_mesh_command_ux_contract.py
+++ b/tests/test_mesh_command_ux_contract.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowire.mcp.server import create_mcp_server
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "concepts" / "mesh-command-ux.md"
+WEB_CONCEPTS = ROOT / "web" / "app" / "docs" / "concepts" / "page.tsx"
+
+
+def _contract_text() -> str:
+    return CONTRACT.read_text()
+
+
+def _one_line(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_mesh_command_contract_names_minimum_command_set() -> None:
+    text = _contract_text()
+
+    for command in (
+        "status",
+        "peers",
+        "pending-asks",
+        "ask",
+        "notify",
+        "schedule",
+        "timeline",
+        "result",
+        "doctor",
+    ):
+        assert f"| `{command}` |" in text
+
+    assert "Optional review controls" in text
+
+
+def test_mesh_command_contract_defines_json_and_human_rendering() -> None:
+    text = _contract_text()
+
+    for field in (
+        '"command"',
+        '"status"',
+        '"schema_version"',
+        '"target"',
+        '"data"',
+        '"warnings"',
+        '"next_actions"',
+    ):
+        assert field in text
+
+    for status in ("`ok`", "`empty`", "`partial`", "`error`"):
+        assert status in text
+
+    for section_line in (
+        "- `status`: one daemon line",
+        "- `peers`: table columns",
+        "- `pending-asks`: group inbound and outbound",
+        "- `ask`: print the new `correlation_id`",
+        "- `notify`: print the notification id only as observability",
+        "- `schedule`: print schedule id",
+        "- `timeline`: show newest relevant turns/events first",
+        "- `result`: show the latest known answer",
+        "- `doctor`: keep the existing ok/warn/fail/skip hierarchy",
+    ):
+        assert section_line in text
+
+
+def test_mesh_command_contract_preserves_agent_messaging_lifecycle() -> None:
+    text = _contract_text()
+
+    required_rules = (
+        "Agents must not use `SendMessage` for Repowire peers.",
+        "`ask` is non-blocking and returns a `correlation_id` immediately.",
+        "bare `ack(correlation_id)`",
+        "`ack(correlation_id, message)`",
+        "`ask(reply_to=correlation_id, ...)`",
+        "`notify` is fire-and-forget.",
+        "`schedule --kind ask` opens an ask thread",
+        "`schedule --kind notify` delivers a fire-and-forget notification",
+    )
+    for rule in required_rules:
+        assert rule in text
+
+
+def test_mesh_command_contract_keeps_related_work_out_of_scope() -> None:
+    text = _contract_text()
+    one_line = _one_line(text)
+
+    assert "not a new daemon job store" in one_line
+    assert "must not imply a daemon-backed job lifecycle" in text
+    assert "durable tracked work" in text
+    assert "ACP/channel broker readiness" in text
+    assert "should not claim those states are implemented" in one_line
+    assert "a plugin is a convenience package, not a replacement for setup" in one_line
+
+
+def test_web_docs_mirror_core_command_contract() -> None:
+    text = WEB_CONCEPTS.read_text()
+
+    for token in (
+        "status",
+        "peers",
+        "pending-asks",
+        "ask",
+        "notify",
+        "schedule",
+        "timeline",
+        "result",
+        "doctor",
+        "schema_version",
+        "SendMessage",
+        "tracked-work lifecycle",
+        "ACP/channel broker health",
+    ):
+        assert token in text
+
+
+def test_mcp_tool_instructions_match_command_contract() -> None:
+    tools = create_mcp_server()._tool_manager._tools
+
+    list_doc = tools["list_peers"].fn.__doc__ or ""
+    ask_doc = tools["ask"].fn.__doc__ or ""
+    ack_doc = tools["ack"].fn.__doc__ or ""
+    notify_doc = tools["notify_peer"].fn.__doc__ or ""
+    broadcast_doc = tools["broadcast"].fn.__doc__ or ""
+
+    assert "Use ask/notify_peer for repowire peers" in _one_line(list_doc)
+    assert "SendMessage is only for same-session" in _one_line(list_doc)
+    assert "Open a non-blocking ask thread" in ask_doc
+    ask_doc_line = _one_line(ask_doc)
+    assert "not a synchronous wait or delivery receipt" in ask_doc_line
+    assert "Use notify_peer for fire-and-forget" in ask_doc_line
+    assert "Do not use SendMessage for mesh peers" in ask_doc
+    assert "Bare ack" in ack_doc
+    assert "Reply ack" in ack_doc
+    assert "Fire-and-forget" in notify_doc
+    assert "does NOT guarantee agent receipt" in notify_doc
+    assert "Do not use SendMessage" in notify_doc
+    assert "Do not use SendMessage" in broadcast_doc

--- a/web/app/docs/_nav.ts
+++ b/web/app/docs/_nav.ts
@@ -24,7 +24,7 @@ export const docsNav: DocsNavSection[] = [
         slug: "concepts",
         href: "/docs/concepts",
         label: "Concepts",
-        summary: "Peers, circles, message types, control surfaces, and session roadmap.",
+        summary: "Peers, circles, message types, command UX, and session roadmap.",
       },
     ],
   },

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -62,6 +62,22 @@ export default function Concepts() {
         </dl>
       </Section>
 
+      <Section title="Mesh command UX">
+        <p>
+          Repowire&rsquo;s command layer has a stable contract for common mesh operations:
+          <Mono>status</Mono>, <Mono>peers</Mono>, <Mono>pending-asks</Mono>, <Mono>ask</Mono>, <Mono>notify</Mono>, <Mono>schedule</Mono>, <Mono>timeline</Mono>, <Mono>result</Mono>, and <Mono>doctor</Mono>.
+        </p>
+        <p>
+          Every command should have a human rendering for steering the mesh and a JSON rendering for agents, plugins, tests, and scripts. The JSON envelope carries <Mono>command</Mono>, <Mono>status</Mono>, <Mono>schema_version</Mono>, <Mono>data</Mono>, plus optional <Mono>target</Mono>, <Mono>warnings</Mono>, and <Mono>next_actions</Mono>.
+        </p>
+        <p>
+          Agents use Repowire tools for mesh peers: <Mono>ask</Mono> for tracked work, <Mono>notify_peer</Mono> for fire-and-forget updates, and <Mono>ack</Mono> to close inbound asks. <Mono>SendMessage</Mono> is only for same-session harness teammates.
+        </p>
+        <p>
+          <Mono>timeline</Mono> and <Mono>result</Mono> are views over existing peer, ask, schedule, event, and session-history data until a separate tracked-work lifecycle exists. ACP/channel broker health is reserved for the channel health work rather than claimed by this command contract.
+        </p>
+      </Section>
+
       <Section title="Lazy repair">
         <p>
           Repowire avoids polling. Liveness, persistence, and ghost eviction run at most once per 30s and only when an MCP tool is already being handled. Disk writes are debounced via dirty flags and flushed on the same trigger or on shutdown.


### PR DESCRIPTION
## Summary
- add a mesh command UX contract for status/peers/pending-asks/ask/notify/schedule/timeline/result/doctor
- define routing boundaries, JSON envelope, human rendering rules, and ask/ack/notify lifecycle semantics
- mirror the core contract in shipped web docs and add focused contract tests against docs plus MCP tool instructions

## Verification
- uv run --extra dev pytest tests/test_mesh_command_ux_contract.py
- uv run --extra dev ruff check tests/test_mesh_command_ux_contract.py
- npm ci (web)
- npm run lint (web)
- git diff --check
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers

## Beads
- repowire-w67.13 closed locally
- bd dolt push was attempted but this worktree Beads DB has no Dolt remote configured
- Beads JSONL ledgers are not included in the product commit

## Scope boundaries
- Does not implement Claude marketplace/plugin packaging; this contract is input for that follow-up
- Does not implement daemon-backed tracked jobs/results
- Does not claim ACP/channel broker health is implemented
