### PR TITLE
fix: target Telegram peer selections by id

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,7 +7,7 @@ The mental model behind repowire. Read once, refer rarely.
 - [Message types](message-types.md) — `ask`, `ack`, `notify`, `broadcast`.
 - [Mesh command UX contract](mesh-command-ux.md) — command ids, JSON and human rendering, and agent-facing invocation rules.
 - [Tracked work lifecycle](tracked-work-lifecycle.md) — future daemon-backed work state, status/result/cancel semantics, and boundaries from ask/ack.
-- [Anya routing](anya-routing.md) — design contract for choosing direct answers, peer asks, spawned peers, schedules, jobs, or user clarification.
+- [Persona routing](persona-routing.md) — design contract for orchestrator personas choosing direct answers, peer asks, spawned peers, schedules, jobs, or user clarification.
 - [Claude Code plugin packaging](claude-code-plugin-packaging.md) — optional marketplace plugin boundaries, layout, and drift checks.
 - [Lazy repair](lazy-repair.md) — why repowire has no polling loops.
 - [Control surfaces](control-surfaces.md) — dashboard, Telegram, Slack as peers.

--- a/docs/concepts/persona-routing.md
+++ b/docs/concepts/persona-routing.md
@@ -1,20 +1,24 @@
-# Anya routing
+# Persona routing
 
-Status: product/design contract for the Anya personal-assistant layer. This is
-not a daemon runtime implementation, a permissions model, a durable job store,
-or an ACP micro-persona contract. It defines how Anya should decide which
+Status: product/design contract for an orchestrator persona routing layer. This
+is not a daemon runtime implementation, a permissions model, a durable job
+store, or an ACP micro-persona contract. "Anya" is Prass's personal
+instantiation of this pattern, not a default Repowire persona or a product name.
+The contract defines how a persona-backed orchestrator should decide which
 Repowire primitive or future job surface to use for a request.
 
 ## Problem
 
-Anya sits above the mesh. A user should be able to ask one assistant for help
-without deciding whether the next action is a direct answer, a peer ask, a new
-worker session, a scheduled reminder, a durable job, or a clarification prompt.
+A persona-backed orchestrator sits above the mesh. A user should be able to ask
+one assistant for help without deciding whether the next action is a direct
+answer, a peer ask, a new worker session, a scheduled reminder, a durable job,
+or a clarification prompt.
 
 The router is the decision layer for that handoff. It consumes the user's
 request, visible mesh state, persona context, memory hints, and future job
-state, then returns one explicit route plan. The plan may be executed by Anya
-or shown to the user for approval depending on confidence, scope, and risk.
+state, then returns one explicit route plan. The plan may be executed by the
+active orchestrator persona or shown to the user for approval depending on
+confidence, scope, and risk.
 
 ## Boundaries
 
@@ -25,12 +29,12 @@ or shown to the user for approval depending on confidence, scope, and risk.
   job.
 - Persona SOUL.md guides identity, voice, and standing preferences. It is not a
   permission policy and must not override current user instructions.
-- Mesh memory and Anya memory remain deliberate-write systems. Routing may
+- Mesh memory and persona memory remain deliberate-write systems. Routing may
   propose a memory write only through the memory approval path; it must never
   write memory as a side effect.
-- Permissions and scopes are deferred to the Anya scopes model. Until then,
-  routes that would read private data, write state, execute tools, spend money,
-  or delegate broad authority must ask the user.
+- Permissions and scopes are deferred to a future persona scopes model. Until
+  then, routes that would read private data, write state, execute tools, spend
+  money, or delegate broad authority must ask the user.
 - The router should not add polling loops. Watchdogs and delayed follow-ups use
   Repowire schedules or future job deadlines.
 
@@ -76,9 +80,9 @@ names are acceptable in prose but must not be the only routing key when a
 
 ### Answer directly
 
-Use `answer_direct` when Anya can satisfy the request from current context,
-stable product knowledge, or a small bounded inspection that does not require a
-different executor.
+Use `answer_direct` when the active persona can satisfy the request from
+current context, stable product knowledge, or a small bounded inspection that
+does not require a different executor.
 
 Good fits:
 
@@ -88,7 +92,8 @@ Good fits:
 - producing a short plan that the user explicitly asked for.
 
 Do not answer directly when the request needs live project state from another
-peer, private data Anya is not scoped to read, or durable follow-through.
+peer, private data the active persona is not scoped to read, or durable
+follow-through.
 
 ### Ask a peer
 
@@ -145,8 +150,8 @@ Prefer `use_acp_persona` when:
 - cancellation can be represented through the tracked-work cancel contract;
 - failure can fall back to a full peer or user clarification.
 
-Until the ACP micro-persona contract exists, Anya must not claim this route is
-available. It may return `create_job` with
+Until the ACP micro-persona contract exists, the active persona must not claim
+this route is available. It may return `create_job` with
 `preferred_executor="acp_persona:<name>"` as design intent, or fall back to
 `ask_user`, `ask_peer`, or `spawn_peer`.
 
@@ -200,10 +205,10 @@ The job request should carry:
 - deadline, TTL, retry policy, and schedule hints;
 - initial progress note and provenance links.
 
-Until the jobs contract is implemented, this route is design-only. Anya may
-explain that the task should become a job later and use an `ask_peer`,
-`spawn_peer`, or `schedule` fallback only if that fallback is acceptable without
-durable job semantics.
+Until the jobs contract is implemented, this route is design-only. The active
+persona may explain that the task should become a job later and use an
+`ask_peer`, `spawn_peer`, or `schedule` fallback only if that fallback is
+acceptable without durable job semantics.
 
 ### Ask the user
 
@@ -259,9 +264,9 @@ Fallback behavior:
 Request: "Track the release checklist and tell me when it is ready."
 
 Route: `create_job` once jobs exist. The job owns the checklist, progress,
-result, and cancellation path. Today, Anya should explain that durable jobs are
-not available and can schedule a self-wake or ask an orchestrator peer only as a
-weaker fallback.
+result, and cancellation path. Today, the active persona should explain that
+durable jobs are not available and can schedule a self-wake or ask an
+orchestrator peer only as a weaker fallback.
 
 ### Investigate
 
@@ -290,10 +295,10 @@ guessing from old chat.
 
 ### Remind
 
-Request: "Remind me tomorrow morning to review the Anya spec."
+Request: "Remind me tomorrow morning to review the persona routing spec."
 
-Route: `schedule` with `kind="notify"` to the requested user surface or Anya's
-orchestrator session. Include the schedule id and cancellation path.
+Route: `schedule` with `kind="notify"` to the requested user surface or the
+active orchestrator session. Include the schedule id and cancellation path.
 
 ### Cancel
 

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -561,7 +561,8 @@ class TelegramPeer:
 
         self._reply_target = peer
         self._pending_retry = None
-        await self._tg_send(f"Now talking to *@{_esc(peer)}*\\.")
+        label = await self._peer_label_for_target(peer)
+        await self._tg_send(f"Now talking to *@{_esc(label)}*\\.")
 
     async def _on_photo(self, photo: dict, caption: str, message_id: int | None = None) -> None:
         """Handle incoming Telegram photo — upload to daemon, ask peer."""
@@ -710,15 +711,19 @@ class TelegramPeer:
             folder = Path(path).name or name
             desc = p.get("description", "")
             branch = p.get("metadata", {}).get("branch", "")
+            circle = p.get("circle", "")
             icon = "🟢" if p.get("status") == "online" else "🟡"
+            target = self._peer_target(p)
 
             line = f"{icon} *{_esc(folder)}* `{_esc(name)}`"
+            if circle:
+                line += f" `{_esc(circle)}`"
             if branch:
                 line += f" `{_esc(branch)}`"
             if desc:
                 line += f"\n  _{_esc(desc)}_"
             lines.append(line)
-            buttons.append(("💬 " + folder, f"target:{name}"))
+            buttons.append(("💬 " + self._peer_button_label(p), f"target:{target}"))
 
         # 2-column grid when >4 peers; 1-column otherwise.
         if len(buttons) > 4:
@@ -727,6 +732,43 @@ class TelegramPeer:
             rows = [[b] for b in buttons]
 
         await self._tg_send("\n".join(lines), markup=_kb(rows))
+
+    def _peer_target(self, peer: dict[str, Any]) -> str:
+        target = peer.get("peer_id") or peer.get("display_name") or peer.get("name") or "?"
+        return str(target)
+
+    def _peer_button_label(self, peer: dict[str, Any]) -> str:
+        name = str(peer.get("display_name") or peer.get("name") or "?")
+        path = str(peer.get("path") or "")
+        folder = Path(path).name or name
+        circle = peer.get("circle")
+        return f"{folder} · {circle}" if circle else folder
+
+    async def _peer_label_for_target(self, target: str) -> str:
+        peers = await self._fetch_online_peers()
+        for peer in peers:
+            identifiers = {
+                str(peer.get("peer_id") or ""),
+                str(peer.get("display_name") or ""),
+                str(peer.get("name") or ""),
+            }
+            if target in identifiers:
+                name = str(peer.get("display_name") or peer.get("name") or target)
+                circle = peer.get("circle")
+                return f"{name} ({circle})" if circle else name
+        return target
+
+    async def _peer_retry_markup(self) -> dict | None:
+        peers = await self._fetch_online_peers(use_cache=False)
+        active = [p for p in peers if p.get("status") in ("online", "busy")]
+        if not active:
+            return None
+        buttons = [
+            ("💬 " + self._peer_button_label(peer), f"target:{self._peer_target(peer)}")
+            for peer in active
+        ]
+        rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
+        return _kb(rows)
 
     async def _ask(
         self,
@@ -787,9 +829,11 @@ class TelegramPeer:
                     mode=mode,
                     attachments=attachments,
                 )
+                markup = await self._peer_retry_markup()
                 await self._tg_send(
                     f"✗ Couldn't reach *@{_esc(peer)}*: {_esc(str(detail))}\n"
-                    f"Tap a peer to resend, or type a new message to cancel\\."
+                    f"Tap a peer to resend, or type a new message to cancel\\.",
+                    markup=markup,
                 )
         except Exception as e:
             self._pending_retry = PendingRetry(
@@ -798,9 +842,11 @@ class TelegramPeer:
                 mode=mode,
                 attachments=attachments,
             )
+            markup = await self._peer_retry_markup()
             await self._tg_send(
                 f"⚠️ Daemon unreachable: {_esc(str(e))}\n"
-                f"Tap a peer to retry, or type a new message to cancel\\."
+                f"Tap a peer to retry, or type a new message to cancel\\.",
+                markup=markup,
             )
 
     # -- Telegram API --

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -283,6 +283,97 @@ async def test_send_peer_message_includes_attachments(
     assert post.await_args.kwargs["json"]["attachments"][0]["id"] == "att123"
 
 
+@pytest.mark.asyncio
+async def test_peer_picker_targets_peer_id_for_duplicate_names(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_tg_send", send)
+    monkeypatch.setattr(
+        telegram_bot,
+        "_fetch_online_peers",
+        AsyncMock(return_value=[
+            {
+                "peer_id": "repow-default",
+                "display_name": "repowire-codex",
+                "status": "busy",
+                "circle": "default",
+                "path": "/projects/repowire",
+            },
+            {
+                "peer_id": "repow-66",
+                "display_name": "repowire-codex",
+                "status": "online",
+                "circle": "66",
+                "path": "/projects/repowire",
+            },
+        ]),
+    )
+
+    await telegram_bot._cmd_peers()
+
+    markup = send.await_args.kwargs["markup"]
+    buttons = [button for row in markup["inline_keyboard"] for button in row]
+    assert {button["callback_data"] for button in buttons} == {
+        "target:repow-default",
+        "target:repow-66",
+    }
+    assert {button["text"] for button in buttons} == {
+        "💬 repowire · default",
+        "💬 repowire · 66",
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_error_offers_peer_id_buttons(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = AsyncMock()
+    post.return_value = SimpleNamespace(
+        status_code=409,
+        json=lambda: {
+            "detail": (
+                "Ambiguous peer name 'repowire-codex': matches in circles "
+                "['66', 'default']."
+            ),
+        },
+        text="ambiguous",
+    )
+    send = AsyncMock()
+    monkeypatch.setattr(telegram_bot._http, "post", post)
+    monkeypatch.setattr(telegram_bot, "_tg_send", send)
+    monkeypatch.setattr(
+        telegram_bot,
+        "_fetch_online_peers",
+        AsyncMock(return_value=[
+            {
+                "peer_id": "repow-default",
+                "display_name": "repowire-codex",
+                "status": "busy",
+                "circle": "default",
+                "path": "/projects/repowire",
+            },
+            {
+                "peer_id": "repow-66",
+                "display_name": "repowire-codex",
+                "status": "online",
+                "circle": "66",
+                "path": "/projects/repowire",
+            },
+        ]),
+    )
+
+    await telegram_bot._ask("repowire-codex", "ping")
+
+    markup = send.await_args.kwargs["markup"]
+    buttons = [button for row in markup["inline_keyboard"] for button in row]
+    assert {button["callback_data"] for button in buttons} == {
+        "target:repow-default",
+        "target:repow-66",
+    }
+    assert telegram_bot._pending_retry is not None
+
+
 # -- PendingRetry TTL --
 
 

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -90,9 +90,12 @@ export default function Concepts() {
         </p>
       </Section>
 
-      <Section title="Anya routing">
+      <Section title="Persona routing">
         <p>
-          Anya routing is a product/design contract for the personal-assistant layer above the mesh. It is not shipped daemon behavior yet. The router decides whether Anya should answer directly, ask an existing peer, spawn a full peer, use a future ACP persona, schedule a reminder or watchdog, use an existing future job, create a new job, or ask the user for clarification.
+          Persona routing is a design contract for an orchestrator persona layer above the mesh. It is not shipped daemon behavior yet, and no persona is enabled by default. Anya is Prass&apos;s personal instantiation of this pattern, not the Repowire product default.
+        </p>
+        <p>
+          The router decides whether the active persona should answer directly, ask an existing peer, spawn a full peer, use a future ACP persona, schedule a reminder or watchdog, use an existing future job, create a new job, or ask the user for clarification.
         </p>
         <p>
           Inputs include the request, requester, intent, scope, visible peers, schedules, persona context, memory references, policy, and future tracked-work records. Outputs carry a route, confidence, reason, target, concrete action, approval requirement, fallback, and provenance links.


### PR DESCRIPTION
## Summary
- make Telegram peer picker and retry buttons target daemon `peer_id` when available instead of display name
- label duplicate peer names with their circle so tapped rows are concrete
- rename the public Anya routing concept to Persona routing and frame Anya as Prass's personal instantiation, not a default Repowire product persona

## Verification
- `uv run pytest tests/test_telegram_bot.py -q`
- `uv run ruff check repowire/telegram/bot.py tests/test_telegram_bot.py`
- `uv run ty check repowire/telegram/bot.py`
- `cd web && npm run lint -- app/docs/concepts/page.tsx`
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`
- `git diff --check`

Tracks repowire-co6.
