### PR TITLE
Add runtime identity birth certificates

### DIFF
--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -27,7 +27,7 @@ order is:
 | Level | Signal | Authority | Notes |
 | --- | --- | --- | --- |
 | 1 | Daemon-minted `peer_id` in the live registry | Authoritative routing identity | Exact key for asks, acks, notifications, and peer lookup. |
-| 2 | Daemon-minted runtime identity envelope | Authoritative handoff proof | Planned birth certificate for SessionStart/channel connect to hand MCP a peer identity without path search. |
+| 2 | Daemon-minted runtime identity envelope | Authoritative handoff proof | Birth certificate minted during SessionStart registration so MCP can adopt a peer identity without path search. |
 | 3 | Local pane runtime metadata plus process proof | Local adoption proof | Valid only when backend, daemon peer id, and owning agent process match the current MCP process. |
 | 4 | Durable `SessionMapping` / session binding records | Compatibility and provenance | Useful for restoring circle, role, description, runtime session pointers, and history relationships; not pane ownership proof. |
 | 5 | Durable spawn ownership plus live tmux evidence | Destructive-action proof | Authorizes kill/restart of a daemon-spawned pane. It does not prove caller identity for MCP tools. |
@@ -66,40 +66,42 @@ There is one protected case: a fresh live `orchestrator` peer keeps sticky owner
 
 MCP lazy registration treats tmux pane lookup as a locator, not as identity proof. A by-pane daemon result is accepted only when local pane runtime metadata proves the same daemon peer id, backend, and owning agent process. If that proof is missing or belongs to another process, MCP registers or resolves its own peer instead of adopting the incumbent. This keeps path and display name as useful context while avoiding path-based identity takeover.
 
-The remaining compatibility fallback is path+backend lookup when MCP starts
-without pane context, no local metadata is available, and exactly one online
-candidate matches. This is a narrow bridge for stripped tmux environments, not
-an identity source of truth. The daemon-minted birth certificate described below
-is the intended replacement.
+MCP lazy registration checks a daemon-minted birth certificate before the
+remaining compatibility fallback. That fallback is path+backend lookup when MCP
+starts without pane context, no local metadata is available, and exactly one
+online candidate matches. This is a narrow bridge for stripped tmux
+environments, not an identity source of truth.
 
-## Runtime birth certificate direction
+## Runtime birth certificates
 
-Future SessionStart and channel-connect paths should mint a short-lived runtime
-identity envelope after daemon registration. The envelope should be created by
-the daemon or contain daemon-unguessable proof, then be written where the local
-runtime and MCP server can read it.
+Hook-based `SessionStart` registration mints a short-lived runtime identity
+envelope after daemon registration. The envelope is persisted in SQLite with an
+unguessable nonce and written into local hook metadata where the MCP server can
+read it.
 
-Minimum envelope fields:
+Current envelope fields:
 
 - `peer_id`
 - `display_name`
 - `backend`
-- `circle`
+- `project_path`
 - `runtime_session_id` or hook `session_id` when known
 - `pane_id` when the runtime is pane-local
 - `agent_pid` / process proof when available
 - `issued_at` and `expires_at`
-- an unguessable nonce or daemon-verifiable token
+- an unguessable nonce
+- small metadata such as circle and role
 
-MCP lazy registration should eventually consult this envelope before pane,
-metadata, or path lookup. Validation should reject expired envelopes, backend
-mismatches, pane reuse, process mismatches, and daemon peer ids that no longer
-exist or no longer match the envelope. When the envelope is absent or invalid,
-MCP may register a fresh peer or fail closed for strict outbound tools; it
-should not silently adopt identity from path alone.
+MCP lazy registration validates this envelope through the daemon before
+path+backend lookup. Validation rejects expired envelopes, backend mismatches,
+pane reuse, process mismatches, and envelope fields that do not match persisted
+daemon state. If the daemon restarted and no in-memory peer exists, a valid
+certificate can rehydrate the peer from persisted identity evidence. When the
+envelope is absent or invalid, MCP may register a fresh peer or fail closed for
+strict outbound tools; it should not silently adopt identity from path alone.
 
-This direction does not make the daemon the owner of raw transcript history and
-does not authorize destructive pane actions. Runtime session ids remain source
+Birth certificates do not make the daemon the owner of raw transcript history
+and do not authorize destructive pane actions. Runtime session ids remain source
 history/provenance. Spawn ownership remains the kill/restart proof.
 
 ## Display-name ambiguity

--- a/docs/reference/sqlite-state-expansion-plan.md
+++ b/docs/reference/sqlite-state-expansion-plan.md
@@ -11,7 +11,7 @@ helpers:
 - Legacy JSON files under `~/.repowire/`, kept as one-time import sources and
   downgrade artifacts, not active daemon write targets for migrated domains.
 
-The SQLite path currently covers schedules, session bindings, dashboard/session events, and peer session mappings. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, and lifecycle status. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup. `PeerRegistry` imports legacy `sessions.json` once into `peer_session_mappings` and stops writing new `sessions.json` state.
+The SQLite path currently covers schedules, session bindings, runtime identity certificates, dashboard/session events, and peer session mappings. `StateDatabase` owns WAL mode, `synchronous=NORMAL`, foreign keys, busy timeout, schema versioning, and the `legacy_imports` audit table. `SQLiteScheduleStore` is adapter-compatible with `ScheduleStore`, imports `schedules.json` once when the SQL table is empty, and leaves the JSON file untouched for downgrade and backcompat. `SQLiteSessionBindingStore` persists binding identifiers, runtime source locators, cursors, provenance, resume capability metadata, lifecycle status, and daemon-minted runtime birth certificates. It deliberately does not persist raw transcript bodies. `SQLiteEventStore` imports legacy `events.json` once, appends/updates event payloads in SQLite, and seeds the bounded in-memory event window at daemon startup. `PeerRegistry` imports legacy `sessions.json` once into `peer_session_mappings` and stops writing new `sessions.json` state.
 
 Other state remains JSON or in-memory:
 
@@ -39,6 +39,9 @@ Current SQLite slices:
 - Peer mappings use SQLite; `sessions.json` is not written by the daemon app.
 - Asks, query futures, transport state, and raw transcripts keep their current ownership.
 - Session bindings are stored in SQLite as control/provenance metadata and are used by compatible timeline/transcript and session-control slices when an unambiguous binding exists.
+- Runtime identity certificates are stored in SQLite as short-lived nonce-backed
+  envelopes for MCP identity adoption and daemon-restart rehydration. They are
+  peer identity proof, not pane kill/restart ownership proof.
 - Dashboard/session events remain a bounded in-memory deque for route/SSE compatibility;
   persistence is backed by SQLite instead of new `events.json` writes.
 - `events.json` remains in place for downgrade/export compatibility and one-time import.

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -589,11 +589,33 @@ class PeerRegistry:
         role: PeerRole = PeerRole.AGENT,
         agent_pid: int | None = None,
         circle_source: CircleSource | None = None,
+        preferred_session_id: str | None = None,
     ) -> str:
         """Find existing mapping or allocate a new session_id. Must hold lock.
 
         Returns the session_id (existing or new).
         """
+        if preferred_session_id:
+            mapping = self._mappings.get(preferred_session_id)
+            if (
+                mapping is not None
+                and mapping.display_name == display_name
+                and mapping.circle == circle
+                and mapping.backend == backend
+            ):
+                mapping.path = path
+                mapping.updated_at = datetime.now(timezone.utc).isoformat()
+                if agent_pid is not None:
+                    mapping.agent_pid = agent_pid
+                self._mappings_dirty = True
+                logger.info(
+                    "Reusing preferred session %s for %s@%s",
+                    preferred_session_id,
+                    display_name,
+                    circle,
+                )
+                return preferred_session_id
+
         for sid, mapping in self._mappings.items():
             if (
                 mapping.display_name == display_name
@@ -858,6 +880,7 @@ class PeerRegistry:
                 allocated_id = self._find_or_allocate_mapping(
                     assigned_name, circle, backend, path, role=role,
                     agent_pid=agent_pid, circle_source=circle_source,
+                    preferred_session_id=peer_id,
                 )
                 if effective_pane_id:
                     self._release_pane(effective_pane_id, allocated_id)

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -328,16 +328,39 @@ class RegisterResponse(BaseModel):
     peer_id: str
     display_name: str
     pane_assigned: bool = True
+    birth_certificate: dict[str, Any] | None = None
 
 
-async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str, bool]:
+class ValidateBirthCertificateRequest(BaseModel):
+    """Request to validate a daemon-minted runtime identity certificate."""
+
+    birth_certificate: dict[str, Any] = Field(..., min_length=1)
+    backend: AgentType
+    path: str | None = None
+    pane_id: str | None = None
+    agent_pid: int | None = None
+
+
+class ValidateBirthCertificateResponse(BaseModel):
+    """Validated peer identity from a runtime birth certificate."""
+
+    ok: bool = True
+    peer_id: str
+    display_name: str
+    peer: PeerInfo
+
+
+async def _register_peer_impl(
+    request: RegisterPeerRequest,
+) -> tuple[str, str, bool, dict[str, Any] | None]:
     """Shared implementation for peer registration endpoints.
 
-    Returns (peer_id, assigned_display_name, pane_assigned). ``pane_assigned``
-    is True iff the caller requested a pane_id and the registered peer ended
-    up owning it; False when the daemon's sticky-orchestrator branch refused
-    to displace a live orchestrator. When no pane_id was requested,
-    pane_assigned defaults to True (vacuously: nothing to assign).
+    Returns (peer_id, assigned_display_name, pane_assigned, birth_certificate).
+    ``pane_assigned`` is True iff the caller requested a pane_id and the
+    registered peer ended up owning it; False when the daemon's
+    sticky-orchestrator branch refused to displace a live orchestrator. When no
+    pane_id was requested, pane_assigned defaults to True (vacuously: nothing
+    to assign).
     """
     circle = request.circle or "global"
 
@@ -369,6 +392,7 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str, b
             detail=str(exc),
         ) from exc
     binding_store = getattr(get_app_state(), "session_binding_store", None)
+    birth_certificate: dict[str, Any] | None = None
     if binding_store is not None:
         try:
             binding_store.upsert_observation(
@@ -386,13 +410,32 @@ async def _register_peer_impl(request: RegisterPeerRequest) -> tuple[str, str, b
                 status="active",
                 metadata=_binding_metadata(request.metadata),
             )
+            cert = binding_store.mint_birth_certificate(
+                peer_id=peer_id,
+                display_name=display_name,
+                backend=request.backend,
+                project_path=request.path,
+                runtime_session_id=request.metadata.get("hook_session_id"),
+                pane_id=request.pane_id,
+                agent_pid=request.agent_pid,
+                parent_pid=request.parent_pid,
+                metadata={
+                    **_binding_metadata(request.metadata),
+                    "circle": circle,
+                    "role": request.role.value,
+                },
+            )
+            birth_certificate = cert.as_envelope()
         except Exception:
-            logger.warning("Failed to persist session binding for peer registration", exc_info=True)
+            logger.warning(
+                "Failed to persist session binding/certificate for peer registration",
+                exc_info=True,
+            )
     pane_assigned = True
     if request.pane_id:
         registered = await peer_registry.get_peer(peer_id)
         pane_assigned = bool(registered and registered.pane_id == request.pane_id)
-    return peer_id, display_name, pane_assigned
+    return peer_id, display_name, pane_assigned, birth_certificate
 
 
 @router.post("/peers", response_model=RegisterResponse)
@@ -401,9 +444,81 @@ async def create_peer(
     _: str | None = Depends(require_auth),
 ) -> RegisterResponse:
     """Register a new peer (CLI-friendly endpoint)."""
-    peer_id, display_name, pane_assigned = await _register_peer_impl(request)
+    peer_id, display_name, pane_assigned, birth_certificate = await _register_peer_impl(request)
     return RegisterResponse(
-        peer_id=peer_id, display_name=display_name, pane_assigned=pane_assigned,
+        peer_id=peer_id,
+        display_name=display_name,
+        pane_assigned=pane_assigned,
+        birth_certificate=birth_certificate,
+    )
+
+
+@router.post(
+    "/peers/identity/validate",
+    response_model=ValidateBirthCertificateResponse,
+)
+async def validate_runtime_identity(
+    request: ValidateBirthCertificateRequest,
+    _: str | None = Depends(require_auth),
+) -> ValidateBirthCertificateResponse:
+    """Validate a daemon-minted runtime birth certificate for MCP adoption."""
+    state = get_app_state()
+    binding_store = getattr(state, "session_binding_store", None)
+    if binding_store is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Runtime identity certificate store is unavailable",
+        )
+    cert = binding_store.validate_birth_certificate(
+        request.birth_certificate,
+        backend=request.backend,
+        project_path=request.path,
+        pane_id=request.pane_id,
+        agent_pid=request.agent_pid,
+    )
+    if cert is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Runtime identity certificate is invalid or expired",
+        )
+
+    peer_registry = get_peer_registry()
+    peer = await peer_registry.get_peer(cert.peer_id)
+    if peer is None:
+        circle = cert.metadata.get("circle") if isinstance(cert.metadata, dict) else None
+        role = cert.metadata.get("role") if isinstance(cert.metadata, dict) else None
+        try:
+            peer_id, _display_name = await peer_registry.allocate_and_register(
+                circle=circle or "default",
+                backend=AgentType(cert.backend),
+                path=cert.project_path,
+                pane_id=cert.pane_id,
+                metadata={
+                    "hook_session_id": cert.runtime_session_id,
+                    "birth_certificate_nonce": cert.nonce,
+                },
+                role=PeerRole(role or PeerRole.AGENT.value),
+                peer_id=cert.peer_id,
+                initial_status=PeerStatus.ONLINE,
+                agent_pid=cert.agent_pid,
+                parent_pid=cert.parent_pid,
+                circle_source="fallback",
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Runtime identity certificate could not rehydrate peer: {exc}",
+            ) from exc
+        peer = await peer_registry.get_peer(peer_id)
+    if peer is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Peer not found after runtime identity validation",
+        )
+    return ValidateBirthCertificateResponse(
+        peer_id=peer.peer_id,
+        display_name=peer.display_name,
+        peer=_peer_to_info(peer),
     )
 
 
@@ -1168,9 +1283,12 @@ async def register_peer(
     _: str | None = Depends(require_auth),
 ) -> RegisterResponse:
     """Register a new peer in the mesh (legacy endpoint)."""
-    peer_id, display_name, pane_assigned = await _register_peer_impl(request)
+    peer_id, display_name, pane_assigned, birth_certificate = await _register_peer_impl(request)
     return RegisterResponse(
-        peer_id=peer_id, display_name=display_name, pane_assigned=pane_assigned,
+        peer_id=peer_id,
+        display_name=display_name,
+        pane_assigned=pane_assigned,
+        birth_certificate=birth_certificate,
     )
 
 

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 
 class StateDatabase:
@@ -189,6 +189,36 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS runtime_identity_certificates (
+                    nonce TEXT PRIMARY KEY,
+                    peer_id TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    backend TEXT NOT NULL,
+                    project_path TEXT NOT NULL,
+                    runtime_session_id TEXT,
+                    pane_id TEXT,
+                    agent_pid INTEGER,
+                    parent_pid INTEGER,
+                    issued_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}'
+                )
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_runtime_identity_certificates_peer
+                ON runtime_identity_certificates(peer_id)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_runtime_identity_certificates_runtime
+                ON runtime_identity_certificates(backend, runtime_session_id)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
@@ -214,6 +244,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (4, "peer session mappings for PeerRegistry identity state"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (5, "daemon-minted runtime identity birth certificates"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/session_bindings.py
+++ b/repowire/daemon/state/session_bindings.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+import secrets
 import sqlite3
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -13,6 +14,7 @@ from repowire.config.models import AgentType
 from repowire.daemon.state.database import StateDatabase
 
 BindingStatus = Literal["active", "detached", "resumable", "archived", "lost", "superseded"]
+DEFAULT_CERTIFICATE_TTL_SECONDS = 24 * 60 * 60
 
 
 @dataclass
@@ -33,6 +35,40 @@ class SessionBinding:
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: str = ""
     last_seen_at: str = ""
+
+
+@dataclass
+class RuntimeIdentityCertificate:
+    """Daemon-minted proof that binds a live runtime to a peer identity."""
+
+    nonce: str
+    peer_id: str
+    display_name: str
+    backend: str
+    project_path: str
+    runtime_session_id: str | None
+    pane_id: str | None
+    agent_pid: int | None
+    parent_pid: int | None
+    issued_at: str
+    expires_at: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_envelope(self) -> dict[str, Any]:
+        return {
+            "nonce": self.nonce,
+            "peer_id": self.peer_id,
+            "display_name": self.display_name,
+            "backend": self.backend,
+            "project_path": self.project_path,
+            "runtime_session_id": self.runtime_session_id,
+            "pane_id": self.pane_id,
+            "agent_pid": self.agent_pid,
+            "parent_pid": self.parent_pid,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "metadata": self.metadata,
+        }
 
 
 def _now() -> str:
@@ -94,6 +130,142 @@ class SQLiteSessionBindingStore:
             created_at=row["created_at"],
             last_seen_at=row["last_seen_at"],
         )
+
+    @staticmethod
+    def _row_to_certificate(row: sqlite3.Row | None) -> RuntimeIdentityCertificate | None:
+        if row is None:
+            return None
+        return RuntimeIdentityCertificate(
+            nonce=row["nonce"],
+            peer_id=row["peer_id"],
+            display_name=row["display_name"],
+            backend=row["backend"],
+            project_path=row["project_path"],
+            runtime_session_id=row["runtime_session_id"],
+            pane_id=row["pane_id"],
+            agent_pid=row["agent_pid"],
+            parent_pid=row["parent_pid"],
+            issued_at=row["issued_at"],
+            expires_at=row["expires_at"],
+            metadata=_json_loads(row["metadata"]),
+        )
+
+    def mint_birth_certificate(
+        self,
+        *,
+        peer_id: str,
+        display_name: str,
+        backend: AgentType | str,
+        project_path: str | None,
+        runtime_session_id: str | None,
+        pane_id: str | None,
+        agent_pid: int | None,
+        parent_pid: int | None,
+        metadata: dict[str, Any] | None = None,
+        ttl_seconds: int = DEFAULT_CERTIFICATE_TTL_SECONDS,
+        issued_at: str | None = None,
+    ) -> RuntimeIdentityCertificate:
+        """Persist and return an unguessable runtime identity certificate."""
+        now = issued_at or _now()
+        issued = datetime.fromisoformat(now)
+        expires = issued + timedelta(seconds=ttl_seconds)
+        cert = RuntimeIdentityCertificate(
+            nonce=secrets.token_urlsafe(32),
+            peer_id=peer_id,
+            display_name=display_name,
+            backend=_backend_value(backend),
+            project_path=project_path or "",
+            runtime_session_id=runtime_session_id,
+            pane_id=pane_id,
+            agent_pid=agent_pid,
+            parent_pid=parent_pid,
+            issued_at=now,
+            expires_at=expires.isoformat(),
+            metadata=metadata or {},
+        )
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO runtime_identity_certificates(
+                    nonce, peer_id, display_name, backend, project_path,
+                    runtime_session_id, pane_id, agent_pid, parent_pid,
+                    issued_at, expires_at, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    cert.nonce,
+                    cert.peer_id,
+                    cert.display_name,
+                    cert.backend,
+                    cert.project_path,
+                    cert.runtime_session_id,
+                    cert.pane_id,
+                    cert.agent_pid,
+                    cert.parent_pid,
+                    cert.issued_at,
+                    cert.expires_at,
+                    _json_dumps(cert.metadata),
+                ),
+            )
+        return cert
+
+    def validate_birth_certificate(
+        self,
+        envelope: dict[str, Any],
+        *,
+        backend: AgentType | str,
+        project_path: str | None,
+        pane_id: str | None = None,
+        agent_pid: int | None = None,
+    ) -> RuntimeIdentityCertificate | None:
+        """Return the persisted certificate when the caller proves the same runtime.
+
+        This is deliberately stricter than path lookup: the nonce must match
+        daemon state, backend/path must match the current process, optional
+        pane evidence must not contradict, pid evidence must match when both
+        sides have it, and expired envelopes fail closed.
+        """
+        nonce = envelope.get("nonce")
+        if not isinstance(nonce, str) or not nonce:
+            return None
+        row = self._conn.execute(
+            "SELECT * FROM runtime_identity_certificates WHERE nonce = ?",
+            (nonce,),
+        ).fetchone()
+        cert = self._row_to_certificate(row)
+        if cert is None:
+            return None
+        try:
+            if datetime.fromisoformat(cert.expires_at) <= datetime.now(timezone.utc):
+                return None
+        except (TypeError, ValueError):
+            return None
+        normalized_backend = _backend_value(backend)
+        if cert.backend != normalized_backend:
+            return None
+        if cert.project_path != (project_path or ""):
+            return None
+        if envelope.get("peer_id") != cert.peer_id:
+            return None
+        if envelope.get("display_name") != cert.display_name:
+            return None
+        if envelope.get("backend") != cert.backend:
+            return None
+        if envelope.get("project_path") != cert.project_path:
+            return None
+        if envelope.get("runtime_session_id") != cert.runtime_session_id:
+            return None
+        if cert.pane_id and pane_id and cert.pane_id != pane_id:
+            return None
+        if envelope.get("pane_id") != cert.pane_id:
+            return None
+        if cert.agent_pid is not None and agent_pid is not None and cert.agent_pid != agent_pid:
+            return None
+        if envelope.get("agent_pid") != cert.agent_pid:
+            return None
+        if envelope.get("parent_pid") != cert.parent_pid:
+            return None
+        return cert
 
     def _find_existing(
         self,

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -71,7 +71,7 @@ def _register_peer_http(
     turn_state: str | None = None,
     agent_pid: int | None = None,
     parent_pid: int | None = None,
-) -> tuple[str | None, str | None, bool, bool]:
+) -> tuple[str | None, str | None, bool, bool, dict | None]:
     """Register peer via HTTP POST /peers.
 
     Returns (peer_id, display_name, hijack_rejected, pane_assigned).
@@ -118,12 +118,19 @@ def _register_peer_http(
             f"repowire: SessionStart rejected by daemon pane-hijack guard: {detail}",
             file=sys.stderr,
         )
-        return None, None, True, False
+        return None, None, True, False, None
     if status_code is not None and 200 <= status_code < 300 and result:
         # pane_assigned defaults True for older daemons that don't return it.
         pane_assigned = bool(result.get("pane_assigned", True))
-        return result.get("peer_id"), result.get("display_name"), False, pane_assigned
-    return None, None, False, False
+        birth_certificate = result.get("birth_certificate")
+        return (
+            result.get("peer_id"),
+            result.get("display_name"),
+            False,
+            pane_assigned,
+            birth_certificate if isinstance(birth_certificate, dict) else None,
+        )
+    return None, None, False, False, None
 
 
 def get_peer_name(cwd: str) -> str:
@@ -432,7 +439,7 @@ def main(backend: str = "claude-code") -> int:
         #     and trip the guard.
         agent_pid_val = os.getppid()
         parent_pid_val = _read_ppid_of(agent_pid_val)
-        peer_id, display_name, hijack_rejected, pane_assigned = _register_peer_http(
+        registration_result = _register_peer_http(
             cwd,
             circle,
             backend_type,
@@ -444,6 +451,12 @@ def main(backend: str = "claude-code") -> int:
             turn_state=initial_turn_state,
             agent_pid=agent_pid_val,
             parent_pid=parent_pid_val,
+        )
+        peer_id, display_name, hijack_rejected, pane_assigned = registration_result[:4]
+        birth_certificate = (
+            registration_result[4]
+            if len(registration_result) > 4 and isinstance(registration_result[4], dict)
+            else None
         )
         if hijack_rejected:
             # Daemon rejected this pane claim. Don't touch the incumbent's
@@ -521,6 +534,7 @@ def main(backend: str = "claude-code") -> int:
                 "peer_id": peer_id,
                 "agent_pid": agent_pid_val,
                 "parent_pid": parent_pid_val,
+                "birth_certificate": birth_certificate,
             },
         )
 

--- a/repowire/hooks/utils.py
+++ b/repowire/hooks/utils.py
@@ -120,6 +120,16 @@ def ws_hook_meta_path(pane_id: str | None) -> Path:
     return pane_logs_dir() / f"ws-hook-{get_pane_file(pane_id)}.meta.json"
 
 
+def runtime_birth_certificate_path(
+    *, backend: str, agent_pid: int | str | None, pane_id: str | None = None
+) -> Path:
+    """Path for the daemon-minted identity certificate owned by an agent pid."""
+    pid = str(agent_pid or "unknown")
+    pane = get_pane_file(pane_id)
+    safe_backend = backend.replace("/", "-").replace("\\", "-")
+    return pane_logs_dir() / f"birth-{safe_backend}-{pid}-{pane}.json"
+
+
 def ws_hook_legacy_cwd_path(pane_id: str | None) -> Path:
     """Legacy cwd file retained for backward compatibility with older hooks/tests."""
     return pane_logs_dir() / f"ws-hook-{get_pane_file(pane_id)}.cwd"
@@ -151,6 +161,33 @@ def write_pane_runtime_metadata(pane_id: str | None, metadata: dict) -> None:
     cwd = metadata.get("cwd")
     if cwd:
         ws_hook_legacy_cwd_path(pane_id).write_text(str(cwd))
+
+    cert = metadata.get("birth_certificate")
+    backend = metadata.get("backend")
+    agent_pid = metadata.get("agent_pid")
+    if isinstance(cert, dict) and backend and agent_pid is not None:
+        runtime_birth_certificate_path(
+            backend=str(backend),
+            agent_pid=agent_pid,
+            pane_id=pane_id,
+        ).write_text(json.dumps(cert))
+
+
+def read_runtime_birth_certificates(*, backend: str, agent_pid: int | None) -> list[dict]:
+    """Read local daemon-minted certificate candidates for the current runtime."""
+    if agent_pid is None:
+        return []
+    safe_backend = backend.replace("/", "-").replace("\\", "-")
+    pattern = f"birth-{safe_backend}-{agent_pid}-*.json"
+    certificates: list[dict] = []
+    for path in pane_logs_dir().glob(pattern):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            certificates.append(data)
+    return certificates
 
 
 def clear_pending_cids(pane_id: str | None) -> None:

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -13,7 +13,11 @@ from mcp.server.fastmcp import FastMCP
 
 from repowire.config.models import DEFAULT_DAEMON_URL
 from repowire.hooks._tmux import get_pane_id, get_tmux_info
-from repowire.hooks.utils import get_display_name, read_pane_runtime_metadata
+from repowire.hooks.utils import (
+    get_display_name,
+    read_pane_runtime_metadata,
+    read_runtime_birth_certificates,
+)
 from repowire.protocol.errors import DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError
 from repowire.spawn_hints import consume_hint_full
 
@@ -274,6 +278,62 @@ def _peer_result_matches_current_process(peer: dict, pane_meta: dict) -> bool:
     return str(peer_id) == str(meta_peer_id)
 
 
+def read_runtime_birth_certificate() -> list[dict]:
+    """Read local daemon-minted certificate candidates for this MCP process."""
+    backend = _detect_backend()
+    agent_pid = os.getppid()
+    candidates: list[dict] = []
+    pane_id = get_pane_id()
+    if pane_id:
+        pane_meta = read_pane_runtime_metadata(pane_id)
+        cert = pane_meta.get("birth_certificate")
+        if isinstance(cert, dict):
+            candidates.append(cert)
+    candidates.extend(read_runtime_birth_certificates(backend=backend, agent_pid=agent_pid))
+    seen: set[str] = set()
+    deduped: list[dict] = []
+    for cert in candidates:
+        nonce = cert.get("nonce")
+        key = str(nonce) if nonce else repr(sorted(cert.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cert)
+    return deduped
+
+
+async def _try_birth_certificate_identity(
+    *,
+    pane_id: str | None,
+    backend: str,
+    cwd: Path,
+) -> bool:
+    """Validate a daemon-minted certificate and cache its peer identity."""
+    for certificate in read_runtime_birth_certificate():
+        try:
+            result = await daemon_request(
+                "POST",
+                "/peers/identity/validate",
+                {
+                    "birth_certificate": certificate,
+                    "backend": backend,
+                    "path": str(cwd),
+                    "pane_id": pane_id,
+                    "agent_pid": os.getppid(),
+                },
+            )
+        except (DaemonConnectionError, DaemonHTTPError, DaemonTimeoutError) as e:
+            logger.debug("Runtime birth certificate validation failed: %s", e)
+            continue
+        peer_payload = result.get("peer")
+        peer = peer_payload if isinstance(peer_payload, dict) else result
+        if not isinstance(peer, dict):
+            continue
+        _cache_identity(peer)
+        return True
+    return False
+
+
 async def _get_my_peer_name() -> str:
     """Get own peer name. Cached after first successful resolution.
 
@@ -427,6 +487,18 @@ async def _ensure_registered(*, strict: bool = False) -> None:
 
     tmux_info = get_tmux_info()
     pane_id = tmux_info["pane_id"]
+    backend = _detect_backend()
+    try:
+        cwd = Path.cwd()
+    except OSError as e:
+        logger.warning("Cannot resolve cwd for MCP registration: %s", e)
+        return
+
+    if await _try_birth_certificate_identity(pane_id=pane_id, backend=backend, cwd=cwd):
+        _registered = True
+        await _touch_last_seen()
+        return
+
     skip_path_backend_fallback = False
     if pane_id:
         pane_meta = read_pane_runtime_metadata(pane_id)
@@ -469,14 +541,6 @@ async def _ensure_registered(*, strict: bool = False) -> None:
             return
         except Exception:
             pass
-
-    backend = _detect_backend()
-
-    try:
-        cwd = Path.cwd()
-    except OSError as e:
-        logger.warning("Cannot resolve cwd for MCP registration: %s", e)
-        return
 
     if not skip_path_backend_fallback:
         # Last-resort identity resolution: find hook-registered peer by path+backend.

--- a/tests/test_mcp_peer_identity.py
+++ b/tests/test_mcp_peer_identity.py
@@ -361,20 +361,64 @@ async def test_ensure_registered_treats_single_path_backend_candidate_as_compati
     assert ("POST", "/peers") not in calls
 
 
-@pytest.mark.xfail(
-    reason="repowire-0ml birth-certificate implementation is not shipped yet",
-    strict=True,
-)
 @pytest.mark.asyncio
 async def test_ensure_registered_uses_daemon_minted_birth_certificate_before_path_lookup():
-    """Future contract: daemon-minted identity proof replaces path adoption.
+    """Daemon-minted identity proof is authoritative before path adoption."""
+    certificate = {
+        "nonce": "nonce-1",
+        "peer_id": "repow-default-cert",
+        "display_name": "agentbox-codex",
+        "backend": "codex",
+        "project_path": str(Path.cwd()),
+        "runtime_session_id": "runtime-1",
+        "pane_id": None,
+        "agent_pid": 12345,
+        "parent_pid": 1,
+        "issued_at": "2026-05-25T10:00:00+00:00",
+        "expires_at": "2026-05-26T10:00:00+00:00",
+        "metadata": {},
+    }
+    calls: list[tuple[str, str]] = []
 
-    Once the runtime birth certificate exists, MCP should validate it before
-    any path+backend lookup. The certificate path is intentionally not modeled
-    in production code yet, so this xfail is an executable marker for the next
-    implementation slice.
-    """
-    assert hasattr(mcp_server, "read_runtime_birth_certificate")
+    async def daemon_router(method, url, body=None, params=None):  # noqa: ARG001
+        del params
+        calls.append((method, url))
+        if method == "POST" and url == "/peers/identity/validate":
+            assert body["birth_certificate"] == certificate
+            assert body["backend"] == "codex"
+            return {
+                "peer_id": "repow-default-cert",
+                "display_name": "agentbox-codex",
+                "peer": {
+                    "peer_id": "repow-default-cert",
+                    "display_name": "agentbox-codex",
+                    "circle": "default",
+                    "role": "agent",
+                    "path": str(Path.cwd()),
+                    "backend": "codex",
+                },
+            }
+        if method == "POST" and url.endswith("/touch"):
+            return {"ok": True}
+        if method == "GET" and url == "/peers":
+            raise AssertionError("path+backend lookup must not run before certificate")
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    with patch.object(
+            mcp_server, "get_tmux_info", return_value={"pane_id": None, "session_name": None},
+         ), \
+         patch.object(mcp_server, "get_pane_id", return_value=None), \
+         patch.object(mcp_server.os, "getppid", return_value=12345), \
+         patch.object(mcp_server, "_detect_backend", return_value="codex"), \
+         patch.object(
+             mcp_server, "read_runtime_birth_certificate", return_value=[certificate],
+         ), \
+         patch.object(mcp_server, "daemon_request", new=AsyncMock(side_effect=daemon_router)):
+        await mcp_server._ensure_registered()
+
+    assert mcp_server._cached_peer_id == "repow-default-cert"
+    assert mcp_server._cached_peer_name == "agentbox-codex"
+    assert ("GET", "/peers") not in calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -34,7 +34,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4}
+        assert versions == {1, 2, 3, 4, 5}
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -44,6 +44,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert "session_bindings" in tables
         assert "events" in tables
         assert "peer_session_mappings" in tables
+        assert "runtime_identity_certificates" in tables
     finally:
         db.close()
 
@@ -56,7 +57,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4}
+        assert versions == {1, 2, 3, 4, 5}
     finally:
         db2.close()
 
@@ -224,6 +225,60 @@ def test_sqlite_session_binding_store_upsert_and_lookup_fields(tmp_path: Path) -
         db.close()
 
 
+def test_sqlite_session_binding_store_mints_and_validates_birth_certificate(
+    tmp_path: Path,
+) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteSessionBindingStore(db)
+        cert = store.mint_birth_certificate(
+            peer_id="repow-default-a1",
+            display_name="repo-claude-code",
+            backend="claude-code",
+            project_path="/repo",
+            runtime_session_id="runtime-1",
+            pane_id="%77",
+            agent_pid=12345,
+            parent_pid=1,
+            metadata={"circle": "default"},
+            issued_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+        validated = store.validate_birth_certificate(
+            cert.as_envelope(),
+            backend="claude-code",
+            project_path="/repo",
+            pane_id="%77",
+            agent_pid=12345,
+        )
+        assert validated is not None
+        assert validated.peer_id == "repow-default-a1"
+
+        assert store.validate_birth_certificate(
+            {**cert.as_envelope(), "backend": "codex"},
+            backend="codex",
+            project_path="/repo",
+            pane_id="%77",
+            agent_pid=12345,
+        ) is None
+        assert store.validate_birth_certificate(
+            cert.as_envelope(),
+            backend="claude-code",
+            project_path="/repo",
+            pane_id="%99",
+            agent_pid=12345,
+        ) is None
+        assert store.validate_birth_certificate(
+            cert.as_envelope(),
+            backend="claude-code",
+            project_path="/repo",
+            pane_id="%77",
+            agent_pid=99999,
+        ) is None
+    finally:
+        db.close()
+
+
 async def test_create_app_uses_sqlite_schedule_store_and_imports_legacy_json(
     monkeypatch,
     tmp_path: Path,
@@ -283,7 +338,12 @@ async def test_test_app_wires_session_binding_store_and_observes_hooks(tmp_path:
                 },
             )
             assert reg.status_code == 200
-            peer_id = reg.json()["peer_id"]
+            reg_body = reg.json()
+            peer_id = reg_body["peer_id"]
+            birth_certificate = reg_body["birth_certificate"]
+            assert birth_certificate["peer_id"] == peer_id
+            assert birth_certificate["runtime_session_id"] == "hook-session-1"
+            assert birth_certificate["pane_id"] == "%77"
 
             binding = app.state.session_binding_store.get_by_runtime_session(
                 "hook-session-1",
@@ -293,6 +353,32 @@ async def test_test_app_wires_session_binding_store_and_observes_hooks(tmp_path:
             assert binding is not None
             assert binding.peer_id == peer_id
             assert binding.metadata["hook_session_id"] == "hook-session-1"
+
+            validated = await client.post(
+                "/peers/identity/validate",
+                json={
+                    "birth_certificate": birth_certificate,
+                    "backend": "claude-code",
+                    "path": "/repo",
+                    "pane_id": "%77",
+                },
+            )
+            assert validated.status_code == 200
+            assert validated.json()["peer_id"] == peer_id
+
+            app.state.peer_registry._peers.clear()
+            rehydrated = await client.post(
+                "/peers/identity/validate",
+                json={
+                    "birth_certificate": birth_certificate,
+                    "backend": "claude-code",
+                    "path": "/repo",
+                    "pane_id": "%77",
+                },
+            )
+            assert rehydrated.status_code == 200
+            assert rehydrated.json()["peer_id"] == peer_id
+            assert rehydrated.json()["peer"]["display_name"] == "repo-claude-code"
 
             chat = await client.post(
                 "/events/chat",


### PR DESCRIPTION
## Summary
- Mint daemon-backed runtime identity birth certificates during peer registration and persist them in SQLite.
- Write the certificate into hook-local metadata and have MCP validate it before path/backend fallback.
- Allow valid certificates to rehydrate an in-memory peer after daemon restart without changing destructive pane ownership rules.
- Update peer identity and SQLite state docs for the landed slice.

## Tests
- `uv run --extra dev pytest`
- `uv run --extra dev ruff check repowire/`
- `uv run --extra dev ty check repowire/`
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`
- `graphify update .` ran; generated graph JSON/cache churn was intentionally not kept in the product commit because it produced a large unrelated diff and deleted the tracked HTML viz.

## Notes
- Beads issues repowire-0ml, repowire-b46, and repowire-kh5 were annotated but left open because channel-connect minting and the wider destructive-ownership/restart matrix remain follow-up work.
- Reviewed README/MCP/Python-client/web docs from the hygiene prompt; no public MCP tool, CLI, Python client, or dashboard surface changed in this slice.