### PR TITLE
Adopt durable ownership for pane-less restarts

### DIFF
--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -18,6 +18,8 @@ from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import Peer, PeerRole
 from repowire.spawn import SpawnConfig, SpawnResult, kill_pane, spawn_peer
 from repowire.spawn_ownership import (
+    OwnershipValidation,
+    find_spawn_ownership_for_peer,
     forget_spawn_ownership,
     record_spawn_ownership,
     validate_spawn_ownership,
@@ -338,7 +340,7 @@ async def spawn(
 
 
 def _durable_ownership_error_detail(peer: Peer) -> dict[str, object]:
-    validation = validate_spawn_ownership(peer)
+    validation = _effective_ownership_validation(peer)
     return {
         "error": validation.error or "unsupported_pane_ownership",
         "hint": validation.hint
@@ -355,7 +357,32 @@ def _has_spawn_ownership(peer: Peer) -> bool:
 
     if peer.pane_id and peer.pane_id in _SPAWNED_PANE_IDS:
         return True
-    return validate_spawn_ownership(peer).ok
+    return _effective_ownership_validation(peer).ok
+
+
+def _effective_ownership_validation(peer: Peer) -> OwnershipValidation:
+    """Validate explicit ownership, adopting by identity when pane fields are absent."""
+
+    if peer.pane_id:
+        return validate_spawn_ownership(peer)
+    return find_spawn_ownership_for_peer(peer)
+
+
+def _peer_with_adopted_ownership(peer: Peer) -> Peer:
+    """Return a peer copy with durable pane proof adopted when uniquely valid."""
+
+    if peer.pane_id:
+        return peer
+    validation = find_spawn_ownership_for_peer(peer)
+    if not validation.ok or validation.record is None:
+        return peer
+    return peer.model_copy(
+        update={
+            "pane_id": validation.record.pane_id,
+            "tmux_session": validation.record.tmux_session,
+            "machine": validation.record.machine,
+        }
+    )
 
 
 @router.post("/kill-peer", response_model=KillResponse)
@@ -397,7 +424,7 @@ async def kill_registered_peer(
             },
         )
 
-    peer = resolved
+    peer = _peer_with_adopted_ownership(resolved)
     # Only kill the pane if the daemon spawned it. We track spawned pane_ids
     # in _SPAWNED_PANE_IDS at /spawn time. tmux_session is NOT a reliable
     # ownership signal — the OpenCode plugin sends it from any user-attached
@@ -516,7 +543,7 @@ async def restart_peer(
             },
         )
 
-    peer = resolved
+    peer = _peer_with_adopted_ownership(resolved)
     self_machine = socket.gethostname()
     if peer.machine and peer.machine != "unknown" and peer.machine != self_machine:
         raise HTTPException(

--- a/repowire/spawn_ownership.py
+++ b/repowire/spawn_ownership.py
@@ -24,6 +24,7 @@ OWNERSHIP_PATH = Config.get_config_dir() / "spawn_ownership.json"
 
 OwnershipError = Literal[
     "missing_ownership",
+    "ambiguous_ownership",
     "ownership_machine_mismatch",
     "ownership_peer_mismatch",
     "ownership_identity_mismatch",
@@ -127,6 +128,81 @@ def get_spawn_ownership(pane_id: str) -> SpawnOwnershipRecord | None:
     return _load_records().get(pane_id)
 
 
+def find_spawn_ownership_for_peer(peer: Peer) -> OwnershipValidation:
+    """Find unique durable pane ownership proof for a peer identity.
+
+    Used after daemon restart when the live runtime may still be in tmux but did
+    not re-run SessionStart, so the rehydrated peer record lacks pane fields.
+    This never infers ownership from mappings alone: a matching durable proof
+    must also have live tmux evidence for its recorded pane.
+    """
+
+    self_machine = socket.gethostname()
+    matches: list[OwnershipValidation] = []
+    saw_identity_match = False
+    saw_dead_pane = False
+    saw_mismatch = False
+
+    for record in _load_records().values():
+        if record.machine and record.machine != self_machine:
+            continue
+        if record.peer_id and record.peer_id != peer.peer_id:
+            continue
+        if not _record_matches_peer_identity(record, peer):
+            continue
+
+        saw_identity_match = True
+        evidence = probe_tmux_pane(record.pane_id)
+        if evidence is None:
+            saw_dead_pane = True
+            continue
+        if (
+            evidence.tmux_session != record.tmux_session
+            or _norm_path(evidence.current_path) != _norm_path(record.path)
+        ):
+            saw_mismatch = True
+            continue
+        matches.append(OwnershipValidation(ok=True, record=record, evidence=evidence))
+
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        return OwnershipValidation(
+            ok=False,
+            error="ambiguous_ownership",
+            hint=(
+                "Multiple durable Repowire spawn ownership proofs match this peer "
+                "identity; refusing to guess which pane to kill."
+            ),
+        )
+    if saw_dead_pane:
+        return OwnershipValidation(
+            ok=False,
+            error="pane_not_live",
+            hint="The recorded pane is not visible in tmux; refusing to use stale proof.",
+        )
+    if saw_mismatch:
+        return OwnershipValidation(
+            ok=False,
+            error="pane_identity_mismatch",
+            hint="Live tmux pane evidence does not match the ownership proof.",
+        )
+    if saw_identity_match:
+        return OwnershipValidation(
+            ok=False,
+            error="missing_ownership",
+            hint="No live durable Repowire spawn ownership proof matches this peer.",
+        )
+    return OwnershipValidation(
+        ok=False,
+        error="missing_ownership",
+        hint=(
+            "No durable Repowire spawn ownership proof exists for this peer identity. "
+            "Manual peers and pre-proof spawns are left untouched."
+        ),
+    )
+
+
 def validate_spawn_ownership(peer: Peer) -> OwnershipValidation:
     """Validate that ``peer`` still corresponds to a daemon-spawned live pane."""
 
@@ -201,6 +277,15 @@ def validate_spawn_ownership(peer: Peer) -> OwnershipValidation:
         )
 
     return OwnershipValidation(ok=True, record=record, evidence=evidence)
+
+
+def _record_matches_peer_identity(record: SpawnOwnershipRecord, peer: Peer) -> bool:
+    return (
+        record.backend == _enum_value(peer.backend)
+        and record.circle == (peer.circle or "default")
+        and record.role == _enum_value(peer.role)
+        and _norm_path(record.path) == _norm_path(peer.path)
+    )
 
 
 def probe_tmux_pane(pane_id: str) -> TmuxPaneEvidence | None:

--- a/tests/test_restart_peer_route.py
+++ b/tests/test_restart_peer_route.py
@@ -86,21 +86,20 @@ async def _register(
     path: str,
     backend: str = "claude-code",
     role: str = "agent",
-    pane_id: str = "%101",
+    pane_id: str | None = "%101",
     machine: str | None = None,
 ) -> str:
-    response = await client.post(
-        "/peers",
-        json={
-            "name": Path(path).name,
-            "path": path,
-            "circle": "default",
-            "backend": backend,
-            "machine": machine or socket.gethostname(),
-            "role": role,
-            "pane_id": pane_id,
-        },
-    )
+    payload = {
+        "name": Path(path).name,
+        "path": path,
+        "circle": "default",
+        "backend": backend,
+        "machine": machine or socket.gethostname(),
+        "role": role,
+    }
+    if pane_id is not None:
+        payload["pane_id"] = pane_id
+    response = await client.post("/peers", json=payload)
     assert response.status_code == 200, response.text
     return response.json()["display_name"]
 
@@ -241,6 +240,163 @@ class TestRestartPeerRoute:
         assert body["peer_id"] == peer.peer_id
         mock_kill.assert_not_called()
         mock_spawn.assert_not_called()
+
+    async def test_dry_run_adopts_unique_durable_ownership_for_paneless_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(
+            env.client,
+            path=str(tmp_path),
+            pane_id=None,
+            machine="unknown",
+        )
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        assert peer.pane_id is None
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+            peer_id=peer.peer_id,
+        )
+
+        monkeypatch.setattr(
+            "repowire.spawn_ownership.probe_tmux_pane",
+            lambda pane_id: TmuxPaneEvidence(
+                pane_id=pane_id,
+                tmux_session="default:proj",
+                current_path=str(tmp_path),
+                pane_pid="12345",
+            ),
+        )
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "restart_available"
+        assert body["tmux_session"] == "default:proj"
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    async def test_restart_refuses_ambiguous_durable_ownership_for_paneless_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(env.client, path=str(tmp_path), pane_id=None)
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+        )
+        record_spawn_ownership(
+            pane_id="%615",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj-2",
+        )
+
+        def fake_probe(pane_id: str) -> TmuxPaneEvidence:
+            return TmuxPaneEvidence(
+                pane_id=pane_id,
+                tmux_session="default:proj" if pane_id == "%614" else "default:proj-2",
+                current_path=str(tmp_path),
+                pane_pid="12345",
+            )
+
+        monkeypatch.setattr("repowire.spawn_ownership.probe_tmux_pane", fake_probe)
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert detail["error"] == "unsupported_pane_ownership"
+        assert "Multiple durable Repowire spawn ownership proofs" in detail["hint"]
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    async def test_restart_refuses_stale_durable_ownership_for_paneless_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(env.client, path=str(tmp_path), pane_id=None)
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+        )
+        monkeypatch.setattr("repowire.spawn_ownership.probe_tmux_pane", lambda _pane_id: None)
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert detail["error"] == "unsupported_pane_ownership"
+        assert "not visible in tmux" in detail["hint"]
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    async def test_kill_peer_adopts_durable_ownership_for_paneless_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(env.client, path=str(tmp_path), pane_id=None)
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+            peer_id=peer.peer_id,
+        )
+        monkeypatch.setattr(
+            "repowire.spawn_ownership.probe_tmux_pane",
+            lambda pane_id: TmuxPaneEvidence(
+                pane_id=pane_id,
+                tmux_session="default:proj",
+                current_path=str(tmp_path),
+                pane_pid="12345",
+            ),
+        )
+
+        with patch.object(spawn_routes, "kill_pane", return_value=True) as mock_kill:
+            response = await env.client.post("/kill-peer", json={"peer_identifier": name})
+
+        assert response.status_code == 200, response.text
+        assert response.json()["tmux_killed"] is True
+        mock_kill.assert_called_once_with("%614")
+        assert await env.registry.get_peer(peer.peer_id) is None
 
     async def test_stale_durable_ownership_is_refused_when_pane_not_live(
         self, env, tmp_path, monkeypatch,


### PR DESCRIPTION
## Summary
- allow restart/kill to adopt a unique durable spawn ownership proof when the persisted peer record lacks pane fields after daemon restart
- require exact backend/path/circle/role identity plus local live tmux evidence before adopting a pane
- refuse ambiguous, stale, or mismatched ownership records instead of guessing

## Verification
- `uv run pytest tests/test_restart_peer_route.py -q` → 12 passed
- `uv run ruff check repowire/ tests/test_restart_peer_route.py`
- `uv run ty check repowire/`
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`

## Notes
- This is the post-merge follow-up to #296 for the daemon-restart smoke blocker.
- No docs/web changes in this follow-up; no extra web lint needed.
- Beads/root issue ledgers are excluded.
