### PR TITLE
feat: expose ACP and channel health diagnostics

### DIFF
--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -12,6 +12,7 @@ from repowire.client import AsyncRepowireClient
 async with AsyncRepowireClient() as client:
     health = await client.health()
     print(health.version)
+    print(health.channel.status, health.acp_broker.status)
 
 # with auth and a custom base
 async with AsyncRepowireClient(
@@ -23,6 +24,11 @@ async with AsyncRepowireClient(
 ```
 
 You can also inject your own `httpx.AsyncClient` via the `client=` kwarg, in which case ownership stays with you and `aclose()` becomes a no-op.
+
+`health.channel` and `health.acp_broker` are passive readiness snapshots. They
+do not spawn ACP subprocesses or probe agents; they report daemon-known state
+such as channel runtime/auth readiness, configured ACP peers, in-flight broker
+prompts, permission-relay pending count, and the last recorded error.
 
 ## Identity
 

--- a/docs/troubleshooting/diagnostics.md
+++ b/docs/troubleshooting/diagnostics.md
@@ -18,6 +18,19 @@ Shows:
 
 First stop for any "did the install actually work?" question.
 
+## `repowire doctor`
+
+```bash
+repowire doctor
+```
+
+Runs concrete health checks and includes daemon-reported channel/ACP broker
+state when the daemon is reachable. The channel check reports whether the
+experimental Claude Code channel is configured, whether `bun` is available, and
+whether the token in `~/.claude.json` matches the daemon auth token. The ACP
+broker check reports readiness, configured ACP peers, in-flight prompts, and
+the last broker or permission-relay error seen by the daemon.
+
 ## `repowire peer list`
 
 ```bash

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
 
 from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
 from repowire.acp.models import AcpPeerConfig
@@ -43,6 +45,11 @@ class AcpClientManager:
         self._lock = asyncio.Lock()
         self._closed = False
         self._approval_broker = approval_broker
+        self._in_flight = 0
+        self._last_error: str | None = None
+        self._last_error_peer_id: str | None = None
+        self._last_error_at: str | None = None
+        self._last_success_at: str | None = None
 
     async def get_or_create(self, spec: AcpPeerSpec) -> AcpClient:
         """Return the live ``AcpClient`` for ``spec.peer_id``, starting it if needed."""
@@ -76,16 +83,46 @@ class AcpClientManager:
         cache entry would just be a corpse.
         """
         client = await self.get_or_create(spec)
+        self._in_flight += 1
         try:
             result = await client.prompt(text, timeout=timeout)
-        except AcpClientError:
+        except AcpClientError as e:
+            self._record_error(spec.peer_id, e)
             await self._drop_if_crashed(spec.peer_id, client)
             raise
+        finally:
+            self._in_flight = max(0, self._in_flight - 1)
         # Belt-and-braces: if the client decided it's crashed after a "successful"
         # call (shouldn't happen today, but cheap to guard), evict it too.
         if client.crashed:
             await self._drop_if_crashed(spec.peer_id, client)
+        self._last_error = None
+        self._last_error_peer_id = None
+        self._last_error_at = None
+        self._last_success_at = _utc_now()
         return result
+
+    def _record_error(self, peer_id: str, error: BaseException | None = None) -> None:
+        self._last_error = str(error) if error is not None else "ACP prompt failed"
+        self._last_error_peer_id = peer_id
+        self._last_error_at = _utc_now()
+
+    def health_snapshot(self) -> dict[str, Any]:
+        """Return passive ACP broker state for /health and doctor.
+
+        This intentionally does not spawn clients or probe subprocesses; it only
+        reports what the broker already knows from prior delivery attempts.
+        """
+        return {
+            "manager_initialized": True,
+            "closed": self._closed,
+            "active_clients": len(self._clients),
+            "in_flight": self._in_flight,
+            "last_error": self._last_error,
+            "last_error_peer_id": self._last_error_peer_id,
+            "last_error_at": self._last_error_at,
+            "last_success_at": self._last_success_at,
+        }
 
     async def _drop_if_crashed(self, peer_id: str, client: AcpClient) -> None:
         """Drop ``peer_id`` from cache iff the cached entry is ``client``.
@@ -119,3 +156,7 @@ class AcpClientManager:
                 await c.close()
             except Exception as e:  # noqa: BLE001 — best-effort shutdown
                 logger.warning("AcpClientManager: close error: %s", e)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -51,6 +52,8 @@ class ApprovalBroker:
         self._timeout_seconds = timeout_seconds
         self._pending: dict[str, _PendingPermission] = {}
         self._lock = asyncio.Lock()
+        self._last_error: str | None = None
+        self._last_error_at: str | None = None
 
     async def request_permission(
         self,
@@ -101,6 +104,8 @@ class ApprovalBroker:
                 message="permission request timed out",
                 timed_out=True,
             )
+            self._last_error = "permission request timed out"
+            self._last_error_at = _utc_now()
         finally:
             async with self._lock:
                 self._pending.pop(pending.request_id, None)
@@ -132,6 +137,8 @@ class ApprovalBroker:
                 message=message,
             )
             pending.future.set_result(decision)
+            self._last_error = None
+            self._last_error_at = None
             return decision
 
     async def get_pending(self, request_id: str) -> dict[str, Any] | None:
@@ -177,6 +184,15 @@ class ApprovalBroker:
         except Exception:
             return None
 
+    def health_snapshot(self) -> dict[str, Any]:
+        """Return passive permission relay state for /health and doctor."""
+        return {
+            "pending": len(self._pending),
+            "timeout_seconds": self._timeout_seconds,
+            "last_error": self._last_error,
+            "last_error_at": self._last_error_at,
+        }
+
 
 def _first_option_id(options: list[dict[str, Any]]) -> str | None:
     for option in options:
@@ -210,3 +226,7 @@ def _normalize_payload(value: Any) -> dict[str, Any]:
         if attr is not None:
             out[name] = attr
     return out or {"repr": repr(value)}
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -20,12 +20,50 @@ from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerRole
 
 
+class ChannelHealth(BaseModel):
+    """Passive Claude Code channel transport health."""
+
+    status: str = "inactive"
+    configured: bool = False
+    runtime_available: bool = False
+    stop_hook_fallback: bool = True
+    last_error: str | None = None
+
+
+class AcpPermissionHealth(BaseModel):
+    """Passive ACP permission relay health."""
+
+    pending: int = 0
+    timeout_seconds: float | None = None
+    last_error: str | None = None
+    last_error_at: str | None = None
+
+
+class AcpBrokerHealth(BaseModel):
+    """Passive broker-side ACP health."""
+
+    status: str = "inactive"
+    enabled: bool = False
+    sdk_available: bool = False
+    manager_initialized: bool = False
+    configured_peers: int = 0
+    active_clients: int = 0
+    in_flight: int = 0
+    last_error: str | None = None
+    last_error_peer_id: str | None = None
+    last_error_at: str | None = None
+    last_success_at: str | None = None
+    permissions: AcpPermissionHealth = Field(default_factory=AcpPermissionHealth)
+
+
 class Health(BaseModel):
     """Daemon health response."""
 
     status: str
     version: str
     relay_mode: bool = False
+    channel: ChannelHealth = Field(default_factory=ChannelHealth)
+    acp_broker: AcpBrokerHealth = Field(default_factory=AcpBrokerHealth)
 
 
 class ClientPeer(BaseModel):

--- a/repowire/daemon/routes/health.py
+++ b/repowire/daemon/routes/health.py
@@ -2,12 +2,53 @@
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import shutil
+from typing import Any, Literal
+
 from fastapi import APIRouter, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from repowire import __version__
 
 router = APIRouter(tags=["health"])
+
+
+class ChannelHealth(BaseModel):
+    """Passive Claude Code channel transport health."""
+
+    status: Literal["inactive", "ready", "degraded"]
+    configured: bool = False
+    runtime_available: bool = False
+    stop_hook_fallback: bool = True
+    last_error: str | None = None
+
+
+class AcpPermissionHealth(BaseModel):
+    """Passive ACP permission relay health."""
+
+    pending: int = 0
+    timeout_seconds: float | None = None
+    last_error: str | None = None
+    last_error_at: str | None = None
+
+
+class AcpBrokerHealth(BaseModel):
+    """Passive broker-side ACP health."""
+
+    status: Literal["inactive", "ready", "busy", "degraded"]
+    enabled: bool = False
+    sdk_available: bool = False
+    manager_initialized: bool = False
+    configured_peers: int = 0
+    active_clients: int = 0
+    in_flight: int = 0
+    last_error: str | None = None
+    last_error_peer_id: str | None = None
+    last_error_at: str | None = None
+    last_success_at: str | None = None
+    permissions: AcpPermissionHealth = Field(default_factory=AcpPermissionHealth)
 
 
 class HealthResponse(BaseModel):
@@ -16,15 +57,126 @@ class HealthResponse(BaseModel):
     status: str
     version: str
     relay_mode: bool = False
+    channel: ChannelHealth
+    acp_broker: AcpBrokerHealth
 
 
 @router.get("/health", response_model=HealthResponse)
 async def health_check(request: Request) -> HealthResponse:
     """Check daemon health status."""
     relay_mode = getattr(request.app.state, "relay_mode", False)
+    config = getattr(request.app.state, "config", None)
 
     return HealthResponse(
         status="ok",
         version=__version__,
         relay_mode=relay_mode,
+        channel=_channel_health(config),
+        acp_broker=await _acp_broker_health(request, config),
     )
+
+
+def _channel_health(config: Any) -> ChannelHealth:
+    from repowire.installers.claude_code import CLAUDE_JSON
+
+    entry = _channel_config_entry(CLAUDE_JSON)
+    configured = entry is not None
+    runtime_available = shutil.which("bun") is not None
+    if not configured:
+        return ChannelHealth(
+            status="inactive",
+            configured=False,
+            runtime_available=runtime_available,
+            stop_hook_fallback=True,
+        )
+    last_error = None
+    expected_token = getattr(getattr(config, "daemon", None), "auth_token", None)
+    configured_token = None
+    env = entry.get("env") if isinstance(entry, dict) else None
+    if isinstance(env, dict):
+        configured_token = env.get("REPOWIRE_AUTH_TOKEN")
+    if not runtime_available:
+        last_error = "bun runtime not found"
+    elif expected_token and configured_token != expected_token:
+        last_error = "channel auth token differs from daemon auth token"
+    elif not expected_token and configured_token:
+        last_error = "channel auth token is set but daemon auth is disabled"
+    return ChannelHealth(
+        status="degraded" if last_error else "ready",
+        configured=True,
+        runtime_available=runtime_available,
+        stop_hook_fallback=True,
+        last_error=last_error,
+    )
+
+
+def _channel_config_entry(path: Any) -> dict[str, Any] | None:
+    try:
+        config = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    entry = config.get("mcpServers", {}).get("repowire-channel")
+    return entry if isinstance(entry, dict) else None
+
+
+async def _acp_broker_health(request: Request, config: Any) -> AcpBrokerHealth:
+    enabled = bool(getattr(getattr(config, "experiments", None), "acp_broker_client", False))
+    sdk_available = importlib.util.find_spec("acp") is not None
+    manager = getattr(request.app.state, "acp_manager", None)
+    snapshot = _health_snapshot(manager)
+    permission_snapshot = _health_snapshot(
+        getattr(request.app.state, "acp_permission_broker", None),
+    )
+    configured_peers = await _count_acp_peers(getattr(request.app.state, "peer_registry", None))
+
+    last_error = snapshot.get("last_error")
+    permissions = AcpPermissionHealth(**permission_snapshot)
+    if not enabled:
+        status: Literal["inactive", "ready", "busy", "degraded"] = "inactive"
+    elif not sdk_available:
+        status = "degraded"
+        last_error = last_error or "agent-client-protocol SDK not installed"
+    elif manager is None:
+        status = "degraded"
+        last_error = last_error or "ACP client manager not initialized"
+    elif snapshot.get("closed"):
+        status = "degraded"
+        last_error = last_error or "ACP client manager is closed"
+    elif permissions.last_error:
+        status = "degraded"
+        last_error = last_error or permissions.last_error
+    elif int(snapshot.get("in_flight") or 0) > 0:
+        status = "busy"
+    elif last_error:
+        status = "degraded"
+    else:
+        status = "ready"
+
+    return AcpBrokerHealth(
+        status=status,
+        enabled=enabled,
+        sdk_available=sdk_available,
+        manager_initialized=bool(snapshot.get("manager_initialized")),
+        configured_peers=configured_peers,
+        active_clients=int(snapshot.get("active_clients") or 0),
+        in_flight=int(snapshot.get("in_flight") or 0),
+        last_error=last_error,
+        last_error_peer_id=snapshot.get("last_error_peer_id"),
+        last_error_at=snapshot.get("last_error_at"),
+        last_success_at=snapshot.get("last_success_at"),
+        permissions=permissions,
+    )
+
+
+def _health_snapshot(obj: Any) -> dict[str, Any]:
+    if obj is None or not hasattr(obj, "health_snapshot"):
+        return {}
+    snapshot = obj.health_snapshot()
+    return snapshot if isinstance(snapshot, dict) else {}
+
+
+async def _count_acp_peers(registry: Any) -> int:
+    if registry is None or not hasattr(registry, "get_all_peers"):
+        return 0
+    peers = await registry.get_all_peers()
+    return sum(1 for peer in peers if getattr(peer, "metadata", {}).get("acp"))

--- a/repowire/doctor.py
+++ b/repowire/doctor.py
@@ -12,6 +12,7 @@ Status semantics:
 
 from __future__ import annotations
 
+import json
 import shutil
 import sqlite3
 import subprocess
@@ -19,6 +20,7 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -103,10 +105,12 @@ def check_daemon(daemon_url: str, timeout: float = 2.0) -> CheckResult:
 
     version = payload.get("version", "?")
     relay_mode = " (relay mode)" if payload.get("relay_mode") else ""
+    children = _daemon_health_children(payload)
     return CheckResult(
         "Daemon reachable",
-        Status.OK,
+        _worst(children) if children else Status.OK,
         f"{daemon_url} — v{version}{relay_mode}",
+        children=children,
     )
 
 
@@ -386,13 +390,13 @@ def check_relay(config: Config, timeout: float = 5.0) -> CheckResult:
     return CheckResult("Relay", Status.OK, f"reachable at {url} — {key_state}")
 
 
-def check_channel_transport() -> CheckResult:
+def check_channel_transport(config: Config | None = None) -> CheckResult:
     """Channel transport is opt-in; only inspect if claude-code is detected."""
     if not shutil.which("claude"):
         return CheckResult(
             "Channel transport (experimental)", Status.SKIP, "claude-code not detected",
         )
-    from repowire.installers.claude_code import check_channel_installed
+    from repowire.installers.claude_code import CLAUDE_JSON, check_channel_installed
 
     if not check_channel_installed():
         return CheckResult(
@@ -401,18 +405,105 @@ def check_channel_transport() -> CheckResult:
             "not configured (default hooks transport)",
         )
 
+    children: list[CheckResult] = []
     bun = shutil.which("bun")
     if not bun:
-        return CheckResult(
-            "Channel transport (experimental)",
-            Status.FAIL,
-            "configured but `bun` not on PATH",
-        )
+        children.append(CheckResult("bun runtime", Status.FAIL, "not found on PATH"))
+    else:
+        children.append(CheckResult("bun runtime", Status.OK, bun))
+
+    auth_result = _check_channel_auth(config or Config(), CLAUDE_JSON)
+    children.append(auth_result)
+    children.append(
+        CheckResult(
+            "Stop hook fallback",
+            Status.OK,
+            "installed hooks keep Stop fallback for dashboard chat_turns/reminders",
+        ),
+    )
+    worst = _worst(children)
+    if worst is Status.OK:
+        detail = f"configured, bun at {bun}"
+    else:
+        detail = "configured but degraded; see child checks"
     return CheckResult(
         "Channel transport (experimental)",
-        Status.OK,
-        f"configured, bun at {bun}",
+        worst,
+        detail,
+        children=children,
     )
+
+
+def _daemon_health_children(payload: dict[str, Any]) -> list[CheckResult]:
+    children: list[CheckResult] = []
+    channel = payload.get("channel")
+    if isinstance(channel, dict):
+        status = str(channel.get("status") or "unknown")
+        last_error = channel.get("last_error")
+        configured = bool(channel.get("configured"))
+        runtime = bool(channel.get("runtime_available"))
+        if status == "degraded":
+            result_status = Status.FAIL
+        elif status == "ready":
+            result_status = Status.OK
+        else:
+            result_status = Status.SKIP
+        detail = f"status={status}, configured={configured}, bun={runtime}"
+        if last_error:
+            detail += f", last_error={last_error}"
+        children.append(CheckResult("Channel broker health", result_status, detail))
+
+    acp = payload.get("acp_broker")
+    if isinstance(acp, dict):
+        status = str(acp.get("status") or "unknown")
+        last_error = acp.get("last_error")
+        enabled = bool(acp.get("enabled"))
+        peers = int(acp.get("configured_peers") or 0)
+        in_flight = int(acp.get("in_flight") or 0)
+        if status == "degraded":
+            result_status = Status.FAIL
+        elif status in {"ready", "busy"}:
+            result_status = Status.OK
+        else:
+            result_status = Status.SKIP
+        detail = (
+            f"status={status}, enabled={enabled}, configured_peers={peers}, "
+            f"in_flight={in_flight}"
+        )
+        if last_error:
+            detail += f", last_error={last_error}"
+        children.append(CheckResult("ACP broker health", result_status, detail))
+    return children
+
+
+def _check_channel_auth(config: Config, claude_json: Path) -> CheckResult:
+    expected = config.daemon.auth_token
+    try:
+        raw = json.loads(claude_json.read_text())
+    except FileNotFoundError:
+        return CheckResult("Channel auth", Status.FAIL, f"{claude_json} missing")
+    except json.JSONDecodeError as exc:
+        return CheckResult("Channel auth", Status.FAIL, f"{claude_json} invalid JSON: {exc}")
+
+    entry = raw.get("mcpServers", {}).get("repowire-channel")
+    if not isinstance(entry, dict):
+        return CheckResult("Channel auth", Status.FAIL, "repowire-channel entry missing")
+    env = entry.get("env")
+    configured = env.get("REPOWIRE_AUTH_TOKEN") if isinstance(env, dict) else None
+    if expected and configured != expected:
+        return CheckResult(
+            "Channel auth",
+            Status.FAIL,
+            "stale token in ~/.claude.json; rerun `repowire setup --experimental-channels`",
+        )
+    if not expected and configured:
+        return CheckResult(
+            "Channel auth",
+            Status.WARN,
+            "token is set in ~/.claude.json but daemon auth is disabled",
+        )
+    detail = "matches daemon auth token" if expected else "daemon auth disabled"
+    return CheckResult("Channel auth", Status.OK, detail)
 
 
 def check_repowire_version() -> CheckResult:
@@ -446,7 +537,7 @@ def run_all(config: Config, daemon_url: str) -> list[CheckResult]:
         check_auth_token(config),
         check_state_database(config),
         check_relay(config),
-        check_channel_transport(),
+        check_channel_transport(config),
     ]
 
 

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -717,10 +717,15 @@ async def test_manager_drops_client_when_subprocess_crashes(tmp_path: Path) -> N
             await mgr.prompt(spec, "second")
         assert "crash-peer" not in mgr._clients  # type: ignore[attr-defined]
         assert first_client.crashed is True
+        health = mgr.health_snapshot()
+        assert health["last_error_peer_id"] == "crash-peer"
+        assert "prompt failed" in health["last_error"]
+        assert health["active_clients"] == 0
 
         # 3: a fresh client is spawned; we should get a normal echo again
         r3 = await mgr.prompt(spec, "third")
         assert r3.text == "[ok] third"
+        assert mgr.health_snapshot()["last_error"] is None
         respawned = await mgr.get_or_create(spec)
         assert respawned is not first_client
         assert isinstance(respawned, AcpClient)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -97,6 +97,30 @@ class TestDaemon:
         assert r.status is Status.OK
         assert "9.9.9" in r.detail
 
+    def test_reachable_reports_degraded_acp_child(self):
+        def handler(_request):
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ok",
+                    "version": "9.9.9",
+                    "acp_broker": {
+                        "status": "degraded",
+                        "enabled": True,
+                        "configured_peers": 1,
+                        "in_flight": 0,
+                        "last_error": "agent-client-protocol SDK not installed",
+                    },
+                },
+            )
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_daemon("http://localhost:8377")
+        assert r.status is Status.FAIL
+        child = next(c for c in r.children if c.name == "ACP broker health")
+        assert child.status is Status.FAIL
+        assert "last_error=agent-client-protocol SDK not installed" in child.detail
+
     def test_connect_error_fails(self):
         def handler(_request):
             raise httpx.ConnectError("nope")
@@ -279,23 +303,50 @@ class TestChannelTransport:
             r = check_channel_transport()
         assert r.status is Status.SKIP
 
-    def test_configured_no_bun_fails(self):
+    def test_configured_no_bun_fails(self, tmp_path: Path):
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers":{"repowire-channel":{}}}')
+
         def which(tool):
             if tool == "claude":
                 return "/p/claude"
             return None
         with patch("repowire.doctor.shutil.which", side_effect=which), \
-             patch("repowire.installers.claude_code.check_channel_installed", return_value=True):
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=True), \
+             patch("repowire.installers.claude_code.CLAUDE_JSON", claude_json):
             r = check_channel_transport()
         assert r.status is Status.FAIL
 
-    def test_configured_with_bun_ok(self):
+    def test_configured_with_bun_ok(self, tmp_path: Path):
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text('{"mcpServers":{"repowire-channel":{}}}')
+
         def which(tool):
             return f"/p/{tool}" if tool in ("claude", "bun") else None
         with patch("repowire.doctor.shutil.which", side_effect=which), \
-             patch("repowire.installers.claude_code.check_channel_installed", return_value=True):
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=True), \
+             patch("repowire.installers.claude_code.CLAUDE_JSON", claude_json):
             r = check_channel_transport()
         assert r.status is Status.OK
+
+    def test_configured_stale_auth_fails(self, tmp_path: Path):
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            '{"mcpServers":{"repowire-channel":{"env":{"REPOWIRE_AUTH_TOKEN":"old"}}}}',
+        )
+
+        def which(tool):
+            return f"/p/{tool}" if tool in ("claude", "bun") else None
+
+        config = Config(daemon=DaemonConfig(auth_token="new"))
+        with patch("repowire.doctor.shutil.which", side_effect=which), \
+             patch("repowire.installers.claude_code.check_channel_installed", return_value=True), \
+             patch("repowire.installers.claude_code.CLAUDE_JSON", claude_json):
+            r = check_channel_transport(config)
+        assert r.status is Status.FAIL
+        auth = next(c for c in r.children if c.name == "Channel auth")
+        assert auth.status is Status.FAIL
+        assert "stale token" in auth.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -72,7 +72,58 @@ class TestHealth:
     async def test_health(self, client):
         r = await client.get("/health")
         assert r.status_code == 200
-        assert r.json()["status"] == "ok"
+        body = r.json()
+        assert body["status"] == "ok"
+        assert "channel" in body
+        assert "acp_broker" in body
+        assert body["acp_broker"]["status"] == "inactive"
+
+    async def test_health_reports_acp_broker_snapshot(self, monkeypatch):
+        monkeypatch.setattr("repowire.daemon.routes.health.shutil.which", lambda _tool: None)
+        monkeypatch.setattr(
+            "repowire.daemon.routes.health.importlib.util.find_spec",
+            lambda _name: object(),
+        )
+        cfg = Config()
+        cfg.experiments.acp_broker_client = True
+
+        class FakeManager:
+            def health_snapshot(self):
+                return {
+                    "manager_initialized": True,
+                    "active_clients": 1,
+                    "in_flight": 2,
+                    "last_error": None,
+                }
+
+        class FakePermissionBroker:
+            def health_snapshot(self):
+                return {"pending": 1, "timeout_seconds": 60.0, "last_error": None}
+
+        class FakeRegistry:
+            async def get_all_peers(self):
+                return [
+                    SimpleNamespace(metadata={"acp": {"command": "codex-acp"}}),
+                    SimpleNamespace(metadata={}),
+                ]
+
+        app = FastAPI()
+        app.state.config = cfg
+        app.state.peer_registry = FakeRegistry()
+        app.state.acp_manager = FakeManager()
+        app.state.acp_permission_broker = FakePermissionBroker()
+        app.include_router(health.router)
+
+        t = ASGITransport(app=app)
+        async with AsyncClient(transport=t, base_url="http://test") as c:
+            r = await c.get("/health")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["acp_broker"]["status"] == "busy"
+        assert body["acp_broker"]["configured_peers"] == 1
+        assert body["acp_broker"]["active_clients"] == 1
+        assert body["acp_broker"]["in_flight"] == 2
+        assert body["acp_broker"]["permissions"]["pending"] == 1
 
 
 # -- Peers --

--- a/web/app/docs/reference/client/page.tsx
+++ b/web/app/docs/reference/client/page.tsx
@@ -25,6 +25,7 @@ export default function ClientReference() {
 async with AsyncRepowireClient() as client:
     health = await client.health()
     print(health.version)
+    print(health.channel.status, health.acp_broker.status)
 
 # with auth and a custom base
 async with AsyncRepowireClient(
@@ -36,6 +37,9 @@ async with AsyncRepowireClient(
         </Code>
         <p>
           You can also inject your own <Mono>httpx.AsyncClient</Mono> via the <Mono>client=</Mono> kwarg, in which case ownership stays with you and <Mono>aclose()</Mono> becomes a no-op.
+        </p>
+        <p>
+          <Mono>health.channel</Mono> and <Mono>health.acp_broker</Mono> are passive readiness snapshots for channel runtime/auth state, ACP broker prompts, permission relay state, and the daemon&rsquo;s last recorded broker error.
         </p>
       </Section>
 


### PR DESCRIPTION
## Summary
- add compatibility-preserving /health diagnostics for channel and ACP readiness/last_error
- expose typed Python client health models and doctor output for daemon health children plus local channel checks
- document the diagnostics and client fields in reference/troubleshooting docs and mirrored web docs

## Verification
- uv run --extra dev pytest <focused ACP/doctor/route tests> (11 tests)
- uv run --extra dev ruff check <touched Python/tests>
- uv run --extra dev ty check repowire/

Beads: repowire-w67.12 closed by worker; Beads ledger churn intentionally excluded from product commit.