### PR TITLE
feat(orchestrator): add persona SOUL support

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -11,4 +11,5 @@ The mental model behind repowire. Read once, refer rarely.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.
 - [Orchestrator pattern](orchestrator.md) — a peer whose job is coordinating other peers.
+- [Personas](personas.md) — SOUL.md identity files for orchestrator and persona sessions.
 - [Session-native roadmap](session-native-roadmap.md) — where the v0.14 architecture train is headed.

--- a/docs/concepts/orchestrator.md
+++ b/docs/concepts/orchestrator.md
@@ -44,6 +44,10 @@ summaries, cleanup, and review nudges, with a clear owner and cancellation path.
 Durable board or memory writes should happen only for real state transitions or
 forward-applicable lessons, not just because a hook fired.
 
+## Persona (SOUL.md)
+
+The orchestrator can carry a persistent identity through a `SOUL.md` file. The active persona is injected into the agent's context at every `SessionStart`, sitting below user/orchestrator directives and above untrusted retrieved content. See [personas](./personas.md) for layout, CLI, and precedence.
+
 ## When *not* to orchestrate
 
 - Two peers, ad-hoc work. Talk directly.

--- a/docs/concepts/personas.md
+++ b/docs/concepts/personas.md
@@ -1,0 +1,70 @@
+# Personas (SOUL.md)
+
+Personas are a lightweight way to give the orchestrator a stable identity, voice, and set of standing preferences. A persona is a single Markdown file called `SOUL.md` that the orchestrator session loads on startup.
+
+> **Status:** experimental. Persona files are framed as identity/context, not as a safety or permission policy. Permissioning is a separate concern.
+
+## Where SOUL.md lives
+
+Two locations are searched, in this order:
+
+1. **Workspace override** — `~/.repowire/orchestrator/personas/<name>/SOUL.md`
+2. **Global persona** — `~/.repowire/personas/<name>/SOUL.md`
+
+Workspace beats global when both exist, so a single orchestrator workspace can carry per-machine tweaks without editing the shared persona file.
+
+## Active persona marker
+
+The orchestrator workspace tracks which persona is active via:
+
+```
+~/.repowire/orchestrator/personas/ACTIVE_PERSONA
+```
+
+This file holds a single line — the persona name. It is set with `repowire orchestrator persona use <name>` and cleared with `repowire orchestrator persona clear`.
+
+## CLI
+
+```bash
+repowire orchestrator persona list           # show discoverable personas
+repowire orchestrator persona show [name]    # print the resolved SOUL.md
+repowire orchestrator persona path [name]    # print just the path
+repowire orchestrator persona use <name>     # set active persona
+repowire orchestrator persona clear          # remove the active marker
+```
+
+`list` marks the active persona with `*` and shows source (`workspace` vs `global`) plus a 12-char SHA-256 prefix so you can confirm what is actually being loaded.
+
+## Injection and precedence
+
+When the orchestrator peer starts, its `SessionStart` hook appends a `[Repowire Persona]` block to the additional context delivered to the agent. The block contains:
+
+- Persona name
+- Resolved SOUL.md path, source (workspace/global), and SHA-256 short hash
+- A precedence preamble
+- The SOUL.md body
+
+The precedence preamble states explicitly that SOUL.md sits **below** platform safety and explicit user/orchestrator directives, and **above** workspace guidance, memory, skills, and untrusted retrieved content. This ordering, from highest to lowest authority:
+
+1. System / platform safety
+2. Explicit user or orchestrator directives in the current turn
+3. **Persona SOUL.md**
+4. Workspace `AGENTS.md`, skills, memory, prior turns
+5. Untrusted retrieved content
+
+Personas are advisory identity context, not a sandbox. Treat them like a profile, not a policy.
+
+## Authoring a SOUL.md
+
+A SOUL.md is freeform Markdown. Useful sections in practice:
+
+- **Identity** — who this persona is and how they introduce themselves
+- **Voice** — tone, format defaults, how they answer
+- **Working preferences** — defaults for handoffs, escalation, when to ask vs decide
+- **Domain context** — projects, peers, recurring patterns they should know
+
+Keep it short. The whole file is replayed into the orchestrator's context on every session start.
+
+## Hash visibility
+
+Every surface that mentions a persona also surfaces its short SHA-256 prefix. If two sessions disagree about what an orchestrator should sound like, comparing hashes is the fastest way to see whether one of them is loading a stale or workspace-overridden copy.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,6 +113,23 @@ Create one-shot or recurring scheduled mesh messages. Without `--cron`, `WHEN_OR
 
 `schedule self` targets the current CLI peer identity by default and is the easiest way to wake the same session later. `schedule create` targets another peer and requires `--from-peer` so the daemon knows who the scheduled message is from. `--kind ask` opens an ask thread when the schedule fires; `notify` is fire-and-forget.
 
+## `repowire orchestrator persona`
+
+```bash
+repowire orchestrator persona list
+repowire orchestrator persona show [NAME]
+repowire orchestrator persona path [NAME]
+repowire orchestrator persona use NAME
+repowire orchestrator persona clear
+```
+
+Manage orchestrator persona `SOUL.md` files. Repowire resolves personas from
+`~/.repowire/orchestrator/personas/<name>/SOUL.md` first, then
+`~/.repowire/personas/<name>/SOUL.md`. `use` writes the workspace active marker,
+and the orchestrator `SessionStart` hook injects the active persona with its
+source path and SHA-256 short hash. Persona context is identity guidance, not a
+permission policy.
+
 ## `repowire build-ui`
 
 ```bash

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1554,6 +1554,118 @@ def orchestrator_start(runtime: str | None, service: bool) -> None:
     console.print(f"[green]✓[/] Orchestrator spawned at [cyan]{result.tmux_session}[/]")
     console.print(f"  Attach: [cyan]tmux attach -t {circle}[/]")
     console.print(f"  Dashboard: {daemon_url}/dashboard")
+    try:
+        from repowire.orchestrator import load_active_soul
+
+        soul = load_active_soul()
+        if soul is not None:
+            console.print(
+                f"  Persona: [cyan]{soul.name}[/] "
+                f"([dim]{soul.source}[/], sha256:{soul.short_hash})"
+            )
+    except Exception:
+        pass
+
+
+# -- orchestrator persona subgroup -------------------------------------------
+
+
+@orchestrator.group(name="persona")
+def orchestrator_persona() -> None:
+    """Manage orchestrator persona SOUL.md files (experimental)."""
+    pass
+
+
+@orchestrator_persona.command(name="list")
+def orchestrator_persona_list() -> None:
+    """List discoverable personas in workspace + global persona dirs."""
+    from repowire.orchestrator import list_personas
+
+    rows = list_personas()
+    if not rows:
+        console.print("[dim]No personas found.[/]")
+        console.print(
+            "Drop a SOUL.md at "
+            "[cyan]~/.repowire/personas/<name>/SOUL.md[/] to get started."
+        )
+        return
+    for row in rows:
+        marker = "[green]*[/]" if row.active else " "
+        console.print(
+            f"{marker} [cyan]{row.name}[/] "
+            f"[dim]({row.source}, sha256:{row.short_hash})[/]\n"
+            f"    {row.path}"
+        )
+
+
+@orchestrator_persona.command(name="show")
+@click.argument("name", required=False)
+def orchestrator_persona_show(name: str | None) -> None:
+    """Show resolved SOUL.md for NAME (or the active persona)."""
+    from repowire.orchestrator import get_active_persona, load_soul
+
+    target = name or get_active_persona()
+    if not target:
+        console.print("[yellow]No persona named and no active persona set.[/]")
+        return
+    soul = load_soul(target)
+    if soul is None:
+        console.print(f"[red]✗[/] No SOUL.md found for persona {target!r}")
+        return
+    console.print(
+        f"[cyan]{soul.name}[/] [dim]({soul.source}, sha256:{soul.short_hash})[/]"
+    )
+    console.print(f"[dim]{soul.path}[/]")
+    console.print()
+    console.print(soul.content.strip())
+
+
+@orchestrator_persona.command(name="use")
+@click.argument("name")
+def orchestrator_persona_use(name: str) -> None:
+    """Mark NAME as the active workspace persona."""
+    from repowire.orchestrator import set_active_persona
+
+    try:
+        soul = set_active_persona(name)
+    except FileNotFoundError as e:
+        console.print(f"[red]✗[/] {e}")
+        return
+    except ValueError as e:
+        console.print(f"[red]✗[/] {e}")
+        return
+    console.print(
+        f"[green]✓[/] Active persona set to [cyan]{soul.name}[/] "
+        f"[dim](source={soul.source}, sha256:{soul.short_hash})[/]"
+    )
+
+
+@orchestrator_persona.command(name="clear")
+def orchestrator_persona_clear() -> None:
+    """Remove the active persona marker."""
+    from repowire.orchestrator import clear_active_persona
+
+    if clear_active_persona():
+        console.print("[green]✓[/] Active persona cleared.")
+    else:
+        console.print("[dim]No active persona was set.[/]")
+
+
+@orchestrator_persona.command(name="path")
+@click.argument("name", required=False)
+def orchestrator_persona_path(name: str | None) -> None:
+    """Print resolved SOUL.md path for NAME (or active persona)."""
+    from repowire.orchestrator import find_soul_path, get_active_persona
+
+    target = name or get_active_persona()
+    if not target:
+        console.print("[yellow]No persona named and no active persona set.[/]")
+        return
+    path, source = find_soul_path(target)
+    if path is None:
+        console.print(f"[red]✗[/] No SOUL.md found for persona {target!r}")
+        return
+    console.print(f"{path} [dim]({source})[/]")
 
 
 @main.group()

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -525,7 +525,25 @@ def main(backend: str = "claude-code") -> int:
 
         peers_context = format_peers_context(peers, display_name) if peers else ""
 
-        sections = [s for s in (self_context, peers_context) if s]
+        persona_context = ""
+        effective_role = (self_peer or {}).get("role") or hint_role
+        if effective_role == "orchestrator":
+            try:
+                from repowire.orchestrator import (
+                    build_soul_context,
+                    load_active_soul,
+                )
+
+                soul = load_active_soul()
+                if soul is not None:
+                    persona_context = build_soul_context(soul)
+            except Exception as e:  # noqa: BLE001 - never block SessionStart
+                print(
+                    f"repowire: persona injection skipped: {e}",
+                    file=sys.stderr,
+                )
+
+        sections = [s for s in (self_context, peers_context, persona_context) if s]
         if sections:
             output = {
                 "hookSpecificOutput": {

--- a/repowire/orchestrator/__init__.py
+++ b/repowire/orchestrator/__init__.py
@@ -8,6 +8,20 @@ template at `repowire/orchestrator/template/`.
 See GitHub issue #38 and `/Users/prass/.claude/plans/plan-it-out-glittery-bentley.md`.
 """
 
+from repowire.orchestrator.persona import (
+    ActiveSoul,
+    PersonaSummary,
+    build_soul_context,
+    clear_active_persona,
+    find_soul_path,
+    get_active_persona,
+    list_personas,
+    load_active_soul,
+    load_soul,
+    set_active_persona,
+    validate_persona_name,
+    write_soul,
+)
 from repowire.orchestrator.workspace import (
     backup_workspace,
     init_workspace,
@@ -18,10 +32,22 @@ from repowire.orchestrator.workspace import (
 )
 
 __all__ = [
+    "ActiveSoul",
+    "PersonaSummary",
     "backup_workspace",
+    "build_soul_context",
+    "clear_active_persona",
+    "find_soul_path",
+    "get_active_persona",
     "init_workspace",
     "is_installed",
+    "list_personas",
+    "load_active_soul",
+    "load_soul",
+    "set_active_persona",
     "update_workspace",
+    "validate_persona_name",
     "validate_workspace",
     "workspace_path",
+    "write_soul",
 ]

--- a/repowire/orchestrator/persona.py
+++ b/repowire/orchestrator/persona.py
@@ -1,0 +1,228 @@
+"""Persona SOUL.md support for orchestrator workspaces."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from repowire.config.models import Config
+from repowire.orchestrator.workspace import workspace_path
+
+_PERSONA_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+ACTIVE_PERSONA_FILE = "ACTIVE_PERSONA"
+SOUL_FILE = "SOUL.md"
+
+
+@dataclass(frozen=True)
+class ActiveSoul:
+    """Resolved persona identity loaded from a SOUL.md file."""
+
+    name: str
+    path: Path
+    sha256: str
+    content: str
+    source: str
+
+    @property
+    def short_hash(self) -> str:
+        return self.sha256[:12]
+
+
+@dataclass(frozen=True)
+class PersonaSummary:
+    """Metadata for a discoverable persona SOUL.md."""
+
+    name: str
+    path: Path
+    source: str
+    sha256: str
+    active: bool = False
+
+    @property
+    def short_hash(self) -> str:
+        return self.sha256[:12]
+
+
+def validate_persona_name(name: str) -> str:
+    """Validate a persona name that maps to a local directory."""
+    cleaned = name.strip()
+    if not _PERSONA_RE.fullmatch(cleaned):
+        raise ValueError("Persona name must match ^[a-zA-Z0-9._-]+$")
+    return cleaned
+
+
+def active_persona_path() -> Path:
+    """Return the workspace-local active persona marker path."""
+    return workspace_path() / "personas" / ACTIVE_PERSONA_FILE
+
+
+def global_persona_dir(name: str) -> Path:
+    """Return ~/.repowire/personas/<name>/."""
+    return Config.get_config_dir() / "personas" / validate_persona_name(name)
+
+
+def workspace_persona_dir(name: str) -> Path:
+    """Return ~/.repowire/orchestrator/personas/<name>/."""
+    return workspace_path() / "personas" / validate_persona_name(name)
+
+
+def default_soul_path(name: str) -> Path:
+    """Default write target for reusable personas."""
+    return global_persona_dir(name) / SOUL_FILE
+
+
+def workspace_soul_path(name: str) -> Path:
+    """Workspace-local override target."""
+    return workspace_persona_dir(name) / SOUL_FILE
+
+
+def find_soul_path(name: str) -> tuple[Path, str] | tuple[None, None]:
+    """Resolve a SOUL.md, preferring workspace-local over global persona."""
+    local = workspace_soul_path(name)
+    if local.is_file():
+        return local, "workspace"
+    global_path = default_soul_path(name)
+    if global_path.is_file():
+        return global_path, "global"
+    return None, None
+
+
+def _hash_content(content: str) -> str:
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def load_soul(name: str) -> ActiveSoul | None:
+    """Load active SOUL.md content and hash for a persona."""
+    path, source = find_soul_path(name)
+    if path is None or source is None:
+        return None
+    content = path.read_text(encoding="utf-8")
+    digest = _hash_content(content)
+    return ActiveSoul(
+        name=validate_persona_name(name),
+        path=path,
+        sha256=digest,
+        content=content,
+        source=source,
+    )
+
+
+def get_active_persona() -> str | None:
+    """Return the workspace active persona name, if configured."""
+    marker = active_persona_path()
+    if not marker.is_file():
+        return None
+    raw = marker.read_text(encoding="utf-8").strip()
+    if not raw:
+        return None
+    return validate_persona_name(raw)
+
+
+def set_active_persona(name: str) -> ActiveSoul:
+    """Set the workspace active persona after verifying its SOUL.md exists."""
+    soul = load_soul(name)
+    if soul is None:
+        raise FileNotFoundError(f"No SOUL.md found for persona {name!r}")
+    marker = active_persona_path()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(f"{soul.name}\n", encoding="utf-8")
+    return soul
+
+
+def clear_active_persona() -> bool:
+    """Remove the active persona marker. Returns True if a marker was cleared."""
+    marker = active_persona_path()
+    if not marker.exists():
+        return False
+    marker.unlink()
+    return True
+
+
+def load_active_soul() -> ActiveSoul | None:
+    """Load the currently active workspace persona, if configured."""
+    name = get_active_persona()
+    if name is None:
+        return None
+    return load_soul(name)
+
+
+def write_soul(
+    name: str, content: str, *, workspace: bool = False, overwrite: bool = False
+) -> Path:
+    """Write SOUL.md for a persona and return the path."""
+    path = workspace_soul_path(name) if workspace else default_soul_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not overwrite:
+        raise FileExistsError(path)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def list_personas() -> list[PersonaSummary]:
+    """List personas discovered in workspace and global persona directories."""
+    found: dict[tuple[str, str], PersonaSummary] = {}
+    active = get_active_persona()
+    active_path = find_soul_path(active)[0] if active else None
+    for source, root in (
+        ("workspace", workspace_path() / "personas"),
+        ("global", Config.get_config_dir() / "personas"),
+    ):
+        if not root.is_dir():
+            continue
+        for soul_path in root.glob(f"*/{SOUL_FILE}"):
+            name = soul_path.parent.name
+            try:
+                validate_persona_name(name)
+            except ValueError:
+                continue
+            content = soul_path.read_text(encoding="utf-8")
+            found[(source, name)] = PersonaSummary(
+                name=name,
+                path=soul_path,
+                source=source,
+                sha256=_hash_content(content),
+                active=active_path is not None and soul_path == active_path,
+            )
+    return sorted(found.values(), key=lambda item: (item.name, item.source))
+
+
+def build_soul_context(soul: ActiveSoul) -> str:
+    """Render SOUL.md for first-turn injection.
+
+    This is intentionally framed as persona context below platform and user
+    directives, not as a safety or permission policy.
+    """
+    return (
+        "[Repowire Persona]\n"
+        f"Active persona: {soul.name}\n"
+        f"SOUL.md: {soul.path} ({soul.source}, sha256:{soul.short_hash})\n\n"
+        "Precedence: system/platform safety and explicit user/orchestrator "
+        "directives override this persona file. Workspace AGENTS.md, skills, "
+        "memory, retrieved context, and untrusted content sit below it.\n\n"
+        f"{soul.content.strip()}"
+    )
+
+
+__all__ = [
+    "ACTIVE_PERSONA_FILE",
+    "SOUL_FILE",
+    "ActiveSoul",
+    "PersonaSummary",
+    "active_persona_path",
+    "build_soul_context",
+    "clear_active_persona",
+    "default_soul_path",
+    "find_soul_path",
+    "get_active_persona",
+    "global_persona_dir",
+    "list_personas",
+    "load_active_soul",
+    "load_soul",
+    "set_active_persona",
+    "validate_persona_name",
+    "workspace_persona_dir",
+    "workspace_soul_path",
+    "write_soul",
+]

--- a/tests/test_orchestrator_persona.py
+++ b/tests/test_orchestrator_persona.py
@@ -1,0 +1,167 @@
+"""Tests for repowire.orchestrator.persona."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from repowire.cli import main
+from repowire.orchestrator import persona
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_config_dir = tmp_path / ".repowire"
+    fake_config_dir.mkdir()
+    monkeypatch.setattr(
+        "repowire.config.models.Config.get_config_dir",
+        classmethod(lambda cls: fake_config_dir),
+    )
+    return fake_config_dir
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_validate_persona_name_accepts_safe_chars() -> None:
+    assert persona.validate_persona_name("anya") == "anya"
+    assert persona.validate_persona_name("Anya-2.0_test") == "Anya-2.0_test"
+
+
+@pytest.mark.parametrize("bad", ["", "../etc", "a/b", "anya!", " "])
+def test_validate_persona_name_rejects_unsafe(bad: str) -> None:
+    with pytest.raises(ValueError):
+        persona.validate_persona_name(bad)
+
+
+def test_find_soul_prefers_workspace_over_global(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "global")
+    _write(
+        tmp_config / "orchestrator" / "personas" / "anya" / "SOUL.md",
+        "workspace",
+    )
+    path, source = persona.find_soul_path("anya")
+    assert source == "workspace"
+    assert path is not None and path.read_text(encoding="utf-8") == "workspace"
+
+
+def test_find_soul_falls_back_to_global(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "global")
+    path, source = persona.find_soul_path("anya")
+    assert source == "global"
+    assert path is not None
+
+
+def test_find_soul_returns_none_when_missing(tmp_config: Path) -> None:
+    path, source = persona.find_soul_path("ghost")
+    assert path is None and source is None
+
+
+def test_load_soul_hashes_content(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "I am Anya.\n")
+    soul = persona.load_soul("anya")
+    assert soul is not None
+    assert soul.name == "anya"
+    assert soul.source == "global"
+    assert len(soul.sha256) == 64
+    assert soul.short_hash == soul.sha256[:12]
+
+
+def test_set_and_clear_active_persona(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "soul")
+    assert persona.get_active_persona() is None
+    persona.set_active_persona("anya")
+    assert persona.get_active_persona() == "anya"
+    active = persona.load_active_soul()
+    assert active is not None and active.name == "anya"
+    assert persona.clear_active_persona() is True
+    assert persona.get_active_persona() is None
+    assert persona.clear_active_persona() is False
+
+
+def test_set_active_persona_rejects_missing(tmp_config: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        persona.set_active_persona("ghost")
+
+
+def test_list_personas_dedupes_and_marks_active(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "global")
+    _write(tmp_config / "personas" / "scout" / "SOUL.md", "scout")
+    _write(
+        tmp_config / "orchestrator" / "personas" / "anya" / "SOUL.md",
+        "workspace",
+    )
+    persona.set_active_persona("anya")
+    listing = persona.list_personas()
+    names = [(p.name, p.source) for p in listing]
+    assert ("anya", "workspace") in names
+    assert ("anya", "global") in names
+    assert ("scout", "global") in names
+    actives = {(p.name, p.source) for p in listing if p.active}
+    assert actives == {("anya", "workspace")}
+
+
+def test_build_soul_context_includes_precedence_and_hash(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "I am Anya.")
+    soul = persona.load_soul("anya")
+    assert soul is not None
+    text = persona.build_soul_context(soul)
+    assert "[Repowire Persona]" in text
+    assert "anya" in text
+    assert soul.short_hash in text
+    assert "Precedence" in text
+    assert "I am Anya." in text
+
+
+def test_write_soul_creates_and_respects_overwrite(tmp_config: Path) -> None:
+    path = persona.write_soul("anya", "first")
+    assert path.read_text(encoding="utf-8") == "first"
+    with pytest.raises(FileExistsError):
+        persona.write_soul("anya", "second")
+    persona.write_soul("anya", "second", overwrite=True)
+    assert path.read_text(encoding="utf-8") == "second"
+
+
+# -- CLI integration --------------------------------------------------------
+
+
+def test_cli_persona_list_empty(tmp_config: Path) -> None:
+    result = CliRunner().invoke(main, ["orchestrator", "persona", "list"])
+    assert result.exit_code == 0
+    assert "No personas found" in result.output
+
+
+def test_cli_persona_use_list_show_clear(tmp_config: Path) -> None:
+    _write(tmp_config / "personas" / "anya" / "SOUL.md", "I am Anya.\n")
+    runner = CliRunner()
+
+    res = runner.invoke(main, ["orchestrator", "persona", "use", "anya"])
+    assert res.exit_code == 0, res.output
+    assert "Active persona set to" in res.output
+
+    res = runner.invoke(main, ["orchestrator", "persona", "list"])
+    assert res.exit_code == 0
+    assert "anya" in res.output
+    assert "*" in res.output
+
+    res = runner.invoke(main, ["orchestrator", "persona", "show"])
+    assert res.exit_code == 0
+    assert "I am Anya." in res.output
+
+    res = runner.invoke(main, ["orchestrator", "persona", "path"])
+    assert res.exit_code == 0
+    assert "SOUL.md" in res.output
+
+    res = runner.invoke(main, ["orchestrator", "persona", "clear"])
+    assert res.exit_code == 0
+    assert "cleared" in res.output
+
+
+def test_cli_persona_use_missing_errors(tmp_config: Path) -> None:
+    res = CliRunner().invoke(main, ["orchestrator", "persona", "use", "ghost"])
+    assert res.exit_code == 0
+    assert "No SOUL.md" in res.output

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -108,6 +108,15 @@ export default function Concepts() {
         </p>
       </Section>
 
+      <Section title="Personas">
+        <p>
+          Orchestrator personas are local <Mono>SOUL.md</Mono> files that define identity, voice, and standing preferences. Repowire resolves workspace personas from <Mono>~/.repowire/orchestrator/personas/&lt;name&gt;/SOUL.md</Mono> before global personas in <Mono>~/.repowire/personas/&lt;name&gt;/SOUL.md</Mono>.
+        </p>
+        <p>
+          <Mono>repowire orchestrator persona use &lt;name&gt;</Mono> marks the active persona. On SessionStart, orchestrator peers receive a persona context block with the resolved source and SHA-256 short hash. This is identity guidance, not a permission policy.
+        </p>
+      </Section>
+
       <Section title="Control surfaces">
         <p>
           The dashboard, Telegram bot, and Slack bot are peers too. They show up in <Mono>list_peers</Mono> alongside agents and can ask, notify, and broadcast.

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -78,6 +78,22 @@ repowire schedule delete SCHEDULE_ID`}
         </p>
       </Cmd>
 
+      <Cmd
+        name="repowire orchestrator persona"
+        usage={`repowire orchestrator persona list
+repowire orchestrator persona show [NAME]
+repowire orchestrator persona path [NAME]
+repowire orchestrator persona use NAME
+repowire orchestrator persona clear`}
+      >
+        <p>
+          Manage orchestrator persona <Mono>SOUL.md</Mono> files. Repowire resolves workspace personas from <Mono>~/.repowire/orchestrator/personas/&lt;name&gt;/SOUL.md</Mono> first, then global personas from <Mono>~/.repowire/personas/&lt;name&gt;/SOUL.md</Mono>. <Mono>use</Mono> writes the workspace active marker.
+        </p>
+        <p>
+          On SessionStart, orchestrator peers receive the active persona with its source path and SHA-256 short hash. Persona context is identity guidance, not a permission policy.
+        </p>
+      </Cmd>
+
       <Cmd name="repowire telegram start" usage="repowire telegram start">
         <p>
           Run the Telegram bot peer. Reads <Mono>TELEGRAM_BOT_TOKEN</Mono> and <Mono>TELEGRAM_CHAT_ID</Mono> from the environment. The bot registers as the <Mono>telegram</Mono> peer; messages from it are framed as human input.


### PR DESCRIPTION
## Summary
- Add orchestrator persona SOUL.md resolution with workspace/global lookup, active marker, content hash, and context rendering.
- Add `repowire orchestrator persona` CLI commands for list/show/path/use/clear and print active persona on orchestrator start.
- Inject active persona context for orchestrator SessionStart only, with precedence framing and docs in markdown plus web docs.

## Verification
- `uv run pytest tests/test_orchestrator_persona.py tests/test_cli_orchestrator.py tests/test_session_handler.py -q` -> 62 passed
- `uv run ruff check` on touched Python/test files -> passed
- `uv run ty check repowire/orchestrator/persona.py repowire/hooks/session_handler.py repowire/cli.py` -> passed
- `npm run lint -- app/docs/concepts/page.tsx app/docs/reference/cli/page.tsx` -> passed
- `npm run build` -> passed
- `uv run pytest -q` -> 1317 passed
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> passed advisory

## Notes
- Commit used `--no-verify` to keep Beads JSONL ledgers out of the product commit.
- Does not ship Prass-specific Anya content in the repo. Local Anya install is a post-merge/local setup step from the existing vault draft.
- Permissioning, memory approval, jobs, and `/give-life` guided persona creation remain deferred.