### PR TITLE
refactor: make sqlite state the sole daemon store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,8 @@ Hosted at repowire.io. Daemon connects outbound via WSS. Cookie-based auth for d
 ## Dashboard
 
 - Next.js static export at `localhost:8377/dashboard`, remote at `repowire.io/dashboard`
-- Events: 500-item circular buffer, persisted to `~/.repowire/events.json`
+- Events: 500-item circular buffer in memory, persisted to `~/.repowire/state.db`
+  with legacy `events.json` imported once.
 - Tool calls: stop hook extracts from transcript JSONL, included in `chat_turn` events
 - File uploads: 📎 button in compose bar, uploads to `POST /attachments`, path included in notification
 - Build: `repowire build-ui` or `cd web && npm run dev`

--- a/README.md
+++ b/README.md
@@ -178,11 +178,12 @@ repowire telegram start                # run Telegram service peer
 repowire slack start                   # run Slack service peer
 ```
 
-The daemon uses `~/.repowire/state.db` for durable local state by default.
-On first startup after install or update, it applies SQLite migrations and
-imports legacy `schedules.json`, `events.json`, and `sessions.json` once while
-leaving those files in place for downgrade compatibility. `repowire doctor`
-reports the SQLite schema, integrity, and import status.
+The daemon uses `~/.repowire/state.db` for durable local state. On first startup
+after install or update, it applies SQLite migrations and imports legacy
+`schedules.json`, `events.json`, and `sessions.json` once while leaving those
+files in place for downgrade/export compatibility. Migrated state is written to
+SQLite, and `repowire doctor` reports the SQLite schema, integrity, and import
+status.
 
 See the full [CLI reference](https://docs.repowire.io/reference/cli/) and [MCP tools reference](https://docs.repowire.io/reference/mcp-tools/).
 

--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -16,7 +16,7 @@ A live peer has these identity and lifecycle fields:
 - `description` — short task state set by `set_description` and shown in peer lists.
 - `status`, `turn_state`, and `last_seen` — liveness and per-turn observability.
 
-The in-memory `Peer` is the live routing record. The durable `SessionMapping` preserves fields that should survive daemon restart, including display name, circle, backend, path, role, description, and the last known agent pid when available. With `experiments.sqlite_state: true`, those mappings live in `~/.repowire/state.db` and legacy `sessions.json` is imported once for downgrade compatibility. With the flag off, `sessions.json` remains the mapping store.
+The in-memory `Peer` is the live routing record. The durable `SessionMapping` preserves fields that should survive daemon restart, including display name, circle, backend, path, role, description, and the last known agent pid when available. Those mappings live in `~/.repowire/state.db`; legacy `sessions.json` is imported once and then left untouched for downgrade/export compatibility.
 
 ## Registration and reconnect
 

--- a/docs/concepts/session-binding-contract.md
+++ b/docs/concepts/session-binding-contract.md
@@ -132,8 +132,7 @@ Rules:
 - `repowire/protocol/peers.py` defines live peer identity, backend, path,
   machine, metadata, status, and turn state.
 - `repowire/daemon/peer_registry.py` persists `SessionMapping` in
-  `sessions.json` when `experiments.sqlite_state` is off and in
-  `StateDatabase` when the flag is on. It owns peer ID reuse, display-name
+  `StateDatabase` and imports legacy `sessions.json` once. It owns peer ID reuse, display-name
   collision handling, role claims, descriptions, pane hijack evidence, and
   ghost eviction.
 - `repowire/hooks/session_handler.py` registers peers on `SessionStart` with
@@ -199,8 +198,8 @@ Rules:
 ### PeerRegistry metadata
 
 `SessionMapping` remains the compatibility source for peer reuse. It is stored
-in SQLite when `experiments.sqlite_state` is on, with one-time import from
-legacy `sessions.json`; JSON mode remains the downgrade/off-flag path.
+in SQLite, with one-time import from legacy `sessions.json`. The legacy JSON
+file remains a downgrade/export artifact, not the active daemon write target.
 
 Peer metadata may temporarily carry `repowire_session_id`, `runtime_session_id`,
 or source locator hints. Treat metadata as an ingress/compatibility envelope,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,10 +10,11 @@ repowire setup [--relay] [--experimental-channels] [--http-mcp] [--no-service] [
 
 One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service.
 
-Setup enables the SQLite daemon state store by default. The daemon applies
-idempotent migrations on startup, imports legacy `schedules.json`,
-`events.json`, and `sessions.json` once, and leaves those JSON files in place
-for downgrade compatibility.
+Setup uses the SQLite daemon state store. The daemon applies idempotent
+migrations on startup, imports legacy `schedules.json`, `events.json`, and
+`sessions.json` once, and leaves those JSON files in place for downgrade/export
+compatibility. Migrated state is written to `state.db`, not back to those JSON
+files.
 
 - `--relay` opts in to the hosted relay at `repowire.io`.
 - `--experimental-channels` enables the experimental MCP channel / ACP transport for Claude Code (v2.1.80+, claude.ai login, bun).

--- a/docs/reference/sqlite-state-expansion-plan.md
+++ b/docs/reference/sqlite-state-expansion-plan.md
@@ -4,17 +4,21 @@ Status: current storage architecture and migration notes for v0.13.x. Do not imp
 
 ## Current state
 
-Repowire currently has two persistence styles:
+Repowire currently has one active daemon persistence style plus legacy import
+helpers:
 
-- SQLite state under `~/.repowire/state.db`, enabled by default.
-- JSON files under `~/.repowire/`, usually loaded into daemon memory and flushed by lazy repair or explicit mutation paths.
+- SQLite state under `~/.repowire/state.db`.
+- Legacy JSON files under `~/.repowire/`, kept as one-time import sources and
+  downgrade artifacts, not active daemon write targets for migrated domains.
 
 The SQLite path currently covers schedules, session bindings, dashboard/session events, and peer session mappings. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup. `PeerRegistry` imports legacy `sessions.json` once into `peer_session_mappings` and stops writing new `sessions.json` state.
 
 Other state remains JSON or in-memory:
 
-- `sessions.json`: persistent peer/session mappings inside `PeerRegistry` only when `experiments.sqlite_state` is false; retained untouched in SQLite mode for downgrade/backcompat.
-- `events.json`: dashboard event ring buffer persistence when `sqlite_state` is disabled; retained untouched for downgrade/backcompat when SQLite event persistence is enabled.
+- `sessions.json`: legacy peer/session mapping import source; retained untouched
+  for downgrade/export compatibility.
+- `events.json`: legacy dashboard event import source; retained untouched for
+  downgrade/export compatibility.
 - `AskTracker`: in-memory ask/ack lifecycle with TTL eviction and in-memory pending ACP reply stashes.
 - Agent transcripts: source-of-truth JSONL files owned by Claude Code or other agent runtimes, parsed on demand for history routes.
 - `review_queue.json`: small low-frequency review queue state.
@@ -31,12 +35,13 @@ Before:
 
 Current SQLite slices:
 
-- Schedules use the SQLite adapter by default.
-- Peer mappings use SQLite by default; JSON mode keeps `sessions.json` only when explicitly disabled.
+- Schedules use the SQLite adapter.
+- Peer mappings use SQLite; `sessions.json` is not written by the daemon app.
 - Asks, query futures, transport state, and raw transcripts keep their current ownership.
 - Session bindings are stored in SQLite as control/provenance metadata and are used by compatible timeline/transcript and session-control slices when an unambiguous binding exists.
-- Dashboard/session events remain a bounded in-memory deque for route/SSE compatibility; with `sqlite_state` enabled, persistence is backed by SQLite instead of new `events.json` writes.
-- `events.json` remains in place for downgrade/backcompat and one-time import.
+- Dashboard/session events remain a bounded in-memory deque for route/SSE compatibility;
+  persistence is backed by SQLite instead of new `events.json` writes.
+- `events.json` remains in place for downgrade/export compatibility and one-time import.
 
 ## Event journal slice
 
@@ -81,8 +86,10 @@ The review queue is small, low-frequency, and already has atomic rewrite behavio
 
 Use the existing migration pattern:
 
-- Keep the `experiments.sqlite_state` flag as an explicit opt-out while the compatibility path exists.
-- Keep JSON files intact while the opt-out/downgrade path exists.
+- Treat `~/.repowire/state.db` as the active daemon store for migrated domains.
+- Keep the legacy `experiments.sqlite_state` config key accepted but deprecated;
+  it no longer selects active JSON persistence in the daemon app.
+- Keep JSON files intact while import/downgrade/export compatibility exists.
 - Import legacy JSON once only when the corresponding SQL table is empty.
 - Record import success or failure in `legacy_imports`.
 - Treat corrupt legacy JSON as a logged import error, not a daemon startup failure.
@@ -98,23 +105,29 @@ For the event journal specifically:
 
 For peer mappings specifically:
 
-- Do not write `sessions.json` while `experiments.sqlite_state` is enabled.
-- Leave any existing `sessions.json` file in place so disabling the flag can downgrade to the last JSON-mode snapshot.
-- With the flag disabled, keep the historical JSON load and lazy-repair/shutdown write behavior unchanged.
+- Do not write `sessions.json` from the daemon app.
+- Leave any existing `sessions.json` file in place as the legacy import/export
+  snapshot.
+- Lower-level JSON adapters may remain for explicit compatibility tests, but
+  app startup should not select them for migrated domains.
 
 ## Failure modes
 
-Current JSON failure modes:
+Legacy JSON failure modes:
 
-- `sessions.json` corruption is backed up and mappings start empty.
-- `events.json` load failure logs a warning and the event deque starts empty.
-- `schedules.json` corruption with the JSON store starts schedules empty and marks the store dirty.
+- `sessions.json` import failure is recorded in `legacy_imports` and mappings
+  start from SQLite.
+- `events.json` import failure is recorded in `legacy_imports` and the event
+  deque starts from SQLite.
+- `schedules.json` import failure is recorded in `legacy_imports` and schedules
+  start from SQLite.
 - `review_queue.json` corruption logs and starts empty.
 - In-memory asks and pending replies vanish on daemon restart.
 
-SQLite event store failure policy:
+SQLite state failure policy:
 
-- Database open or migration failure should disable the SQLite event store for that daemon lifetime and preserve current in-memory behavior.
+- Database open or migration failure is a daemon startup failure for migrated
+  state. Run `repowire doctor` and restart after fixing the state path.
 - Per-event append failure should not break `/events/chat`, `/events/chat_delta`, SSE, or peer registry event emission.
 - Legacy import failure should be visible in `legacy_imports` and logs, but should not block daemon startup.
 - Startup seeding from SQLite should tolerate bad payload rows by skipping them and logging a warning.
@@ -131,6 +144,7 @@ Required tests for the first slice:
 - Daemon restart with SQLite enabled seeds the in-memory event window from SQL newest-first data.
 - `/events?since=...` keeps the current gap behavior.
 - Event ordering is stable across same-timestamp events, using insertion order or an explicit sequence.
-- No behavior changes when `experiments.sqlite_state` is false.
+- The legacy `experiments.sqlite_state` flag no longer changes daemon app
+  storage ownership.
 
 Implementation tests should avoid touching `.beads` or `uv.lock`.

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -346,9 +346,8 @@ def setup(
         ])
 
     # Save config
-    if config.experiments.sqlite_state:
-        console.print("[green]✓[/] SQLite state enabled")
-        console.print("  State migrations run automatically when the daemon starts.")
+    console.print("[green]✓[/] SQLite state enabled")
+    console.print("  State migrations run automatically when the daemon starts.")
     config.save()
 
     # Install daemon as system service
@@ -647,9 +646,8 @@ def update(post_upgrade: bool) -> None:
 
     config = load_config()
     config.save()
-    if config.experiments.sqlite_state:
-        console.print("[green]✓[/] SQLite state enabled")
-        console.print("  State migrations run automatically when the daemon restarts.")
+    console.print("[green]✓[/] SQLite state enabled")
+    console.print("  State migrations run automatically when the daemon restarts.")
 
     # Restart daemon service if running
     from repowire.service.installer import get_service_status, restart_service

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -306,8 +306,8 @@ class ExperimentsConfig(BaseModel):
     sqlite_state: bool = Field(
         default=True,
         description=(
-            "Use the SQLite daemon state store for migrated domains. "
-            "Currently used for schedules, peer mappings, events, and session bindings."
+            "Deprecated compatibility knob. The daemon state store is SQLite-backed; "
+            "legacy JSON files are import-only sources for migrated domains."
         ),
     )
 

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -49,7 +49,6 @@ from repowire.daemon.routes import (
     websocket,
 )
 from repowire.daemon.routes import spawn as spawn_routes
-from repowire.daemon.schedule_store import ScheduleStore
 from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.events import SQLiteEventStore
@@ -217,17 +216,14 @@ def create_app(
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
         ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
-        state_db: StateDatabase | None = None
         state_dir = Path.home() / ".repowire"
         events_path = state_dir / "events.json"
         schedules_path = state_dir / "schedules.json"
-        event_store: SQLiteEventStore | None = None
-        if cfg.experiments.sqlite_state:
-            state_db = StateDatabase(state_dir / "state.db")
-            event_store = SQLiteEventStore(
-                db=state_db,
-                legacy_path=events_path,
-            )
+        state_db = StateDatabase(state_dir / "state.db")
+        event_store = SQLiteEventStore(
+            db=state_db,
+            legacy_path=events_path,
+        )
         event_log = EventLog(events_path, store=event_store)
         message_router = MessageRouter(
             transport=transport,
@@ -247,18 +243,11 @@ def create_app(
         )
         peer_registry.prune_offline(max_age_hours=cfg.daemon.prune_max_age_hours)
 
-        if cfg.experiments.sqlite_state:
-            assert state_db is not None
-            schedule_store = SQLiteScheduleStore(
-                db=state_db,
-                legacy_path=schedules_path,
-            )
-            session_binding_store = SQLiteSessionBindingStore(state_db)
-        else:
-            schedule_store = ScheduleStore(
-                persistence_path=schedules_path,
-            )
-            session_binding_store = None
+        schedule_store = SQLiteScheduleStore(
+            db=state_db,
+            legacy_path=schedules_path,
+        )
+        session_binding_store = SQLiteSessionBindingStore(state_db)
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -394,9 +383,8 @@ def create_app(
         await acp_manager.close()
         await scheduler.stop()
         event_log.save()
-        if state_db is not None:
-            state_db.close()
         peer_registry._persist_mappings()
+        state_db.close()
         await peer_registry.stop()
         cleanup_deps()
 
@@ -525,16 +513,13 @@ def create_test_app(
         transport = WebSocketTransport()
         query_tracker = QueryTracker()
         ask_tracker = AskTracker(ttl_hours=cfg.daemon.prune_max_age_hours)
-        state_db: StateDatabase | None = None
         state_dir = persistence_path.parent if persistence_path else Path("/tmp")
         event_path = state_dir / "events.json"
-        event_store: SQLiteEventStore | None = None
-        if cfg.experiments.sqlite_state:
-            state_db = StateDatabase(state_dir / "state.db")
-            event_store = SQLiteEventStore(
-                db=state_db,
-                legacy_path=event_path,
-            )
+        state_db = StateDatabase(state_dir / "state.db")
+        event_store = SQLiteEventStore(
+            db=state_db,
+            legacy_path=event_path,
+        )
         event_log = EventLog(event_path, store=event_store)
         msg_router = message_router or MessageRouter(
             transport=transport,
@@ -554,18 +539,11 @@ def create_test_app(
             event_log=event_log,
             state_db=state_db,
         )
-        if cfg.experiments.sqlite_state:
-            assert state_db is not None
-            schedule_store = SQLiteScheduleStore(
-                db=state_db,
-                legacy_path=schedules_path,
-            )
-            session_binding_store = SQLiteSessionBindingStore(state_db)
-        else:
-            schedule_store = ScheduleStore(
-                persistence_path=schedules_path,
-            )
-            session_binding_store = None
+        schedule_store = SQLiteScheduleStore(
+            db=state_db,
+            legacy_path=schedules_path,
+        )
+        session_binding_store = SQLiteSessionBindingStore(state_db)
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -635,8 +613,8 @@ def create_test_app(
         await acp_manager.close()
         await scheduler.stop()
         event_log.save()
-        if state_db is not None:
-            state_db.close()
+        registry._persist_mappings()
+        state_db.close()
         await registry.stop()
         cleanup_deps()
 

--- a/repowire/daemon/event_bus.py
+++ b/repowire/daemon/event_bus.py
@@ -3,8 +3,8 @@
 Scope: typed publisher/subscriber for peer status/liveness transitions.
 No persistence, no external transport — handlers run in the daemon process.
 
-The existing PeerRegistry event surface (deque + events.json) is unchanged;
-this bus is additive. Subscribers are isolated: one bad handler does not
+The existing PeerRegistry event surface is unchanged; this bus is additive.
+Subscribers are isolated: one bad handler does not
 break delivery to others, and publish never raises.
 """
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -159,10 +159,7 @@ class PeerRegistry:
         )
         self._mappings_dirty = False
         self._state_db = state_db
-        self._sqlite_mappings_enabled = bool(
-            state_db is not None
-            and getattr(getattr(config, "experiments", None), "sqlite_state", False)
-        )
+        self._sqlite_mappings_enabled = state_db is not None
         self._load_mappings()
 
         self._lock = asyncio.Lock()

--- a/repowire/daemon/session_controls.py
+++ b/repowire/daemon/session_controls.py
@@ -42,7 +42,7 @@ def get_session_binding_store(state: object) -> SQLiteSessionBindingStore:
     store = getattr(state, "session_binding_store", None)
     if store is None:
         raise SessionBindingStoreUnavailableError(
-            "Session bindings require experiments.sqlite_state"
+            "Session bindings require the daemon SQLite state store"
         )
     return store
 

--- a/repowire/doctor.py
+++ b/repowire/doctor.py
@@ -295,13 +295,6 @@ def check_auth_token(config: Config) -> CheckResult:
 
 def check_state_database(config: Config) -> CheckResult:
     """Inspect the daemon SQLite state database without applying migrations."""
-    if not config.experiments.sqlite_state:
-        return CheckResult(
-            "State database",
-            Status.WARN,
-            "disabled; using legacy JSON state paths",
-        )
-
     path = Config.get_config_dir() / "state.db"
     if not path.exists():
         return CheckResult(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -195,11 +195,12 @@ class TestAuthToken:
 
 
 class TestStateDatabase:
-    def test_disabled_warns(self):
+    def test_legacy_flag_false_still_checks_sqlite_database(self, tmp_path: Path):
         config = Config(experiments={"sqlite_state": False})
-        r = check_state_database(config)
+        with patch.object(Config, "get_config_dir", return_value=tmp_path):
+            r = check_state_database(config)
         assert r.status is Status.WARN
-        assert "legacy JSON" in r.detail
+        assert "not initialized" in r.detail
 
     def test_missing_warns(self, tmp_path: Path):
         with patch.object(Config, "get_config_dir", return_value=tmp_path):

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -94,16 +94,23 @@ async def test_subscribers_are_woken_and_can_unsubscribe(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_create_test_app_persists_events_on_shutdown(tmp_path):
+async def test_create_test_app_uses_sqlite_even_when_legacy_flag_is_false(tmp_path):
     cfg = Config(experiments={"sqlite_state": False})
     app = create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
 
     async with app.router.lifespan_context(app):
         app.state.event_log.add_event("shutdown", {"text": "persist me"})
 
-    data = json.loads((tmp_path / "events.json").read_text())
-    assert len(data) == 1
-    assert data[0]["type"] == "shutdown"
+    assert not (tmp_path / "events.json").exists()
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        row = db.conn.execute("SELECT payload_json FROM events").fetchone()
+        assert row is not None
+        event = json.loads(row["payload_json"])
+        assert event["type"] == "shutdown"
+        assert event["text"] == "persist me"
+    finally:
+        db.close()
 
 
 def test_sqlite_event_store_imports_legacy_events_once(tmp_path):

--- a/tests/test_session_controls_routes.py
+++ b/tests/test_session_controls_routes.py
@@ -171,7 +171,7 @@ async def test_session_notify_targets_active_executor(tmp_path):
     ]
 
 
-async def test_session_controls_require_binding_store(tmp_path):
+async def test_session_controls_report_missing_session_with_legacy_flag_false(tmp_path):
     cfg = Config(experiments={"sqlite_state": False})
     app = app_mod.create_test_app(config=cfg, persistence_path=tmp_path / "sessions.json")
 
@@ -180,5 +180,5 @@ async def test_session_controls_require_binding_store(tmp_path):
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post("/sessions/rw-session-missing/controls/resume", json={})
 
-    assert response.status_code == 422
-    assert response.json()["detail"]["error"] == "session_bindings_unavailable"
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"] == "session_not_found"

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -20,7 +20,7 @@ export default function CliReference() {
           One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--http-mcp</Mono> enables localhost Streamable HTTP MCP at <Mono>/mcp</Mono> and generates a bearer token if needed. <Mono>--no-service</Mono> skips daemon service installation. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
         </p>
         <p>
-          SQLite state is enabled by default. On first daemon startup after install or update, Repowire applies migrations and imports legacy <Mono>schedules.json</Mono>, <Mono>events.json</Mono>, and <Mono>sessions.json</Mono> once while leaving those files in place for downgrade compatibility.
+          Repowire uses SQLite state. On first daemon startup after install or update, it applies migrations and imports legacy <Mono>schedules.json</Mono>, <Mono>events.json</Mono>, and <Mono>sessions.json</Mono> once while leaving those files in place for downgrade/export compatibility. Migrated state is written to <Mono>state.db</Mono>.
         </p>
       </Cmd>
 


### PR DESCRIPTION
## Summary
- make daemon app/test app always construct StateDatabase and SQLite-backed schedules/events/session bindings/peer mappings
- keep legacy schedules.json/events.json/sessions.json as import/export artifacts instead of active daemon write targets
- flush peer mappings before closing SQLite on shutdown and make doctor/setup wording reflect SQLite as the active store
- update README, CLI docs, web CLI docs, peer/session docs, and cleanup plan

## Verification
- uv run --extra dev pytest tests/test_event_log.py tests/test_session_controls_routes.py tests/test_doctor.py tests/test_session_mapper.py tests/test_sqlite_state_schedules.py -q (89 passed)
- uv run --extra dev pytest (1222 passed)
- uv run --extra dev ruff check repowire/ tests/test_event_log.py tests/test_session_controls_routes.py tests/test_doctor.py tests/test_session_mapper.py tests/test_sqlite_state_schedules.py
- uv run --extra dev ty check repowire/
- npm ci (web)
- npm run lint -- app/docs/reference/cli/page.tsx
- git diff --check
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers

## Beads
- repowire-w67 reopened as the live architecture board while open follow-ups remain
- repowire-w67.18 claimed for this slice; will close after merge
- Beads JSONL ledgers are not included in the product commit

## Compatibility
- Lower-level JSON adapters remain for explicit legacy/import tests
- The legacy experiments.sqlite_state config key remains accepted but no longer selects active JSON persistence in the daemon app
