### PR TITLE
Add durable peer restart command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -86,6 +86,7 @@ repowire peer new PATH [--circle CIRCLE]   # spawn a new peer in tmux
 repowire peer list                          # god-view list (all circles, includes caller)
 repowire peer describe NAME_OR_ID [--circle C]  # full state for one peer
 repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
+repowire peer restart NAME_OR_ID [--circle C] [--dry-run] [-m MESSAGE]
 repowire peer prune                         # remove offline peers from the registry
 repowire peer whoami [--register --backend B --name NAME --circle C --path P]  # read-only identity, or self-register
 repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME] [--direction inbound|outbound|both] [--json]
@@ -99,6 +100,10 @@ repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]
 `peer describe` accepts either a display name (`clitcoin-claude-code`) or a peer id (`repow-5-abd4d21e`). Pass `--circle` when a display name is ambiguous across circles — without it, the command refuses to guess and prints the same misroute-style refusal the daemon emits internally. Output includes identity (project, circle, role, backend), liveness (status, path, machine, last-seen), open ask threads in both directions, and the last few communication events involving the peer. Reads `GET /peers`, `GET /peers/{id}`, `GET /asks/pending?direction=both`, and `GET /events` — no new daemon endpoints.
 
 `peer claim-role orchestrator` repairs an existing registered peer when the durable session mapping has the wrong role after daemon restart. It updates the live peer and its persisted session mapping, demoting offline or stale orchestrator holders in the same circle. It refuses to demote a fresh online/busy holder unless `--force` is passed. Omit `--peer` only from inside a registered peer shell where Repowire can discover the current peer.
+
+`peer restart` intentionally restarts a daemon-spawned peer on the same backend, path, circle, role, and mesh identity. It is for reloading runtime startup context such as `AGENTS.md` or an orchestrator `SOUL.md` without changing the address other peers use. The daemon only preserves the same `peer_id` through the normal exact backend+path reconnect path; it does not force-rebind arbitrary peer IDs. Restart is same-host and daemon-owned-pane only. If the peer was attached manually, the daemon cannot prove it is safe to kill and the command refuses instead of touching the pane. Use `--dry-run` to check whether a peer is restartable.
+
+Restart uses `resume_mode=fresh_runtime_context`. That means the new runtime loads its normal startup context and mesh primer again; it does not guarantee transcript replay or exact backend conversation resume. Any deeper resume behavior is backend capability-specific and should be treated as best effort.
 
 ## `repowire schedule`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,7 +43,7 @@ HTTP MCP is never exposed through the hosted relay. The default stdio MCP server
 
 ## `daemon.spawn`
 
-Spawn is disabled until `allowed_paths` and at least one runtime command are configured. `commands` is keyed by backend (`claude-code`, `codex`, `gemini`, `antigravity`, `opencode`, `pi`) and is the single launch profile used by MCP `spawn_peer`, dashboard spawn, backend switching, and `repowire orchestrator start`.
+Spawn is disabled until `allowed_paths` and at least one runtime command are configured. `commands` is keyed by backend (`claude-code`, `codex`, `gemini`, `antigravity`, `opencode`, `pi`) and is the single launch profile used by MCP `spawn_peer`, dashboard spawn, backend switching, `repowire peer restart`, and `repowire orchestrator start`.
 
 `allowed_commands` is a deprecated compatibility field. When present in an older config, Repowire normalizes it into `commands` while loading config; new configs should not add it.
 

--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -93,6 +93,8 @@ outbound = await client.pending_asks(peer_id=peer.peer_id, direction="outbound")
 
 `spawn` launches a new agent session subject to `daemon.spawn.commands` and `daemon.spawn.allowed_paths`. `spawn_config` reports which backend launch profiles are configured. Omit `circle` to use the daemon default (`default`), or pass it explicitly for another circle. `kill_peer` terminates a peer cleanly.
 
+`restart_peer` intentionally restarts a daemon-spawned peer on the same backend, path, circle, role, and mesh identity. It refuses cross-host peers and panes the daemon cannot prove it spawned. The response includes `resume_mode`; the first mode is `fresh_runtime_context`, which reloads startup context but does not guarantee transcript replay or exact backend conversation resume.
+
 ```python
 info = await client.spawn_config()
 if "claude-code" in info.commands:
@@ -103,6 +105,9 @@ if "claude-code" in info.commands:
         message="help me draft a reference page",
     )
     print(spawn.display_name, spawn.tmux_session)
+
+restart = await client.restart_peer("project-c-claude-code", dry_run=True)
+print(restart.status, restart.resume_mode)
 ```
 
 ## Errors

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -2285,6 +2285,65 @@ def peer_unregister(name: str) -> None:
         console.print(f"[red]Failed to unregister peer: {e}[/]")
 
 
+@peer.command(name="restart")
+@click.argument("name")
+@click.option("--circle", "-c", help="Circle to scope display-name lookup")
+@click.option("--from-peer", help="Caller peer identity for future authorization")
+@click.option("--dry-run", is_flag=True, help="Check restart capability without killing")
+@click.option("--message", "-m", help="Optional seed message for the restarted runtime")
+def peer_restart(
+    name: str,
+    circle: str | None,
+    from_peer: str | None,
+    dry_run: bool,
+    message: str | None,
+) -> None:
+    """Restart a daemon-spawned peer while preserving mesh identity."""
+    from urllib.parse import quote
+
+    import httpx
+
+    body: dict[str, object] = {"dry_run": dry_run}
+    if circle:
+        body["circle"] = circle
+    if from_peer:
+        body["from_peer"] = from_peer
+    if message:
+        body["message"] = message
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(
+                f"{_get_daemon_url()}/peers/{quote(name, safe='')}/restart",
+                json=body,
+            )
+            if resp.status_code == 404:
+                raise click.ClickException(f"Peer '{name}' not found")
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.ConnectError:
+        raise click.ClickException(
+            "Cannot connect to daemon. Run 'repowire serve' first."
+        ) from None
+    except httpx.HTTPStatusError as e:
+        detail = e.response.text
+        try:
+            detail = e.response.json().get("detail", detail)
+        except ValueError:
+            pass
+        raise click.ClickException(f"Failed to restart peer: {detail}") from e
+
+    action = "Restart available" if dry_run else "Restarted"
+    console.print(
+        f"[green]✓[/] {action} for [cyan]{data.get('display_name')}[/] "
+        f"([dim]{data.get('peer_id')}[/])"
+    )
+    console.print(f"  backend: {data.get('backend')}")
+    console.print(f"  mode: {data.get('resume_mode')}")
+    if data.get("tmux_session"):
+        console.print(f"  tmux: {data.get('tmux_session')}")
+
+
 @peer.command(name="ask")
 @click.argument("name")
 @click.argument("query")

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -167,6 +167,23 @@ class KillPeerResult(BaseModel):
     tmux_killed: bool | None = None
 
 
+class RestartPeerResult(BaseModel):
+    """Result of restarting a registered peer."""
+
+    ok: bool = True
+    status: str
+    restarted: bool = False
+    peer_id: str
+    display_name: str
+    backend: str
+    path: str
+    circle: str
+    tmux_session: str | None = None
+    resume_mode: str = "fresh_runtime_context"
+    unsupported_reason: str | None = None
+    command: str | None = None
+
+
 class AttachmentInfo(BaseModel):
     """Uploaded attachment metadata."""
 
@@ -575,6 +592,31 @@ class AsyncRepowireClient:
             await self._request("POST", "/kill-peer", json=payload)
         )
 
+    async def restart_peer(
+        self,
+        peer_identifier: str,
+        *,
+        circle: str | None = None,
+        from_peer: str | None = None,
+        dry_run: bool = False,
+        message: str | None = None,
+    ) -> RestartPeerResult:
+        """Restart a registered daemon-spawned peer on the same backend."""
+        payload: dict[str, Any] = {"dry_run": dry_run}
+        if circle is not None:
+            payload["circle"] = circle
+        if from_peer is not None:
+            payload["from_peer"] = from_peer
+        if message is not None:
+            payload["message"] = message
+        return RestartPeerResult.model_validate(
+            await self._request(
+                "POST",
+                f"/peers/{quote(peer_identifier, safe='')}/restart",
+                json=payload,
+            )
+        )
+
     async def upload_attachment(
         self,
         file: bytes | str | Path,
@@ -621,6 +663,7 @@ __all__ = [
     "PendingAsk",
     "QueryResult",
     "RegisterPeerResult",
+    "RestartPeerResult",
     "SpawnConfigInfo",
     "SpawnResult",
     "ToolCall",

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -131,6 +131,10 @@ class ClaimRoleResponse(BaseModel):
 class RegisterPeerRequest(BaseModel):
     """Request to register a peer."""
 
+    peer_id: str | None = Field(
+        None,
+        description="Optional daemon-assigned peer_id for same-identity reconnect",
+    )
     name: str = Field(..., min_length=1, pattern=r"^[a-zA-Z0-9._-]+$", description="Peer name")
     path: str | None = Field(None, description="Working directory path")
     machine: str | None = Field(None, description="Machine hostname")
@@ -343,6 +347,7 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
             metadata=request.metadata,
             machine=request.machine or socket.gethostname(),
             role=request.role,
+            peer_id=request.peer_id,
             turn_state=request.turn_state,
             initial_status=(
                 PeerStatus.OFFLINE

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -371,9 +371,248 @@ class SwitchBackendResponse(BaseModel):
     command: str = Field(..., description="The configured backend command used to spawn")
 
 
+class RestartPeerRequest(BaseModel):
+    """Request to intentionally restart a peer on the same backend."""
+
+    circle: str | None = Field(None, description="Circle to scope display-name lookup")
+    from_peer: str | None = Field(
+        None, description="Caller peer_id or display_name — used for future authorization"
+    )
+    dry_run: bool = Field(False, description="Validate restart capability without killing")
+    message: str | None = Field(
+        None,
+        description=(
+            "Optional seed message delivered to the restarted runtime after boot. "
+            "Does not imply backend transcript resume."
+        ),
+    )
+
+
+class RestartPeerResponse(BaseModel):
+    """Result of a peer restart request."""
+
+    ok: bool = True
+    status: str
+    restarted: bool = False
+    peer_id: str
+    display_name: str
+    backend: AgentType
+    path: str
+    circle: str
+    tmux_session: str | None = None
+    resume_mode: str = "fresh_runtime_context"
+    unsupported_reason: str | None = None
+    command: str | None = None
+
+
 def _command_for_backend(new_backend: AgentType) -> str | None:
     """Return the configured command for a backend/runtime profile."""
     return _runtime_commands().get(new_backend)
+
+
+@router.post("/peers/{name}/restart", response_model=RestartPeerResponse)
+async def restart_peer(
+    name: str,
+    request: RestartPeerRequest,
+    _: str | None = Depends(require_auth),
+) -> RestartPeerResponse:
+    """Restart a daemon-spawned peer while preserving mesh identity.
+
+    This is intentionally narrower than transcript resume. It kills a
+    daemon-owned local pane, respawns the same backend/path/circle, and passes
+    the existing peer_id through the spawn hint so the new SessionStart can
+    reconnect to the same mesh identity. Backends reload their normal runtime
+    context on startup; exact conversation resume is backend-specific and not
+    claimed here.
+    """
+    peer_registry = get_peer_registry()
+    await peer_registry.lazy_repair()
+    await _authorize_kill(peer_registry, request.from_peer)
+    resolved = await peer_registry.resolve_peer_strict(name, circle=request.circle)
+
+    if isinstance(resolved, list):
+        if not resolved:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Peer not found: {name}",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": f"Ambiguous peer identifier: {name}",
+                "candidates": [
+                    {
+                        "peer_id": p.peer_id,
+                        "display_name": p.display_name,
+                        "circle": p.circle,
+                        "tmux_session": p.tmux_session,
+                    }
+                    for p in resolved
+                ],
+            },
+        )
+
+    peer = resolved
+    self_machine = socket.gethostname()
+    if peer.machine and peer.machine != self_machine:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "cross_host",
+                "hint": "Peer restart is same-host only in this slice.",
+                "peer_machine": peer.machine,
+                "self_machine": self_machine,
+            },
+        )
+
+    if not peer.path:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "missing_path",
+                "hint": "Peer has no recorded working directory; cannot restart.",
+            },
+        )
+
+    command = _command_for_backend(peer.backend)
+    if command is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "command_unavailable",
+                "hint": (
+                    f"No entry in daemon.spawn.commands maps to {peer.backend.value!r}. "
+                    f"Add daemon.spawn.commands.{peer.backend.value} to ~/.repowire/config.yaml."
+                ),
+                "backend": peer.backend.value,
+            },
+        )
+
+    _validate_spawn_path(peer.path)
+
+    if not peer.pane_id or peer.pane_id not in _SPAWNED_PANE_IDS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "unsupported_pane_ownership",
+                "hint": (
+                    "Restart only supports daemon-spawned peers in this slice. "
+                    "Externally attached peers are left untouched."
+                ),
+                "pane_id": peer.pane_id,
+            },
+        )
+
+    spawn_circle = peer.circle or "default"
+    resolved_path = str(Path(peer.path).expanduser().resolve())
+    if request.dry_run:
+        return RestartPeerResponse(
+            status="restart_available",
+            restarted=False,
+            peer_id=peer.peer_id,
+            display_name=peer.display_name,
+            backend=peer.backend,
+            path=resolved_path,
+            circle=spawn_circle,
+            tmux_session=peer.tmux_session,
+            command=command,
+        )
+
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    try:
+        await ask_tracker.begin_quiesce(peer.peer_id)
+    except QuiesceFailedError as e:
+        if not e.open_cids:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "restart_in_progress",
+                    "hint": "Another restart/switch is in progress for this peer. Retry shortly.",
+                },
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "in_flight_asks",
+                "hint": (
+                    "Peer has open asks; restart would orphan them. "
+                    "Retry after they're acked or evicted."
+                ),
+                "open_asks": e.open_cids,
+            },
+        ) from e
+
+    try:
+        pane_id = peer.pane_id
+        if not pane_id or pane_id not in _SPAWNED_PANE_IDS:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error": "unsupported_pane_ownership",
+                    "hint": "Peer pane ownership changed before restart could begin.",
+                    "pane_id": pane_id,
+                },
+            )
+        if not kill_pane(pane_id):
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={
+                    "error": "kill_failed",
+                    "hint": (
+                        "tmux kill-pane failed for the peer's pane; the old runtime may "
+                        "still be alive. Aborting restart to avoid duplicate runtimes."
+                    ),
+                    "pane_id": pane_id,
+                },
+            )
+        _SPAWNED_PANE_IDS.discard(pane_id)
+        await peer_registry.mark_offline(peer.peer_id)
+
+        try:
+            result: SpawnResult = spawn_peer(
+                SpawnConfig(
+                    path=resolved_path,
+                    circle=spawn_circle,
+                    backend=peer.backend,
+                    command=command,
+                    message=request.message,
+                    role=peer.role.value,
+                    peer_id=peer.peer_id,
+                )
+            )
+        except (ValueError, RuntimeError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
+            ) from e
+
+        if result.pane_id:
+            _SPAWNED_PANE_IDS.add(result.pane_id)
+            task = asyncio.create_task(
+                post_spawn_warmup(
+                    peer.backend,
+                    result.pane_id,
+                    path=resolved_path,
+                    circle=spawn_circle,
+                    message=result.message,
+                )
+            )
+            _BACKGROUND_TASKS.add(task)
+            task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+        return RestartPeerResponse(
+            status="restarted",
+            restarted=True,
+            peer_id=peer.peer_id,
+            display_name=peer.display_name,
+            backend=peer.backend,
+            path=resolved_path,
+            circle=spawn_circle,
+            tmux_session=result.tmux_session,
+            command=command,
+        )
+    finally:
+        await ask_tracker.end_quiesce(peer.peer_id)
 
 
 @router.post("/peers/{name}/switch-backend", response_model=SwitchBackendResponse)

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -63,6 +63,7 @@ def _register_peer_http(
     circle: str,
     backend: AgentType,
     *,
+    peer_id: str | None = None,
     circle_source: str | None = None,
     pane_id: str | None = None,
     metadata: dict | None = None,
@@ -85,6 +86,8 @@ def _register_peer_http(
         "circle": circle,
         "backend": backend,
     }
+    if peer_id:
+        payload["peer_id"] = peer_id
     if circle_source:
         payload["circle_source"] = circle_source
     if pane_id:
@@ -389,6 +392,9 @@ def main(backend: str = "claude-code") -> int:
             circle = "default"
             circle_source = "fallback"
         hint_role = hint.get("role") if hint else None
+        hint_peer_id = hint.get("peer_id") if hint else None
+        if not isinstance(hint_peer_id, str):
+            hint_peer_id = None
         # Spawn-seed-drop guard: if the daemon spawned this peer with a seed
         # message, mark turn_state=pending_first_turn so orchestrators can
         # see the brief never landed and re-send via notify_peer. The first
@@ -419,6 +425,7 @@ def main(backend: str = "claude-code") -> int:
             cwd,
             circle,
             backend_type,
+            peer_id=hint_peer_id,
             circle_source=circle_source,
             pane_id=pane_id,
             metadata=metadata,

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -26,6 +26,7 @@ class SpawnConfig:
     command: str = ""  # Full command to run (e.g., "claude --model opus")
     message: str | None = None  # Optional warmup intent passed to post_spawn_warmup
     role: str | None = None  # Optional peer role (e.g. "orchestrator"); default agent
+    peer_id: str | None = None  # Optional same-id reconnect hint for durable restart
 
     @property
     def display_name(self) -> str:
@@ -90,6 +91,7 @@ def spawn_peer(config: SpawnConfig) -> SpawnResult:
         config.backend.value,
         config.circle,
         role=config.role,
+        peer_id=config.peer_id,
         pending_first_turn=bool(config.message),
     )
 

--- a/repowire/spawn_hints.py
+++ b/repowire/spawn_hints.py
@@ -57,6 +57,7 @@ def write_hint(
     circle: str,
     *,
     role: str | None = None,
+    peer_id: str | None = None,
     pending_first_turn: bool = False,
 ) -> None:
     """Record spawn intent so a peer registering from this path+backend can
@@ -75,6 +76,8 @@ def write_hint(
     }
     if role:
         payload["role"] = role
+    if peer_id:
+        payload["peer_id"] = peer_id
     if pending_first_turn:
         payload["pending_first_turn"] = True
     target = _hint_path(path, backend)
@@ -102,8 +105,8 @@ def consume_hint(path: str, backend: str) -> str | None:
 def consume_hint_full(path: str, backend: str) -> dict | None:
     """Read and delete the spawn hint for (path, backend), returning the full payload.
 
-    Returns a dict with at least 'circle' (str), and optionally 'role' (str).
-    None when no fresh hint exists.
+    Returns a dict with at least 'circle' (str), and optionally 'role' (str)
+    and 'peer_id' (str). None when no fresh hint exists.
     """
     target = _hint_path(path, backend)
     queue = _read_hint_queue(target)
@@ -141,6 +144,9 @@ def consume_hint_full(path: str, backend: str) -> dict | None:
     role = selected.get("role")
     if isinstance(role, str) and role:
         out["role"] = role
+    peer_id = selected.get("peer_id")
+    if isinstance(peer_id, str) and peer_id:
+        out["peer_id"] = peer_id
     if selected.get("pending_first_turn") is True:
         out["pending_first_turn"] = True
     return out

--- a/tests/test_cli_peer_agy.py
+++ b/tests/test_cli_peer_agy.py
@@ -37,6 +37,16 @@ def _response(status: int = 200, json_body: dict | list | None = None, text: str
     return resp
 
 
+def _http_status_error(response: MagicMock):
+    import httpx
+
+    request = httpx.Request("POST", "http://127.0.0.1:8377/test")
+    raw = httpx.Response(response.status_code, request=request, text=response.text)
+    raw._json = response.json.return_value  # type: ignore[attr-defined]
+    raw.json = response.json
+    return httpx.HTTPStatusError("error", request=request, response=raw)
+
+
 # --- peer whoami ---------------------------------------------------------------
 
 
@@ -121,6 +131,103 @@ def test_whoami_no_pane_no_name_exits_nonzero(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "No registered peer" in result.output
+
+
+# --- peer asks -----------------------------------------------------------------
+
+
+def test_peer_restart_posts_request_and_prints_response(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(
+        200,
+        {
+            "ok": True,
+            "status": "restarted",
+            "restarted": True,
+            "peer_id": "repow-default-abc12345",
+            "display_name": "proj-claude-code",
+            "backend": "claude-code",
+            "path": "/tmp/proj",
+            "circle": "default",
+            "tmux_session": "default:proj",
+            "resume_mode": "fresh_runtime_context",
+            "command": "claude",
+        },
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "peer",
+            "restart",
+            "proj-claude-code",
+            "--circle",
+            "default",
+            "--from-peer",
+            "dashboard",
+            "--message",
+            "reload context",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.args[0].endswith("/peers/proj-claude-code/restart")
+    assert client.post.call_args.kwargs["json"] == {
+        "dry_run": False,
+        "circle": "default",
+        "from_peer": "dashboard",
+        "message": "reload context",
+    }
+    assert "Restarted" in result.output
+    assert "fresh_runtime_context" in result.output
+    assert "default:proj" in result.output
+
+
+def test_peer_restart_dry_run_output(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    client.post.return_value = _response(
+        200,
+        {
+            "ok": True,
+            "status": "restart_available",
+            "restarted": False,
+            "peer_id": "repow-default-abc12345",
+            "display_name": "proj-claude-code",
+            "backend": "claude-code",
+            "path": "/tmp/proj",
+            "circle": "default",
+            "tmux_session": "default:proj",
+            "resume_mode": "fresh_runtime_context",
+        },
+    )
+
+    result = CliRunner().invoke(main, ["peer", "restart", "proj-claude-code", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert client.post.call_args.kwargs["json"] == {"dry_run": True}
+    assert "Restart available" in result.output
+
+
+def test_peer_restart_prints_http_error_detail(monkeypatch) -> None:
+    client = _make_client(monkeypatch)
+    response = _response(
+        409,
+        {
+            "detail": {
+                "error": "unsupported_pane_ownership",
+                "hint": "Restart only supports daemon-spawned peers in this slice.",
+            }
+        },
+        text="conflict",
+    )
+    response.raise_for_status.side_effect = _http_status_error(response)
+    client.post.return_value = response
+
+    result = CliRunner().invoke(main, ["peer", "restart", "proj-claude-code"])
+
+    assert result.exit_code != 0
+    assert "Failed to restart peer" in result.output
+    assert "unsupported_pane_ownership" in result.output
 
 
 # --- peer asks -----------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ from httpx import ASGITransport, AsyncClient
 from repowire.client import AsyncRepowireClient, ClientPeer, ToolCall
 from repowire.config.models import Config, DaemonConfig
 from repowire.daemon.ask_tracker import AskTracker
-from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.deps import cleanup_deps, get_config, init_deps
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
@@ -84,6 +84,45 @@ async def test_health_and_spawn_config(client: AsyncRepowireClient):
     assert spawn_config.enabled is False
     assert spawn_config.commands == {}
     assert spawn_config.allowed_commands == []
+
+
+async def test_restart_peer_client_posts_payload(client: AsyncRepowireClient, tmp_path: Path):
+    cfg = get_config()
+    cfg.daemon.spawn.commands[spawn_routes.AgentType.CLAUDE_CODE] = "claude"
+    cfg.daemon.spawn.allowed_paths = ["/"]
+    registered = await client.register_peer(
+        "proj",
+        path=str(tmp_path),
+        circle="default",
+        pane_id="%77",
+    )
+    spawn_routes._SPAWNED_PANE_IDS.add("%77")
+    try:
+        with patch.object(spawn_routes, "kill_pane", return_value=True), \
+            patch.object(
+                spawn_routes,
+                "spawn_peer",
+                return_value=spawn_routes.SpawnResult(
+                    display_name="proj",
+                    tmux_session="default:proj",
+                    pane_id="%88",
+                ),
+            ), \
+            patch.object(spawn_routes, "post_spawn_warmup", new_callable=AsyncMock):
+            result = await client.restart_peer(
+                registered.peer_id,
+                circle="default",
+                from_peer="dashboard",
+                message="reload context",
+            )
+    finally:
+        spawn_routes._SPAWNED_PANE_IDS.discard("%77")
+        spawn_routes._SPAWNED_PANE_IDS.discard("%88")
+
+    assert result.status == "restarted"
+    assert result.restarted is True
+    assert result.peer_id == registered.peer_id
+    assert result.resume_mode == "fresh_runtime_context"
 
 
 def test_client_peer_defaults_to_daemon_default_circle():

--- a/tests/test_restart_peer_route.py
+++ b/tests/test_restart_peer_route.py
@@ -1,0 +1,221 @@
+"""HTTP route tests for POST /peers/{name}/restart."""
+
+from __future__ import annotations
+
+import socket
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import peers as peers_routes
+from repowire.daemon.routes import spawn as spawn_routes
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import PeerRole
+from repowire.spawn import SpawnResult
+
+
+def _make_test_app(tmp_path: Path):
+    cfg = Config()
+    cfg.daemon.spawn.commands = {
+        AgentType.CLAUDE_CODE: "claude",
+        AgentType.CODEX: "codex",
+    }
+    cfg.daemon.spawn.allowed_paths = ["/"]
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    ask_tracker = AskTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        ask_tracker=ask_tracker,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+    app_state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=tracker,
+        ask_tracker=ask_tracker,
+        message_router=router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, app_state)
+    app = FastAPI()
+    app.include_router(peers_routes.router)
+    app.include_router(spawn_routes.router)
+    return app, registry, ask_tracker
+
+
+@pytest.fixture
+async def env(tmp_path):
+    spawn_routes._SPAWNED_PANE_IDS.clear()
+    app, registry, ask_tracker = _make_test_app(tmp_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield SimpleNamespace(client=client, registry=registry, ask_tracker=ask_tracker)
+    spawn_routes._SPAWNED_PANE_IDS.clear()
+    cleanup_deps()
+
+
+async def _register(
+    client: AsyncClient,
+    *,
+    path: str,
+    backend: str = "claude-code",
+    role: str = "agent",
+    pane_id: str = "%101",
+    machine: str | None = None,
+) -> str:
+    response = await client.post(
+        "/peers",
+        json={
+            "name": Path(path).name,
+            "path": path,
+            "circle": "default",
+            "backend": backend,
+            "machine": machine or socket.gethostname(),
+            "role": role,
+            "pane_id": pane_id,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["display_name"]
+
+
+def _spawn_result(pane_id: str = "%202") -> SpawnResult:
+    return SpawnResult(
+        display_name="proj",
+        tmux_session="default:proj",
+        pane_id=pane_id,
+    )
+
+
+class TestRestartPeerRoute:
+    async def test_daemon_owned_success_preserves_peer_id_and_role(self, env, tmp_path):
+        name = await _register(
+            env.client,
+            path=str(tmp_path),
+            role=PeerRole.ORCHESTRATOR.value,
+            pane_id="%101",
+        )
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        spawn_routes._SPAWNED_PANE_IDS.add("%101")
+
+        with patch.object(spawn_routes, "kill_pane", return_value=True) as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer", return_value=_spawn_result()) as mock_spawn, \
+            patch.object(spawn_routes, "post_spawn_warmup", new_callable=AsyncMock):
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"message": "reload context"},
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "restarted"
+        assert body["restarted"] is True
+        assert body["peer_id"] == peer.peer_id
+        assert body["display_name"] == peer.display_name
+        assert body["resume_mode"] == "fresh_runtime_context"
+        mock_kill.assert_called_once_with("%101")
+        spawn_cfg = mock_spawn.call_args.args[0]
+        assert spawn_cfg.peer_id == peer.peer_id
+        assert spawn_cfg.backend is AgentType.CLAUDE_CODE
+        assert spawn_cfg.path == str(tmp_path.resolve())
+        assert spawn_cfg.role == PeerRole.ORCHESTRATOR.value
+        assert spawn_cfg.message == "reload context"
+        assert "%101" not in spawn_routes._SPAWNED_PANE_IDS
+        assert "%202" in spawn_routes._SPAWNED_PANE_IDS
+        restarted_peer = await env.registry.get_peer(peer.peer_id)
+        assert restarted_peer is not None
+        assert restarted_peer.status.value == "offline"
+
+    async def test_dry_run_reports_available_without_kill_or_spawn(self, env, tmp_path):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%101")
+        spawn_routes._SPAWNED_PANE_IDS.add("%101")
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "restart_available"
+        assert response.json()["restarted"] is False
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    async def test_non_daemon_owned_pane_is_refused(self, env, tmp_path):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%external")
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(f"/peers/{name}/restart", json={})
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["error"] == "unsupported_pane_ownership"
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+        assert await env.registry.get_peer(name) is not None
+
+    async def test_open_ask_blocks_restart(self, env, tmp_path):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%101")
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        spawn_routes._SPAWNED_PANE_IDS.add("%101")
+        cid = await env.ask_tracker.register(
+            from_peer_id="dashboard",
+            from_peer_name="dashboard",
+            to_peer_id=peer.peer_id,
+            to_peer_name=peer.display_name,
+            text="still working?",
+        )
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(f"/peers/{name}/restart", json={})
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert detail["error"] == "in_flight_asks"
+        assert cid in detail["open_asks"]
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+        assert await env.registry.get_peer(name) is not None
+
+    async def test_spawn_failure_releases_quiesce_and_old_pane_ownership(self, env, tmp_path):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%101")
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        spawn_routes._SPAWNED_PANE_IDS.add("%101")
+
+        with patch.object(spawn_routes, "kill_pane", return_value=True), \
+            patch.object(spawn_routes, "spawn_peer", side_effect=RuntimeError("tmux failed")):
+            response = await env.client.post(f"/peers/{name}/restart", json={})
+
+        assert response.status_code == 500
+        assert "tmux failed" in response.text
+        assert peer.peer_id not in env.ask_tracker._quiescing
+        assert "%101" not in spawn_routes._SPAWNED_PANE_IDS
+        kept = await env.registry.get_peer(peer.peer_id)
+        assert kept is not None
+        assert kept.status.value == "offline"

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -312,6 +312,44 @@ class TestSessionMain:
         "repowire.hooks.session_handler.get_tmux_info",
         return_value={
             "pane_id": "%1",
+            "session_name": None,
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.subprocess.Popen")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    def test_session_start_uses_restart_peer_id_hint(
+        self, mock_branch, mock_status, mock_popen, mock_tmux, mock_register, mock_fetch, tmp_path,
+    ):
+        from repowire.spawn_hints import write_hint
+
+        with patch("repowire.config.models.CACHE_DIR", tmp_path):
+            write_hint(
+                str(tmp_path),
+                "claude-code",
+                "default",
+                peer_id="repow-default-restart1",
+            )
+            result = _run_with_input({
+                "hook_event_name": "SessionStart",
+                "cwd": str(tmp_path),
+                "session_id": "abc12345-rest",
+            })
+            assert result == 0
+            call_args = mock_register.call_args
+            assert call_args.kwargs["peer_id"] == "repow-default-restart1"
+            assert call_args.kwargs["circle_source"] == "spawn_hint"
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=("repow-default-abc12345", "test-claude-code", False),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
             "session_name": "default",
             "window_name": "test",
         },

--- a/tests/test_spawn_hints.py
+++ b/tests/test_spawn_hints.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from repowire import spawn_hints
-from repowire.spawn_hints import consume_hint, write_hint
+from repowire.spawn_hints import consume_hint, consume_hint_full, write_hint
 
 
 @pytest.fixture
@@ -38,6 +38,21 @@ def test_hints_keyed_by_path_and_backend(tmp_cache: Path) -> None:
     write_hint("/tmp/proj", "claude-code", "7")
     assert consume_hint("/tmp/proj", "codex") == "5"
     assert consume_hint("/tmp/proj", "claude-code") == "7"
+
+
+def test_hint_preserves_restart_peer_id(tmp_cache: Path) -> None:
+    write_hint(
+        "/tmp/proj",
+        "codex",
+        "agentbox",
+        role="orchestrator",
+        peer_id="repow-agentbox-abc12345",
+    )
+    assert consume_hint_full("/tmp/proj", "codex") == {
+        "circle": "agentbox",
+        "role": "orchestrator",
+        "peer_id": "repow-agentbox-abc12345",
+    }
 
 
 def test_hints_for_same_path_and_backend_are_fifo(tmp_cache: Path) -> None:

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -53,6 +53,7 @@ repowire service uninstall`}
         usage={`repowire peer list
 repowire peer describe NAME_OR_ID [--circle C]
 repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
+repowire peer restart NAME_OR_ID [--circle C] [--dry-run] [-m MESSAGE]
 repowire peer prune
 repowire peer whoami [--register --backend B --name NAME --circle C --path P]
 repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME]
@@ -63,6 +64,9 @@ repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]`}
         </p>
         <p>
           <Mono>peer whoami</Mono>, <Mono>peer asks</Mono>, and <Mono>peer ack</Mono> are shellable mesh primitives for runtimes whose hooks do not fire yet. They use the local daemon token automatically and let an Antigravity <Mono>agy</Mono> session self-register, poll pending asks, and close them from a shell.
+        </p>
+        <p>
+          <Mono>peer restart</Mono> intentionally restarts a daemon-spawned peer on the same backend, path, circle, role, and mesh identity. It is for reloading startup context such as <Mono>AGENTS.md</Mono> or an orchestrator <Mono>SOUL.md</Mono>. It refuses cross-host peers and panes the daemon cannot prove it spawned. The restart mode is <Mono>fresh_runtime_context</Mono>: startup context is reloaded, but transcript replay and exact backend conversation resume are not guaranteed.
         </p>
       </Cmd>
 

--- a/web/app/docs/reference/client/page.tsx
+++ b/web/app/docs/reference/client/page.tsx
@@ -105,6 +105,9 @@ outbound = await client.pending_asks(peer_id=peer.peer_id, direction="outbound")
         <p>
           <Mono>spawn</Mono> launches a new agent session subject to <Mono>daemon.spawn.commands</Mono> and <Mono>daemon.spawn.allowed_paths</Mono>. <Mono>spawn_config</Mono> reports which backend launch profiles are configured. Omit <Mono>circle</Mono> to use the daemon default (<Mono>default</Mono>), or pass it explicitly for another circle. <Mono>kill_peer</Mono> terminates a peer cleanly.
         </p>
+        <p>
+          <Mono>restart_peer</Mono> intentionally restarts a daemon-spawned peer on the same backend, path, circle, role, and mesh identity. It refuses cross-host peers and panes the daemon cannot prove it spawned. The response includes <Mono>resume_mode</Mono>; <Mono>fresh_runtime_context</Mono> reloads startup context but does not guarantee transcript replay or exact backend conversation resume.
+        </p>
         <Code>
 {`info = await client.spawn_config()
 if "claude-code" in info.commands:
@@ -114,7 +117,10 @@ if "claude-code" in info.commands:
         circle="docs",
         message="help me draft a reference page",
     )
-    print(spawn.display_name, spawn.tmux_session)`}
+    print(spawn.display_name, spawn.tmux_session)
+
+restart = await client.restart_peer("project-c-claude-code", dry_run=True)
+print(restart.status, restart.resume_mode)`}
         </Code>
       </Section>
 


### PR DESCRIPTION
## Summary
- Adds `POST /peers/{name}/restart`, `repowire peer restart`, and `AsyncRepowireClient.restart_peer`.
- Restarts only same-host daemon-spawned peers with proven pane ownership, preserving backend/path/circle/role and passing the existing peer_id through spawn hints for normal exact backend+path reconnect.
- Documents `resume_mode=fresh_runtime_context`: startup context is reloaded, but transcript replay/backend-native resume is not guaranteed.

## Safety
- Refuses manually attached or unproven panes with `unsupported_pane_ownership`.
- Uses the existing ask quiesce barrier and blocks restarts with open asks.
- CLI restart failures exit non-zero; dry-run/success exit 0.

## Verification
Worker reported before commit:
- `uv run pytest` -> 1328 passed
- focused pytest -> 95 passed
- `uv run ruff check repowire/` -> passed
- `uv run ty check repowire/` -> passed

Coordinator after amend/hygiene:
- `npm run lint -- app/docs/reference/cli/page.tsx app/docs/reference/client/page.tsx` -> passed
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> passed advisory
- `git diff --check HEAD^..HEAD` -> passed

Tracks repowire-a6a.

## Notes
- I amended the local commit before push to remove accidental Beads/root ledger files from the product commit; product files only remain.
- `repowire-9f8` pane-ownership hardening remains adjacent: this command avoids stale pane metadata by requiring daemon-owned panes rather than solving temporary same-pane claim hardening here.