### PR TITLE
fix: protect orchestrator pane identity

### DIFF
--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -10,7 +10,7 @@ A live peer has these identity and lifecycle fields:
 - `display_name` / `name` — human-facing name. It can collide across circles, so it is not globally unique.
 - `circle` — routing scope. Peers normally message peers in the same circle unless the caller passes an explicit circle or has a role that bypasses circles.
 - `backend` — agent runtime, such as `claude-code`, `codex`, `gemini`, `antigravity`, `opencode`, or `pi`.
-- `path` — working directory used for name allocation and reconnect checks.
+- `path` — working directory used for name allocation, filtering, and operator context. It is not sufficient by itself to prove peer identity.
 - `pane_id` / WebSocket binding — local delivery endpoint for hook-based peers.
 - `role` — `agent` by default; service, human, and orchestrator roles can bypass normal circle visibility.
 - `description` — short task state set by `set_description` and shown in peer lists.
@@ -32,7 +32,11 @@ A reconnect may reclaim an existing `peer_id` only when the claim still describe
 
 If the check fails, the stale `peer_id` claim is ignored and the daemon allocates or adopts a different identity. This prevents an old environment variable or stale pane metadata from binding a different session's WebSocket to the wrong peer.
 
-When a new peer claims a pane already held by another peer, the old peer loses that pane binding and is marked offline. Pane lookup should then resolve to the current live owner, not a zombie registration.
+When a new peer claims a pane already held by another peer, the old peer normally loses that pane binding and is marked offline. Pane lookup should then resolve to the current live owner, not a zombie registration.
+
+There is one protected case: a fresh live `orchestrator` peer keeps sticky ownership of its tmux pane. If a temporary same-pane session starts in a split terminal, the daemon can register that session without assigning the pane (`pane_assigned=false`). The temporary peer can still use outbound MCP/HTTP tools, but it does not get inbound hook transport and must not clear the incumbent orchestrator's pane metadata or WebSocket hook.
+
+MCP lazy registration treats tmux pane lookup as a locator, not as identity proof. A by-pane daemon result is accepted only when local pane runtime metadata proves the same daemon peer id, backend, and owning agent process. If that proof is missing or belongs to another process, MCP registers or resolves its own peer instead of adopting the incumbent. This keeps path and display name as useful context while avoiding path-based identity takeover.
 
 ## Display-name ambiguity
 

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -648,6 +648,30 @@ class PeerRegistry:
         self._mappings_dirty = True
         return session_id
 
+    def _is_fresh_orchestrator_pane(self, pane_id: str) -> Peer | None:
+        """Return the live orchestrator peer holding ``pane_id``, or None.
+
+        "Live" matches ``get_orchestrator`` semantics: role=ORCHESTRATOR,
+        status ONLINE/BUSY, last_seen within heartbeat tolerance. Must hold
+        lock. Used by ``allocate_and_register`` to make orchestrator pane
+        ownership sticky against same-pane displacement by temporary peers.
+        """
+        tolerance = self.heartbeat_tolerance()
+        now = datetime.now(timezone.utc)
+        for peer in self._peers.values():
+            if peer.pane_id != pane_id:
+                continue
+            if peer.role != PeerRole.ORCHESTRATOR:
+                continue
+            if peer.status not in (PeerStatus.ONLINE, PeerStatus.BUSY):
+                continue
+            if peer.last_seen is None:
+                continue
+            if (now - peer.last_seen).total_seconds() > tolerance:
+                continue
+            return peer
+        return None
+
     def _release_pane(self, pane_id: str, new_peer_id: str) -> None:
         """Clear pane_id from any peer that currently owns it, except new_peer_id.
 
@@ -659,13 +683,35 @@ class PeerRegistry:
         ws-hook is no longer the live owner of that tmux pane, so the peer's
         inbound transport is gone. Leaving it ONLINE with pane_id=None creates
         zombie peers that future sessions may incorrectly claim.
+
+        Exception: a fresh role=ORCHESTRATOR holder is never flipped OFFLINE
+        or detached from the pane by this path. Pane ownership is sticky for
+        the orchestrator; a temporary same-pane claimant must not silently
+        demote or orphan the orchestrator's transport.
         """
+        tolerance = self.heartbeat_tolerance()
+        now = datetime.now(timezone.utc)
         for sid, peer in self._peers.items():
-            if peer.pane_id == pane_id and sid != new_peer_id:
-                old_status = peer.status
-                peer.pane_id = None
-                peer.status = PeerStatus.OFFLINE
-                self._emit_status_change(peer, old_status, PeerStatus.OFFLINE)
+            if peer.pane_id != pane_id or sid == new_peer_id:
+                continue
+            is_fresh_orch = (
+                peer.role == PeerRole.ORCHESTRATOR
+                and peer.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+                and peer.last_seen is not None
+                and (now - peer.last_seen).total_seconds() <= tolerance
+            )
+            if is_fresh_orch:
+                logger.warning(
+                    "_release_pane: preserving fresh orchestrator liveness "
+                    "and pane ownership for %s (%s); status untouched",
+                    peer.display_name,
+                    peer.peer_id,
+                )
+                continue
+            old_status = peer.status
+            peer.pane_id = None
+            peer.status = PeerStatus.OFFLINE
+            self._emit_status_change(peer, old_status, PeerStatus.OFFLINE)
 
     # ------------------------------------------------------------------
     # Allocate + register (atomic, the preferred public API)
@@ -783,14 +829,38 @@ class PeerRegistry:
                             f"matches existing agent_pid={existing.agent_pid}"
                         )
 
+                # Sticky orchestrator pane: if pane_id is held by a fresh
+                # role=ORCHESTRATOR peer and this isn't a same-id reconnect,
+                # do not displace it. Register the new peer pane-less so its
+                # outbound MCP/HTTP path still works, but pane bookkeeping
+                # stays bound to the orchestrator. Without this a sibling-
+                # shell SessionStart in the orchestrator workspace silently
+                # tears down the orchestrator's transport and leaves it
+                # unrecoverable when the temp peer exits.
+                effective_pane_id = pane_id
+                if pane_id:
+                    sticky_holder = self._is_fresh_orchestrator_pane(pane_id)
+                    if sticky_holder is not None:
+                        logger.warning(
+                            "Sticky orchestrator pane: not displacing %s (%s) "
+                            "on pane %s; new peer registers without pane ownership "
+                            "(claim_path=%s claim_backend=%s)",
+                            sticky_holder.display_name,
+                            sticky_holder.peer_id,
+                            pane_id,
+                            path,
+                            backend.value,
+                        )
+                        effective_pane_id = None
+
                 # Fresh registration: daemon owns the name
                 assigned_name = self._build_display_name(path or "", circle, backend)
                 allocated_id = self._find_or_allocate_mapping(
                     assigned_name, circle, backend, path, role=role,
                     agent_pid=agent_pid, circle_source=circle_source,
                 )
-                if pane_id:
-                    self._release_pane(pane_id, allocated_id)
+                if effective_pane_id:
+                    self._release_pane(effective_pane_id, allocated_id)
 
                 # Restore circle, role, and description from persisted mapping.
                 # The mapping is the durable source of truth for these fields;
@@ -818,7 +888,7 @@ class PeerRegistry:
                     role=effective_role,
                     status=initial_status,
                     last_seen=datetime.now(timezone.utc),
-                    pane_id=pane_id,
+                    pane_id=effective_pane_id,
                     tmux_session=tmux_session,
                     path=path or "",
                     machine=machine,

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -327,12 +327,17 @@ class RegisterResponse(BaseModel):
     ok: bool = True
     peer_id: str
     display_name: str
+    pane_assigned: bool = True
 
 
-async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
+async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str, bool]:
     """Shared implementation for peer registration endpoints.
 
-    Returns (peer_id, assigned_display_name).
+    Returns (peer_id, assigned_display_name, pane_assigned). ``pane_assigned``
+    is True iff the caller requested a pane_id and the registered peer ended
+    up owning it; False when the daemon's sticky-orchestrator branch refused
+    to displace a live orchestrator. When no pane_id was requested,
+    pane_assigned defaults to True (vacuously: nothing to assign).
     """
     circle = request.circle or "global"
 
@@ -383,7 +388,11 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str]:
             )
         except Exception:
             logger.warning("Failed to persist session binding for peer registration", exc_info=True)
-    return peer_id, display_name
+    pane_assigned = True
+    if request.pane_id:
+        registered = await peer_registry.get_peer(peer_id)
+        pane_assigned = bool(registered and registered.pane_id == request.pane_id)
+    return peer_id, display_name, pane_assigned
 
 
 @router.post("/peers", response_model=RegisterResponse)
@@ -392,8 +401,10 @@ async def create_peer(
     _: str | None = Depends(require_auth),
 ) -> RegisterResponse:
     """Register a new peer (CLI-friendly endpoint)."""
-    peer_id, display_name = await _register_peer_impl(request)
-    return RegisterResponse(peer_id=peer_id, display_name=display_name)
+    peer_id, display_name, pane_assigned = await _register_peer_impl(request)
+    return RegisterResponse(
+        peer_id=peer_id, display_name=display_name, pane_assigned=pane_assigned,
+    )
 
 
 async def _unregister_peer_impl(name: str, circle: str | None = None) -> None:
@@ -1157,8 +1168,10 @@ async def register_peer(
     _: str | None = Depends(require_auth),
 ) -> RegisterResponse:
     """Register a new peer in the mesh (legacy endpoint)."""
-    peer_id, display_name = await _register_peer_impl(request)
-    return RegisterResponse(peer_id=peer_id, display_name=display_name)
+    peer_id, display_name, pane_assigned = await _register_peer_impl(request)
+    return RegisterResponse(
+        peer_id=peer_id, display_name=display_name, pane_assigned=pane_assigned,
+    )
 
 
 @router.post("/peer/unregister", response_model=OkResponse)

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -71,13 +71,22 @@ def _register_peer_http(
     turn_state: str | None = None,
     agent_pid: int | None = None,
     parent_pid: int | None = None,
-) -> tuple[str | None, str | None, bool]:
+) -> tuple[str | None, str | None, bool, bool]:
     """Register peer via HTTP POST /peers.
 
-    Returns (peer_id, display_name, hijack_rejected). hijack_rejected is True
-    iff the daemon returned 409 because the pane-hijack guard rejected this
-    fresh SessionStart claim (a subprocess agent inheriting its parent's
-    TMUX_PANE). The caller should abort registration cleanly in that case.
+    Returns (peer_id, display_name, hijack_rejected, pane_assigned).
+
+    ``hijack_rejected`` is True iff the daemon returned 409 because the
+    pane-hijack guard rejected this fresh SessionStart claim (a subprocess
+    agent inheriting its parent's TMUX_PANE). The caller should abort
+    registration cleanly in that case.
+
+    ``pane_assigned`` is True when this peer owns ``pane_id`` after
+    registration, False when the daemon's sticky-orchestrator branch
+    refused to displace a live orchestrator. A pane-less peer must skip
+    the destructive takeover block (no incumbent ws-hook kill, no prior-
+    peer offline mark, no pane runtime metadata rewrite) and must not
+    spawn its own ws-hook -- the pane belongs to someone else.
     """
     folder = Path(path).name
     payload: dict = {
@@ -109,10 +118,12 @@ def _register_peer_http(
             f"repowire: SessionStart rejected by daemon pane-hijack guard: {detail}",
             file=sys.stderr,
         )
-        return None, None, True
+        return None, None, True, False
     if status_code is not None and 200 <= status_code < 300 and result:
-        return result.get("peer_id"), result.get("display_name"), False
-    return None, None, False
+        # pane_assigned defaults True for older daemons that don't return it.
+        pane_assigned = bool(result.get("pane_assigned", True))
+        return result.get("peer_id"), result.get("display_name"), False, pane_assigned
+    return None, None, False, False
 
 
 def get_peer_name(cwd: str) -> str:
@@ -421,7 +432,7 @@ def main(backend: str = "claude-code") -> int:
         #     and trip the guard.
         agent_pid_val = os.getppid()
         parent_pid_val = _read_ppid_of(agent_pid_val)
-        peer_id, display_name, hijack_rejected = _register_peer_http(
+        peer_id, display_name, hijack_rejected, pane_assigned = _register_peer_http(
             cwd,
             circle,
             backend_type,
@@ -456,6 +467,22 @@ def main(backend: str = "claude-code") -> int:
             return 0
         if not display_name:
             display_name = folder_name  # fallback if daemon unreachable
+
+        # Sticky orchestrator pane: the daemon registered this peer but
+        # refused to give it pane ownership because a live orchestrator
+        # holds the pane. Do not touch the incumbent ws-hook, prior-peer
+        # status, or pane runtime metadata. The new peer remains usable
+        # outbound (MCP/HTTP) but does not own this pane and gets no
+        # ws-hook of its own; inbound hook delivery stays with the incumbent.
+        if pane_id and not pane_assigned:
+            print(
+                "repowire: pane "
+                f"{pane_id} held by live orchestrator; registered as "
+                f"{display_name} ({peer_id}) without pane ownership",
+                file=sys.stderr,
+            )
+            lock_fd.close()
+            return 0
 
         # Daemon accepted our claim. NOW perform the destructive takeover
         # steps: evict the incumbent ws-hook, mark its peer offline, clear
@@ -492,6 +519,8 @@ def main(backend: str = "claude-code") -> int:
                 "display_name": display_name,
                 "hook_session_id": hook_session_id,
                 "peer_id": peer_id,
+                "agent_pid": agent_pid_val,
+                "parent_pid": parent_pid_val,
             },
         )
 

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -68,10 +68,25 @@ def _cache_identity(result: dict) -> None:
 
 
 def _orchestrator_self_claim_allowed(peer: dict) -> bool:
-    """Return whether this peer is eligible to reclaim the orchestrator role."""
-    display_name = str(peer.get("display_name") or peer.get("name") or "").lower()
-    path_name = Path(str(peer.get("path") or "")).name.lower()
-    return display_name == "orchestrator" or path_name == "orchestrator"
+    """Return whether this peer is eligible to reclaim the orchestrator role.
+
+    Eligibility is the resolved canonical orchestrator workspace path
+    (``repowire.orchestrator.workspace_path()``), not the basename. A loose
+    basename or display-name match would let any peer rooted at
+    ``/tmp/orchestrator`` or named ``orchestrator`` self-claim the role,
+    which during a pane-displacement window could let a temporary peer seize
+    role from the real orchestrator.
+    """
+    raw_path = peer.get("path")
+    if not raw_path:
+        return False
+    try:
+        from repowire.orchestrator.workspace import workspace_path
+        canonical = workspace_path().resolve()
+        claimed = Path(str(raw_path)).resolve()
+    except (OSError, RuntimeError):
+        return False
+    return claimed == canonical
 
 
 async def _resolve_circle_for_send(
@@ -222,22 +237,41 @@ def _metadata_matches_current_process(pane_meta: dict) -> bool:
 
     Pane metadata can outlive the session that wrote it (no daemon
     process owns the file; cleanup is best-effort via clear_pane_runtime_state).
-    If a daemon restart races with pane reuse, we could read stale metadata
-    pointing at a previous tenant's display_name.
+    If a daemon restart races with pane reuse, we could read stale metadata or
+    a daemon by-pane result pointing at a previous tenant's display_name.
 
-    Reject metadata whose cwd or backend mismatches what we observe now.
+    The durable proof is the agent process that owns this MCP process, not the
+    path. SessionStart writes its observed agent_pid into pane metadata; the
+    MCP server accepts it only when it matches this process' parent.
     """
-    meta_cwd = pane_meta.get("cwd")
     meta_backend = pane_meta.get("backend")
-    if not meta_cwd or not meta_backend:
+    meta_agent_pid = pane_meta.get("agent_pid")
+    if not meta_backend or meta_agent_pid is None:
+        return False
+    if meta_backend != _detect_backend():
         return False
     try:
-        current_cwd = str(Path.cwd())
-    except OSError:
+        return int(meta_agent_pid) == os.getppid()
+    except (TypeError, ValueError):
         return False
-    if str(meta_cwd) != current_cwd:
+
+
+def _peer_result_matches_current_process(peer: dict, pane_meta: dict) -> bool:
+    """Verify a daemon by-pane result describes the current MCP process.
+
+    A pane can stay bound to a live incumbent while a temporary same-pane
+    process starts its own MCP server. In that case /peers/by-pane correctly
+    returns the incumbent, but the temporary process must not cache that
+    identity and impersonate it. Require the daemon peer_id to match validated
+    local pane runtime metadata owned by the current agent process.
+    """
+    if not _metadata_matches_current_process(pane_meta):
         return False
-    return meta_backend == _detect_backend()
+    peer_id = peer.get("peer_id")
+    meta_peer_id = pane_meta.get("peer_id")
+    if not peer_id or not meta_peer_id:
+        return False
+    return str(peer_id) == str(meta_peer_id)
 
 
 async def _get_my_peer_name() -> str:
@@ -259,15 +293,15 @@ async def _get_my_peer_name() -> str:
         return _cached_peer_name
     pane_id = get_pane_id()
     if pane_id:
+        pane_meta = read_pane_runtime_metadata(pane_id)
         try:
             result = await daemon_request("GET", f"/peers/by-pane/{quote(pane_id, safe='')}")
             name = result.get("display_name") or result.get("peer_id")
-            if name:
+            if name and _peer_result_matches_current_process(result, pane_meta):
                 _cache_identity(result)
                 return name
         except Exception:
             pass
-        pane_meta = read_pane_runtime_metadata(pane_id)
         if _metadata_matches_current_process(pane_meta):
             name = pane_meta.get("display_name") or pane_meta.get("peer_id")
             if name:
@@ -393,22 +427,37 @@ async def _ensure_registered(*, strict: bool = False) -> None:
 
     tmux_info = get_tmux_info()
     pane_id = tmux_info["pane_id"]
+    skip_path_backend_fallback = False
     if pane_id:
+        pane_meta = read_pane_runtime_metadata(pane_id)
         try:
             result = await daemon_request("GET", f"/peers/by-pane/{quote(pane_id, safe='')}")
             name = result.get("display_name") or result.get("peer_id")
-            if name:
+            if name and _peer_result_matches_current_process(result, pane_meta):
                 _cache_identity(result)
-            _registered = True
-            await _touch_last_seen()
-            return
+                _registered = True
+                await _touch_last_seen()
+                return
+            if name:
+                # A live pane owner exists, but this process cannot prove it is
+                # that owner. Do not fall through to path+backend adoption: a
+                # same-cwd same-backend temp process would otherwise claim the
+                # incumbent through the generic lookup.
+                skip_path_backend_fallback = True
         except Exception:
             pass
 
-        pane_meta = read_pane_runtime_metadata(pane_id)
-        if pane_meta.get("display_name") and _cached_peer_name is None:
+        if (
+            _metadata_matches_current_process(pane_meta)
+            and pane_meta.get("display_name")
+            and _cached_peer_name is None
+        ):
             _cached_peer_name = pane_meta["display_name"]
-        if strict and (pane_meta.get("peer_id") or pane_meta.get("display_name")):
+        if (
+            strict
+            and _metadata_matches_current_process(pane_meta)
+            and (pane_meta.get("peer_id") or pane_meta.get("display_name"))
+        ):
             raise RuntimeError(_hook_disconnect_message(pane_id))
     else:
         name = await _get_my_peer_name()
@@ -429,26 +478,27 @@ async def _ensure_registered(*, strict: bool = False) -> None:
         logger.warning("Cannot resolve cwd for MCP registration: %s", e)
         return
 
-    # Last-resort identity resolution: find hook-registered peer by path+backend.
-    # Only claim when there is exactly one online candidate — multiple matches
-    # are ambiguous and inheriting an arbitrary peer's identity causes
-    # cross-session impersonation (see repowire-c6z).
-    try:
-        result = await daemon_request("GET", "/peers", params={
-            "path": str(cwd),
-            "backend": backend,
-            "status": "online",
-        })
-        candidates = result.get("peers", [])
-        if len(candidates) == 1:
-            assigned = candidates[0].get("display_name")
-            if assigned:
-                _cache_identity(candidates[0])
-                _registered = True
-                await _touch_last_seen()
-                return
-    except (DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError) as e:
-        logger.debug("Path+backend peer lookup failed: %s", e)
+    if not skip_path_backend_fallback:
+        # Last-resort identity resolution: find hook-registered peer by path+backend.
+        # Only claim when there is exactly one online candidate — multiple matches
+        # are ambiguous and inheriting an arbitrary peer's identity causes
+        # cross-session impersonation (see repowire-c6z).
+        try:
+            result = await daemon_request("GET", "/peers", params={
+                "path": str(cwd),
+                "backend": backend,
+                "status": "online",
+            })
+            candidates = result.get("peers", [])
+            if len(candidates) == 1:
+                assigned = candidates[0].get("display_name")
+                if assigned:
+                    _cache_identity(candidates[0])
+                    _registered = True
+                    await _touch_last_seen()
+                    return
+        except (DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError) as e:
+            logger.debug("Path+backend peer lookup failed: %s", e)
 
     # Tmux env is stripped by codex's MCP sandbox, so session_name is None
     # there. Fall back to the spawn hint dropped by the daemon's /spawn route

--- a/tests/test_claim_role.py
+++ b/tests/test_claim_role.py
@@ -235,6 +235,25 @@ def test_cli_claim_role_reports_live_holder_conflict(monkeypatch: pytest.MonkeyP
     assert "Use --force" in result.output
 
 
+def test_mcp_orchestrator_claim_ignores_display_name_shortcut(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer named orchestrator is not eligible unless its path is canonical."""
+    from repowire.orchestrator import workspace as orch_workspace
+
+    canonical = tmp_path / "real-orchestrator"
+    canonical.mkdir()
+    impostor = tmp_path / "some-other-orchestrator"
+    impostor.mkdir()
+    monkeypatch.setattr(orch_workspace, "workspace_path", lambda: canonical)
+
+    assert not mcp_server._orchestrator_self_claim_allowed({
+        "display_name": "orchestrator",
+        "path": str(impostor),
+    })
+
+
 @pytest.mark.asyncio
 async def test_mcp_self_claim_reclaims_orchestrator_after_restart(
     client: tuple[AsyncClient, PeerRegistry],
@@ -250,6 +269,13 @@ async def test_mcp_self_claim_reclaims_orchestrator_after_restart(
     mcp_server._cached_peer_name = "orchestrator-codex"
     mcp_server._cached_my_circle = "default"
     mcp_server._cached_my_role = "agent"
+
+    # Point the canonical orchestrator workspace at the test's orch_dir so
+    # _orchestrator_self_claim_allowed's resolved-path check succeeds. The
+    # basename loophole was removed -- "any folder named orchestrator" no
+    # longer qualifies.
+    from repowire.orchestrator import workspace as orch_workspace
+    monkeypatch.setattr(orch_workspace, "workspace_path", lambda: orch_dir)
 
     async def local_daemon_request(
         method: str,

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -28,11 +28,25 @@ def reset_cache():
 
 
 def _matching_meta(extra: dict | None = None) -> dict:
-    """Build a metadata dict whose cwd+backend match the current process."""
+    """Build pane metadata owned by the current mocked agent process."""
     base = {
         "display_name": "proj-2-claude-code",
         "peer_id": "p-2",
         "cwd": str(Path.cwd()),
+        "backend": mcp_server._detect_backend(),
+        "agent_pid": 12345,
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _matching_peer(extra: dict | None = None) -> dict:
+    """Build a daemon peer dict whose peer_id matches _matching_meta()."""
+    base = {
+        "display_name": "proj-2-claude-code",
+        "peer_id": "p-2",
+        "path": str(Path.cwd()),
         "backend": mcp_server._detect_backend(),
     }
     if extra:
@@ -44,13 +58,41 @@ def _matching_meta(extra: dict | None = None) -> dict:
 async def test_resolves_via_daemon_by_pane():
     """Primary path: daemon /peers/by-pane returns the display_name."""
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=_matching_meta()), \
          patch.object(
              mcp_server, "daemon_request", new=AsyncMock(
-                 return_value={"display_name": "proj-2-claude-code", "peer_id": "p-2"}
+                 return_value=_matching_peer()
              )
          ):
         name = await mcp_server._get_my_peer_name()
     assert name == "proj-2-claude-code"
+
+
+@pytest.mark.asyncio
+async def test_rejects_daemon_by_pane_backend_mismatch():
+    """A temp same-pane process must not cache the incumbent's daemon identity."""
+    incumbent = _matching_peer({
+        "display_name": "orchestrator-codex",
+        "peer_id": "repow-orch",
+        "backend": "codex",
+    })
+
+    with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server, "_detect_backend", return_value="claude-code"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(return_value=incumbent)), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value={
+             "display_name": "orchestrator-codex",
+             "peer_id": "repow-orch",
+             "backend": "codex",
+             "agent_pid": 77777,
+         }), \
+         patch.object(mcp_server, "get_display_name", return_value="temp-claude-code"):
+        name = await mcp_server._get_my_peer_name()
+
+    assert name == "temp-claude-code"
+    assert mcp_server._cached_peer_id is None
 
 
 @pytest.mark.asyncio
@@ -62,6 +104,7 @@ async def test_falls_back_to_pane_metadata_when_daemon_misses():
         raise RuntimeError("daemon unreachable / pane not registered yet")
 
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
          patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
          patch.object(
              mcp_server,
@@ -73,16 +116,15 @@ async def test_falls_back_to_pane_metadata_when_daemon_misses():
 
 
 @pytest.mark.asyncio
-async def test_rejects_stale_metadata_with_cwd_mismatch():
-    """Pane metadata can outlive the session that wrote it (daemon restart
-    + pane reuse). Reject metadata pointing at a different cwd — fall
-    through to cwd-folder fallback rather than mis-claiming identity."""
+async def test_rejects_stale_metadata_with_agent_pid_mismatch():
+    """Reject metadata owned by a different agent process."""
     async def daemon_miss(*_args, **_kw):
         raise RuntimeError("nope")
 
-    stale = _matching_meta({"cwd": "/some/other/abandoned/path"})
+    stale = _matching_meta({"agent_pid": 77777})
 
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
          patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
          patch.object(mcp_server, "read_pane_runtime_metadata", return_value=stale), \
          patch.object(mcp_server, "get_display_name", return_value="current-folder"):
@@ -100,6 +142,7 @@ async def test_rejects_stale_metadata_with_backend_mismatch():
     stale = _matching_meta({"backend": "some-other-backend"})
 
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
          patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
          patch.object(mcp_server, "read_pane_runtime_metadata", return_value=stale), \
          patch.object(mcp_server, "get_display_name", return_value="current-folder"):
@@ -108,12 +151,13 @@ async def test_rejects_stale_metadata_with_backend_mismatch():
 
 
 @pytest.mark.asyncio
-async def test_rejects_metadata_missing_cwd_or_backend():
-    """Metadata without cwd+backend fields can't be validated — reject it."""
+async def test_rejects_metadata_missing_backend_or_agent_pid():
+    """Metadata without backend+agent_pid fields can't be validated."""
     async def daemon_miss(*_args, **_kw):
         raise RuntimeError("nope")
 
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
          patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)), \
          patch.object(
              mcp_server,
@@ -141,12 +185,17 @@ async def test_cwd_fallback_not_cached():
 
     # Daemon comes back; second call resolves to suffixed name via daemon
     with patch.object(mcp_server, "get_pane_id", return_value="%42"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=_matching_meta({
+             "display_name": "proj-2",
+             "peer_id": "p",
+         })), \
          patch.object(
              mcp_server,
              "daemon_request",
-             new=AsyncMock(return_value={"display_name": "proj-2", "peer_id": "p"}),
+             new=AsyncMock(return_value=_matching_peer({"display_name": "proj-2", "peer_id": "p"})),
          ):
-        name = await mcp_server._get_my_peer_name()
+            name = await mcp_server._get_my_peer_name()
     assert name == "proj-2"
 
 
@@ -166,6 +215,7 @@ async def test_two_peers_same_cwd_resolve_distinctly():
     async def resolve_for_pane(pane_id: str) -> str:
         mcp_server._cached_peer_name = None
         with patch.object(mcp_server, "get_pane_id", return_value=pane_id), \
+             patch.object(mcp_server.os, "getppid", return_value=12345), \
              patch.object(
                  mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_miss)
              ), \
@@ -305,6 +355,114 @@ async def test_ensure_registered_marks_explicit_tmux_default_as_tmux():
 
 
 @pytest.mark.asyncio
+async def test_ensure_registered_ignores_by_pane_incumbent_backend_mismatch():
+    """Pane lookup may return the live incumbent, not the current MCP process.
+
+    When a temporary same-pane process starts, it should register fresh instead
+    of caching the incumbent's peer_id and sending MCP calls as that peer.
+    """
+    posted_body = {}
+    incumbent = {
+        "display_name": "orchestrator-codex",
+        "peer_id": "repow-orch",
+        "path": str(Path.cwd()),
+        "backend": "codex",
+    }
+
+    async def daemon_router(method, url, body=None, params=None):  # noqa: ARG001
+        del params
+        if method == "GET" and url.startswith("/peers/by-pane/"):
+            return incumbent
+        if method == "GET" and url == "/peers":
+            return {"peers": []}
+        if method == "GET" and url.startswith("/peers/"):
+            raise RuntimeError("name lookup miss")
+        if method == "POST" and url == "/peers":
+            posted_body.update(body or {})
+            return {
+                "peer_id": "repow-temp",
+                "display_name": "project-claude-code",
+                "path": str(Path.cwd()),
+                "backend": "claude-code",
+            }
+        if method == "POST" and url.endswith("/touch"):
+            return {"ok": True}
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    with patch.object(
+            mcp_server, "get_tmux_info", return_value={"pane_id": "%42", "session_name": None},
+         ), \
+         patch.object(mcp_server, "_detect_backend", return_value="claude-code"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_router)), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value={
+             "display_name": "orchestrator-codex",
+             "peer_id": "repow-orch",
+             "backend": "codex",
+             "agent_pid": 77777,
+         }), \
+         patch.object(mcp_server, "get_display_name", return_value="project"):
+        await mcp_server._ensure_registered()
+
+    assert mcp_server._cached_peer_id == "repow-temp"
+    assert mcp_server._cached_peer_name == "project-claude-code"
+    assert posted_body["backend"] == "claude-code"
+    assert posted_body["pane_id"] == "%42"
+
+
+@pytest.mark.asyncio
+async def test_ensure_registered_skips_path_backend_after_failed_pane_proof():
+    """A failed pane proof must block path+backend adoption in the same call."""
+    posted_body = {}
+    incumbent = {
+        "display_name": "orchestrator-codex",
+        "peer_id": "repow-orch",
+        "path": str(Path.cwd()),
+        "backend": "codex",
+    }
+
+    async def daemon_router(method, url, body=None, params=None):  # noqa: ARG001
+        del params
+        if method == "GET" and url.startswith("/peers/by-pane/"):
+            return incumbent
+        if method == "GET" and url == "/peers":
+            raise AssertionError("path+backend fallback must be skipped")
+        if method == "GET" and url.startswith("/peers/"):
+            raise RuntimeError("name lookup miss")
+        if method == "POST" and url == "/peers":
+            posted_body.update(body or {})
+            return {
+                "peer_id": "repow-temp",
+                "display_name": "project-codex",
+                "path": str(Path.cwd()),
+                "backend": "codex",
+            }
+        if method == "POST" and url.endswith("/touch"):
+            return {"ok": True}
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    with patch.object(
+            mcp_server, "get_tmux_info", return_value={"pane_id": "%42", "session_name": None},
+         ), \
+         patch.object(mcp_server, "_detect_backend", return_value="codex"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_router)), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value={
+             "display_name": "orchestrator-codex",
+             "peer_id": "repow-orch",
+             "backend": "codex",
+             "agent_pid": 77777,
+         }), \
+         patch.object(mcp_server, "get_display_name", return_value="project"):
+        await mcp_server._ensure_registered()
+
+    assert mcp_server._cached_peer_id == "repow-temp"
+    assert mcp_server._cached_peer_name == "project-codex"
+    assert posted_body["backend"] == "codex"
+    assert posted_body["pane_id"] == "%42"
+
+
+@pytest.mark.asyncio
 async def test_ensure_registered_claims_when_exactly_one_candidate():
     """The single-candidate case is the legitimate use of path+backend
     fallback: hook-registered peer exists, MCP subprocess started without
@@ -334,10 +492,15 @@ async def test_ensure_registered_claims_when_exactly_one_candidate():
 @pytest.mark.asyncio
 async def test_caches_after_first_resolution():
     with patch.object(mcp_server, "get_pane_id", return_value="%42") as mock_pane, \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=_matching_meta({
+             "display_name": "p",
+             "peer_id": "x",
+         })), \
          patch.object(
              mcp_server,
              "daemon_request",
-             new=AsyncMock(return_value={"display_name": "p", "peer_id": "x"}),
+             new=AsyncMock(return_value=_matching_peer({"display_name": "p", "peer_id": "x"})),
          ):
         await mcp_server._get_my_peer_name()
         await mcp_server._get_my_peer_name()
@@ -430,12 +593,17 @@ async def test_ensure_registered_re_resolves_in_same_call_after_touch_404():
                 raise mcp_server.DaemonHTTPError(404, "Peer not found")
             return {"ok": True}
         if method == "GET" and path.startswith("/peers/by-pane/"):
-            return {"display_name": "fresh-name", "peer_id": "fresh-id"}
+            return _matching_peer({"display_name": "fresh-name", "peer_id": "fresh-id"})
         raise AssertionError(f"unexpected request: {method} {path}")
 
     tmux_info = {"pane_id": "%99", "session_name": None}
     with patch.object(mcp_server, "get_tmux_info", return_value=tmux_info), \
          patch.object(mcp_server, "get_pane_id", return_value="%99"), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "read_pane_runtime_metadata", return_value=_matching_meta({
+             "display_name": "fresh-name",
+             "peer_id": "fresh-id",
+         })), \
          patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_router)):
         await mcp_server._ensure_registered()
 

--- a/tests/test_pane_ownership_recovery.py
+++ b/tests/test_pane_ownership_recovery.py
@@ -1,0 +1,255 @@
+"""Regressions for sticky-orchestrator pane ownership.
+
+A temporary peer that registers on a pane already held by a live
+orchestrator must not displace the orchestrator's pane bookkeeping or
+liveness. Backend never switches inside a single peer_id; the failure
+class these tests pin down is destructive pane transfer + no recovery
+on the temp peer's exit, which left the original orchestrator with
+broken transport/window routing when the temp peer closed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import PeerRole, PeerStatus
+
+
+def _make_registry(tmp_path: Path) -> PeerRegistry:
+    cfg = Config()
+    cfg.daemon.heartbeat_interval = 30
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = 10**9
+    return registry
+
+
+PANE = "%42"
+
+
+@pytest.mark.asyncio
+async def test_sticky_orchestrator_pane_blocks_displacement(tmp_path: Path) -> None:
+    """A fresh codex orchestrator must keep pane_id, status, role when a
+    different-path claude registers on the same pane. The claude is
+    registered (so it can still call MCP outbound) but pane_id=None."""
+    registry = _make_registry(tmp_path)
+    orch_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/home/u/.repowire/orchestrator",
+        pane_id=PANE,
+        role=PeerRole.ORCHESTRATOR,
+        machine="m",
+    )
+
+    claim_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/home/u/projects/temp",
+        pane_id=PANE,
+        machine="m",
+    )
+
+    orch = await registry.get_peer(orch_id)
+    claim = await registry.get_peer(claim_id)
+    assert orch is not None and claim is not None
+    assert orch.pane_id == PANE
+    assert orch.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+    assert orch.role == PeerRole.ORCHESTRATOR
+    assert claim.pane_id is None
+    by_pane = await registry.get_peer_by_pane(PANE)
+    assert by_pane is not None and by_pane.peer_id == orch_id
+
+
+@pytest.mark.asyncio
+async def test_temp_peer_exit_leaves_orchestrator_intact(tmp_path: Path) -> None:
+    """After the temp peer goes OFFLINE (its WS closes), the orchestrator
+    still owns the pane and is reachable -- no manual repair needed."""
+    registry = _make_registry(tmp_path)
+    orch_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/home/u/.repowire/orchestrator",
+        pane_id=PANE,
+        role=PeerRole.ORCHESTRATOR,
+        machine="m",
+    )
+    claim_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/home/u/projects/temp",
+        pane_id=PANE,
+        machine="m",
+    )
+
+    await registry.mark_offline(claim_id)
+
+    orch = await registry.get_peer(orch_id)
+    assert orch is not None
+    assert orch.pane_id == PANE
+    assert orch.role == PeerRole.ORCHESTRATOR
+    assert orch.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+    by_pane = await registry.get_peer_by_pane(PANE)
+    assert by_pane is not None and by_pane.peer_id == orch_id
+
+
+@pytest.mark.asyncio
+async def test_non_orchestrator_incumbent_still_displaces(tmp_path: Path) -> None:
+    """Sticky behavior is scoped to ORCHESTRATOR. A new SessionStart on a
+    pane held by a regular agent is still a real takeover (current
+    semantics: pane re-bound, prior peer marked OFFLINE)."""
+    registry = _make_registry(tmp_path)
+    old_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/home/u/projects/foo",
+        pane_id=PANE,
+        machine="m",
+    )
+
+    new_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/home/u/projects/bar",
+        pane_id=PANE,
+        machine="m",
+    )
+
+    old = await registry.get_peer(old_id)
+    new = await registry.get_peer(new_id)
+    assert old is not None and new is not None
+    assert old.pane_id is None
+    assert old.status == PeerStatus.OFFLINE
+    assert new.pane_id == PANE
+
+
+@pytest.mark.asyncio
+async def test_release_pane_preserves_orchestrator_liveness(tmp_path: Path) -> None:
+    """Unit-level: _release_pane must not flip or detach a fresh ORCHESTRATOR.
+
+    Pane ownership is sticky for the orchestrator. A temporary claimant on
+    the same pane must not leave the live orchestrator online but pane-less.
+    """
+    registry = _make_registry(tmp_path)
+    orch_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/home/u/.repowire/orchestrator",
+        pane_id=PANE,
+        role=PeerRole.ORCHESTRATOR,
+        machine="m",
+    )
+
+    async with registry._lock:
+        registry._release_pane(PANE, new_peer_id="some-other-id")
+
+    orch = await registry.get_peer(orch_id)
+    assert orch is not None
+    assert orch.pane_id == PANE
+    assert orch.status in (PeerStatus.ONLINE, PeerStatus.BUSY)  # liveness preserved
+    assert orch.role == PeerRole.ORCHESTRATOR
+
+
+@pytest.mark.asyncio
+async def test_register_route_reports_unassigned_sticky_orchestrator_pane(
+    tmp_path: Path,
+) -> None:
+    """HTTP registration must expose pane_assigned=false on sticky refusal.
+
+    The hook consumes this wire field to avoid killing the incumbent ws-hook
+    or clearing pane runtime metadata.
+    """
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from repowire.daemon.deps import cleanup_deps, init_deps
+    from repowire.daemon.routes import peers
+
+    registry = _make_registry(tmp_path)
+    cfg = registry._config
+    state = SimpleNamespace(
+        config=cfg,
+        transport=registry._transport,
+        query_tracker=registry._query_tracker,
+        message_router=registry._router,
+        peer_registry=registry,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+    app = FastAPI()
+    app.include_router(peers.router)
+    try:
+        orch_id, _ = await registry.allocate_and_register(
+            circle="default",
+            backend=AgentType.CODEX,
+            path="/home/u/.repowire/orchestrator",
+            pane_id=PANE,
+            role=PeerRole.ORCHESTRATOR,
+            machine="m",
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            response = await client.post(
+                "/peers",
+                json={
+                    "name": "temp",
+                    "path": "/home/u/projects/temp",
+                    "circle": "default",
+                    "backend": "claude-code",
+                    "pane_id": PANE,
+                },
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pane_assigned"] is False
+
+        by_pane = await registry.get_peer_by_pane(PANE)
+        assert by_pane is not None
+        assert by_pane.peer_id == orch_id
+        temp = await registry.get_peer(body["peer_id"])
+        assert temp is not None
+        assert temp.pane_id is None
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_release_pane_still_offlines_agent(tmp_path: Path) -> None:
+    """Sanity: the preservation rule is scoped to ORCHESTRATOR; regular
+    agents are still marked OFFLINE when their pane gets reassigned."""
+    registry = _make_registry(tmp_path)
+    agent_id, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/home/u/projects/foo",
+        pane_id=PANE,
+        machine="m",
+    )
+
+    async with registry._lock:
+        registry._release_pane(PANE, new_peer_id="some-other-id")
+
+    agent = await registry.get_peer(agent_id)
+    assert agent is not None
+    assert agent.pane_id is None
+    assert agent.status == PeerStatus.OFFLINE

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -244,7 +244,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code", False),
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -276,7 +276,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code", False),
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -306,7 +306,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code", False),
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -387,7 +387,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "newproj-claude-code", False),
+        return_value=("repow-default-abc12345", "newproj-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -442,7 +442,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code", False),
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -495,7 +495,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=("repow-default-abc12345", "test-claude-code", False),
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -549,7 +549,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=(None, None, True),  # hijack_rejected=True
+        return_value=(None, None, True, False),  # hijack_rejected=True
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -621,7 +621,7 @@ class TestSessionMain:
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(
         "repowire.hooks.session_handler._register_peer_http",
-        return_value=(None, None, False),  # transport failure / 5xx: no accept, no 409
+        return_value=(None, None, False, False),  # transport failure / 5xx: no accept, no 409
     )
     @patch(
         "repowire.hooks.session_handler.get_tmux_info",
@@ -687,4 +687,77 @@ class TestSessionMain:
             assert meta_path.exists()
             assert json.loads(meta_path.read_text()) == incumbent_meta
             assert pid_path.exists()
+            assert pid_path.read_text() == "12345"
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=(
+            "repow-default-temp",
+            "temp-claude-code",
+            False,
+            False,
+        ),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    @patch("repowire.hooks.session_handler._read_ppid_of", return_value=99999)
+    def test_pane_unassigned_registration_leaves_incumbent_untouched(
+        self,
+        mock_read_ppid,
+        mock_branch,
+        mock_status,
+        mock_tmux,
+        mock_register,
+        mock_fetch,
+        tmp_path,
+    ):
+        """pane_assigned=False is a non-destructive sticky-pane refusal."""
+        with patch("repowire.config.models.CACHE_DIR", tmp_path), \
+             patch("repowire.hooks.session_handler._mark_peer_offline") as mock_offline, \
+             patch("repowire.hooks.session_handler.clear_pane_runtime_state") as mock_clear, \
+             patch("repowire.hooks.session_handler.spawn_ws_hook") as mock_spawn, \
+             patch("repowire.hooks.session_handler.write_pane_runtime_metadata") as mock_write:
+            log_dir = tmp_path / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            incumbent_meta = {
+                "backend": "codex",
+                "cwd": "/incumbent/orchestrator",
+                "hook_session_id": "orchestrator-session",
+                "peer_id": "repow-default-orchestrator",
+                "display_name": "orchestrator-codex",
+            }
+            meta_path = log_dir / "ws-hook-1.meta.json"
+            pid_path = log_dir / "ws-hook-1.pid"
+            meta_path.write_text(json.dumps(incumbent_meta))
+            pid_path.write_text("12345")
+
+            with patch("repowire.hooks.session_handler.fcntl") as mock_fcntl, \
+                 patch("repowire.hooks.session_handler.os.kill") as mock_kill:
+                mock_fcntl.LOCK_EX = 2
+                mock_fcntl.LOCK_NB = 4
+                mock_fcntl.flock.side_effect = OSError("Resource temporarily unavailable")
+
+                result = _run_with_input({
+                    "hook_event_name": "SessionStart",
+                    "cwd": "/temp/project",
+                    "session_id": "temp-session",
+                })
+
+            assert result == 0
+            mock_register.assert_called_once()
+            mock_kill.assert_not_called()
+            mock_offline.assert_not_called()
+            mock_clear.assert_not_called()
+            mock_spawn.assert_not_called()
+            mock_write.assert_not_called()
+            assert json.loads(meta_path.read_text()) == incumbent_meta
             assert pid_path.read_text() == "12345"

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -776,22 +776,30 @@ class TestMcpRegistration:
         mcp_server._cached_peer_name = None
 
     @pytest.mark.asyncio
+    @patch("repowire.mcp.server.read_pane_runtime_metadata")
+    @patch("repowire.mcp.server.os.getppid", return_value=12345)
     @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
     @patch(
         "repowire.mcp.server.get_tmux_info",
         return_value={"pane_id": "%1", "session_name": "0", "window_name": "repowire"},
     )
     async def test_existing_pane_peer_skips_registration(
-        self, _mock_tmux, mock_request: AsyncMock,
+        self, _mock_tmux, mock_request: AsyncMock, _mock_getppid, mock_meta,
     ) -> None:
         """If the pane already has a peer, MCP should not create a duplicate."""
         import repowire.mcp.server as mcp_server
 
         mcp_server._registered = False
         mcp_server._cached_peer_name = None
+        mock_meta.return_value = {
+            "peer_id": "repow-0-abc12345",
+            "display_name": "repowire-codex",
+            "backend": mcp_server._detect_backend(),
+            "agent_pid": 12345,
+        }
         mock_request.side_effect = [
-            {"display_name": "repowire-codex"},  # GET /peers/by-pane
-            {"ok": True},  # POST /peers/repowire-codex/touch
+            {"peer_id": "repow-0-abc12345", "display_name": "repowire-codex"},
+            {"ok": True},  # POST /peers/repow-0-abc12345/touch
         ]
 
         await mcp_server._ensure_registered()
@@ -799,7 +807,7 @@ class TestMcpRegistration:
         assert mock_request.await_count == 2
         assert mock_request.await_args_list[0].args == ("GET", "/peers/by-pane/%251")
         assert mock_request.await_args_list[1].args == (
-            "POST", "/peers/repowire-codex/touch",
+            "POST", "/peers/repow-0-abc12345/touch",
         )
         assert mcp_server._cached_peer_name == "repowire-codex"
 
@@ -808,6 +816,7 @@ class TestMcpRegistration:
 
     @pytest.mark.asyncio
     @patch("repowire.mcp.server.read_pane_runtime_metadata")
+    @patch("repowire.mcp.server.os.getppid", return_value=12345)
     @patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock)
     @patch(
         "repowire.mcp.server.get_tmux_info",
@@ -817,6 +826,7 @@ class TestMcpRegistration:
         self,
         _mock_tmux,
         mock_request: AsyncMock,
+        _mock_getppid,
         mock_meta,
     ) -> None:
         """Hook-managed tmux peers should not silently re-register over HTTP."""
@@ -828,6 +838,8 @@ class TestMcpRegistration:
         mock_meta.return_value = {
             "peer_id": "repow-0-abc12345",
             "display_name": "repowire-codex",
+            "backend": mcp_server._detect_backend(),
+            "agent_pid": 12345,
         }
 
         with pytest.raises(RuntimeError, match="inbound transport is disconnected"):


### PR DESCRIPTION
## Summary
- keep fresh orchestrator pane ownership sticky when a temporary same-pane session registers
- expose `pane_assigned=false` from peer registration and make SessionStart exit non-destructively in that case
- make MCP by-pane identity adoption require local runtime proof (peer_id/backend/agent_pid), not path or display name
- require canonical orchestrator workspace path for `claim_orchestrator_role`, removing display-name/basename shortcuts
- document path as metadata/context rather than peer identity proof

## Validation
- `uv run pytest -q` -> 1362 passed, 1 warning
- `uv run pytest tests/test_pane_ownership_recovery.py tests/test_session_handler.py tests/test_claim_role.py tests/test_mcp_peer_identity.py tests/test_spawn.py::TestMcpRegistration -q` -> 74 passed
- `uv run ruff check repowire/` -> passed
- `uv run ty check repowire/` -> passed
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> advisory passed

## Notes
- `repowire-9f8` was not visible in this worktree's Beads DB, so no Beads JSONL was committed.
- Follow-up source-of-truth investigation was delegated to a Codex peer; it recommended daemon-minted peer_id plus runtime-session birth certificates as the longer-term authority and filed follow-up Beads repowire-709, repowire-0ml, repowire-b46, and repowire-kh5.
