### PR TITLE
feat(cli): add agy mesh fallback commands

### DIFF
--- a/docs/agents/antigravity.md
+++ b/docs/agents/antigravity.md
@@ -30,6 +30,24 @@ The Antigravity CLI plugin layout validates cleanly, but two pieces of end-to-en
 
 When upstream lands hook/MCP support, the installer will be tightened to write the verified shapes and `doctor` will flip from `WARN` to `OK` without changes to the surrounding integration.
 
+## CLI fallback (while hooks are pending)
+
+Until `agy` fires plugin hooks, an agy session can still participate in the mesh by shelling out to the daemon over HTTP. Three commands cover the lifecycle:
+
+```bash
+# 1. Self-register the running agy session as a peer (one-time per session).
+repowire peer whoami --register --backend antigravity \
+    --name agy-demo --circle default
+
+# 2. List inbound asks for the current pane (defaults to $TMUX_PANE).
+repowire peer asks
+
+# 3. Close an ask, optionally with a reply.
+repowire peer ack ask-abc123 -m "pong"
+```
+
+All three resolve identity in this order: explicit `--peer-id` / `--pane-id`, `$TMUX_PANE`, then `--peer NAME`. `peer whoami` (no flags) is a read-only check that prints the registered identity for the current pane. See [CLI reference](../reference/cli.md) for full flag listings.
+
 ## Spawn
 
 Default spawn command: `agy --dangerously-skip-permissions`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -87,7 +87,12 @@ repowire peer list                          # god-view list (all circles, includ
 repowire peer describe NAME_OR_ID [--circle C]  # full state for one peer
 repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
 repowire peer prune                         # remove offline peers from the registry
+repowire peer whoami [--register --backend B --name NAME --circle C --path P]  # read-only identity, or self-register
+repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME] [--direction inbound|outbound|both] [--json]
+repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]
 ```
+
+`peer whoami`, `peer asks`, and `peer ack` are the shellable mesh primitives intended for agents whose hooks don't fire today (notably [Antigravity `agy`](../agents/antigravity.md)). They wrap existing daemon HTTP endpoints (`/peers`, `/peers/by-pane`, `/asks/pending`, `/ack`) with no new daemon surface and automatically use the local `daemon.auth_token` when configured. Identity resolves in this order: explicit `--peer-id` → `--pane-id` → `$TMUX_PANE` → `--peer NAME`. Use `peer whoami --register --backend antigravity` once at session start to self-onboard.
 
 `peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP [`list_peers`](mcp-tools.md#list_peers) tool defaults to a peer-facing view (online only, caller hidden).
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -2263,6 +2263,278 @@ def peer_prune(force: bool, dry_run: bool) -> None:
     console.print(f"\n[bold green]Pruned {removed} peer(s)[/]")
 
 
+def _auth_headers() -> dict[str, str]:
+    """Return Authorization headers from daemon.auth_token if configured.
+
+    Reads `~/.repowire/config.yaml` via `load_config()`. Returns an empty dict
+    when no token is set (so callers can always splat `**_auth_headers()`).
+    Swallows config-load errors silently — the daemon will return 401 if auth
+    is actually required, which is a clearer signal than a CLI-side traceback.
+    """
+    try:
+        from repowire.config.models import load_config
+        token = load_config().daemon.auth_token
+    except Exception:
+        return {}
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _resolve_peer_id_for_asks(
+    client: Any,
+    *,
+    peer_id: str | None,
+    pane_id: str | None,
+    peer_name: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve a peer_id for /asks/pending lookup.
+
+    Order: explicit peer_id → explicit pane_id → TMUX_PANE → --peer NAME.
+    Returns (peer_id, error_message). On success error_message is None.
+    """
+    import os
+    from urllib.parse import quote
+
+    daemon = _get_daemon_url()
+    headers = _auth_headers()
+
+    if peer_id:
+        return peer_id, None
+
+    pane = pane_id or os.environ.get("TMUX_PANE")
+    if pane:
+        resp = client.get(f"{daemon}/peers/by-pane/{quote(pane, safe='')}", headers=headers)
+        if resp.status_code == 200:
+            body = resp.json()
+            resolved = body.get("peer_id")
+            if resolved:
+                return resolved, None
+        if not peer_name:
+            return None, (
+                f"No peer registered for pane {pane}. "
+                "Run `repowire peer whoami --register --backend <type>` first."
+            )
+
+    if peer_name:
+        resp = client.get(f"{daemon}/peers/{quote(peer_name, safe='')}", headers=headers)
+        if resp.status_code == 404:
+            return None, f"Peer '{peer_name}' not found"
+        resp.raise_for_status()
+        return resp.json().get("peer_id"), None
+
+    return None, "No peer identity (set TMUX_PANE, or pass --peer-id/--pane-id/--peer)"
+
+
+@peer.command(name="whoami")
+@click.option("--register", is_flag=True, help="Register a new peer instead of read-only lookup")
+@click.option("--name", help="Display name (defaults to current folder name)")
+@click.option(
+    "--backend",
+    type=click.Choice(["claude-code", "codex", "gemini", "antigravity", "opencode", "pi"]),
+    help="Agent backend type (required with --register)",
+)
+@click.option("--circle", "-c", default=None, help="Circle (default: 'default')")
+@click.option("--path", "-p", default=None, help="Working directory (defaults to cwd)")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of formatted text")
+def peer_whoami(
+    register: bool,
+    name: str | None,
+    backend: str | None,
+    circle: str | None,
+    path: str | None,
+    as_json: bool,
+) -> None:
+    """Print current peer identity, or register a new peer with --register.
+
+    Read-only mode (default): uses TMUX_PANE → /peers/by-pane, or --name → /peers/{name}.
+    Register mode: POSTs /peers with backend/circle/path (and TMUX_PANE if present).
+    Designed as the bootstrap entry point for agents whose hooks don't fire (e.g. agy).
+    """
+    import json as _json
+    import os
+    import sys
+    from urllib.parse import quote
+
+    import httpx
+
+    daemon = _get_daemon_url()
+    headers = _auth_headers()
+    pane_id = os.environ.get("TMUX_PANE")
+
+    def _emit(info: dict) -> None:
+        if as_json:
+            click.echo(_json.dumps(info, indent=2))
+        else:
+            console.print(f"[cyan]peer_id:[/] {info.get('peer_id', '')}")
+            display = info.get("display_name") or info.get("name", "")
+            console.print(f"[cyan]display_name:[/] {display}")
+            if info.get("backend"):
+                console.print(f"[cyan]backend:[/] {info['backend']}")
+            if info.get("circle"):
+                console.print(f"[cyan]circle:[/] {info['circle']}")
+            if info.get("status"):
+                console.print(f"[cyan]status:[/] {info['status']}")
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            if register:
+                if not backend:
+                    console.print("[red]--register requires --backend[/]")
+                    sys.exit(2)
+                actual_path = path or str(Path.cwd())
+                actual_name = name or Path(actual_path).name
+                body: dict = {
+                    "name": actual_name,
+                    "path": actual_path,
+                    "backend": backend,
+                    "metadata": {"repowire_cli_fallback": True},
+                }
+                if circle:
+                    body["circle"] = circle
+                if pane_id:
+                    body["pane_id"] = pane_id
+                resp = client.post(f"{daemon}/peers", json=body, headers=headers)
+                if resp.status_code >= 400:
+                    console.print(f"[red]Register failed: {resp.status_code} {resp.text}[/]")
+                    sys.exit(1)
+                data = resp.json()
+                _emit({
+                    "peer_id": data.get("peer_id"),
+                    "display_name": data.get("display_name"),
+                    "backend": backend,
+                    "circle": circle or "default",
+                })
+                return
+
+            # Read-only lookup
+            if pane_id and not name:
+                resp = client.get(
+                    f"{daemon}/peers/by-pane/{quote(pane_id, safe='')}", headers=headers,
+                )
+                if resp.status_code == 200:
+                    _emit(resp.json())
+                    return
+            if name:
+                resp = client.get(f"{daemon}/peers/{quote(name, safe='')}", headers=headers)
+                if resp.status_code == 404:
+                    console.print(f"[red]Peer '{name}' not found[/]")
+                    sys.exit(1)
+                resp.raise_for_status()
+                _emit(resp.json())
+                return
+            console.print(
+                "[yellow]No registered peer for this pane.[/] "
+                "Pass --name to look up by name, or --register to create one."
+            )
+            sys.exit(1)
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+        sys.exit(1)
+
+
+@peer.command(name="asks")
+@click.option("--peer-id", "peer_id", default=None, help="Explicit peer_id to query")
+@click.option("--pane-id", "pane_id", default=None, help="Tmux pane id (overrides $TMUX_PANE)")
+@click.option("--peer", "peer_name", default=None, help="Resolve peer_id via display name")
+@click.option(
+    "--direction",
+    type=click.Choice(["inbound", "outbound", "both"]),
+    default="inbound",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of table")
+def peer_asks(
+    peer_id: str | None,
+    pane_id: str | None,
+    peer_name: str | None,
+    direction: str,
+    as_json: bool,
+) -> None:
+    """List pending asks for this peer (CLI fallback for agents without hooks)."""
+    import json as _json
+    import sys
+
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resolved, err = _resolve_peer_id_for_asks(
+                client, peer_id=peer_id, pane_id=pane_id, peer_name=peer_name,
+            )
+            if err:
+                console.print(f"[red]{err}[/]")
+                sys.exit(1)
+
+            resp = client.get(
+                f"{_get_daemon_url()}/asks/pending",
+                params={"peer_id": resolved, "direction": direction},
+                headers=_auth_headers(),
+            )
+            if resp.status_code >= 400:
+                console.print(f"[red]/asks/pending failed: {resp.status_code} {resp.text}[/]")
+                sys.exit(1)
+            asks = resp.json().get("asks", [])
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+        sys.exit(1)
+
+    if as_json:
+        click.echo(_json.dumps(asks, indent=2))
+        return
+
+    if not asks:
+        console.print("[dim]No pending asks[/]")
+        return
+
+    for a in asks:
+        cid = a.get("correlation_id", "")
+        frm = a.get("from_peer", "?")
+        to = a.get("to_peer", "?")
+        text = (a.get("text") or "").replace("\n", " ")
+        if len(text) > 100:
+            text = text[:97] + "..."
+        console.print(f"[cyan]{cid}[/]  {frm} → {to}  {text}")
+
+
+@peer.command(name="ack")
+@click.argument("correlation_id")
+@click.option("-m", "--message", default=None, help="Optional reply message (closes the thread)")
+@click.option("--from-peer", "from_peer", default=None, help="Acking peer identity (compat-only)")
+def peer_ack(correlation_id: str, message: str | None, from_peer: str | None) -> None:
+    """Close an open ask. With -m, delivers the message as a reply."""
+    import sys
+
+    import httpx
+
+    body: dict = {"correlation_id": correlation_id}
+    if message is not None:
+        body["message"] = message
+    if from_peer:
+        body["from_peer"] = from_peer
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.post(f"{_get_daemon_url()}/ack", json=body, headers=_auth_headers())
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+        sys.exit(1)
+
+    if resp.status_code == 200:
+        console.print(
+            f"[green]Acked #{correlation_id}{' with reply' if message else ''}[/]"
+        )
+        return
+    if resp.status_code == 404:
+        console.print(f"[red]No open ask with correlation_id: {correlation_id}[/]")
+        sys.exit(1)
+    if resp.status_code == 410:
+        console.print(f"[red]Ask {correlation_id} is already closed; reply not delivered[/]")
+        sys.exit(1)
+    if resp.status_code == 503:
+        console.print("[red]Reply delivery failed (asker has no live transport); ask still open[/]")
+        sys.exit(1)
+    console.print(f"[red]/ack failed: {resp.status_code} {resp.text}[/]")
+    sys.exit(1)
+
+
 # =============================================================================
 # hooks command group - backward compatibility alias for claude
 # =============================================================================

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -172,6 +172,11 @@ def _binding_id_for_peer(state: object, peer: Peer | None) -> str | None:
     )
 
 
+def _uses_cli_polling_fallback(peer: Peer) -> bool:
+    """Whether asks can be opened for a peer that polls /asks/pending itself."""
+    return bool(peer.metadata.get("repowire_cli_fallback"))
+
+
 def _emit_ack_event(
     *,
     peer_registry: PeerRegistry,
@@ -411,6 +416,22 @@ async def open_ask(
         await ask_tracker.close(cid, reason="evicted")
         raise HTTPException(status_code=404, detail=str(e))
     except TransportError as e:
+        if _uses_cli_polling_fallback(peer):
+            logger.info(
+                "Ask %s queued for CLI-polling peer %s (%s): %s",
+                cid,
+                peer.display_name,
+                peer.peer_id,
+                e,
+            )
+            if request.reply_to:
+                prior = await ask_tracker.close(request.reply_to, reason="reply_to")
+                if prior is None:
+                    logger.debug(
+                        "ask reply_to=%s: prior ask not found or already closed",
+                        request.reply_to,
+                    )
+            return AskResponse(correlation_id=cid)
         await ask_tracker.close(cid, reason="send_failed")
         raise HTTPException(
             status_code=503,

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -121,6 +121,33 @@ class TestAsk:
         # No phantom open ask should remain
         assert at.open_count() == 0
 
+    async def test_cli_polling_peer_keeps_ask_when_transport_absent(self, env):
+        client, _, at, msg_router = env
+        await _register_peer(client, "alice")
+        r = await client.post("/peers", json={
+            "name": "agy",
+            "path": "/tmp/agy",
+            "circle": "default",
+            "backend": "antigravity",
+            "metadata": {"repowire_cli_fallback": True},
+        })
+        assert r.status_code == 200, r.text
+        agy = r.json()["display_name"]
+        msg_router.send_ask.side_effect = TransportError("No connection")
+
+        r = await client.post("/ask", json={
+            "from_peer": "alice", "to_peer": agy, "text": "?",
+        })
+
+        assert r.status_code == 200, r.text
+        cid = r.json()["correlation_id"]
+        ask = await at.get(cid)
+        assert ask is not None
+        assert not ask.closed
+        pending = await client.get("/asks/pending", params={"peer_id": ask.to_peer_id})
+        assert pending.status_code == 200
+        assert pending.json()["asks"][0]["correlation_id"] == cid
+
     async def test_reply_to_closes_prior(self, env):
         client, _, at, _ = env
         await _register_peer(client, "alice")

--- a/tests/test_cli_peer_agy.py
+++ b/tests/test_cli_peer_agy.py
@@ -1,0 +1,256 @@
+"""CLI tests for agy-mesh fallback commands: peer whoami / asks / ack."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from repowire.cli import main
+
+
+def _make_client(monkeypatch) -> MagicMock:
+    client = MagicMock()
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+    return client
+
+
+def _set_auth_token(monkeypatch, token: str = "secret-token") -> None:
+    monkeypatch.setattr(
+        "repowire.config.models.load_config",
+        lambda: SimpleNamespace(daemon=SimpleNamespace(auth_token=token)),
+    )
+
+
+def _response(status: int = 200, json_body: dict | list | None = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_body if json_body is not None else {}
+    resp.text = text
+    if status >= 400:
+        resp.raise_for_status.side_effect = Exception(f"http {status}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+# --- peer whoami ---------------------------------------------------------------
+
+
+def test_whoami_reads_pane(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX_PANE", "%42")
+    client = _make_client(monkeypatch)
+    client.get.return_value = _response(
+        200,
+        {
+            "peer_id": "p-1",
+            "display_name": "agy-demo",
+            "backend": "antigravity",
+            "circle": "default",
+            "status": "online",
+        },
+    )
+
+    result = CliRunner().invoke(main, ["peer", "whoami"])
+
+    assert result.exit_code == 0, result.output
+    assert "p-1" in result.output
+    assert "agy-demo" in result.output
+    assert "/peers/by-pane/" in client.get.call_args.args[0]
+
+
+def test_whoami_register_posts_with_backend_and_pane(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX_PANE", "%9")
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(
+        200, {"peer_id": "p-99", "display_name": "agy-demo", "ok": True},
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["peer", "whoami", "--register", "--backend", "antigravity",
+         "--name", "agy-demo", "--circle", "default", "--path", "/tmp/x"],
+    )
+
+    assert result.exit_code == 0, result.output
+    body = client.post.call_args.kwargs["json"]
+    assert body == {
+        "name": "agy-demo",
+        "path": "/tmp/x",
+        "backend": "antigravity",
+        "metadata": {"repowire_cli_fallback": True},
+        "circle": "default",
+        "pane_id": "%9",
+    }
+    assert "p-99" in result.output
+
+
+def test_whoami_register_uses_config_auth_token(monkeypatch) -> None:
+    _set_auth_token(monkeypatch)
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(
+        200, {"peer_id": "p-99", "display_name": "agy-demo"},
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["peer", "whoami", "--register", "--backend", "antigravity", "--name", "agy-demo"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+def test_whoami_register_requires_backend(monkeypatch) -> None:
+    _make_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["peer", "whoami", "--register"])
+
+    assert result.exit_code == 2
+    assert "--backend" in result.output
+
+
+def test_whoami_no_pane_no_name_exits_nonzero(monkeypatch) -> None:
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    _make_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["peer", "whoami"])
+
+    assert result.exit_code == 1
+    assert "No registered peer" in result.output
+
+
+# --- peer asks -----------------------------------------------------------------
+
+
+def test_asks_uses_explicit_peer_id(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.get.return_value = _response(
+        200,
+        {"asks": [{
+            "correlation_id": "ask-abc",
+            "from_peer": "claude",
+            "to_peer": "agy-demo",
+            "text": "ping",
+            "created_at": "2026-05-23T10:00:00Z",
+            "direction": "inbound",
+        }]},
+    )
+
+    result = CliRunner().invoke(main, ["peer", "asks", "--peer-id", "p-1"])
+
+    assert result.exit_code == 0, result.output
+    assert client.get.call_args.kwargs["params"] == {"peer_id": "p-1", "direction": "inbound"}
+    assert "ask-abc" in result.output
+    assert "claude" in result.output
+
+
+def test_asks_uses_config_auth_token(monkeypatch) -> None:
+    _set_auth_token(monkeypatch)
+    client = _make_client(monkeypatch)
+    client.get.return_value = _response(200, {"asks": []})
+
+    result = CliRunner().invoke(main, ["peer", "asks", "--peer-id", "p-1"])
+
+    assert result.exit_code == 0, result.output
+    assert client.get.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+def test_asks_resolves_pane_to_peer_id(monkeypatch) -> None:
+    monkeypatch.setenv("TMUX_PANE", "%7")
+    client = _make_client(monkeypatch)
+    client.get.side_effect = [
+        _response(200, {"peer_id": "p-7", "display_name": "agy-demo"}),
+        _response(200, {"asks": []}),
+    ]
+
+    result = CliRunner().invoke(main, ["peer", "asks"])
+
+    assert result.exit_code == 0, result.output
+    assert client.get.call_args_list[0].args[0].endswith("/peers/by-pane/%257")
+    assert client.get.call_args_list[1].kwargs["params"]["peer_id"] == "p-7"
+
+
+def test_asks_no_identity_exits_nonzero(monkeypatch) -> None:
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    _make_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["peer", "asks"])
+
+    assert result.exit_code == 1
+    assert "No peer identity" in result.output
+
+
+def test_asks_json_output(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.get.return_value = _response(200, {"asks": [{"correlation_id": "x"}]})
+
+    result = CliRunner().invoke(main, ["peer", "asks", "--peer-id", "p-1", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"correlation_id"' in result.output
+
+
+# --- peer ack ------------------------------------------------------------------
+
+
+def test_ack_bare(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(200, {"ok": True})
+
+    result = CliRunner().invoke(main, ["peer", "ack", "ask-abc"])
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.kwargs["json"] == {"correlation_id": "ask-abc"}
+    assert "Acked #ask-abc" in result.output
+
+
+def test_ack_with_message_and_from_peer(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(200, {"ok": True})
+
+    result = CliRunner().invoke(
+        main, ["peer", "ack", "ask-abc", "-m", "pong", "--from-peer", "agy-demo"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.kwargs["json"] == {
+        "correlation_id": "ask-abc",
+        "message": "pong",
+        "from_peer": "agy-demo",
+    }
+    assert "with reply" in result.output
+
+
+def test_ack_uses_config_auth_token(monkeypatch) -> None:
+    _set_auth_token(monkeypatch)
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(200, {"ok": True})
+
+    result = CliRunner().invoke(main, ["peer", "ack", "ask-abc"])
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+def test_ack_404(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(404, text="not found")
+
+    result = CliRunner().invoke(main, ["peer", "ack", "missing"])
+
+    assert result.exit_code == 1
+    assert "No open ask" in result.output
+
+
+def test_ack_410_already_closed(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(410, text="closed")
+
+    result = CliRunner().invoke(main, ["peer", "ack", "old", "-m", "late"])
+
+    assert result.exit_code == 1
+    assert "already closed" in result.output

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -53,10 +53,16 @@ repowire service uninstall`}
         usage={`repowire peer list
 repowire peer describe NAME_OR_ID [--circle C]
 repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
-repowire peer prune`}
+repowire peer prune
+repowire peer whoami [--register --backend B --name NAME --circle C --path P]
+repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME]
+repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]`}
       >
         <p>
           Inspect and repair registered peers. <Mono>peer list</Mono> is an operator view across all circles. <Mono>peer describe</Mono> shows one peer&apos;s identity, role, liveness, open asks, and recent events. <Mono>peer claim-role orchestrator</Mono> is a narrow repair command for an existing peer whose durable session mapping lost the orchestrator role after daemon restart; it refuses to demote a fresh online or busy holder unless <Mono>--force</Mono> is passed.
+        </p>
+        <p>
+          <Mono>peer whoami</Mono>, <Mono>peer asks</Mono>, and <Mono>peer ack</Mono> are shellable mesh primitives for runtimes whose hooks do not fire yet. They use the local daemon token automatically and let an Antigravity <Mono>agy</Mono> session self-register, poll pending asks, and close them from a shell.
         </p>
       </Cmd>
 


### PR DESCRIPTION
## Summary

- Add shellable `repowire peer whoami`, `repowire peer asks`, and `repowire peer ack` commands for runtimes whose hooks do not fire yet, especially Antigravity `agy`.
- Mark CLI-registered fallback peers with metadata so `/ask` keeps tracked asks open for polling peers when no live transport exists, while normal peers still 503 and roll back.
- Document the Antigravity CLI fallback in agent docs, CLI reference, and mirrored web CLI docs.

## Validation

- `uv run --extra dev pytest tests/test_cli_peer_agy.py tests/test_ask_routes.py::TestAsk::test_transport_error_returns_503_and_rolls_back tests/test_ask_routes.py::TestAsk::test_cli_polling_peer_keeps_ask_when_transport_absent -q` -> 17 passed
- `uv run --extra dev ruff check repowire/cli.py repowire/daemon/routes/asks.py tests/test_cli_peer_agy.py tests/test_ask_routes.py` -> passed
- `uv run --extra dev ty check repowire/cli.py repowire/daemon/routes/asks.py` -> passed
- `npm run lint -- app/docs/reference/cli/page.tsx` -> passed after `npm ci`
- `uv run --extra dev pytest -q` -> 1299 passed
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> advisory only

## Live smoke

Installed this branch locally, restarted the daemon, then registered a synthetic Antigravity fallback peer via CLI:

```bash
TMUX_PANE='%agytest2' repowire peer whoami --register --backend antigravity --name agy-cli-smoke --circle default --path /tmp/agy-smoke-...
```

Then opened a tracked ask to the new peer id, verified it appeared with:

```bash
repowire peer asks --peer-id <agy-peer-id> --json
```

and closed it with:

```bash
repowire peer ack <cid> -m 'pong from agy CLI fallback smoke' --from-peer <agy-peer-id>
```

The ack reply delivered back to the requester. The synthetic smoke peer was unregistered afterward.

## Notes

This does not claim Antigravity plugin hooks or MCP are working. It is the fallback path until upstream `agy` actually fires plugin hooks or documents MCP plugin wiring.
