### PR TITLE
docs: define tracked work lifecycle

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -6,6 +6,7 @@ The mental model behind repowire. Read once, refer rarely.
 - [Peer identity lifecycle](peer-identity-lifecycle.md) — registration, reconnect, stale fields, and routing observability.
 - [Message types](message-types.md) — `ask`, `ack`, `notify`, `broadcast`.
 - [Mesh command UX contract](mesh-command-ux.md) — command ids, JSON and human rendering, and agent-facing invocation rules.
+- [Tracked work lifecycle](tracked-work-lifecycle.md) — future daemon-backed work state, status/result/cancel semantics, and boundaries from ask/ack.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.
 - [Orchestrator pattern](orchestrator.md) — a peer whose job is coordinating other peers.

--- a/docs/concepts/mesh-command-ux.md
+++ b/docs/concepts/mesh-command-ux.md
@@ -133,7 +133,8 @@ Human output should be brief and scannable:
 
 `timeline` and `result` are views over existing peer, ask, schedule, event, and
 session-history data. They must not imply a daemon-backed job lifecycle unless
-the tracked-work design is implemented separately.
+the [tracked-work lifecycle](tracked-work-lifecycle.md) is implemented
+separately.
 
 Until durable tracked work exists:
 

--- a/docs/concepts/tracked-work-lifecycle.md
+++ b/docs/concepts/tracked-work-lifecycle.md
@@ -1,0 +1,218 @@
+# Tracked work lifecycle
+
+Status: architecture contract for future daemon-backed tracked work. This
+document defines the lifecycle Repowire should implement separately from
+conversational `ask`/`ack`. It does not claim that a durable job store, new
+dashboard workflow, ACP/channel health model, or backend resume execution is
+shipped today.
+
+## Problem
+
+`ask` is a conversation thread: one peer asks another peer something, and the
+recipient closes the thread with `ack`. That is useful for collaboration, but it
+is not enough for durable work items that need explicit ownership, status,
+progress, result data, cancellation, retention, and visibility across session
+reattachments.
+
+Tracked work is the daemon-owned lifecycle for those durable work items. A
+tracked work item may originate from a CLI command, MCP tool, dashboard action,
+Telegram/Slack command, orchestrator workflow, schedule, or future session
+command. Once accepted, its lifecycle is represented by daemon state, not by
+whether one chat message has been acknowledged.
+
+## Boundary from ask/ack
+
+Tracked work and ask/ack must remain separate primitives:
+
+- `ask` opens a non-blocking conversational thread and returns a
+  `correlation_id`; `ack` closes that thread.
+- Tracked work opens a daemon work record and returns a `work_id`; status is
+  read and changed through work lifecycle APIs.
+- An ask may create, reference, or comment on tracked work, but acking the ask
+  does not complete the work.
+- A tracked work item may emit notifications or asks for human input, but those
+  asks are child communication events, not the source of truth for the work
+  state.
+- Ask reminder, pending reply, TTL, and reply-routing behavior remain owned by
+  `AskTracker`.
+
+## State model
+
+The daemon should expose these states as the canonical tracked-work lifecycle:
+
+| State | Meaning | Terminal |
+| --- | --- | --- |
+| `queued` | The daemon accepted the work, stored it, and has not yet selected or reached an executor. | No |
+| `delivered` | The daemon delivered the work request to the selected peer/session/transport, but the executor has not reported active execution. | No |
+| `running` | The executor has accepted the work and is actively working. | No |
+| `awaiting_input` | Execution is paused waiting for user, peer, approval, credential, or external input. | No |
+| `completed` | The work finished successfully and result metadata is available. | Yes |
+| `failed` | The work ended with an error result. | Yes |
+| `cancelled` | Cancellation was requested and the daemon reached a cancellation boundary. | Yes |
+| `blocked` | The work cannot make progress without a new decision or dependency that is not merely ordinary user input. | No |
+| `expired` | The work exceeded its TTL, deadline, or retention policy before completion. | Yes |
+| `unavailable` | The target session, executor, backend, or required capability is unavailable before execution can continue. | Yes |
+
+State transitions should be monotonic except for explicitly documented repair
+paths. Lazy repair may move non-terminal work to `unavailable`, `expired`, or
+another more accurate state when a user-visible request discovers stale daemon
+state. It must not rely on polling.
+
+## Status contract
+
+`status` is the read model for work lifecycle state. It should be cheap to read
+and stable enough for agents, dashboard views, and scripts.
+
+Recommended fields:
+
+| Field | Purpose |
+| --- | --- |
+| `work_id` | Daemon-generated stable identifier. |
+| `state` | One state from the lifecycle table. |
+| `state_reason` | Short machine-readable reason such as `executor_busy`, `permission_required`, `deadline_elapsed`, `capability_missing`, or `cancel_requested`. |
+| `phase` | Optional executor-defined phase label for display. |
+| `progress` | Optional bounded progress object, for example `{"current": 2, "total": 5, "unit": "checks"}`. |
+| `owner_peer_id` | Peer that owns or last owned execution, when known. |
+| `repowire_session_id` | Durable session/workstream binding when known. |
+| `circle` | Visibility and routing scope. |
+| `created_by_peer_id` | Peer or service that created the work. |
+| `created_at` | Daemon acceptance time. |
+| `updated_at` | Last daemon-observed lifecycle update. |
+| `deadline_at` | Optional deadline used for expiry. |
+| `expires_at` | Optional retention or auto-expiry boundary. |
+| `result_summary` | Small display summary for terminal work. |
+| `links` | Related ask IDs, schedule IDs, event IDs, or session timeline pointers. |
+
+Status reads must distinguish "no such work" from "work exists but is not
+visible to this caller." The API may return a generic not-found result to
+callers outside the visibility boundary, but internal audit logs should preserve
+the difference.
+
+## Result contract
+
+`result` is available only for terminal work. Non-terminal result reads should
+return the current `status` plus a clear `result_state` such as `not_ready`.
+
+Recommended terminal result fields:
+
+- `work_id`
+- `state`: `completed`, `failed`, `cancelled`, `expired`, or `unavailable`
+- `summary`: short human-readable outcome
+- `data`: small structured payload for machine consumers
+- `error`: structured error object for `failed` and relevant `unavailable`
+  results
+- `artifacts`: pointers to files, attachments, logs, branches, PRs, or timeline
+  events
+- `completed_at`
+- `provenance`: source events, executor peer/session, and transport receipt
+  pointers that explain how the daemon observed the terminal state
+
+Result payloads should stay bounded. Large logs, transcripts, diffs, and
+artifacts should be stored as external artifacts or provenance pointers, not
+inline daemon state.
+
+## Cancel semantics
+
+Cancellation is a request first, then a terminal state after the daemon reaches
+a defined boundary.
+
+Expected behavior:
+
+- `cancel(work_id)` records a cancel request even if the executor is not
+  currently reachable.
+- If work is still `queued`, cancellation can move directly to `cancelled`
+  without contacting a transport.
+- If work is `delivered`, `running`, `awaiting_input`, or `blocked`, the daemon
+  should send the runtime/backend cancel instruction when the transport exposes
+  one.
+- A work item should report a pending cancel reason while cancellation is in
+  flight, rather than claiming `cancelled` immediately.
+- Terminal states win over late cancel requests. Cancelling `completed`,
+  `failed`, `cancelled`, `expired`, or `unavailable` work should be idempotent
+  and return the existing terminal status.
+- Cancel requests must be audit-visible even when best-effort transport cancel
+  fails.
+
+## Protocol cancel before transport teardown
+
+When the daemon or adapter needs to tear down a transport for a live tracked
+work item, protocol-level cancel must be attempted before closing the transport
+whenever the connection is still usable.
+
+Required order:
+
+1. Mark the work with `state_reason=cancel_requested` or equivalent pending
+   cancel metadata.
+2. Send the backend/runtime protocol cancel request, such as an ACP
+   `session/cancel` equivalent for the active runtime session.
+3. Wait only for the configured bounded acknowledgement window.
+4. Close or tear down the transport if needed.
+5. Move the work to `cancelled`, `failed`, or `unavailable` based on the best
+   daemon-observed outcome.
+
+If the connection is already broken, the daemon may skip the protocol cancel and
+mark the work `unavailable` or `failed` with provenance showing that no
+protocol-cancel attempt was possible. This contract defines ordering only; it
+does not expand ACP/channel health diagnostics.
+
+## Storage boundary
+
+Tracked work is daemon control state and belongs under a daemon-owned store
+interface. The first implementation may be in-memory for contract slicing, but
+durable tracked work should persist through the existing daemon state boundary
+used for schedules, session bindings, and events.
+
+Persist:
+
+- work identity, lifecycle state, timestamps, owner, creator, circle, and
+  session pointers;
+- small status/progress/result metadata;
+- cancel requests and terminal outcomes;
+- provenance pointers to asks, schedules, session events, runtime sessions,
+  transport receipts, artifacts, and logs.
+
+Do not persist:
+
+- raw runtime transcript bodies as authoritative work state;
+- unbounded logs or full command output inline;
+- backend secrets, approval credentials, tokens, or private transport handles;
+- Beads ledgers or product-repo issue tracker data as part of work records.
+
+The store should have an explicit retention policy for terminal work. Retention
+cleanup must follow Repowire's lazy-repair philosophy and should be triggered by
+user-visible requests, startup/shutdown, or bounded maintenance hooks, not a new
+polling loop.
+
+## Session and circle visibility
+
+Tracked work is visible through both the durable session model and the mesh
+circle model:
+
+- `repowire_session_id` groups work with a durable workstream when known.
+- `owner_peer_id` is the current or last executor; it may be absent for queued
+  work or detached sessions.
+- `circle` scopes default visibility and name resolution.
+- Peers in the same circle may see work addressed to that circle according to
+  role policy.
+- Human/service/orchestrator peers that already bypass circle lookup may inspect
+  work across circles only through explicit role policy, not by display-name
+  guessing.
+- Exact IDs override display names for routing and inspection. `work_id`,
+  `peer_id`, and `repowire_session_id` should avoid ambiguous name lookup.
+
+If a work item targets a detached or resumable session with no active executor,
+it should remain `queued`, become `unavailable`, or report a clear capability
+error. It must not silently fall back to a peer with the same display name or
+working directory.
+
+## Non-goals
+
+- No changes to ask reminder, ack, pending reply, or ask TTL semantics.
+- No ACP/channel broker health matrix or readiness dashboard.
+- No Claude plugin packaging or marketplace behavior.
+- No SQLite cleanup, migration consolidation, or broad state-store refactor in
+  this design slice.
+- No dashboard UI implementation.
+- No graphify update requirement.
+- No automatic Beads issue import/export or product commits containing Beads
+  ledger churn.

--- a/tests/test_tracked_work_lifecycle_contract.py
+++ b/tests/test_tracked_work_lifecycle_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "concepts" / "tracked-work-lifecycle.md"
+CONCEPT_INDEX = ROOT / "docs" / "concepts" / "index.md"
+MESH_COMMAND_CONTRACT = ROOT / "docs" / "concepts" / "mesh-command-ux.md"
+
+
+def _contract_text() -> str:
+    return CONTRACT.read_text()
+
+
+def _one_line(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_tracked_work_contract_defines_canonical_states() -> None:
+    text = _contract_text()
+
+    for state in (
+        "queued",
+        "delivered",
+        "running",
+        "awaiting_input",
+        "completed",
+        "failed",
+        "cancelled",
+        "blocked",
+        "expired",
+        "unavailable",
+    ):
+        assert f"| `{state}` |" in text
+
+    for terminal_state in ("completed", "failed", "cancelled", "expired", "unavailable"):
+        assert re.search(rf"\| `{terminal_state}` \|.*\| Yes \|", text)
+
+    for non_terminal_state in (
+        "queued",
+        "delivered",
+        "running",
+        "awaiting_input",
+        "blocked",
+    ):
+        assert re.search(rf"\| `{non_terminal_state}` \|.*\| No \|", text)
+
+
+def test_tracked_work_contract_separates_ask_ack_from_work_lifecycle() -> None:
+    text = _contract_text()
+    one_line = _one_line(text)
+
+    assert "separately from conversational `ask`/`ack`" in one_line
+    assert "`ask` opens a non-blocking conversational thread" in text
+    assert "Tracked work opens a daemon work record and returns a `work_id`" in text
+    assert "acking the ask does not complete the work" in one_line
+    assert (
+        "Ask reminder, pending reply, TTL, and reply-routing behavior remain owned by `AskTracker`"
+        in one_line
+    )
+
+
+def test_tracked_work_contract_pins_status_result_and_cancel_semantics() -> None:
+    text = _contract_text()
+
+    for field in (
+        "`work_id`",
+        "`state`",
+        "`state_reason`",
+        "`phase`",
+        "`progress`",
+        "`owner_peer_id`",
+        "`repowire_session_id`",
+        "`circle`",
+        "`result_summary`",
+    ):
+        assert field in text
+
+    for phrase in (
+        "`result` is available only for terminal work",
+        "Non-terminal result reads should return the current `status`",
+        "`cancel(work_id)` records a cancel request",
+        "Terminal states win over late cancel requests",
+        "Cancel requests must be audit-visible",
+    ):
+        assert phrase in _one_line(text)
+
+
+def test_tracked_work_contract_requires_cancel_before_transport_teardown() -> None:
+    text = _contract_text()
+
+    assert "protocol-level cancel must be attempted before closing the transport" in text
+    assert "Mark the work with `state_reason=cancel_requested`" in text
+    assert "Send the backend/runtime protocol cancel request" in text
+    assert "Wait only for the configured bounded acknowledgement window" in text
+    assert (
+        "This contract defines ordering only; it does not expand ACP/channel health diagnostics"
+        in _one_line(text)
+    )
+
+
+def test_tracked_work_contract_defines_storage_and_visibility_boundaries() -> None:
+    text = _contract_text()
+    one_line = _one_line(text)
+
+    assert "Tracked work is daemon control state" in text
+    assert "raw runtime transcript bodies" in text
+    assert "Beads ledgers or product-repo issue tracker data" in text
+    assert "Retention cleanup must follow Repowire's lazy-repair philosophy" in one_line
+    assert "`repowire_session_id` groups work with a durable workstream" in text
+    assert "`circle` scopes default visibility and name resolution" in text
+    assert "Exact IDs override display names" in text
+    assert "must not silently fall back to a peer with the same display name" in one_line
+
+
+def test_tracked_work_contract_keeps_related_work_out_of_scope() -> None:
+    text = _contract_text()
+
+    for phrase in (
+        "No changes to ask reminder",
+        "No ACP/channel broker health matrix",
+        "No Claude plugin packaging",
+        "No SQLite cleanup",
+        "No dashboard UI implementation",
+        "No graphify update requirement",
+        "No automatic Beads issue import/export",
+    ):
+        assert phrase in text
+
+
+def test_concept_docs_link_tracked_work_contract() -> None:
+    assert "[Tracked work lifecycle](tracked-work-lifecycle.md)" in CONCEPT_INDEX.read_text()
+    assert (
+        "[tracked-work lifecycle](tracked-work-lifecycle.md)"
+        in MESH_COMMAND_CONTRACT.read_text()
+    )

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -78,6 +78,15 @@ export default function Concepts() {
         </p>
       </Section>
 
+      <Section title="Tracked work lifecycle">
+        <p>
+          Durable tracked work is a separate daemon-backed lifecycle from conversational <Mono>ask</Mono>/<Mono>ack</Mono>. The design reserves <Mono>work_id</Mono> records with states such as <Mono>queued</Mono>, <Mono>delivered</Mono>, <Mono>running</Mono>, <Mono>awaiting_input</Mono>, <Mono>completed</Mono>, <Mono>failed</Mono>, <Mono>cancelled</Mono>, <Mono>blocked</Mono>, <Mono>expired</Mono>, and <Mono>unavailable</Mono>.
+        </p>
+        <p>
+          Status, result, and cancel semantics belong to that work lifecycle. Acks may close related conversation threads, but they do not complete work. Session and circle visibility should resolve by exact ids where possible, and protocol cancel should be attempted before transport teardown when a live backend connection can still accept it.
+        </p>
+      </Section>
+
       <Section title="Lazy repair">
         <p>
           Repowire avoids polling. Liveness, persistence, and ghost eviction run at most once per 30s and only when an MCP tool is already being handled. Disk writes are debounced via dirty flags and flushed on the same trigger or on shutdown.


### PR DESCRIPTION
## Summary
- add a tracked-work lifecycle contract for daemon-owned jobs/tasks distinct from ask/ack
- link the contract from concept docs, mesh command UX docs, and mirrored web docs
- add focused contract tests for states, status/result/cancel semantics, storage/visibility, and non-goals

## Verification
- uv run pytest tests/test_tracked_work_lifecycle_contract.py tests/test_mesh_command_ux_contract.py
- uv run ruff check tests/test_tracked_work_lifecycle_contract.py
- npm ci (web)
- npm run lint -- app/docs/concepts/page.tsx
- python3 scripts/pre_pr_hygiene.py

Beads: repowire-w67.11 closed by worker; bd dolt push complete.