### PR TITLE
feat(hooks): inject daemon-derived self identity at SessionStart

### DIFF
--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -22,6 +22,8 @@ The in-memory `Peer` is the live routing record. The durable `SessionMapping` pr
 
 On registration, the daemon allocates a `peer_id` and builds a display name from the working directory and backend. If another active peer in the same circle already holds the display name, the daemon suffixes the new name. Offline same-name peers may be pruned so a fresh session can reclaim the name cleanly.
 
+During hook-based `SessionStart`, the agent receives a compact self-identity context block from the daemon's effective peer record. That block includes the display name, peer id, circle, backend, role, project path, and branch when known. It is intentionally based on the daemon's `/peers` view, not only local tmux or spawn-hint guesses, so restored circle and role state are visible to the session.
+
 A reconnect may reclaim an existing `peer_id` only when the claim still describes the same peer identity. Today that check is intentionally narrow and v0.13-compatible:
 
 - backend must match;

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -159,6 +159,110 @@ def _mark_peer_offline(peer_id: str | None) -> None:
     daemon_post(f"/peers/{quote(peer_id, safe='')}/offline", {})
 
 
+_CIRCLE_SOURCE_LABELS = {
+    "tmux": "from tmux session",
+    "spawn_hint": "from spawn hint",
+    "fallback": "default fallback",
+}
+
+
+def _find_self_peer(
+    peers: list[dict] | None,
+    *,
+    peer_id: str | None,
+    display_name: str,
+) -> dict | None:
+    """Locate this session's record in a /peers list.
+
+    Prefer peer_id (unique); fall back to display_name when the id is not
+    yet known (registration HTTP transport hiccup) or absent from the
+    record. Returns None when no record matches — caller falls back to the
+    registration/request values.
+    """
+    if not peers:
+        return None
+    if peer_id:
+        for p in peers:
+            if p.get("peer_id") == peer_id:
+                return p
+    for p in peers:
+        if p.get("display_name") == display_name or p.get("name") == display_name:
+            return p
+    return None
+
+
+def format_self_context(
+    *,
+    display_name: str,
+    peer_id: str | None,
+    circle: str,
+    circle_source: str | None,
+    backend: str,
+    role: str | None,
+    cwd: str,
+    branch: str | None,
+    self_peer: dict | None = None,
+) -> str:
+    """Render a 'who you are on the mesh' block from daemon registration result.
+
+    When ``self_peer`` is provided (the daemon's record from /peers), its
+    effective fields win over the registration/request values for
+    display_name, peer_id, circle, backend, role, path, and metadata.branch.
+    This matters when the daemon restored circle/role from persisted state
+    or canonicalized the display_name — the agent sees what other peers
+    will actually see. Request values are only the fallback.
+    """
+    eff_display_name = display_name
+    eff_peer_id = peer_id
+    eff_circle = circle
+    eff_backend = backend
+    eff_role = role
+    eff_path = cwd
+    eff_branch = branch
+
+    if self_peer:
+        eff_display_name = (
+            self_peer.get("display_name") or self_peer.get("name") or eff_display_name
+        )
+        eff_peer_id = self_peer.get("peer_id") or eff_peer_id
+        eff_circle = self_peer.get("circle") or eff_circle
+        eff_backend = self_peer.get("backend") or eff_backend
+        # role is an enum on the daemon side; serialized as a string. Empty
+        # / missing => keep request fallback.
+        peer_role = self_peer.get("role")
+        if peer_role:
+            eff_role = peer_role
+        peer_path = self_peer.get("path")
+        if peer_path:
+            eff_path = peer_path
+        meta_branch = (self_peer.get("metadata") or {}).get("branch")
+        if meta_branch:
+            eff_branch = meta_branch
+
+    source_label = _CIRCLE_SOURCE_LABELS.get(circle_source or "", circle_source or "")
+    circle_str = f"{eff_circle} ({source_label})" if source_label else eff_circle
+    project = Path(eff_path).name or eff_display_name
+
+    lines = ["[Repowire Mesh] You are registered on the mesh as:"]
+    if eff_peer_id:
+        lines.append(f"  - display_name: {eff_display_name}  (peer_id: {eff_peer_id})")
+    else:
+        lines.append(f"  - display_name: {eff_display_name}")
+    lines.append(f"  - circle: {circle_str}")
+    lines.append(f"  - backend: {eff_backend}")
+    if eff_role:
+        lines.append(f"  - role: {eff_role}")
+    lines.append(f"  - project: {project}  (path: {eff_path})")
+    if eff_branch:
+        lines.append(f"  - branch: {eff_branch}")
+    lines.append(
+        f"Peers in circle '{eff_circle}' reach you as @{eff_display_name}. "
+        "Cross-circle replies only land when the asker used reply_to on an "
+        "existing thread."
+    )
+    return "\n".join(lines)
+
+
 def format_peers_context(peers: list[dict], my_name: str) -> str:
     """Format peers into context string for Claude."""
     other_peers = [p for p in peers if p["name"] != my_name and p["status"] == "online"]
@@ -400,18 +504,36 @@ def main(backend: str = "claude-code") -> int:
             # Child inherited the flock via pass_fds; release our copy.
             lock_fd.close()
 
-        # Fetch peers and output context for Claude
+        # Anchor identity from the daemon's effective view of this peer.
+        # /peers is the source of truth — the daemon may have restored
+        # circle/role from persisted state or canonicalized the display
+        # name. Fall back to registration/request values only when the
+        # self record isn't available (e.g. daemon unreachable).
         peers = fetch_peers()
-        if peers:
-            context = format_peers_context(peers, display_name)
-            if context:
-                output = {
-                    "hookSpecificOutput": {
-                        "hookEventName": "SessionStart",
-                        "additionalContext": context,
-                    }
+        self_peer = _find_self_peer(peers, peer_id=peer_id, display_name=display_name)
+        self_context = format_self_context(
+            display_name=display_name,
+            peer_id=peer_id,
+            circle=circle,
+            circle_source=circle_source,
+            backend=backend,
+            role=hint_role,
+            cwd=cwd,
+            branch=branch,
+            self_peer=self_peer,
+        )
+
+        peers_context = format_peers_context(peers, display_name) if peers else ""
+
+        sections = [s for s in (self_context, peers_context) if s]
+        if sections:
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": "\n\n".join(sections),
                 }
-                print(json.dumps(output))
+            }
+            print(json.dumps(output))
 
     elif event == "SessionEnd":
         # Don't mark peer offline here - SessionEnd fires frequently during

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -6,10 +6,167 @@ from pathlib import Path
 from unittest.mock import patch
 
 from repowire.hooks.session_handler import (
+    _find_self_peer,
     format_peers_context,
+    format_self_context,
     get_peer_name,
     main,
 )
+
+
+class TestFindSelfPeer:
+    def test_prefers_peer_id_match(self):
+        peers = [
+            {"peer_id": "repow-other", "display_name": "alice", "name": "alice"},
+            {"peer_id": "repow-me", "display_name": "different-name", "name": "x"},
+        ]
+        result = _find_self_peer(peers, peer_id="repow-me", display_name="alice")
+        assert result is not None
+        assert result["peer_id"] == "repow-me"
+
+    def test_falls_back_to_display_name(self):
+        peers = [
+            {"peer_id": "repow-other", "display_name": "alice", "name": "alice"},
+        ]
+        result = _find_self_peer(peers, peer_id=None, display_name="alice")
+        assert result is not None
+        assert result["display_name"] == "alice"
+
+    def test_returns_none_when_not_found(self):
+        peers = [{"peer_id": "repow-x", "display_name": "x", "name": "x"}]
+        assert _find_self_peer(peers, peer_id="repow-me", display_name="me") is None
+
+    def test_none_peers_list(self):
+        assert _find_self_peer(None, peer_id="x", display_name="x") is None
+
+
+class TestFormatSelfContext:
+    def _base_kwargs(self, **overrides):
+        kwargs = {
+            "display_name": "repowire-claude-code",
+            "peer_id": "repow-default-abc12345",
+            "circle": "default",
+            "circle_source": "tmux",
+            "backend": "claude-code",
+            "role": None,
+            "cwd": "/Users/x/projects/repowire",
+            "branch": None,
+        }
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_includes_peer_id_when_assigned(self):
+        result = format_self_context(**self._base_kwargs())
+        assert "display_name: repowire-claude-code" in result
+        assert "peer_id: repow-default-abc12345" in result
+        assert "circle: default (from tmux session)" in result
+        assert "backend: claude-code" in result
+        assert "project: repowire" in result
+        assert "path: /Users/x/projects/repowire" in result
+        assert "@repowire-claude-code" in result
+
+    def test_omits_peer_id_when_none(self):
+        result = format_self_context(**self._base_kwargs(peer_id=None))
+        assert "display_name: repowire-claude-code" in result
+        assert "peer_id" not in result
+
+    def test_includes_role_when_set(self):
+        result = format_self_context(**self._base_kwargs(role="worker"))
+        assert "role: worker" in result
+
+    def test_omits_role_when_none(self):
+        result = format_self_context(**self._base_kwargs(role=None))
+        assert "role:" not in result
+
+    def test_includes_branch_when_set(self):
+        result = format_self_context(**self._base_kwargs(branch="feat/x"))
+        assert "branch: feat/x" in result
+
+    def test_omits_branch_when_none(self):
+        result = format_self_context(**self._base_kwargs(branch=None))
+        assert "branch:" not in result
+
+    def test_circle_source_tmux_label(self):
+        result = format_self_context(**self._base_kwargs(circle_source="tmux"))
+        assert "(from tmux session)" in result
+
+    def test_circle_source_spawn_hint_label(self):
+        result = format_self_context(
+            **self._base_kwargs(circle="arch", circle_source="spawn_hint"),
+        )
+        assert "circle: arch (from spawn hint)" in result
+
+    def test_circle_source_fallback_label(self):
+        result = format_self_context(
+            **self._base_kwargs(circle="default", circle_source="fallback"),
+        )
+        assert "circle: default (default fallback)" in result
+
+    def test_self_peer_overrides_request_values(self):
+        """Daemon-effective values from /peers win over request defaults.
+
+        Covers the main case for this revision: when the daemon has
+        restored circle/role from persisted state (or canonicalized the
+        display_name), the agent must see those — not the values the
+        hook sent at registration time.
+        """
+        self_peer = {
+            "peer_id": "repow-default-effective-id",
+            "display_name": "canonical-name",
+            "name": "canonical-name",
+            "circle": "restored-circle",
+            "backend": "codex",
+            "role": "worker",
+            "path": "/canonical/path/project-x",
+            "metadata": {"branch": "feat/restored"},
+        }
+        result = format_self_context(
+            **self._base_kwargs(
+                display_name="request-name",
+                peer_id="repow-default-request-id",
+                circle="request-circle",
+                backend="claude-code",
+                role=None,
+                cwd="/request/path/proj",
+                branch="request-branch",
+            ),
+            self_peer=self_peer,
+        )
+        assert "canonical-name" in result
+        assert "request-name" not in result
+        assert "repow-default-effective-id" in result
+        assert "repow-default-request-id" not in result
+        assert "restored-circle" in result
+        assert "request-circle" not in result
+        assert "backend: codex" in result
+        assert "role: worker" in result
+        assert "project: project-x" in result
+        assert "path: /canonical/path/project-x" in result
+        assert "branch: feat/restored" in result
+
+    def test_self_peer_partial_falls_back_per_field(self):
+        """Missing self_peer fields fall back to request values one by one."""
+        self_peer = {"peer_id": "repow-x", "display_name": "x", "circle": "circle-from-peer"}
+        result = format_self_context(
+            **self._base_kwargs(
+                display_name="x",
+                peer_id="repow-x",
+                circle="request-circle",
+                backend="claude-code",
+                role="request-role",
+                branch="request-branch",
+            ),
+            self_peer=self_peer,
+        )
+        assert "circle-from-peer" in result
+        assert "backend: claude-code" in result
+        assert "role: request-role" in result
+        assert "branch: request-branch" in result
+
+    def test_circle_source_none_shows_circle_only(self):
+        result = format_self_context(**self._base_kwargs(circle_source=None))
+        assert "circle: default" in result
+        assert "(" not in result.split("circle: default", 1)[1].split("\n", 1)[0]
 
 
 def _run_with_input(input_data: dict) -> int:


### PR DESCRIPTION
## Summary
- prepend a SessionStart self-identity block with display name, peer id, circle, backend, role, path, and branch
- resolve that block from the daemon's existing /peers view by peer_id first, falling back to registration/request values only when needed
- document the identity-context behavior in the peer identity lifecycle concept doc

## Tests
- uv run pytest tests/test_session_handler.py -x -q -> 33 passed
- uv run ruff check repowire/hooks/session_handler.py tests/test_session_handler.py -> passed
- uv run ty check repowire/hooks/session_handler.py -> passed
- git diff --check -> passed
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers -> advisory only, docs/concepts reviewed
- Earlier worker full suite before the daemon-effective revision: uv run pytest -q -> 1275 passed

Closes repowire-o3g.