### PR TITLE
Adopt durable ownership for stale pane records

### DIFF
--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -361,20 +361,32 @@ def _has_spawn_ownership(peer: Peer) -> bool:
 
 
 def _effective_ownership_validation(peer: Peer) -> OwnershipValidation:
-    """Validate explicit ownership, adopting by identity when pane fields are absent."""
+    """Validate explicit ownership, falling back to unique identity proof.
 
+    After a daemon restart, a rehydrated peer can have no pane id or a stale pane
+    id from old runtime metadata. A direct valid pane proof wins, but failed
+    direct validation may fall back to a unique durable proof for the exact peer
+    identity plus live tmux evidence.
+    """
+
+    direct: OwnershipValidation | None = None
     if peer.pane_id:
-        return validate_spawn_ownership(peer)
-    return find_spawn_ownership_for_peer(peer)
+        direct = validate_spawn_ownership(peer)
+        if direct.ok:
+            return direct
+    adopted = find_spawn_ownership_for_peer(peer)
+    if adopted.ok or direct is None or adopted.error == "ambiguous_ownership":
+        return adopted
+    return direct
 
 
 def _peer_with_adopted_ownership(peer: Peer) -> Peer:
     """Return a peer copy with durable pane proof adopted when uniquely valid."""
 
-    if peer.pane_id:
-        return peer
-    validation = find_spawn_ownership_for_peer(peer)
+    validation = _effective_ownership_validation(peer)
     if not validation.ok or validation.record is None:
+        return peer
+    if peer.pane_id == validation.record.pane_id:
         return peer
     return peer.model_copy(
         update={

--- a/tests/test_restart_peer_route.py
+++ b/tests/test_restart_peer_route.py
@@ -288,6 +288,52 @@ class TestRestartPeerRoute:
         mock_kill.assert_not_called()
         mock_spawn.assert_not_called()
 
+    async def test_dry_run_adopts_unique_durable_ownership_for_stale_pane_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(
+            env.client,
+            path=str(tmp_path),
+            pane_id="%610",
+            machine="unknown",
+        )
+        peer = await env.registry.get_peer(name)
+        assert peer is not None
+        assert peer.pane_id == "%610"
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+        )
+
+        monkeypatch.setattr(
+            "repowire.spawn_ownership.probe_tmux_pane",
+            lambda pane_id: TmuxPaneEvidence(
+                pane_id=pane_id,
+                tmux_session="default:proj",
+                current_path=str(tmp_path),
+                pane_pid="12345",
+            ) if pane_id == "%614" else None,
+        )
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "restart_available"
+        assert body["tmux_session"] == "default:proj"
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
     async def test_restart_refuses_ambiguous_durable_ownership_for_paneless_peer(
         self, env, tmp_path, monkeypatch,
     ):
@@ -312,6 +358,55 @@ class TestRestartPeerRoute:
         )
 
         def fake_probe(pane_id: str) -> TmuxPaneEvidence:
+            return TmuxPaneEvidence(
+                pane_id=pane_id,
+                tmux_session="default:proj" if pane_id == "%614" else "default:proj-2",
+                current_path=str(tmp_path),
+                pane_pid="12345",
+            )
+
+        monkeypatch.setattr("repowire.spawn_ownership.probe_tmux_pane", fake_probe)
+
+        with patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            patch.object(spawn_routes, "spawn_peer") as mock_spawn:
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 409
+        detail = response.json()["detail"]
+        assert detail["error"] == "unsupported_pane_ownership"
+        assert "Multiple durable Repowire spawn ownership proofs" in detail["hint"]
+        mock_kill.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    async def test_restart_refuses_ambiguous_fallback_for_stale_pane_peer(
+        self, env, tmp_path, monkeypatch,
+    ):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%610")
+        record_spawn_ownership(
+            pane_id="%614",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj",
+        )
+        record_spawn_ownership(
+            pane_id="%615",
+            path=str(tmp_path),
+            backend=AgentType.CLAUDE_CODE,
+            circle="default",
+            role=PeerRole.AGENT,
+            display_name=name,
+            tmux_session="default:proj-2",
+        )
+
+        def fake_probe(pane_id: str) -> TmuxPaneEvidence | None:
+            if pane_id == "%610":
+                return None
             return TmuxPaneEvidence(
                 pane_id=pane_id,
                 tmux_session="default:proj" if pane_id == "%614" else "default:proj-2",


### PR DESCRIPTION
## Summary
- allow restart/kill ownership validation to fall back from a stale recorded pane id to a unique durable ownership proof for the same peer identity
- keep direct pane proof as the fast path when valid
- refuse ambiguous alternate durable proofs rather than guessing

## Verification
- `uv run pytest tests/test_restart_peer_route.py -q` → 14 passed
- `uv run ruff check repowire/ tests/test_restart_peer_route.py`
- `uv run ty check repowire/`
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`

## Notes
- Post-merge follow-up to #297 for live smoke where the daemon rehydrated stale pane `%610` while durable proof and live tmux evidence pointed at `%614`.
- No docs/web changes in this follow-up.
- Beads/root issue ledgers are excluded.
