### PR TITLE
feat: add update check opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ https://repowire.io/dashboard
 ```bash
 repowire setup                         # install hooks/MCP/plugin/service for detected agents
 repowire setup --http-mcp              # opt in to localhost Streamable HTTP MCP at /mcp
+repowire setup --update-checks         # let status/doctor report available updates
+repowire update                        # explicit package upgrade + hook reinstall + daemon restart
 repowire status                        # show installed components and daemon status
 repowire doctor                        # run diagnostics
 repowire service restart               # restart the installed daemon service
@@ -207,12 +209,16 @@ daemon:
       codex: "codex --dangerously-bypass-approvals-and-sandbox"
       gemini: "gemini --yolo"
     allowed_paths: [~/git, ~/projects]
+updates:
+  check_enabled: false
 
 relay:
   enabled: true
   url: "wss://repowire.io"
   api_key: "rw_..."
 ```
+
+Update checks are off by default. If enabled with `repowire setup --update-checks`, `repowire status` and `repowire doctor` may report that a newer release is available, but they do not upgrade packages, rewrite hooks, or restart services. Use `repowire update` when you want to upgrade explicitly; it preserves enabled package extras such as `repowire[acp]` where practical.
 
 Security defaults:
 

--- a/docs/quickstart/setup.md
+++ b/docs/quickstart/setup.md
@@ -20,6 +20,7 @@ When setup finishes, the daemon is listening on `127.0.0.1:8377`. Open a new age
 repowire setup --relay                  # also connect to the hosted relay at repowire.io
 repowire setup --experimental-channels  # use the MCP channel transport (Claude Code v2.1.80+, claude.ai login, bun)
 repowire setup --http-mcp               # enable localhost Streamable HTTP MCP at /mcp
+repowire setup --update-checks          # let status/doctor report new Repowire releases
 repowire setup --non-interactive        # take flag values only, no prompts
 ```
 
@@ -28,6 +29,8 @@ repowire setup --non-interactive        # take flag values only, no prompts
 `--experimental-channels` replaces tmux-injection delivery with direct MCP-channel / ACP delivery for Claude Code only. It is experimental. See [Claude Code setup](../agents/claude-code.md).
 
 `--http-mcp` is a local-only experimental MCP endpoint for clients that need Streamable HTTP instead of the default stdio server. It generates a `daemon.auth_token` if needed and requires clients to send `Authorization: Bearer <token>`. The normal `repowire mcp` stdio server remains the default setup path.
+
+`--update-checks` opts this machine into update availability checks from `repowire status` and `repowire doctor`. It only reports that a newer release exists; `repowire update` remains the explicit command that upgrades the installed package, reinstalls hooks/plugins, and restarts the daemon service when needed.
 
 ## Verifying
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,7 +5,7 @@ The `repowire` command is a thin wrapper around setup, the daemon, and the bot p
 ## `repowire setup`
 
 ```bash
-repowire setup [--relay] [--experimental-channels] [--http-mcp] [--no-service] [--non-interactive]
+repowire setup [--relay] [--experimental-channels] [--http-mcp] [--update-checks|--no-update-checks] [--no-service] [--non-interactive]
 ```
 
 One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service.
@@ -19,6 +19,7 @@ files.
 - `--relay` opts in to the hosted relay at `repowire.io`.
 - `--experimental-channels` enables the experimental MCP channel / ACP transport for Claude Code (v2.1.80+, claude.ai login, bun).
 - `--http-mcp` enables the experimental localhost Streamable HTTP MCP endpoint at `http://127.0.0.1:8377/mcp` and generates `daemon.auth_token` if needed.
+- `--update-checks` lets `repowire status` and `repowire doctor` check PyPI for newer Repowire releases and suggest `repowire update`. Checks are disabled by default and updates are never auto-applied. Use `--no-update-checks` to turn the check off again.
 - `--no-service` skips daemon service installation; run `repowire serve` manually.
 - `--non-interactive` skips prompts and uses flag values only.
 
@@ -37,6 +38,8 @@ repowire status
 ```
 
 Show what's installed, which agents were detected, and whether the daemon is running.
+
+When `updates.check_enabled` is true, status also reports whether a newer Repowire release is available. It does not upgrade anything.
 
 ## `repowire service`
 
@@ -67,6 +70,7 @@ Checks include:
 - Daemon reachable (`GET /health`, prints version)
 - Per-runtime hook + MCP install state (claude-code, codex, gemini, opencode, pi)
 - `tmux`, Python, and package-manager (`uv`/`pipx`/`pip`) availability
+- Update availability when opted in with `repowire setup --update-checks`
 - Spawn allowlist resolves (commands on `PATH`, paths exist as directories)
 - WebSocket auth token state
 - SQLite state database integrity, schema version, import audit, event count, and peer mapping count
@@ -135,9 +139,20 @@ repowire update
 ```
 
 Re-install repowire via the same package manager that installed it. Use after pulling a new release.
-After reinstalling hooks/plugins, `update` restarts the daemon service when it
-is running. SQLite state migrations run during that daemon restart; verify with
+When config enables optional runtime support such as ACP, `update` upgrades the
+matching package extra so the service runtime keeps the dependency. After
+reinstalling hooks/plugins, `update` restarts the daemon service when it is
+running. SQLite state migrations run during that daemon restart; verify with
 `repowire doctor`.
+
+`repowire update` is the only command that upgrades the installed package.
+Hooks, MCP calls, daemon routing, `status`, and `doctor` never auto-update
+Repowire.
+
+When config enables an optional runtime surface that requires package extras,
+such as `experiments.acp_broker_client`, `update` uses an explicit package spec
+like `repowire[acp]` where the package manager supports it so optional
+dependencies are preserved.
 
 ## `repowire uninstall`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,6 +21,8 @@ daemon:
       opencode: "opencode"
       pi: "pi"
     allowed_paths: []
+updates:
+  check_enabled: false
 ```
 
 ## `daemon.auth_token`
@@ -44,3 +46,9 @@ HTTP MCP is never exposed through the hosted relay. The default stdio MCP server
 Spawn is disabled until `allowed_paths` and at least one runtime command are configured. `commands` is keyed by backend (`claude-code`, `codex`, `gemini`, `opencode`, `pi`) and is the single launch profile used by MCP `spawn_peer`, dashboard spawn, backend switching, and `repowire orchestrator start`.
 
 `allowed_commands` is a deprecated compatibility field. When present in an older config, Repowire normalizes it into `commands` while loading config; new configs should not add it.
+
+## `updates.check_enabled`
+
+Opt-in release availability checks for `repowire status` and `repowire doctor`. Default: `false`.
+
+When enabled, those commands may query PyPI and report that a newer Repowire release is available. They never install packages, rewrite hooks, restart services, or mutate daemon routing. `repowire update` remains the explicit upgrade path.

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -133,6 +133,41 @@ _PKG_COMMANDS: dict[str, dict[str, list[str]]] = {
 }
 
 
+def _enabled_package_extras(config: object) -> list[str]:
+    """Return optional package extras required by the current config."""
+    experiments = getattr(config, "experiments", None)
+    extras: list[str] = []
+    if bool(getattr(experiments, "acp_broker_client", False)):
+        extras.append("acp")
+    return extras
+
+
+def _repowire_package_spec(config: object) -> str:
+    extras = _enabled_package_extras(config)
+    if not extras:
+        return "repowire"
+    return f"repowire[{','.join(extras)}]"
+
+
+def _upgrade_command(pkg_mgr: str, config: object) -> list[str]:
+    """Build the package-manager command for `repowire update`.
+
+    Package-manager upgrade commands do not all preserve extras. When an
+    enabled config requires extras, reinstall the tool with the explicit
+    package spec so the upgraded environment still has optional dependencies.
+    """
+    package_spec = _repowire_package_spec(config)
+    if package_spec == "repowire":
+        return _PKG_COMMANDS[pkg_mgr]["upgrade"]
+    if pkg_mgr == "uv":
+        return ["uv", "tool", "install", package_spec, "--upgrade", "--force"]
+    if pkg_mgr == "pipx":
+        return ["pipx", "install", package_spec, "--force"]
+    if pkg_mgr == "pip":
+        return ["pip", "install", "-U", package_spec]
+    return _PKG_COMMANDS[pkg_mgr]["upgrade"]
+
+
 def _prompt_bot_config(
     name: str,
     config_section: object,
@@ -195,6 +230,14 @@ def _daemon_health_ok(host: str, port: int, *, attempts: int = 10) -> bool:
 @click.option("--no-service", is_flag=True, help="Skip daemon service installation")
 @click.option("--relay", is_flag=True, help="Enable hosted relay via repowire.io")
 @click.option(
+    "--update-checks/--no-update-checks",
+    default=None,
+    help=(
+        "Opt status/doctor into checking for newer Repowire releases. "
+        "Updates are never auto-applied."
+    ),
+)
+@click.option(
     "--experimental-channels", is_flag=True,
     help="Use channel transport (experimental, requires claude.ai login and bun)",
 )
@@ -207,6 +250,7 @@ def _daemon_health_ok(host: str, port: int, *, attempts: int = 10) -> bool:
 def setup(
     no_service: bool,
     relay: bool,
+    update_checks: bool | None,
     experimental_channels: bool,
     http_mcp: bool,
     non_interactive: bool,
@@ -273,7 +317,7 @@ def setup(
     if not agents_setup:
         console.print("[yellow]No agent types detected.[/]")
         console.print("Install claude, codex, gemini, opencode, or pi first.")
-        if not (http_mcp or relay or interactive):
+        if not (http_mcp or relay or update_checks is not None or interactive):
             return
     else:
         console.print(f"[green]✓[/] Configured agents: {', '.join(agents_setup)}")
@@ -326,6 +370,18 @@ def setup(
         _enable_http_mcp(config)
         console.print("[green]✓[/] HTTP MCP enabled at http://127.0.0.1:8377/mcp")
         console.print(f"  Bearer token: {_mask_token(config.daemon.auth_token or '')}")
+
+    if update_checks is not None:
+        config.updates.check_enabled = update_checks
+        state = "enabled" if update_checks else "disabled"
+        console.print(f"[green]✓[/] Update checks {state}")
+    elif interactive:
+        config.updates.check_enabled = click.confirm(
+            "Check for Repowire updates in status/doctor?",
+            default=config.updates.check_enabled,
+        )
+        if config.updates.check_enabled:
+            console.print("[green]✓[/] Update checks enabled")
 
     # Bot integrations: show existing config or prompt
     if config.telegram.bot_token:
@@ -389,6 +445,8 @@ def setup(
         hints.append("Telegram bot (mobile control): repowire setup (interactive)")
     if not config.slack.bot_token:
         hints.append("Slack bot: repowire setup (interactive)")
+    if not config.updates.check_enabled:
+        hints.append("Update availability checks: repowire setup --update-checks")
     if hints:
         console.print("")
         console.print("[dim]Optional:[/]")
@@ -600,9 +658,11 @@ def update(post_upgrade: bool) -> None:
     import shutil
     import subprocess
 
+    from repowire.config.models import load_config
     from repowire.installers.claude_code import check_channel_installed
 
     if not post_upgrade:
+        config = load_config()
         old_version = __version__
         pkg_mgr = _detect_package_manager()
         if not pkg_mgr:
@@ -611,9 +671,10 @@ def update(post_upgrade: bool) -> None:
             return
 
         # Upgrade package first, then exec the upgraded CLI for hook/service work.
-        console.print(f"[cyan]Upgrading via {pkg_mgr}...[/]")
+        package_spec = _repowire_package_spec(config)
+        console.print(f"[cyan]Upgrading {package_spec} via {pkg_mgr}...[/]")
         result = subprocess.run(
-            _PKG_COMMANDS[pkg_mgr]["upgrade"], capture_output=True, text=True,
+            _upgrade_command(pkg_mgr, config), capture_output=True, text=True,
         )
         if result.returncode != 0:
             console.print(f"[red]Upgrade failed:[/] {result.stderr[:200]}")
@@ -641,8 +702,6 @@ def update(post_upgrade: bool) -> None:
         _setup_gemini()
     if shutil.which("pi") or (Path.home() / ".pi").exists():
         _setup_pi()
-
-    from repowire.config.models import load_config
 
     config = load_config()
     config.save()
@@ -674,11 +733,21 @@ def status() -> None:
 
     import httpx
 
+    from repowire.config.models import load_config
+    from repowire.doctor import Status, check_update_availability
     from repowire.installers.claude_code import check_hooks_installed
     from repowire.service.installer import get_platform, get_service_status
 
+    config = load_config()
     console.print("[cyan]Mode:[/] unified WebSocket")
     console.print(f"[cyan]Platform:[/] {get_platform()}")
+    console.print("")
+
+    update_result = check_update_availability(config)
+    if update_result.status is Status.WARN:
+        console.print(f"[yellow]![/] {update_result.name}: {update_result.detail}")
+    elif update_result.status is Status.OK:
+        console.print(f"[green]✓[/] {update_result.name}: {update_result.detail}")
     console.print("")
 
     # Check available agent types

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -269,6 +269,26 @@ class SlackConfig(BaseModel):
     channel_id: str | None = Field(None, description="Slack channel ID (C...)")
 
 
+class UpdatesConfig(BaseModel):
+    """Update-check preferences.
+
+    Repowire never mutates its installed package from hooks, MCP calls, daemon
+    routing, or background service work. This config only allows explicit
+    status/doctor checks to report that a newer package is available.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    check_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, status/doctor may check PyPI for a newer Repowire "
+            "release and suggest running `repowire update`. Updates are still "
+            "explicit and are never auto-applied."
+        ),
+    )
+
+
 class ExperimentsConfig(BaseModel):
     """Feature flags for experimental subsystems.
 
@@ -323,6 +343,7 @@ class Config(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     slack: SlackConfig = Field(default_factory=SlackConfig)
+    updates: UpdatesConfig = Field(default_factory=UpdatesConfig)
     experiments: ExperimentsConfig = Field(default_factory=ExperimentsConfig)
 
     @classmethod

--- a/repowire/doctor.py
+++ b/repowire/doctor.py
@@ -510,6 +510,53 @@ def check_repowire_version() -> CheckResult:
     return CheckResult("repowire version", Status.OK, __version__)
 
 
+def _version_parts(version: str) -> tuple[int, ...]:
+    """Parse a simple release version for comparison without adding a dependency."""
+    base = version.split("+", 1)[0].split("-", 1)[0]
+    parts: list[int] = []
+    for part in base.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def check_update_availability(
+    config: Config,
+    *,
+    timeout: float = 2.0,
+    package_url: str = "https://pypi.org/pypi/repowire/json",
+) -> CheckResult:
+    """Report release availability only when update checks are explicitly enabled."""
+    if not config.updates.check_enabled:
+        return CheckResult(
+            "Update availability",
+            Status.SKIP,
+            "disabled; opt in with `repowire setup --update-checks`",
+        )
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(package_url)
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult("Update availability", Status.WARN, f"check failed: {exc}")
+
+    latest = str(payload.get("info", {}).get("version") or "").strip()
+    if not latest:
+        return CheckResult("Update availability", Status.WARN, "PyPI response missing version")
+
+    if _version_parts(latest) > _version_parts(__version__):
+        return CheckResult(
+            "Update availability",
+            Status.WARN,
+            f"{latest} available; run `repowire update` to upgrade",
+        )
+    return CheckResult("Update availability", Status.OK, f"current ({__version__})")
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -531,6 +578,7 @@ def run_all(config: Config, daemon_url: str) -> list[CheckResult]:
         check_python_version(),
         check_tmux(),
         check_package_manager(),
+        check_update_availability(config),
         check_daemon(daemon_url),
         check_runtimes(),
         check_spawn_allowlist(config),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ from repowire.config.models import (
     PeerConfig,
     RelayConfig,
     SpawnSettings,
+    UpdatesConfig,
     load_config,
 )
 
@@ -25,6 +26,7 @@ class TestConfig:
         assert config.relay.enabled is False
         assert config.relay.url == "wss://repowire.io"
         assert len(config.peers) == 0
+        assert config.updates.check_enabled is False
         assert config.experiments.sqlite_state is True
 
     def test_get_peer(self):
@@ -118,6 +120,67 @@ class TestConfig:
         assert loaded.daemon.mcp_http.enabled is True
         assert loaded.daemon.auth_token is not None
         assert loaded.daemon.auth_token.startswith("rw_local_")
+
+    def test_setup_update_checks_flag_writes_config_without_detected_agents(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from repowire.cli import main
+
+        config_path = tmp_path / "config.yaml"
+        monkeypatch.setattr(Config, "get_config_dir", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(Config, "get_config_path", classmethod(lambda cls: config_path))
+        monkeypatch.setattr("repowire.cli._cleanup_legacy_artifacts", lambda: None)
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+
+        result = CliRunner().invoke(
+            main,
+            ["setup", "--update-checks", "--non-interactive", "--no-service"],
+        )
+
+        assert result.exit_code == 0
+        loaded = load_config()
+        assert loaded.updates.check_enabled is True
+
+
+class TestUpdatesConfig:
+    def test_default_off(self):
+        assert UpdatesConfig().check_enabled is False
+
+    def test_can_enable_update_checks(self):
+        assert UpdatesConfig(check_enabled=True).check_enabled is True
+
+
+class TestUpdateCommandHelpers:
+    def test_package_spec_without_extras(self):
+        from repowire.cli import _repowire_package_spec
+
+        assert _repowire_package_spec(Config()) == "repowire"
+
+    def test_package_spec_includes_acp_extra_when_experiment_enabled(self):
+        from repowire.cli import _repowire_package_spec
+
+        config = Config(experiments={"acp_broker_client": True})
+        assert _repowire_package_spec(config) == "repowire[acp]"
+
+    def test_upgrade_command_preserves_acp_extra_for_uv(self):
+        from repowire.cli import _upgrade_command
+
+        config = Config(experiments={"acp_broker_client": True})
+        assert _upgrade_command("uv", config) == [
+            "uv",
+            "tool",
+            "install",
+            "repowire[acp]",
+            "--upgrade",
+            "--force",
+        ]
+
+    def test_upgrade_command_uses_normal_upgrade_without_extras(self):
+        from repowire.cli import _upgrade_command
+
+        assert _upgrade_command("pipx", Config()) == ["pipx", "upgrade", "repowire"]
 
 
 class TestRelayConfig:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -22,6 +22,7 @@ from repowire.doctor import (
     check_spawn_allowlist,
     check_state_database,
     check_tmux,
+    check_update_availability,
     exit_code,
     run_all,
 )
@@ -410,3 +411,33 @@ def test_repowire_version_check():
     r = check_repowire_version()
     assert r.status is Status.OK
     assert r.detail  # should have a version string
+
+
+class TestUpdateAvailability:
+    def test_disabled_skips_without_network(self):
+        with patch("repowire.doctor.httpx.Client") as client:
+            r = check_update_availability(Config())
+        assert r.status is Status.SKIP
+        client.assert_not_called()
+
+    def test_enabled_warns_when_newer_release_exists(self):
+        config = Config(updates={"check_enabled": True})
+
+        def handler(_request):
+            return httpx.Response(200, json={"info": {"version": "999.0.0"}})
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_update_availability(config)
+        assert r.status is Status.WARN
+        assert "999.0.0 available" in r.detail
+        assert "repowire update" in r.detail
+
+    def test_enabled_ok_when_current(self):
+        config = Config(updates={"check_enabled": True})
+
+        def handler(_request):
+            return httpx.Response(200, json={"info": {"version": "0.0.1"}})
+
+        with patch("repowire.doctor.httpx.Client", _mock_client_factory(handler)):
+            r = check_update_availability(config)
+        assert r.status is Status.OK

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -15,9 +15,9 @@ export default function CliReference() {
         The <Mono>repowire</Mono> command is a thin wrapper around setup, the daemon, and the bot peers. Most users only ever need <Mono>setup</Mono>. Everything else is for operators running their own daemon or control surfaces.
       </p>
 
-      <Cmd name="repowire setup" usage="repowire setup [--relay] [--experimental-channels] [--http-mcp] [--no-service] [--non-interactive]">
+      <Cmd name="repowire setup" usage="repowire setup [--relay] [--experimental-channels] [--http-mcp] [--update-checks|--no-update-checks] [--no-service] [--non-interactive]">
         <p>
-          One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--http-mcp</Mono> enables localhost Streamable HTTP MCP at <Mono>/mcp</Mono> and generates a bearer token if needed. <Mono>--no-service</Mono> skips daemon service installation. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
+          One-time install. Detects every supported agent runtime present (Claude Code, Codex, Gemini CLI, OpenCode), wires the appropriate Repowire transport for each, and installs the daemon as a user service. <Mono>--relay</Mono> opts in to the hosted relay at <Mono>repowire.io</Mono>. <Mono>--experimental-channels</Mono> enables the experimental MCP channel / ACP transport for Claude Code. <Mono>--http-mcp</Mono> enables localhost Streamable HTTP MCP at <Mono>/mcp</Mono> and generates a bearer token if needed. <Mono>--update-checks</Mono> lets <Mono>status</Mono> and <Mono>doctor</Mono> check PyPI for newer releases; <Mono>--no-update-checks</Mono> disables it again. <Mono>--no-service</Mono> skips daemon service installation. <Mono>--non-interactive</Mono> skips prompts and uses flag values only.
         </p>
         <p>
           Repowire uses SQLite state. On first daemon startup after install or update, it applies migrations and imports legacy <Mono>schedules.json</Mono>, <Mono>events.json</Mono>, and <Mono>sessions.json</Mono> once while leaving those files in place for downgrade/export compatibility. Migrated state is written to <Mono>state.db</Mono>.
@@ -86,7 +86,7 @@ repowire schedule delete SCHEDULE_ID`}
 
       <Cmd name="repowire update" usage="repowire update">
         <p>
-          Re-install repowire via the same package manager that installed it. Use after pulling a new release. After reinstalling hooks/plugins, <Mono>update</Mono> restarts the daemon service when it is running. SQLite state migrations run during that daemon restart; verify with <Mono>repowire doctor</Mono>.
+          Re-install repowire via the same package manager that installed it. Use after pulling a new release. When config enables optional runtime support such as ACP, <Mono>update</Mono> upgrades the matching package extra so the service runtime keeps the dependency. After reinstalling hooks/plugins, <Mono>update</Mono> restarts the daemon service when it is running. SQLite state migrations run during that daemon restart; verify with <Mono>repowire doctor</Mono>. This is the only command that upgrades the installed package; hooks, MCP calls, daemon routing, <Mono>status</Mono>, and <Mono>doctor</Mono> never auto-update Repowire.
         </p>
       </Cmd>
 


### PR DESCRIPTION
## Summary
- add `updates.check_enabled` plus `repowire setup --update-checks/--no-update-checks`
- let `status` and `doctor` report update availability only when explicitly opted in
- keep package upgrades explicit via `repowire update`, and preserve enabled package extras such as ACP during update
- update README, CLI/config docs, quickstart docs, and mirrored web CLI docs

## Verification
- uv run --extra dev pytest tests/test_config.py tests/test_doctor.py
- uv run --extra dev ruff check repowire/cli.py repowire/config/models.py repowire/doctor.py tests/test_config.py tests/test_doctor.py
- uv run --extra dev ty check repowire/cli.py repowire/config/models.py repowire/doctor.py
- npm ci (web)
- npm run lint -- app/docs/reference/cli/page.tsx
- git diff --check
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers

Beads: repowire-rz9; Beads JSONL kept out of product commit.