### PR TITLE
docs: spec Claude Code plugin packaging

### DIFF
--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -36,6 +36,8 @@ You can still use those surfaces alongside Repowire:
 
 Treat these as capability packaging layers. Repowire's Claude Code integration remains the hooks + MCP transport described above.
 
+A future optional Repowire marketplace plugin should package Claude Code-facing commands, skills, docs, and an MCP bootstrap around the existing `repowire mcp` command. It must not replace `repowire setup`, install a second daemon, own `~/.repowire/config.yaml`, or redefine ask/ack/notify behavior. See [Claude Code plugin packaging](../concepts/claude-code-plugin-packaging.md) for the proposed layout, version/manifest drift checks, and install/update/uninstall docs impact.
+
 ## Channel transport (experimental)
 
 ```bash

--- a/docs/concepts/claude-code-plugin-packaging.md
+++ b/docs/concepts/claude-code-plugin-packaging.md
@@ -1,0 +1,203 @@
+# Claude Code plugin packaging
+
+This is a packaging spec for a future optional Claude Code marketplace plugin.
+It defines what Repowire may bundle through Claude Code's plugin surface without
+changing the daemon, setup, or command semantics.
+
+The plugin is a convenience package. `repowire setup` remains the supported
+daemon, hook, MCP, service, relay, channel, and multi-runtime install path.
+
+## Goals
+
+- Expose Repowire's mesh command UX contract through Claude Code-native
+  packaging where that improves discoverability.
+- Keep command semantics identical to the existing CLI, HTTP, MCP, dashboard,
+  Telegram, and Slack surfaces.
+- Bootstrap the normal `repowire mcp` stdio server when the host already has
+  Repowire installed.
+- Provide Claude Code-facing docs and skills that teach ask, ack, notify,
+  schedule, peer selection, and doctor workflows.
+- Detect plugin/package drift before users confuse plugin install success with
+  a healthy daemon setup.
+
+## Non-goals
+
+- Do not replace `repowire setup`.
+- Do not install or manage the daemon service from the plugin.
+- Do not own `~/.repowire/config.yaml`, relay enrollment, auth tokens, or local
+  state migration.
+- Do not redefine ask/ack/notify lifecycle rules.
+- Do not make tracked-work lifecycle, ACP/channel health, SQLite cleanup, or
+  graphify claims as part of plugin packaging.
+- Do not make Claude Code the only supported runtime. Codex, Gemini CLI,
+  OpenCode, Pi, bots, and dashboard surfaces continue to use the shared daemon.
+
+## Proposed plugin layout
+
+The marketplace package should be small and declarative. Runtime code should
+stay in the installed `repowire` Python package unless Claude Code requires a
+thin wrapper.
+
+```text
+repowire-claude-code-plugin/
+  .claude-plugin/
+    plugin.json
+  commands/
+    status.md
+    peers.md
+    pending-asks.md
+    ask.md
+    notify.md
+    schedule.md
+    timeline.md
+    result.md
+    doctor.md
+  skills/
+    repowire-mesh/SKILL.md
+  hooks/
+    README.md
+  mcp/
+    repowire.json
+  docs/
+    install.md
+    update.md
+    uninstall.md
+    troubleshooting.md
+```
+
+### Manifest
+
+`.claude-plugin/plugin.json` should declare only plugin metadata and the
+Claude Code integration points that are actually bundled:
+
+- plugin name, description, author, homepage, license, and plugin version
+- minimum supported Claude Code version
+- compatible Repowire package version range
+- command entries that map to the command ids from
+  [Mesh command UX contract](mesh-command-ux.md)
+- optional skill entries that teach Repowire usage
+- optional MCP bootstrap entry for `repowire mcp`
+- optional hook documentation or hook config snippets, not a second hook
+  implementation
+
+Command names may be Claude Code slash commands, but each must resolve to one
+canonical command id: `status`, `peers`, `pending-asks`, `ask`, `notify`,
+`schedule`, `timeline`, `result`, or `doctor`.
+
+### Commands
+
+Command files should be prompts or wrappers around the existing surfaces. They
+must consume the mesh command UX contract rather than duplicating behavior:
+
+- human output stays compact and scannable
+- JSON output uses the shared envelope with `command`, `status`,
+  `schema_version`, `data`, optional `target`, `warnings`, and `next_actions`
+- routing prefers `peer_id`; display names require `circle` when ambiguous
+- `ask` remains non-blocking and returns `correlation_id`
+- `notify` remains fire-and-forget
+- `ack` remains the only close/reply operation for inbound asks
+
+If a Claude Code command cannot reach the daemon, it should report a setup or
+doctor next action. It must not silently create an alternate local mesh.
+
+### MCP bootstrap
+
+The plugin may include a Claude Code MCP entry equivalent to:
+
+```json
+{
+  "name": "repowire",
+  "command": "repowire",
+  "args": ["mcp"]
+}
+```
+
+This bootstrap is valid only when `repowire` is already installed on `PATH`.
+If the binary is missing, the plugin should direct the user to install Repowire
+and run `repowire setup`. It should not vendor a second daemon or spawn an
+unmanaged service.
+
+### Hooks
+
+The plugin may document the hooks installed by `repowire setup` or include
+read-only snippets for review. It should not ship a separate hook
+implementation unless that implementation is generated from the same installed
+Repowire package and covered by the same installer tests.
+
+Default Claude Code integration remains:
+
+- `SessionStart` registers the peer, starts the WebSocket hook supervisor, and
+  injects peer context
+- `UserPromptSubmit` marks the peer busy
+- `Notification` repairs idle status
+- `Stop` and `StopFailure` extract chat turns, deliver legacy query responses,
+  fetch pending asks, and repair status
+- `SessionEnd` tears down the supervisor and marks the peer offline
+
+Channel mode remains an explicit `repowire setup --experimental-channels`
+choice. Plugin packaging may describe it, but must keep it experimental.
+
+## Drift checks
+
+Plugin install success is not proof that Repowire is healthy. The plugin should
+surface drift in `doctor` and any install/update docs:
+
+- plugin manifest version vs installed `repowire --version`
+- manifest compatible Repowire range vs local package version
+- command ids in the manifest vs the command ids in
+  `docs/concepts/mesh-command-ux.md`
+- MCP bootstrap command vs the installed `repowire mcp` command
+- hook snippets or docs vs the installer-owned hook commands
+- Claude Code minimum version vs the installed `claude --version`
+- channel transport prerequisites only when channel mode is enabled
+
+Version drift should be a warning when commands still resolve and a failure
+when the plugin points at missing commands, missing binaries, incompatible MCP
+bootstrap, or an unsupported Claude Code version.
+
+## Install docs impact
+
+When Repowire ships a Claude Code marketplace plugin, update these docs
+together:
+
+- `README.md`: state that plugin packaging is optional and still requires the
+  normal Repowire daemon setup.
+- `docs/quickstart/setup.md`: keep `repowire setup` as the canonical machine
+  setup and add the plugin as an optional Claude Code discoverability layer.
+- `docs/agents/claude-code.md`: document plugin install, what it bundles, what
+  it does not install, and how it relates to hooks, MCP, and channel mode.
+- `docs/reference/cli.md`: document any new CLI support used to inspect plugin
+  drift, if such a command is added.
+- `docs/troubleshooting/diagnostics.md`: include plugin drift checks in the
+  doctor explanation.
+- `web/app/docs/*`: mirror any shipped docs page that the dashboard docs expose.
+
+Do not update uninstall docs to imply plugin removal cleans Repowire state.
+Plugin uninstall and Repowire uninstall are separate operations.
+
+## Update docs impact
+
+Plugin update documentation should tell users to:
+
+- update the marketplace plugin through Claude Code
+- update the Repowire package through `repowire update` or their package manager
+- run `repowire setup` after package updates so hooks and MCP entries are
+  rewritten from the installed package
+- run `repowire doctor` to catch version, manifest, MCP, and hook drift
+
+The update path should avoid editing daemon state directly.
+
+## Uninstall docs impact
+
+Plugin uninstall documentation should be explicit:
+
+- removing the Claude Code plugin removes packaged slash commands, skills, and
+  plugin-provided MCP bootstrap entries
+- it does not stop or uninstall the Repowire daemon service
+- it does not remove `~/.repowire/`, relay keys, attachments, events, schedules,
+  or local state
+- users who want to remove Repowire itself should run `repowire uninstall`
+
+If both uninstall paths exist on a machine, docs should recommend removing the
+plugin first only when the user no longer wants Claude Code command packaging;
+the daemon can continue serving other runtimes.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,6 +7,7 @@ The mental model behind repowire. Read once, refer rarely.
 - [Message types](message-types.md) — `ask`, `ack`, `notify`, `broadcast`.
 - [Mesh command UX contract](mesh-command-ux.md) — command ids, JSON and human rendering, and agent-facing invocation rules.
 - [Tracked work lifecycle](tracked-work-lifecycle.md) — future daemon-backed work state, status/result/cancel semantics, and boundaries from ask/ack.
+- [Claude Code plugin packaging](claude-code-plugin-packaging.md) — optional marketplace plugin boundaries, layout, and drift checks.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.
 - [Orchestrator pattern](orchestrator.md) — a peer whose job is coordinating other peers.

--- a/docs/concepts/mesh-command-ux.md
+++ b/docs/concepts/mesh-command-ux.md
@@ -155,7 +155,13 @@ claim those states are implemented.
 ## Plugin packaging boundary
 
 Future Claude Code plugin packaging may ship these commands as slash commands,
-skills, hooks, MCP bootstrap, or documentation. Packaging must consume this
-contract rather than redefine command semantics. Repowire setup remains the core
-daemon and multi-runtime install path; a plugin is a convenience package, not a
-replacement for setup.
+skills, MCP bootstrap, hook documentation, or documentation. Packaging must
+consume this contract rather than redefine command semantics. Repowire setup
+remains the core daemon and multi-runtime install path; a plugin is a
+convenience package, not a replacement for setup.
+
+A plugin manifest should map every packaged command to one command id from this
+contract and should check drift against the installed Repowire package, MCP
+bootstrap command, hook snippets, Claude Code version, and declared compatible
+Repowire version range. The detailed packaging boundary lives in
+[Claude Code plugin packaging](claude-code-plugin-packaging.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,9 @@ nav:
       - concepts/index.md
       - Peers and circles: concepts/peers-and-circles.md
       - Message types: concepts/message-types.md
+      - Mesh command UX contract: concepts/mesh-command-ux.md
+      - Tracked work lifecycle: concepts/tracked-work-lifecycle.md
+      - Claude Code plugin packaging: concepts/claude-code-plugin-packaging.md
       - Lazy repair: concepts/lazy-repair.md
       - Control surfaces: concepts/control-surfaces.md
       - Orchestrator pattern: concepts/orchestrator.md

--- a/tests/test_mesh_command_ux_contract.py
+++ b/tests/test_mesh_command_ux_contract.py
@@ -6,6 +6,7 @@ from repowire.mcp.server import create_mcp_server
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs" / "concepts" / "mesh-command-ux.md"
+PLUGIN_PACKAGING = ROOT / "docs" / "concepts" / "claude-code-plugin-packaging.md"
 WEB_CONCEPTS = ROOT / "web" / "app" / "docs" / "concepts" / "page.tsx"
 
 
@@ -94,6 +95,7 @@ def test_mesh_command_contract_keeps_related_work_out_of_scope() -> None:
     assert "ACP/channel broker readiness" in text
     assert "should not claim those states are implemented" in one_line
     assert "a plugin is a convenience package, not a replacement for setup" in one_line
+    assert "check drift against the installed Repowire package" in one_line
 
 
 def test_web_docs_mirror_core_command_contract() -> None:
@@ -113,8 +115,48 @@ def test_web_docs_mirror_core_command_contract() -> None:
         "SendMessage",
         "tracked-work lifecycle",
         "ACP/channel broker health",
+        "Claude Code marketplace plugin packaging",
+        "repowire setup",
     ):
         assert token in text
+
+
+def test_claude_code_plugin_packaging_spec_preserves_setup_boundary() -> None:
+    text = PLUGIN_PACKAGING.read_text()
+    one_line = _one_line(text)
+
+    for token in (
+        "Do not replace `repowire setup`.",
+        "Do not install or manage the daemon service from the plugin.",
+        "Do not redefine ask/ack/notify lifecycle rules.",
+        "This bootstrap is valid only when `repowire` is already installed on `PATH`.",
+    ):
+        assert token in text
+
+    assert (
+        "Do not make tracked-work lifecycle, ACP/channel health, SQLite cleanup, or graphify claims"
+        in one_line
+    )
+
+    for command in (
+        "status",
+        "peers",
+        "pending-asks",
+        "ask",
+        "notify",
+        "schedule",
+        "timeline",
+        "result",
+        "doctor",
+    ):
+        assert f"`{command}`" in text
+
+    assert "repowire-claude-code-plugin/" in text
+    assert ".claude-plugin/" in text
+    assert "plugin.json" in text
+    assert "manifest compatible Repowire range vs local package version" in text
+    assert "plugin manifest version vs installed `repowire --version`" in text
+    assert "Plugin uninstall and Repowire uninstall are separate operations." in one_line
 
 
 def test_mcp_tool_instructions_match_command_contract() -> None:

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -76,6 +76,9 @@ export default function Concepts() {
         <p>
           <Mono>timeline</Mono> and <Mono>result</Mono> are views over existing peer, ask, schedule, event, and session-history data until a separate tracked-work lifecycle exists. ACP/channel broker health is reserved for the channel health work rather than claimed by this command contract.
         </p>
+        <p>
+          Future Claude Code marketplace plugin packaging may expose these commands as slash commands, skills, docs, and an MCP bootstrap, but it remains optional. The plugin manifest should map to the same command ids and check drift against the installed Repowire package, <Mono>repowire mcp</Mono>, hook snippets, Claude Code version, and the declared compatible Repowire range. It does not replace <Mono>repowire setup</Mono> or install a second daemon.
+        </p>
       </Section>
 
       <Section title="Tracked work lifecycle">


### PR DESCRIPTION
## Summary
- add a Claude Code plugin packaging concept for optional marketplace commands/skills/MCP bootstrap
- link packaging boundaries from Claude Code docs, concept docs, MkDocs nav, mesh command UX, and mirrored web docs
- extend mesh command UX contract tests to pin plugin packaging boundaries and drift-check requirements

## Verification
- uv run pytest tests/test_mesh_command_ux_contract.py
- git diff --check
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers

Beads: repowire-w67.10 docs/contract slice; Beads ledgers excluded from product commit.