### PR TITLE
feat: add mesh memory CLI

### DIFF
--- a/docs/concepts/mesh-memory.md
+++ b/docs/concepts/mesh-memory.md
@@ -1,8 +1,9 @@
 # Mesh memory
 
-> **Status:** design proposal. No code shipped under this name yet. Builds on the
-> orchestrator memory layer described in [orchestrator.md](orchestrator.md) and
-> the persona/SOUL surface described in [personas.md](personas.md).
+> **Status:** first CLI slice shipped; MCP, hook injection, edit/rm commands,
+> and migration helpers remain design proposal. Builds on the orchestrator
+> memory layer described in [orchestrator.md](orchestrator.md) and the
+> persona/SOUL surface described in [personas.md](personas.md).
 
 Repowire today only ships one curated memory surface: the orchestrator
 workspace at `~/.repowire/orchestrator/memory/`. Every other peer either keeps
@@ -23,7 +24,7 @@ without changing the orchestrator's existing role.
 - Deliberate writes only. Hooks and prompts may *suggest* a memory write but
   must never silently mutate memory state.
 - A small CLI/MCP read+write surface that any peer can use without depending on
-  the host agent's own memory implementation.
+  the host agent's own memory implementation. Today this is CLI-only.
 - Composable with the existing
   [orchestrator memory](orchestrator.md#memory-and-procedures) and
   [persona SOUL](personas.md) layers rather than replacing them.
@@ -124,9 +125,9 @@ repowire memory list   [--scope <scope>] [--project <name>] [--persona <name>]
 repowire memory show   <slug> [--scope ...]
 repowire memory search <query> [--scope ...] [--all]
 repowire memory write  <slug> --body "..." [--scope ...] [--type ...] [--description ...]
-repowire memory append <slug> --body "..." [--scope ...]
-repowire memory edit   <slug> [--scope ...]      # opens $EDITOR
-repowire memory rm     <slug> [--scope ...]
+repowire memory write  <slug> --body "..." [--scope ...] --append
+repowire memory edit   <slug> [--scope ...]      # proposed
+repowire memory rm     <slug> [--scope ...]      # proposed
 repowire memory path   [--scope ...]             # print resolved directory
 ```
 
@@ -134,13 +135,17 @@ Scope defaults:
 
 - Inside an orchestrator workspace → `orchestrator`.
 - Inside a registered project peer's CWD → `projects/<auto-detected-name>`.
-- Otherwise → `user` for read commands, refuse with a hint for write commands.
+- Otherwise → `user`.
+
+The first shipped slice writes one Markdown file at a time, protects existing
+files unless `--force` or `--append` is passed, and refreshes the scope
+`MEMORY.md` index. It does not implement MCP tools yet.
 
 `--all` on search walks every scope and prefixes results with their scope path.
 
 ### MCP
 
-Three new tools on the existing MCP server:
+Proposed tools on the existing MCP server:
 
 - `memory_list(scope?, project?, persona?) -> TSV(slug, type, description, updated_at)`
 - `memory_read(slug, scope?, project?, persona?) -> str` — returns the file body
@@ -209,12 +214,13 @@ metadata:
 
 ## Implementation phasing
 
-Docs-only first (this file). Suggested follow-up beads:
+First CLI-only filesystem slice has landed. Suggested follow-up beads:
 
-1. `repowire memory` CLI subcommand with filesystem-only read/write.
-2. MCP `memory_read` / `memory_write` / `memory_list` / `memory_search` tools
+1. MCP `memory_read` / `memory_write` / `memory_list` / `memory_search` tools
    wrapping the same filesystem layer.
-3. SessionStart context injection block (read-only summary).
+2. SessionStart context injection block (read-only summary).
+3. `repowire memory edit` / `repowire memory rm` with user-visible diffs or
+   confirmations.
 4. Migration helper: `repowire memory adopt` to symlink the orchestrator dir
    under `~/.repowire/memory/orchestrator`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,6 +141,33 @@ and the orchestrator `SessionStart` hook injects the active persona with its
 source path and SHA-256 short hash. Persona context is identity guidance, not a
 permission policy.
 
+## `repowire memory`
+
+```bash
+repowire memory path [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory list [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory show SLUG [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory search QUERY [--scope SCOPE] [--project NAME] [--persona NAME] [--all]
+repowire memory write SLUG --body BODY [--scope SCOPE] [--project NAME] [--persona NAME] [--type TYPE] [--description TEXT] [--append|--force]
+```
+
+Inspect and explicitly write filesystem-backed mesh memory under
+`~/.repowire/memory/`. The CLI resolves scope directories, lists Markdown memory
+files, prints a memory by slug, searches memory text, and writes one curated
+memory at a time. It never auto-writes from hooks, transcripts, scheduler jobs,
+or daemon side effects.
+
+Scopes are `global`, `user`, `project`/`projects`, `persona`/`personas`, and
+`orchestrator`. When omitted, the default is `orchestrator` inside the
+orchestrator workspace and `user` elsewhere. Project scope defaults to the
+current directory name unless `--project NAME` is passed. Persona scope uses the
+active orchestrator persona when one is set, or `--persona NAME`.
+
+`write` creates `<slug>.md` with frontmatter (`name`, `description`,
+`metadata.type`, `metadata.updated_at`) and refreshes the scope `MEMORY.md`
+index. Existing memories are protected by default; pass `--force` to overwrite
+or `--append` to add to the current body.
+
 ## `repowire build-ui`
 
 ```bash

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1709,6 +1709,181 @@ def orchestrator_persona_path(name: str | None) -> None:
     console.print(f"{path} [dim]({source})[/]")
 
 
+_MEMORY_SCOPE_CHOICES = [
+    "global",
+    "user",
+    "project",
+    "projects",
+    "persona",
+    "personas",
+    "orchestrator",
+]
+
+
+def _memory_scope_options(fn: Any) -> Any:
+    fn = click.option(
+        "--persona",
+        help="Persona name for --scope persona (defaults to active persona)",
+    )(fn)
+    fn = click.option(
+        "--project",
+        help="Project name for project scope",
+    )(fn)
+    fn = click.option(
+        "--scope",
+        default=None,
+        type=click.Choice(_MEMORY_SCOPE_CHOICES),
+        help="Memory scope. Defaults to orchestrator in that workspace, otherwise user.",
+    )(fn)
+    return fn
+
+
+def _resolve_memory_scope(
+    scope: str | None,
+    project: str | None,
+    persona: str | None,
+) -> Any:
+    from repowire.memory import resolve_scope_path
+
+    return resolve_scope_path(scope, project=project, persona=persona)
+
+
+@main.group()
+def memory() -> None:
+    """Inspect and write explicit filesystem-backed mesh memory."""
+    pass
+
+
+@memory.command(name="path")
+@_memory_scope_options
+def memory_path(scope: str | None, project: str | None, persona: str | None) -> None:
+    """Print the resolved memory directory for a scope."""
+    try:
+        label, path = _resolve_memory_scope(scope, project, persona)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    console.print(f"{path} [dim]({label})[/]")
+
+
+@memory.command(name="list")
+@_memory_scope_options
+def memory_list(scope: str | None, project: str | None, persona: str | None) -> None:
+    """List memory entries in a scope."""
+    from repowire.memory import list_memories, resolve_scope_path
+
+    try:
+        label, path = resolve_scope_path(scope, project=project, persona=persona)
+        rows = list_memories(scope, project=project, persona=persona)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    if not rows:
+        console.print(f"[dim]No memories found in {label} ({path}).[/]")
+        return
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Slug")
+    table.add_column("Type")
+    table.add_column("Description")
+    table.add_column("Updated")
+    for row in rows:
+        table.add_row(row.slug, row.type, row.description, row.updated_at)
+    console.print(table)
+
+
+@memory.command(name="show")
+@click.argument("slug")
+@_memory_scope_options
+def memory_show(
+    slug: str,
+    scope: str | None,
+    project: str | None,
+    persona: str | None,
+) -> None:
+    """Show a memory Markdown file by slug."""
+    from repowire.memory import read_memory
+
+    try:
+        content, path = read_memory(slug, scope, project=project, persona=persona)
+    except (FileNotFoundError, ValueError) as e:
+        raise click.ClickException(str(e)) from e
+    console.print(f"[dim]{path}[/]")
+    console.print()
+    console.print(content.rstrip())
+
+
+@memory.command(name="search")
+@click.argument("query")
+@click.option("--all", "all_scopes_flag", is_flag=True, help="Search every scope")
+@_memory_scope_options
+def memory_search(
+    query: str,
+    all_scopes_flag: bool,
+    scope: str | None,
+    project: str | None,
+    persona: str | None,
+) -> None:
+    """Search memory files by text."""
+    from repowire.memory import search_memories
+
+    try:
+        rows = search_memories(
+            query,
+            scope,
+            project=project,
+            persona=persona,
+            all_scopes=all_scopes_flag,
+        )
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    if not rows:
+        console.print("[dim]No memory matches found.[/]")
+        return
+    for row in rows:
+        console.print(f"[cyan]{row.scope}/{row.slug}:{row.line}[/] {row.snippet}")
+
+
+@memory.command(name="write")
+@click.argument("slug")
+@click.option("--body", required=True, help="Markdown body to write")
+@click.option("--type", "memory_type", default="reference", show_default=True)
+@click.option("--description", default="", help="One-line memory summary")
+@click.option("--append", "append", is_flag=True, help="Append to an existing memory")
+@click.option("--force", is_flag=True, help="Overwrite an existing memory")
+@_memory_scope_options
+def memory_write(
+    slug: str,
+    body: str,
+    memory_type: str,
+    description: str,
+    append: bool,
+    force: bool,
+    scope: str | None,
+    project: str | None,
+    persona: str | None,
+) -> None:
+    """Write one memory Markdown file explicitly."""
+    from repowire.memory import write_memory
+
+    if append and force:
+        raise click.ClickException("--append and --force are mutually exclusive")
+    try:
+        path = write_memory(
+            slug,
+            body,
+            scope,
+            project=project,
+            persona=persona,
+            memory_type=memory_type,
+            description=description,
+            append=append,
+            overwrite=force,
+        )
+    except FileExistsError as e:
+        raise click.ClickException(f"memory already exists: {e.filename}") from e
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    console.print(f"[green]Wrote[/] {path}")
+
+
 @main.group()
 def peer() -> None:
     """Manage peers in the mesh."""

--- a/repowire/memory.py
+++ b/repowire/memory.py
@@ -1,0 +1,346 @@
+"""Filesystem-backed mesh memory helpers.
+
+This module owns only local, explicit memory operations. No hook, scheduler, or
+daemon side effect calls into this layer to learn silently.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from repowire.config.models import Config
+from repowire.orchestrator.persona import get_active_persona, validate_persona_name
+from repowire.orchestrator.workspace import workspace_path
+
+MEMORY_INDEX = "MEMORY.md"
+_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+_SCOPE_ALIASES = {
+    "project": "projects",
+    "projects": "projects",
+    "persona": "personas",
+    "personas": "personas",
+    "global": "global",
+    "user": "user",
+    "orchestrator": "orchestrator",
+}
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single memory file discovered in a resolved scope."""
+
+    scope: str
+    slug: str
+    path: Path
+    type: str
+    description: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class MemorySearchHit:
+    """A search match in a memory file."""
+
+    scope: str
+    slug: str
+    path: Path
+    line: int
+    snippet: str
+
+
+def validate_memory_name(name: str, *, label: str = "name") -> str:
+    """Validate a memory slug, project name, or scope path segment."""
+    cleaned = name.strip()
+    if not _SAFE_NAME_RE.fullmatch(cleaned):
+        raise ValueError(f"{label} must match ^[a-zA-Z0-9._-]+$")
+    return cleaned
+
+
+def memory_root() -> Path:
+    """Return the mesh-memory root directory."""
+    return Config.get_config_dir() / "memory"
+
+
+def normalize_scope(scope: str | None) -> str:
+    """Return a canonical mesh-memory scope."""
+    if scope is None:
+        return default_scope()
+    cleaned = scope.strip().lower()
+    try:
+        return _SCOPE_ALIASES[cleaned]
+    except KeyError as e:
+        raise ValueError(
+            "scope must be one of: global, user, project, projects, "
+            "persona, personas, orchestrator"
+        ) from e
+
+
+def default_scope() -> str:
+    """Resolve the local default scope without consulting the daemon."""
+    try:
+        cwd = Path.cwd().resolve()
+        orchestrator = workspace_path().resolve()
+        if cwd == orchestrator or orchestrator in cwd.parents:
+            return "orchestrator"
+    except OSError:
+        pass
+    return "user"
+
+
+def resolve_scope_path(
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+) -> tuple[str, Path]:
+    """Resolve a mesh-memory scope to its label and directory path."""
+    canonical = normalize_scope(scope)
+    root = memory_root()
+    if canonical == "projects":
+        if project is None:
+            project = Path.cwd().name
+        name = validate_memory_name(project, label="project")
+        return f"projects/{name}", root / "projects" / name
+    if canonical == "personas":
+        name = persona or get_active_persona()
+        if name is None:
+            raise ValueError("persona scope requires --persona or an active persona")
+        safe_name = validate_persona_name(name)
+        return f"personas/{safe_name}", root / "personas" / safe_name
+    if canonical == "orchestrator":
+        return "orchestrator", workspace_path() / "memory"
+    return canonical, root / canonical
+
+
+def iter_scope_paths(
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+    all_scopes: bool = False,
+) -> list[tuple[str, Path]]:
+    """Return scope paths for a targeted command or an all-scope search."""
+    if not all_scopes:
+        return [resolve_scope_path(scope, project=project, persona=persona)]
+
+    root = memory_root()
+    paths: list[tuple[str, Path]] = [
+        ("global", root / "global"),
+        ("user", root / "user"),
+        ("orchestrator", workspace_path() / "memory"),
+    ]
+    for parent, prefix in ((root / "projects", "projects"), (root / "personas", "personas")):
+        if not parent.is_dir():
+            continue
+        for child in sorted(parent.iterdir(), key=lambda p: p.name):
+            if child.is_dir() or child.is_symlink():
+                try:
+                    validate_memory_name(child.name, label=prefix[:-1])
+                except ValueError:
+                    continue
+                paths.append((f"{prefix}/{child.name}", child))
+    return paths
+
+
+def _memory_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in root.glob("*.md")
+        if path.name != MEMORY_INDEX and path.is_file()
+    )
+
+
+def _split_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    if not content.startswith("---\n"):
+        return {}, content
+    marker = "\n---\n"
+    end = content.find(marker, 4)
+    if end == -1:
+        return {}, content
+    raw = content[4:end]
+    body = content[end + len(marker) :]
+    parsed = yaml.safe_load(raw) or {}
+    if not isinstance(parsed, dict):
+        return {}, body
+    return parsed, body
+
+
+def _entry_from_file(scope: str, path: Path) -> MemoryEntry:
+    content = path.read_text(encoding="utf-8")
+    meta, _body = _split_frontmatter(content)
+    raw_metadata = meta.get("metadata")
+    metadata = cast(dict[str, Any], raw_metadata) if isinstance(raw_metadata, dict) else {}
+    slug = str(meta.get("name") or path.stem)
+    return MemoryEntry(
+        scope=scope,
+        slug=slug,
+        path=path,
+        type=str(metadata.get("type") or ""),
+        description=str(meta.get("description") or ""),
+        updated_at=str(metadata.get("updated_at") or _mtime_iso(path)),
+    )
+
+
+def list_memories(
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+) -> list[MemoryEntry]:
+    """List memory entries in a scope. Missing scopes are empty."""
+    label, root = resolve_scope_path(scope, project=project, persona=persona)
+    return [_entry_from_file(label, path) for path in _memory_files(root)]
+
+
+def read_memory(
+    slug: str,
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+) -> tuple[str, Path]:
+    """Read a memory file by slug and return its full Markdown content."""
+    safe_slug = validate_memory_name(slug, label="slug")
+    _label, root = resolve_scope_path(scope, project=project, persona=persona)
+    path = root / f"{safe_slug}.md"
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path.read_text(encoding="utf-8"), path
+
+
+def write_memory(
+    slug: str,
+    body: str,
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+    memory_type: str = "reference",
+    description: str = "",
+    append: bool = False,
+    overwrite: bool = False,
+) -> Path:
+    """Write one explicit memory file and refresh the scope index."""
+    if append and overwrite:
+        raise ValueError("append and overwrite are mutually exclusive")
+    safe_slug = validate_memory_name(slug, label="slug")
+    safe_type = validate_memory_name(memory_type, label="type")
+    label, root = resolve_scope_path(scope, project=project, persona=persona)
+    root.mkdir(parents=True, exist_ok=True)
+    if label == "orchestrator":
+        _ensure_orchestrator_link(root)
+
+    path = root / f"{safe_slug}.md"
+    if path.exists() and not (append or overwrite):
+        raise FileExistsError(path)
+
+    clean_body = body.strip()
+    if append and path.exists():
+        existing = path.read_text(encoding="utf-8")
+        _meta, existing_body = _split_frontmatter(existing)
+        clean_body = f"{existing_body.strip()}\n\n{clean_body}".strip()
+
+    path.write_text(
+        _render_memory(
+            safe_slug,
+            clean_body,
+            memory_type=safe_type,
+            description=description.strip(),
+        ),
+        encoding="utf-8",
+    )
+    _refresh_index(label, root)
+    return path
+
+
+def search_memories(
+    query: str,
+    scope: str | None = None,
+    *,
+    project: str | None = None,
+    persona: str | None = None,
+    all_scopes: bool = False,
+) -> list[MemorySearchHit]:
+    """Search memory Markdown files with case-insensitive substring matching."""
+    needle = query.strip()
+    if not needle:
+        raise ValueError("query must not be empty")
+    lowered = needle.lower()
+    hits: list[MemorySearchHit] = []
+    for label, root in iter_scope_paths(
+        scope, project=project, persona=persona, all_scopes=all_scopes
+    ):
+        for path in _memory_files(root):
+            slug = path.stem
+            for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if lowered in line.lower():
+                    hits.append(
+                        MemorySearchHit(
+                            scope=label,
+                            slug=slug,
+                            path=path,
+                            line=line_no,
+                            snippet=line.strip(),
+                        )
+                    )
+                    break
+    return hits
+
+
+def _mtime_iso(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat(
+        timespec="seconds"
+    )
+
+
+def _render_memory(
+    slug: str,
+    body: str,
+    *,
+    memory_type: str,
+    description: str,
+) -> str:
+    title = slug.replace("-", " ").replace("_", " ").title()
+    if not body.startswith("# "):
+        body = f"# {title}\n\n{body}".strip()
+    frontmatter = yaml.safe_dump(
+        {
+            "name": slug,
+            "description": description,
+            "metadata": {
+                "type": memory_type,
+                "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+        },
+        sort_keys=False,
+    ).strip()
+    return f"---\n{frontmatter}\n---\n\n{body}\n"
+
+
+def _refresh_index(scope: str, root: Path) -> None:
+    entries = [_entry_from_file(scope, path) for path in _memory_files(root)]
+    lines = ["# Memory", ""]
+    for entry in entries:
+        memory_type = f" ({entry.type})" if entry.type else ""
+        description = f" - {entry.description}" if entry.description else ""
+        lines.append(f"- [{entry.slug}]({entry.slug}.md){memory_type}{description}")
+    (root / MEMORY_INDEX).write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _ensure_orchestrator_link(target: Path) -> None:
+    link = memory_root() / "orchestrator"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.exists() or link.is_symlink():
+        return
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pass

--- a/tests/test_mesh_memory.py
+++ b/tests/test_mesh_memory.py
@@ -1,0 +1,214 @@
+"""Tests for filesystem-backed mesh memory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from repowire import memory
+from repowire.cli import main
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_config_dir = tmp_path / ".repowire"
+    fake_config_dir.mkdir()
+    monkeypatch.setattr(
+        "repowire.config.models.Config.get_config_dir",
+        classmethod(lambda cls: fake_config_dir),
+    )
+    return fake_config_dir
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _memory_doc(name: str, body: str, memory_type: str = "project") -> str:
+    return f"""---
+name: {name}
+description: {name} summary
+metadata:
+  type: {memory_type}
+  updated_at: 2026-05-25
+---
+
+# {name}
+
+{body}
+"""
+
+
+def test_resolve_scope_paths(tmp_config: Path) -> None:
+    label, path = memory.resolve_scope_path("global")
+    assert label == "global"
+    assert path == tmp_config / "memory" / "global"
+
+    label, path = memory.resolve_scope_path("project", project="repowire")
+    assert label == "projects/repowire"
+    assert path == tmp_config / "memory" / "projects" / "repowire"
+
+    label, path = memory.resolve_scope_path("project")
+    assert label == f"projects/{Path.cwd().name}"
+    assert path == tmp_config / "memory" / "projects" / Path.cwd().name
+
+
+def test_persona_scope_uses_active_persona(tmp_config: Path) -> None:
+    active = tmp_config / "orchestrator" / "personas" / "ACTIVE_PERSONA"
+    _write(active, "anya\n")
+
+    label, path = memory.resolve_scope_path("persona")
+    assert label == "personas/anya"
+    assert path == tmp_config / "memory" / "personas" / "anya"
+
+
+def test_list_read_and_search_memory(tmp_config: Path) -> None:
+    _write(
+        tmp_config / "memory" / "projects" / "repowire" / "routing.md",
+        _memory_doc("routing", "Transport-neutral routing note."),
+    )
+    _write(
+        tmp_config / "memory" / "projects" / "repowire" / "MEMORY.md",
+        "# Index\n",
+    )
+
+    rows = memory.list_memories("project", project="repowire")
+    assert [(row.slug, row.type, row.description) for row in rows] == [
+        ("routing", "project", "routing summary")
+    ]
+
+    content, path = memory.read_memory("routing", "project", project="repowire")
+    assert path.name == "routing.md"
+    assert "Transport-neutral routing note." in content
+
+    hits = memory.search_memories("neutral", "project", project="repowire")
+    assert len(hits) == 1
+    assert hits[0].scope == "projects/repowire"
+    assert hits[0].slug == "routing"
+
+
+def test_write_memory_creates_file_and_index(tmp_config: Path) -> None:
+    path = memory.write_memory(
+        "operator-style",
+        "**Why:** user prefers direct answers.",
+        "user",
+        memory_type="user",
+        description="communication preference",
+    )
+
+    assert path == tmp_config / "memory" / "user" / "operator-style.md"
+    content, read_path = memory.read_memory("operator-style", "user")
+    assert read_path == path
+    assert "operator-style" in content
+    assert "**Why:** user prefers direct answers." in content
+
+    rows = memory.list_memories("user")
+    assert [(row.slug, row.type, row.description) for row in rows] == [
+        ("operator-style", "user", "communication preference")
+    ]
+    index = tmp_config / "memory" / "user" / "MEMORY.md"
+    assert "[operator-style](operator-style.md)" in index.read_text(encoding="utf-8")
+
+
+def test_write_memory_requires_force_or_append(tmp_config: Path) -> None:
+    memory.write_memory("handoff", "first note", "global")
+
+    with pytest.raises(FileExistsError):
+        memory.write_memory("handoff", "second note", "global")
+
+    memory.write_memory("handoff", "second note", "global", append=True)
+    content, _path = memory.read_memory("handoff", "global")
+    assert "first note" in content
+    assert "second note" in content
+
+    memory.write_memory("handoff", "replacement", "global", overwrite=True)
+    content, _path = memory.read_memory("handoff", "global")
+    assert "replacement" in content
+    assert "first note" not in content
+
+
+def test_search_all_scopes(tmp_config: Path) -> None:
+    _write(
+        tmp_config / "memory" / "global" / "commits.md",
+        _memory_doc("commits", "Use short commit messages.", "global"),
+    )
+    _write(
+        tmp_config / "memory" / "personas" / "anya" / "voice.md",
+        _memory_doc("voice", "Anya answers concisely.", "user"),
+    )
+
+    hits = memory.search_memories("answers", all_scopes=True)
+    assert [(hit.scope, hit.slug) for hit in hits] == [("personas/anya", "voice")]
+
+
+def test_cli_memory_list_show_search(tmp_config: Path) -> None:
+    _write(
+        tmp_config / "memory" / "projects" / "repowire" / "routing.md",
+        _memory_doc("routing", "Transport-neutral routing note."),
+    )
+    runner = CliRunner()
+
+    res = runner.invoke(main, ["memory", "list", "--scope", "project", "--project", "repowire"])
+    assert res.exit_code == 0, res.output
+    assert "routing" in res.output
+    assert "routing summary" in res.output
+
+    res = runner.invoke(
+        main,
+        ["memory", "show", "routing", "--scope", "project", "--project", "repowire"],
+    )
+    assert res.exit_code == 0, res.output
+    assert "Transport-neutral routing note." in res.output
+
+    res = runner.invoke(
+        main,
+        ["memory", "search", "neutral", "--scope", "project", "--project", "repowire"],
+    )
+    assert res.exit_code == 0, res.output
+    assert "projects/repowire/routing" in res.output
+
+
+def test_cli_memory_write_and_duplicate_refusal(tmp_config: Path) -> None:
+    runner = CliRunner()
+
+    res = runner.invoke(
+        main,
+        [
+            "memory",
+            "write",
+            "operator-style",
+            "--scope",
+            "user",
+            "--body",
+            "Prefer concise handoffs.",
+            "--type",
+            "user",
+            "--description",
+            "handoff preference",
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert "Wrote" in res.output
+
+    res = runner.invoke(main, ["memory", "list", "--scope", "user"])
+    assert res.exit_code == 0, res.output
+    assert "operator-style" in res.output
+    assert "handoff preference" in res.output
+
+    res = runner.invoke(main, ["memory", "show", "operator-style", "--scope", "user"])
+    assert res.exit_code == 0, res.output
+    assert "Prefer concise handoffs." in res.output
+
+    res = runner.invoke(main, ["memory", "search", "concise", "--scope", "user"])
+    assert res.exit_code == 0, res.output
+    assert "operator-style" in res.output
+
+    duplicate = runner.invoke(
+        main,
+        ["memory", "write", "operator-style", "--scope", "user", "--body", "again"],
+    )
+    assert duplicate.exit_code != 0
+    assert "memory already exists" in duplicate.output

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -98,6 +98,22 @@ repowire orchestrator persona clear`}
         </p>
       </Cmd>
 
+      <Cmd
+        name="repowire memory"
+        usage={`repowire memory path [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory list [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory show SLUG [--scope SCOPE] [--project NAME] [--persona NAME]
+repowire memory search QUERY [--scope SCOPE] [--project NAME] [--persona NAME] [--all]
+repowire memory write SLUG --body BODY [--scope SCOPE] [--project NAME] [--persona NAME] [--type TYPE] [--description TEXT] [--append|--force]`}
+      >
+        <p>
+          Inspect and explicitly write filesystem-backed mesh memory under <Mono>~/.repowire/memory/</Mono>. The first slice resolves scope directories, lists Markdown memories, prints a memory by slug, searches text, and writes one curated memory at a time.
+        </p>
+        <p>
+          Scopes are <Mono>global</Mono>, <Mono>user</Mono>, <Mono>project</Mono>, <Mono>persona</Mono>, and <Mono>orchestrator</Mono>. Writes never happen from hooks, transcripts, schedules, or daemon side effects. Existing memories are protected unless <Mono>--force</Mono> overwrites or <Mono>--append</Mono> adds to the current body.
+        </p>
+      </Cmd>
+
       <Cmd name="repowire telegram start" usage="repowire telegram start">
         <p>
           Run the Telegram bot peer. Reads <Mono>TELEGRAM_BOT_TOKEN</Mono> and <Mono>TELEGRAM_CHAT_ID</Mono> from the environment. The bot registers as the <Mono>telegram</Mono> peer; messages from it are framed as human input.


### PR DESCRIPTION
## Summary
- add filesystem-backed mesh memory helpers under `~/.repowire/memory`
- add `repowire memory` CLI commands for path/list/show/search/write
- support explicit scopes: global, user, project(s), persona(s), orchestrator
- keep writes deliberate only; no hooks, transcripts, scheduler, daemon, MCP, dashboard, jobs, permissions, or identity source-of-truth changes
- update CLI and mesh-memory docs, including mirrored web CLI reference

## Validation
- `uv run pytest tests/test_mesh_memory.py -q` -> 8 passed
- `uv run ruff check repowire/ tests/test_mesh_memory.py` -> passed
- `uv run ty check repowire/` -> passed
- `npm run lint -- app/docs/reference/cli/page.tsx` -> passed
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> advisory passed

## Notes
- Worker reported full local gates before handoff: `uv run pytest` -> 1371 passed, `uv run ruff check repowire/ tests/test_mesh_memory.py`, and `uv run ty check repowire/` passed.
- `.beads/issues.jsonl` / root `issues.jsonl` are excluded from the product commit.
