### PR TITLE
fix(hooks): cancel tmux copy-mode before injecting keys

### DIFF
--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -77,16 +77,44 @@ def _push_query_cid(pane_id: str, correlation_id: str) -> None:
     push_query_cid(pane_id, correlation_id)
 
 
+def _pane_in_copy_mode(pane_id: str) -> bool:
+    """Return True if the pane is in copy-mode (or any other interactive mode).
+
+    `#{pane_in_mode}` is 1 for copy-mode, view-mode, clock-mode, etc. -X cancel
+    is the correct exit for all of them, so this broad check is fine.
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-t", pane_id, "-p", "#{pane_in_mode}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return False
+        return result.stdout.strip() == "1"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
 def _tmux_send_keys(pane_id: str, text: str) -> bool:
     """Send keys to a tmux pane via subprocess.
 
     Implements Gastown's battle-tested NudgeSession pattern:
-    1. Send text in literal mode (bracketed paste)
-    2. 500ms debounce — tested, required for paste to complete
-    3. Explicitly close bracketed paste mode with ESC[201~
-    4. Enter — submits
+    1. If pane is in copy-mode, cancel out first (otherwise -l lands in the
+       copy buffer and Enter triggers a selection action instead of submit)
+    2. Send text in literal mode (bracketed paste)
+    3. 500ms debounce — tested, required for paste to complete
+    4. Explicitly close bracketed paste mode with ESC[201~
+    5. Enter — submits
     """
     try:
+        if _pane_in_copy_mode(pane_id):
+            subprocess.run(
+                ["tmux", "send-keys", "-t", pane_id, "-X", "cancel"],
+                capture_output=True,
+                check=True,
+            )
         subprocess.run(
             ["tmux", "send-keys", "-t", pane_id, "-l", text],
             capture_output=True,

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -288,20 +288,79 @@ class TestHandleAskAndNotify:
 class TestTmuxSendKeys:
     """Tests for _tmux_send_keys."""
 
+    @staticmethod
+    def _mode_result(in_mode: bool) -> CompletedProcess:
+        return CompletedProcess(
+            args=[], returncode=0, stdout=("1" if in_mode else "0") + "\n", stderr=""
+        )
+
     def test_closes_bracketed_paste_without_bare_escape(self):
+        """Normal mode: no -X cancel issued, just the literal/paste-close/Enter sequence."""
         with (
             patch("repowire.hooks.websocket_hook.subprocess.run") as mock_run,
             patch("repowire.hooks.websocket_hook.time.sleep"),
         ):
+            mock_run.side_effect = [
+                self._mode_result(False),  # display-message (copy-mode probe)
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # -l text
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # -H close
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # Enter
+            ]
             assert _tmux_send_keys("%5", "hello") is True
 
         calls = [call.args[0] for call in mock_run.call_args_list]
         assert calls == [
+            ["tmux", "display-message", "-t", "%5", "-p", "#{pane_in_mode}"],
             ["tmux", "send-keys", "-t", "%5", "-l", "hello"],
             ["tmux", "send-keys", "-t", "%5", "-H", "1b", "5b", "32", "30", "31", "7e"],
             ["tmux", "send-keys", "-t", "%5", "Enter"],
         ]
         assert ["tmux", "send-keys", "-t", "%5", "Escape"] not in calls
+        assert ["tmux", "send-keys", "-t", "%5", "-X", "cancel"] not in calls
+
+    def test_cancels_copy_mode_before_paste(self):
+        """Copy-mode: -X cancel runs before the literal paste, in that order."""
+        with (
+            patch("repowire.hooks.websocket_hook.subprocess.run") as mock_run,
+            patch("repowire.hooks.websocket_hook.time.sleep"),
+        ):
+            mock_run.side_effect = [
+                self._mode_result(True),  # display-message reports copy-mode
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # -X cancel
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # -l text
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # -H close
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),  # Enter
+            ]
+            assert _tmux_send_keys("%5", "hello") is True
+
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        assert calls == [
+            ["tmux", "display-message", "-t", "%5", "-p", "#{pane_in_mode}"],
+            ["tmux", "send-keys", "-t", "%5", "-X", "cancel"],
+            ["tmux", "send-keys", "-t", "%5", "-l", "hello"],
+            ["tmux", "send-keys", "-t", "%5", "-H", "1b", "5b", "32", "30", "31", "7e"],
+            ["tmux", "send-keys", "-t", "%5", "Enter"],
+        ]
+        cancel_idx = calls.index(["tmux", "send-keys", "-t", "%5", "-X", "cancel"])
+        paste_idx = calls.index(["tmux", "send-keys", "-t", "%5", "-l", "hello"])
+        assert cancel_idx < paste_idx, "cancel must precede the literal paste"
+
+    def test_mode_probe_failure_treated_as_not_in_mode(self):
+        """If display-message fails, skip cancel rather than blocking the send."""
+        with (
+            patch("repowire.hooks.websocket_hook.subprocess.run") as mock_run,
+            patch("repowire.hooks.websocket_hook.time.sleep"),
+        ):
+            mock_run.side_effect = [
+                CompletedProcess(args=[], returncode=1, stdout="", stderr="no pane"),
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ]
+            assert _tmux_send_keys("%5", "hello") is True
+
+        calls = [call.args[0] for call in mock_run.call_args_list]
+        assert ["tmux", "send-keys", "-t", "%5", "-X", "cancel"] not in calls
 
 
 class TestIsPaneSafe:


### PR DESCRIPTION
## Summary
- detect when the target tmux pane is in copy/view/clock mode before hook injection
- send `tmux send-keys -X cancel` before the existing literal paste sequence when a mode is active
- preserve normal-mode injection behavior and fall through when the mode probe fails

## Tests
- pytest tests/test_hooks.py -> 41 passed
- uvx ruff check repowire/hooks/websocket_hook.py tests/test_hooks.py -> passed
- uv run ty check repowire/hooks/websocket_hook.py -> passed; pre-existing unrelated unreachable-code diagnostics noted by worker at lines 530/531
- python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers -> advisory only; docs deferred because this is an internal terminal-injection fix with no new public API/config/CLI behavior

Closes repowire-bpy.