### PR TITLE
feat: queue deliveries for hook peers

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,10 +90,13 @@ repowire peer restart NAME_OR_ID [--circle C] [--dry-run] [-m MESSAGE]
 repowire peer prune                         # remove offline peers from the registry
 repowire peer whoami [--register --backend B --name NAME --circle C --path P]  # read-only identity, or self-register
 repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME] [--direction inbound|outbound|both] [--json]
+repowire peer deliveries [--peer-id ID | --pane-id PANE | --peer NAME] [--json]
 repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]
 ```
 
-`peer whoami`, `peer asks`, and `peer ack` are the shellable mesh primitives intended for agents whose hooks don't fire today (notably [Antigravity `agy`](../agents/antigravity.md)). They wrap existing daemon HTTP endpoints (`/peers`, `/peers/by-pane`, `/asks/pending`, `/ack`) with no new daemon surface and automatically use the local `daemon.auth_token` when configured. Identity resolves in this order: explicit `--peer-id` → `--pane-id` → `$TMUX_PANE` → `--peer NAME`. Use `peer whoami --register --backend antigravity` once at session start to self-onboard.
+`peer whoami`, `peer asks`, `peer deliveries`, and `peer ack` are the shellable mesh primitives intended for agents whose hooks don't fire today (notably [Antigravity `agy`](../agents/antigravity.md)). They wrap daemon HTTP endpoints (`/peers`, `/peers/by-pane`, `/asks/pending`, `/deliveries/pending`, `/ack`) and automatically use the local `daemon.auth_token` when configured. Identity resolves in this order: explicit `--peer-id` → `--pane-id` → `$TMUX_PANE` → `--peer NAME`. Use `peer whoami --register --backend antigravity` once at session start to self-onboard.
+
+`peer deliveries` drains one-shot queued deliveries for a peer. Draining deletes the queued rows to avoid duplicate paste/replay. For queued asks, `peer deliveries` shows the original ask text once, while `peer asks` continues to show the open ask until the agent closes it with `peer ack` or the MCP `ack` tool.
 
 For Antigravity interop checks, `python3 scripts/agy_interop_smoke.py --run-cli-fallback` writes a JSON evidence report covering observed hook evidence, MCP availability state, and CLI fallback ask→ack. It records current behaviour only; hook or MCP support is not treated as verified unless the report observes matching daemon evidence.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -7,6 +7,8 @@ daemon:
   host: "127.0.0.1"
   port: 8377
   auth_token: "rw_local_..."
+  delivery_queue_ttl_seconds: 86400
+  delivery_queue_max_per_peer: 100
   mcp_http:
     enabled: false
     bind: "localhost-only"
@@ -48,6 +50,15 @@ Experimental Streamable HTTP MCP endpoint mounted at `http://127.0.0.1:8377/mcp`
 - `allow_dangerous_tools`: allow lifecycle/admin MCP tools over HTTP MCP. Default: `false`; spawn, kill, and schedule mutation stay disabled.
 
 HTTP MCP is never exposed through the hosted relay. The default stdio MCP server installed by `repowire setup` is unchanged and remains the stable path for agents.
+
+## `daemon.delivery_queue_*`
+
+Repowire keeps a small SQLite-backed delivery queue for peers that miss a live WebSocket delivery and later poll from a Stop hook or CLI fallback. Live delivery is always attempted first. If the live transport is unavailable, notifications are queued; asks to CLI-fallback peers are queued for one-shot delivery while the open ask thread remains visible through `/asks/pending` until `ack`.
+
+- `delivery_queue_ttl_seconds`: how long a queued delivery remains drainable. Default: `86400` (24 h). Set `0` to disable queued delivery.
+- `delivery_queue_max_per_peer`: maximum queued rows retained per peer. Default: `100`. Oldest rows are evicted when the cap is exceeded. Set `0` to disable queued delivery.
+
+Draining is delete-on-read through the Stop hook or `repowire peer deliveries`, so the same queued paste is not replayed indefinitely. Ask reminders are separate: open asks continue to appear through `/asks/pending` until closed.
 
 ## `daemon.spawn`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -61,6 +61,8 @@ Open a non-blocking ask thread. In normal use, you tell your local agent what yo
 
 Daemon events for asks and acks include nullable `repowire_session_id`, `from_repowire_session_id`, and `to_repowire_session_id` fields when an existing session binding can be resolved. Peer IDs remain the routing authority.
 
+Live delivery is attempted first. If a CLI-fallback/polling peer has no live transport, the ask stays open and a one-shot queued delivery is stored in SQLite for its next Stop-hook or CLI drain. The queued delivery is deleted after drain; the ask itself still appears in `/asks/pending` until `ack`.
+
 Peer resolution defaults to the caller's circle. Peers whose role bypasses circles (`orchestrator`, `service`, human surfaces) resolve mesh-wide; everything else is scoped to the caller's circle so the daemon's ambiguous-resolve refusal applies. Pass `circle="<name>"` to target a different circle explicitly.
 
 Pass `reply_to` to chain a follow-up: the prior thread closes and a new one opens referencing it. See [misroute refusal](../concepts/message-types.md#misroute-refusal) for what happens when names collide within the resolution scope.
@@ -98,6 +100,8 @@ the hook is older, a non-hook transport handled the notify, or no receipt
 arrived before the daemon returned. When a session binding is known, `/notify`
 responses and hook receipts may include nullable `repowire_session_id`,
 `from_repowire_session_id`, and `to_repowire_session_id` fields for grouping.
+
+If the live transport is unavailable but the daemon can resolve the target peer, `/notify` may return `delivery_state="queued"` and `reason="queued_delivery"`. That means the notification was stored in the SQLite queued-delivery table for the target peer/session and will be delivered once through the recipient's Stop hook or `repowire peer deliveries`, subject to the configured TTL and per-peer cap.
 
 Peer resolution mirrors `ask`: defaults to the caller's circle, except for peers whose role bypasses circles (`orchestrator`, `service`, human surfaces) which resolve mesh-wide. Pass `circle="<name>"` to target a different circle.
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -2896,6 +2896,65 @@ def peer_asks(
         console.print(f"[cyan]{cid}[/]  {frm} → {to}  {text}")
 
 
+@peer.command(name="deliveries")
+@click.option("--peer-id", "peer_id", default=None, help="Explicit peer_id to drain")
+@click.option("--pane-id", "pane_id", default=None, help="Tmux pane id (overrides $TMUX_PANE)")
+@click.option("--peer", "peer_name", default=None, help="Resolve peer_id via display name")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of formatted text")
+def peer_deliveries(
+    peer_id: str | None,
+    pane_id: str | None,
+    peer_name: str | None,
+    as_json: bool,
+) -> None:
+    """Drain queued deliveries for this peer (CLI fallback for polling agents)."""
+    import json as _json
+    import sys
+
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resolved, err = _resolve_peer_id_for_asks(
+                client, peer_id=peer_id, pane_id=pane_id, peer_name=peer_name,
+            )
+            if err:
+                console.print(f"[red]{err}[/]")
+                sys.exit(1)
+            resp = client.get(
+                f"{_get_daemon_url()}/deliveries/pending",
+                params={"peer_id": resolved},
+                headers=_auth_headers(),
+            )
+            if resp.status_code >= 400:
+                console.print(
+                    f"[red]/deliveries/pending failed: {resp.status_code} {resp.text}[/]"
+                )
+                sys.exit(1)
+            deliveries = resp.json().get("deliveries", [])
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to daemon. Run 'repowire serve' first.[/]")
+        sys.exit(1)
+
+    if as_json:
+        click.echo(_json.dumps(deliveries, indent=2))
+        return
+
+    if not deliveries:
+        console.print("[dim]No queued deliveries[/]")
+        return
+
+    for delivery in deliveries:
+        kind = delivery.get("kind", "notify")
+        cid = delivery.get("correlation_id")
+        frm = delivery.get("from_peer", "?")
+        text = (delivery.get("text") or "").replace("\n", " ")
+        if len(text) > 120:
+            text = text[:117] + "..."
+        label = f"{kind} #{cid}" if cid else kind
+        console.print(f"[cyan]{label}[/]  from {frm}  {text}")
+
+
 @peer.command(name="ack")
 @click.argument("correlation_id")
 @click.option("-m", "--message", default=None, help="Optional reply message (closes the thread)")

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -253,6 +253,20 @@ class DaemonConfig(BaseModel):
             "Set to 0 to disable."
         ),
     )
+    delivery_queue_ttl_seconds: float = Field(
+        default=86400,
+        description=(
+            "Seconds a queued delivery for a polling peer remains drainable. "
+            "Set to 0 to disable queued delivery."
+        ),
+    )
+    delivery_queue_max_per_peer: int = Field(
+        default=100,
+        description=(
+            "Maximum queued deliveries retained per peer. Oldest rows are "
+            "evicted when the cap is exceeded. Set to 0 to disable."
+        ),
+    )
 
     # HTTP MCP settings (opt-in)
     mcp_http: MCPHttpConfig = Field(default_factory=MCPHttpConfig)

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -52,6 +52,7 @@ from repowire.daemon.routes import spawn as spawn_routes
 from repowire.daemon.scheduler import Scheduler
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.events import SQLiteEventStore
+from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
 from repowire.daemon.state.schedules import SQLiteScheduleStore
 from repowire.daemon.state.session_bindings import (
     SQLiteSessionBindingStore,
@@ -248,6 +249,11 @@ def create_app(
             legacy_path=schedules_path,
         )
         session_binding_store = SQLiteSessionBindingStore(state_db)
+        queued_delivery_store = SQLiteQueuedDeliveryStore(
+            state_db,
+            ttl_seconds=cfg.daemon.delivery_queue_ttl_seconds,
+            max_per_peer=cfg.daemon.delivery_queue_max_per_peer,
+        )
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -264,6 +270,7 @@ def create_app(
         app.state.schedule_store = schedule_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
+        app.state.queued_delivery_store = queued_delivery_store
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(
             emit_event=peer_registry.add_event,
@@ -284,6 +291,7 @@ def create_app(
             ),
             ask_tracker=ask_tracker,
             session_binding_store=session_binding_store,
+            queued_delivery_store=queued_delivery_store,
         )
         app.state.peer_delivery = peer_delivery
         scheduler = Scheduler(
@@ -544,6 +552,11 @@ def create_test_app(
             legacy_path=schedules_path,
         )
         session_binding_store = SQLiteSessionBindingStore(state_db)
+        queued_delivery_store = SQLiteQueuedDeliveryStore(
+            state_db,
+            ttl_seconds=cfg.daemon.delivery_queue_ttl_seconds,
+            max_per_peer=cfg.daemon.delivery_queue_max_per_peer,
+        )
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -558,6 +571,7 @@ def create_test_app(
         app.state.schedule_store = schedule_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
+        app.state.queued_delivery_store = queued_delivery_store
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(
             emit_event=registry.add_event,
@@ -578,6 +592,7 @@ def create_test_app(
             ),
             ask_tracker=ask_tracker,
             session_binding_store=session_binding_store,
+            queued_delivery_store=queued_delivery_store,
         )
         app.state.peer_delivery = peer_delivery
         scheduler = Scheduler(

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -17,6 +17,7 @@ from repowire.config.models import DEFAULT_QUERY_TIMEOUT, Config
 from repowire.daemon.ask_tracker import AskerIdentity, AskTracker
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
+from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
 from repowire.daemon.state.session_bindings import resolve_repowire_session_id
 from repowire.daemon.transport_router import (
     AskCompletion,
@@ -25,6 +26,7 @@ from repowire.daemon.transport_router import (
     PeerTransportRouter,
     transport_router_from_state,
 )
+from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.messages import AttachmentRef
 
 logger = logging.getLogger(__name__)
@@ -41,7 +43,7 @@ class NotifyDeliveryResult:
 
     status: Literal["sent", "queued"]
     delivery_state: Literal["delivered", "queued"]
-    reason: Literal["transport_delivered", "recipient_busy"]
+    reason: Literal["transport_delivered", "recipient_busy", "queued_delivery"]
     from_peer_id: str | None
     from_peer_name: str
     to_peer_id: str
@@ -72,6 +74,7 @@ class PeerDeliveryService:
         transport_router: PeerTransportRouter | None = None,
         ask_tracker: AskTracker | None = None,
         session_binding_store: Any | None = None,
+        queued_delivery_store: SQLiteQueuedDeliveryStore | None = None,
     ) -> None:
         self._config = config
         self._registry = registry
@@ -79,6 +82,7 @@ class PeerDeliveryService:
         self._transport_router = transport_router
         self._ask_tracker = ask_tracker
         self._session_binding_store = session_binding_store
+        self._queued_delivery_store = queued_delivery_store
 
     def _session_id_for_peer(self, peer: Any | None) -> str | None:
         return resolve_repowire_session_id(self._session_binding_store, peer=peer)
@@ -193,18 +197,64 @@ class PeerDeliveryService:
         from_session_id = self._session_id_for_peer(from_obj)
         to_session_id = self._session_id_for_peer(target)
         attachment_tuple = tuple(attachments or ())
-        transport_result = await self._router().send_notify(
-            NotifyEnvelope(
-                from_peer_id=from_obj.peer_id if from_obj else None,
-                from_peer_name=from_obj.display_name if from_obj else from_peer,
-                target=target,
+        envelope = NotifyEnvelope(
+            from_peer_id=from_obj.peer_id if from_obj else None,
+            from_peer_name=from_obj.display_name if from_obj else from_peer,
+            target=target,
+            text=text,
+            intended_recipient_name=to_peer,
+            attachments=attachment_tuple,
+            from_repowire_session_id=from_session_id,
+            to_repowire_session_id=to_session_id,
+        )
+        try:
+            transport_result = await self._router().send_notify(envelope)
+        except TransportError:
+            if self._queued_delivery_store is None:
+                raise
+            queued = self._queued_delivery_store.enqueue(
+                peer_id=target.peer_id,
+                repowire_session_id=to_session_id,
+                kind="notify",
+                from_peer_id=envelope.from_peer_id,
+                from_peer_name=envelope.from_peer_name,
+                to_peer_name=target.display_name,
                 text=text,
-                intended_recipient_name=to_peer,
-                attachments=attachment_tuple,
+                attachments=[a.model_dump(exclude_none=True) for a in envelope.attachments],
+            )
+            if queued is None:
+                raise
+            self._registry.add_event(
+                "notification",
+                {
+                    "from": envelope.from_peer_name,
+                    "to": target.display_name,
+                    "text": text,
+                    "from_peer_id": envelope.from_peer_id,
+                    "to_peer_id": target.peer_id,
+                    "delivery_status": "queued",
+                    "delivery_state": "queued",
+                    "queue_delivery_id": queued.delivery_id,
+                    "attachments": [
+                        a.model_dump(exclude_none=True) for a in envelope.attachments
+                    ],
+                    "repowire_session_id": to_session_id,
+                    "from_repowire_session_id": from_session_id,
+                    "to_repowire_session_id": to_session_id,
+                },
+            )
+            return NotifyDeliveryResult(
+                status="queued",
+                delivery_state="queued",
+                reason="queued_delivery",
+                from_peer_id=envelope.from_peer_id,
+                from_peer_name=envelope.from_peer_name,
+                to_peer_id=target.peer_id,
+                to_peer_name=target.display_name,
+                repowire_session_id=to_session_id,
                 from_repowire_session_id=from_session_id,
                 to_repowire_session_id=to_session_id,
             )
-        )
         hook_delivery = transport_result.hook_delivery
         if isinstance(hook_delivery, dict):
             additions = {
@@ -222,7 +272,7 @@ class PeerDeliveryService:
         delivery_state: Literal["delivered", "queued"] = (
             "queued" if delivery_status == "queued" else "delivered"
         )
-        reason: Literal["transport_delivered", "recipient_busy"] = (
+        reason: Literal["transport_delivered", "recipient_busy", "queued_delivery"] = (
             "recipient_busy" if delivery_status == "queued" else "transport_delivered"
         )
         return NotifyDeliveryResult(
@@ -504,4 +554,5 @@ def peer_delivery_from_state(
         transport_router=transport_router,
         ask_tracker=getattr(state, "ask_tracker", None),
         session_binding_store=getattr(state, "session_binding_store", None),
+        queued_delivery_store=getattr(state, "queued_delivery_store", None),
     )

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -105,6 +105,22 @@ class PendingAsksResponse(BaseModel):
     asks: list[PendingAsk]
 
 
+class PendingDelivery(BaseModel):
+    delivery_id: str
+    kind: str
+    from_peer: str
+    to_peer: str
+    text: str
+    created_at: str
+    expires_at: str
+    correlation_id: str | None = None
+    attachments: list[dict] = Field(default_factory=list)
+
+
+class PendingDeliveriesResponse(BaseModel):
+    deliveries: list[PendingDelivery]
+
+
 async def _get_peer_or_http(identifier: str, *, circle: str | None = None) -> Peer:
     """Resolve a peer id/display name and convert ambiguity to HTTP errors."""
     peer_registry = get_peer_registry()
@@ -175,6 +191,10 @@ def _binding_id_for_peer(state: object, peer: Peer | None) -> str | None:
 def _uses_cli_polling_fallback(peer: Peer) -> bool:
     """Whether asks can be opened for a peer that polls /asks/pending itself."""
     return bool(peer.metadata.get("repowire_cli_fallback"))
+
+
+def _dump_attachments(attachments: list[AttachmentRef]) -> list[dict]:
+    return [a.model_dump(exclude_none=True) for a in attachments]
 
 
 def _emit_ack_event(
@@ -417,6 +437,19 @@ async def open_ask(
         raise HTTPException(status_code=404, detail=str(e))
     except TransportError as e:
         if _uses_cli_polling_fallback(peer):
+            queue = getattr(state, "queued_delivery_store", None)
+            if queue is not None:
+                queue.enqueue(
+                    peer_id=peer.peer_id,
+                    repowire_session_id=to_repowire_session_id,
+                    kind="ask",
+                    from_peer_id=from_peer_id,
+                    from_peer_name=from_peer_name,
+                    to_peer_name=peer.display_name,
+                    correlation_id=cid,
+                    text=request.text,
+                    attachments=_dump_attachments(request.attachments),
+                )
             logger.info(
                 "Ask %s queued for CLI-polling peer %s (%s): %s",
                 cid,
@@ -664,5 +697,61 @@ async def pending_asks(
                 direction=_direction_for(ask),
             )
             for ask in pending
+        ],
+    )
+
+
+@router.get("/deliveries/pending", response_model=PendingDeliveriesResponse)
+async def pending_deliveries(
+    pane_id: str | None = None,
+    peer_id: str | None = None,
+    max_results: int = 50,
+    _: str | None = Depends(require_auth),
+) -> PendingDeliveriesResponse:
+    """Drain queued deliveries for a polling peer.
+
+    This is delete-on-drain: once a delivery is returned to a Stop hook or CLI
+    polling client, it is removed from the durable queue so the same notify/ask
+    paste is not replayed indefinitely. Ask lifecycle reminders remain governed
+    by `/asks/pending` until the ask is acked.
+    """
+    if not pane_id and not peer_id:
+        raise HTTPException(status_code=400, detail="Must provide pane_id or peer_id")
+    if pane_id and peer_id:
+        raise HTTPException(status_code=400, detail="Provide only one of pane_id or peer_id")
+
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    queue = getattr(state, "queued_delivery_store", None)
+    if queue is None:
+        return PendingDeliveriesResponse(deliveries=[])
+
+    if pane_id:
+        peer = await peer_registry.get_peer_by_pane(pane_id)
+        if not peer:
+            raise HTTPException(status_code=404, detail=f"No peer for pane: {pane_id}")
+        resolved_peer_id = peer.peer_id
+    else:
+        assert peer_id is not None
+        peer = await peer_registry.get_peer(peer_id)
+        if not peer:
+            raise HTTPException(status_code=404, detail=f"No peer with id: {peer_id}")
+        resolved_peer_id = peer.peer_id
+
+    drained = queue.drain_for_peer(resolved_peer_id, max_results=max_results)
+    return PendingDeliveriesResponse(
+        deliveries=[
+            PendingDelivery(
+                delivery_id=d.delivery_id,
+                kind=d.kind,
+                from_peer=d.from_peer_name,
+                to_peer=d.to_peer_name,
+                correlation_id=d.correlation_id,
+                text=d.text,
+                attachments=d.attachments or [],
+                created_at=d.created_at,
+                expires_at=d.expires_at,
+            )
+            for d in drained
         ],
     )

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -85,7 +85,9 @@ class NotifyResponse(BaseModel):
     delivery_state: Literal["delivered", "queued"] = "delivered"
     delivered: bool = True
     queued: bool = False
-    reason: Literal["transport_delivered", "recipient_busy"] = "transport_delivered"
+    reason: Literal[
+        "transport_delivered", "recipient_busy", "queued_delivery",
+    ] = "transport_delivered"
     from_peer_id: str | None = None
     from_peer_name: str | None = None
     to_peer_id: str | None = None

--- a/repowire/daemon/state/__init__.py
+++ b/repowire/daemon/state/__init__.py
@@ -1,6 +1,16 @@
 """SQLite-backed daemon state primitives."""
 
 from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.queued_deliveries import (
+    QueuedDelivery,
+    SQLiteQueuedDeliveryStore,
+)
 from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
 
-__all__ = ["SessionBinding", "SQLiteSessionBindingStore", "StateDatabase"]
+__all__ = [
+    "QueuedDelivery",
+    "SQLiteQueuedDeliveryStore",
+    "SessionBinding",
+    "SQLiteSessionBindingStore",
+    "StateDatabase",
+]

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 class StateDatabase:
@@ -219,6 +219,37 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS queued_deliveries (
+                    delivery_id TEXT PRIMARY KEY,
+                    peer_id TEXT NOT NULL,
+                    repowire_session_id TEXT,
+                    kind TEXT NOT NULL,
+                    from_peer_id TEXT,
+                    from_peer_name TEXT NOT NULL,
+                    to_peer_name TEXT NOT NULL,
+                    correlation_id TEXT,
+                    text TEXT NOT NULL,
+                    attachments_json TEXT NOT NULL DEFAULT '[]',
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL
+                )
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_queued_deliveries_peer_created
+                ON queued_deliveries(peer_id, created_at)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_queued_deliveries_expires
+                ON queued_deliveries(expires_at)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
@@ -251,6 +282,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (5, "daemon-minted runtime identity birth certificates"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (6, "queued deliveries for polling peers"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/queued_deliveries.py
+++ b/repowire/daemon/state/queued_deliveries.py
@@ -1,0 +1,198 @@
+"""SQLite-backed queued delivery store for polling peers."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+from repowire.daemon.state.database import StateDatabase
+
+DeliveryKind = Literal["ask", "notify"]
+
+
+@dataclass(frozen=True)
+class QueuedDelivery:
+    delivery_id: str
+    peer_id: str
+    repowire_session_id: str | None
+    kind: DeliveryKind
+    from_peer_id: str | None
+    from_peer_name: str
+    to_peer_name: str
+    text: str
+    created_at: str
+    expires_at: str
+    correlation_id: str | None = None
+    attachments: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class SQLiteQueuedDeliveryStore:
+    """Durable, capped, delete-on-drain delivery queue."""
+
+    def __init__(
+        self,
+        db: StateDatabase,
+        *,
+        ttl_seconds: float,
+        max_per_peer: int,
+    ) -> None:
+        self._conn = db.conn
+        self._ttl_seconds = max(0.0, ttl_seconds)
+        self._max_per_peer = max(0, max_per_peer)
+
+    def enqueue(
+        self,
+        *,
+        peer_id: str,
+        kind: DeliveryKind,
+        from_peer_name: str,
+        to_peer_name: str,
+        text: str,
+        repowire_session_id: str | None = None,
+        from_peer_id: str | None = None,
+        correlation_id: str | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+        metadata: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> QueuedDelivery | None:
+        """Append one delivery and evict expired/over-cap rows for the peer."""
+        if self._max_per_peer <= 0 or self._ttl_seconds <= 0:
+            return None
+        base = now or datetime.now(timezone.utc)
+        if base.tzinfo is None:
+            base = base.replace(tzinfo=timezone.utc)
+        created_at = base.astimezone(timezone.utc).isoformat()
+        expires_at = (
+            base.astimezone(timezone.utc) + timedelta(seconds=self._ttl_seconds)
+        ).isoformat()
+        delivery = QueuedDelivery(
+            delivery_id=f"qd-{uuid4().hex[:12]}",
+            peer_id=peer_id,
+            repowire_session_id=repowire_session_id,
+            kind=kind,
+            from_peer_id=from_peer_id,
+            from_peer_name=from_peer_name,
+            to_peer_name=to_peer_name,
+            correlation_id=correlation_id,
+            text=text,
+            attachments=attachments or [],
+            metadata=metadata or {},
+            created_at=created_at,
+            expires_at=expires_at,
+        )
+        with self._conn:
+            self._delete_expired_locked(created_at)
+            self._conn.execute(
+                """
+                INSERT INTO queued_deliveries(
+                    delivery_id, peer_id, repowire_session_id, kind, from_peer_id,
+                    from_peer_name, to_peer_name, correlation_id, text,
+                    attachments_json, metadata_json, created_at, expires_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    delivery.delivery_id,
+                    delivery.peer_id,
+                    delivery.repowire_session_id,
+                    delivery.kind,
+                    delivery.from_peer_id,
+                    delivery.from_peer_name,
+                    delivery.to_peer_name,
+                    delivery.correlation_id,
+                    delivery.text,
+                    json.dumps(delivery.attachments or []),
+                    json.dumps(delivery.metadata or {}),
+                    delivery.created_at,
+                    delivery.expires_at,
+                ),
+            )
+            self._enforce_cap_locked(peer_id)
+        return delivery
+
+    def drain_for_peer(
+        self,
+        peer_id: str,
+        *,
+        max_results: int = 50,
+        now: datetime | None = None,
+    ) -> list[QueuedDelivery]:
+        """Return and delete unexpired deliveries for one peer, oldest first."""
+        base = now or datetime.now(timezone.utc)
+        if base.tzinfo is None:
+            base = base.replace(tzinfo=timezone.utc)
+        cutoff = base.astimezone(timezone.utc).isoformat()
+        limit = max(0, max_results)
+        if limit <= 0:
+            return []
+        with self._conn:
+            self._delete_expired_locked(cutoff)
+            rows = self._conn.execute(
+                """
+                SELECT * FROM queued_deliveries
+                WHERE peer_id = ? AND expires_at > ?
+                ORDER BY created_at ASC, delivery_id ASC
+                LIMIT ?
+                """,
+                (peer_id, cutoff, limit),
+            ).fetchall()
+            ids = [row["delivery_id"] for row in rows]
+            if ids:
+                self._conn.executemany(
+                    "DELETE FROM queued_deliveries WHERE delivery_id = ?",
+                    [(delivery_id,) for delivery_id in ids],
+                )
+        return [self._row_to_delivery(row) for row in rows]
+
+    def count_for_peer(self, peer_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM queued_deliveries WHERE peer_id = ?",
+            (peer_id,),
+        ).fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def _delete_expired_locked(self, cutoff_iso: str) -> None:
+        self._conn.execute(
+            "DELETE FROM queued_deliveries WHERE expires_at <= ?",
+            (cutoff_iso,),
+        )
+
+    def _enforce_cap_locked(self, peer_id: str) -> None:
+        rows = self._conn.execute(
+            """
+            SELECT delivery_id FROM queued_deliveries
+            WHERE peer_id = ?
+            ORDER BY created_at DESC, delivery_id DESC
+            LIMIT -1 OFFSET ?
+            """,
+            (peer_id, self._max_per_peer),
+        ).fetchall()
+        if rows:
+            self._conn.executemany(
+                "DELETE FROM queued_deliveries WHERE delivery_id = ?",
+                [(row["delivery_id"],) for row in rows],
+            )
+
+    @staticmethod
+    def _row_to_delivery(row: sqlite3.Row) -> QueuedDelivery:
+        attachments = json.loads(row["attachments_json"] or "[]")
+        metadata = json.loads(row["metadata_json"] or "{}")
+        return QueuedDelivery(
+            delivery_id=row["delivery_id"],
+            peer_id=row["peer_id"],
+            repowire_session_id=row["repowire_session_id"],
+            kind=row["kind"],
+            from_peer_id=row["from_peer_id"],
+            from_peer_name=row["from_peer_name"],
+            to_peer_name=row["to_peer_name"],
+            correlation_id=row["correlation_id"],
+            text=row["text"],
+            attachments=attachments if isinstance(attachments, list) else [],
+            metadata=metadata if isinstance(metadata, dict) else {},
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+        )

--- a/repowire/hooks/ask_lifecycle.py
+++ b/repowire/hooks/ask_lifecycle.py
@@ -92,6 +92,15 @@ def fetch_and_filter_pending(
     return pending
 
 
+def fetch_queued_deliveries(pane_id: str) -> list[dict[str, Any]]:
+    """Drain one-shot queued deliveries for this pane."""
+    result = daemon_get(f"/deliveries/pending?pane_id={quote(pane_id, safe='')}")
+    if not result:
+        return []
+    deliveries = result.get("deliveries", [])
+    return deliveries if isinstance(deliveries, list) else []
+
+
 _BODY_SNIPPET_CHARS = 150
 
 
@@ -118,4 +127,22 @@ def format_reminder_block(asks: list[dict[str, Any]]) -> str:
             body = body[: _BODY_SNIPPET_CHARS - 1] + "…"
         head = f"  - #{cid} from @{from_peer}"
         lines.append(f"{head}: {body}" if body else head)
+    return "\n".join(lines)
+
+
+def format_queued_delivery_block(deliveries: list[dict[str, Any]]) -> str:
+    """Render one-shot queued deliveries as inbound mesh messages."""
+    if not deliveries:
+        return ""
+    lines = [f"[repowire] {len(deliveries)} queued delivery(s) received while offline:"]
+    for delivery in deliveries:
+        kind = delivery.get("kind", "notify")
+        cid = delivery.get("correlation_id")
+        from_peer = delivery.get("from_peer", "?")
+        text = (delivery.get("text") or "").strip()
+        if kind == "ask" and cid:
+            lines.append(f"@{from_peer} [ask #{cid}]: {text}")
+            lines.append(f'  ack("{cid}") or ack("{cid}", "reply")')
+        else:
+            lines.append(f"@{from_peer} [notify]: {text}")
     return "\n".join(lines)

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.adapters import hook_output, normalize
-from repowire.hooks.ask_lifecycle import fetch_and_filter_pending, format_reminder_block
+from repowire.hooks.ask_lifecycle import (
+    fetch_and_filter_pending,
+    fetch_queued_deliveries,
+    format_queued_delivery_block,
+    format_reminder_block,
+)
 from repowire.hooks.chat_delta_streamer import streamer_pid_path
 from repowire.hooks.utils import (
     daemon_post,
@@ -162,9 +167,15 @@ def main(backend: str = "claude-code") -> int:
             Path(payload.transcript_path).expanduser().resolve()
             if payload.transcript_path else None
         )
+        deliveries = fetch_queued_deliveries(pane_id)
         due = fetch_and_filter_pending(pane_id, transcript_path)
+        blocks = []
+        if deliveries:
+            blocks.append(format_queued_delivery_block(deliveries))
         if due:
-            reminder_text = format_reminder_block(due)
+            blocks.append(format_reminder_block(due))
+        if blocks:
+            reminder_text = "\n\n".join(block for block in blocks if block)
 
     # Mark peer online and turn_state=idle (turn finished cleanly).
     if pane_id:

--- a/tests/test_queued_deliveries.py
+++ b/tests/test_queued_deliveries.py
@@ -1,0 +1,230 @@
+"""Tests for SQLite queued delivery fallback."""
+
+from __future__ import annotations
+
+import io
+import json
+import time
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_delivery import PeerDeliveryService
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import asks, messages, peers
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
+from repowire.daemon.transport_router import transport_router_from_state
+from repowire.daemon.websocket_transport import TransportError, WebSocketTransport
+from repowire.hooks.stop_handler import main as stop_main
+
+
+def _make_app(tmp_path: Path, cfg: Config | None = None) -> tuple[FastAPI, SimpleNamespace]:
+    cfg = cfg or Config()
+    transport = WebSocketTransport()
+    query_tracker = QueryTracker()
+    ask_tracker = AskTracker(ttl_hours=24.0)
+    msg_router = MessageRouter(transport=transport, query_tracker=query_tracker)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=msg_router,
+        query_tracker=query_tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+        ask_tracker=ask_tracker,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    registry._last_repair = time.monotonic() + 3600
+    state_db = StateDatabase(tmp_path / "state.db")
+    queue = SQLiteQueuedDeliveryStore(
+        state_db,
+        ttl_seconds=cfg.daemon.delivery_queue_ttl_seconds,
+        max_per_peer=cfg.daemon.delivery_queue_max_per_peer,
+    )
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=query_tracker,
+        ask_tracker=ask_tracker,
+        message_router=msg_router,
+        peer_registry=registry,
+        queued_delivery_store=queue,
+        relay_mode=False,
+        state_db=state_db,
+    )
+    state.peer_delivery = PeerDeliveryService(
+        config=cfg,
+        registry=registry,
+        message_router=msg_router,
+        transport_router=transport_router_from_state(
+            config=cfg,
+            registry=registry,
+            state=state,
+        ),
+        ask_tracker=ask_tracker,
+        queued_delivery_store=queue,
+    )
+    init_deps(cfg, registry, state)
+
+    msg_router.send_notification = AsyncMock()
+    msg_router.send_ask = AsyncMock()
+
+    app = FastAPI()
+    app.include_router(peers.router)
+    app.include_router(messages.router)
+    app.include_router(asks.router)
+    return app, state
+
+
+async def _register(client: AsyncClient, name: str, *, fallback: bool = False) -> dict:
+    body: dict = {
+        "name": name,
+        "path": f"/tmp/{name}",
+        "circle": "default",
+        "backend": "claude-code",
+    }
+    if fallback:
+        body["metadata"] = {"repowire_cli_fallback": True}
+    response = await client.post("/peers", json=body)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_store_expires_caps_and_drains_without_duplicates(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteQueuedDeliveryStore(db, ttl_seconds=60, max_per_peer=2)
+        now = datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc)
+        store.enqueue(
+            peer_id="peer-1", kind="notify", from_peer_name="a", to_peer_name="b",
+            text="old", now=now,
+        )
+        second = store.enqueue(
+            peer_id="peer-1", kind="notify", from_peer_name="a", to_peer_name="b",
+            text="second", now=now + timedelta(seconds=1),
+        )
+        third = store.enqueue(
+            peer_id="peer-1", kind="notify", from_peer_name="a", to_peer_name="b",
+            text="third", now=now + timedelta(seconds=2),
+        )
+
+        assert second is not None and third is not None
+        assert store.count_for_peer("peer-1") == 2
+        drained = store.drain_for_peer("peer-1", now=now + timedelta(seconds=3))
+        assert [d.text for d in drained] == ["second", "third"]
+        assert store.drain_for_peer("peer-1", now=now + timedelta(seconds=4)) == []
+
+        store.enqueue(
+            peer_id="peer-1", kind="notify", from_peer_name="a", to_peer_name="b",
+            text="expires", now=now,
+        )
+        assert store.drain_for_peer("peer-1", now=now + timedelta(seconds=61)) == []
+    finally:
+        db.close()
+
+
+async def test_notify_transport_failure_queues_and_drains(tmp_path: Path) -> None:
+    app, state = _make_app(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        alice = await _register(client, "alice")
+        bob = await _register(client, "bob")
+        state.message_router.send_notification.side_effect = TransportError("No connection")
+
+        response = await client.post("/notify", json={
+            "from_peer": alice["display_name"],
+            "to_peer": bob["display_name"],
+            "text": "offline ping",
+        })
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["delivery_state"] == "queued"
+        assert body["reason"] == "queued_delivery"
+        drained = await client.get("/deliveries/pending", params={"peer_id": bob["peer_id"]})
+        assert drained.status_code == 200
+        assert drained.json()["deliveries"][0]["text"] == "offline ping"
+        drained_again = await client.get(
+            "/deliveries/pending", params={"peer_id": bob["peer_id"]},
+        )
+        assert drained_again.json()["deliveries"] == []
+    cleanup_deps()
+    state.state_db.close()
+
+
+async def test_live_notify_delivery_is_not_queued(tmp_path: Path) -> None:
+    app, state = _make_app(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        alice = await _register(client, "alice")
+        bob = await _register(client, "bob")
+
+        response = await client.post("/notify", json={
+            "from_peer": alice["display_name"],
+            "to_peer": bob["display_name"],
+            "text": "live ping",
+        })
+
+        assert response.status_code == 200, response.text
+        assert response.json()["delivery_state"] == "delivered"
+        assert state.queued_delivery_store.count_for_peer(bob["peer_id"]) == 0
+    cleanup_deps()
+    state.state_db.close()
+
+
+async def test_cli_fallback_ask_is_queued_once_and_still_pending(tmp_path: Path) -> None:
+    app, state = _make_app(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        alice = await _register(client, "alice")
+        agy = await _register(client, "agy", fallback=True)
+        state.message_router.send_ask.side_effect = TransportError("No connection")
+
+        response = await client.post("/ask", json={
+            "from_peer": alice["display_name"],
+            "to_peer": agy["display_name"],
+            "text": "queued ask",
+        })
+
+        assert response.status_code == 200, response.text
+        cid = response.json()["correlation_id"]
+        drained = await client.get("/deliveries/pending", params={"peer_id": agy["peer_id"]})
+        assert drained.json()["deliveries"][0]["correlation_id"] == cid
+        assert (await client.get(
+            "/deliveries/pending", params={"peer_id": agy["peer_id"]},
+        )).json()["deliveries"] == []
+        pending = await client.get("/asks/pending", params={"peer_id": agy["peer_id"]})
+        assert pending.json()["asks"][0]["correlation_id"] == cid
+    cleanup_deps()
+    state.state_db.close()
+
+
+def test_stop_hook_drains_queued_deliveries_before_reminders() -> None:
+    buf = io.StringIO()
+    with patch("sys.stdin") as stdin, redirect_stdout(buf), \
+        patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42"), \
+        patch("repowire.hooks.stop_handler.get_display_name", return_value="bob"), \
+        patch("repowire.hooks.stop_handler.update_status", return_value=True), \
+        patch("repowire.hooks.stop_handler.daemon_post"), \
+        patch("repowire.hooks.stop_handler.fetch_queued_deliveries", return_value=[{
+            "kind": "notify",
+            "from_peer": "alice",
+            "text": "queued hello",
+        }]), \
+        patch("repowire.hooks.stop_handler.fetch_and_filter_pending", return_value=[]):
+        stdin.read.return_value = json.dumps({"cwd": "/tmp/test", "session_id": "s1"})
+
+        assert stop_main() == 0
+
+    out = json.loads(buf.getvalue())
+    assert out["decision"] == "block"
+    assert "queued hello" in out["reason"]
+    assert "@alice [notify]" in out["reason"]

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -34,7 +34,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5}
+        assert versions == {1, 2, 3, 4, 5, 6}
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -45,6 +45,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert "events" in tables
         assert "peer_session_mappings" in tables
         assert "runtime_identity_certificates" in tables
+        assert "queued_deliveries" in tables
     finally:
         db.close()
 
@@ -57,7 +58,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5}
+        assert versions == {1, 2, 3, 4, 5, 6}
     finally:
         db2.close()
 

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -57,13 +57,14 @@ repowire peer restart NAME_OR_ID [--circle C] [--dry-run] [-m MESSAGE]
 repowire peer prune
 repowire peer whoami [--register --backend B --name NAME --circle C --path P]
 repowire peer asks [--peer-id ID | --pane-id PANE | --peer NAME]
+repowire peer deliveries [--peer-id ID | --pane-id PANE | --peer NAME]
 repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]`}
       >
         <p>
           Inspect and repair registered peers. <Mono>peer list</Mono> is an operator view across all circles. <Mono>peer describe</Mono> shows one peer&apos;s identity, role, liveness, open asks, and recent events. <Mono>peer claim-role orchestrator</Mono> is a narrow repair command for an existing peer whose durable session mapping lost the orchestrator role after daemon restart; it refuses to demote a fresh online or busy holder unless <Mono>--force</Mono> is passed.
         </p>
         <p>
-          <Mono>peer whoami</Mono>, <Mono>peer asks</Mono>, and <Mono>peer ack</Mono> are shellable mesh primitives for runtimes whose hooks do not fire yet. They use the local daemon token automatically and let an Antigravity <Mono>agy</Mono> session self-register, poll pending asks, and close them from a shell.
+          <Mono>peer whoami</Mono>, <Mono>peer asks</Mono>, <Mono>peer deliveries</Mono>, and <Mono>peer ack</Mono> are shellable mesh primitives for runtimes whose hooks do not fire yet. They use the local daemon token automatically and let an Antigravity <Mono>agy</Mono> session self-register, poll pending asks, drain one-shot queued deliveries, and close asks from a shell. Draining deliveries deletes those queued rows; open asks still appear through <Mono>peer asks</Mono> until acked.
         </p>
         <p>
           <Mono>peer new</Mono> accepts <Mono>--profile</Mono> to append configured <Mono>daemon.spawn.profiles</Mono> args to the backend command. <Mono>peer restart</Mono> intentionally restarts a daemon-spawned peer on the same backend, path, circle, role, and mesh identity. It is for reloading startup context such as <Mono>AGENTS.md</Mono> or an orchestrator <Mono>SOUL.md</Mono>. It requires explicit spawn ownership proof plus live tmux evidence, so manually attached peers and stale or mismatched pane records are refused instead of killed. Restart is same-window/name first, not same-pane; tmux allocates a fresh pane through the normal spawn path. The restart mode is <Mono>fresh_runtime_context</Mono>: startup context is reloaded, but transcript replay, selected spawn profile, and exact backend conversation resume are not guaranteed unless Repowire deliberately selects and reports a backend-specific mode.

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -29,6 +29,9 @@ export default function ToolsReference() {
           Daemon events for asks and acks include nullable <Mono>repowire_session_id</Mono>, <Mono>from_repowire_session_id</Mono>, and <Mono>to_repowire_session_id</Mono> fields when an existing session binding can be resolved. Peer IDs remain the routing authority.
         </p>
         <p>
+          Live delivery is attempted first. If a CLI-fallback or polling peer has no live transport, the ask stays open and a one-shot SQLite queued delivery is stored for its next Stop-hook or CLI drain. The queued delivery is deleted after drain; the ask itself continues to appear in <Mono>/asks/pending</Mono> until <Mono>ack</Mono>.
+        </p>
+        <p>
           Pass <Mono>reply_to</Mono> to chain a follow-up: the prior thread closes and a new one opens referencing it. Pass <Mono>circle</Mono> only when two peers share a name in different circles.
         </p>
         <Example>
@@ -59,6 +62,9 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
         </p>
         <p>
           On the HTTP <Mono>/notify</Mono> response, <Mono>hook_delivery</Mono> may be present when the recipient is a new enough WebSocket hook. It is a best-effort terminal injection receipt with statuses such as <Mono>injected</Mono>, <Mono>rejected</Mono>, or <Mono>failed</Mono>; <Mono>null</Mono> means the hook is older, a non-hook transport handled the notify, or no receipt arrived before the daemon returned. When a session binding is known, notify responses and hook receipts may include nullable <Mono>repowire_session_id</Mono>, <Mono>from_repowire_session_id</Mono>, and <Mono>to_repowire_session_id</Mono> fields for grouping.
+        </p>
+        <p>
+          If the live transport is unavailable but the daemon can resolve the target peer, <Mono>/notify</Mono> may return <Mono>delivery_state=&quot;queued&quot;</Mono> and <Mono>reason=&quot;queued_delivery&quot;</Mono>. The notification is then stored for one Stop-hook or <Mono>repowire peer deliveries</Mono> drain, subject to the configured TTL and per-peer cap.
         </p>
         <p>
           The special peer <Mono>telegram</Mono> routes to the user&rsquo;s phone. The <Mono>dashboard</Mono> already sees agent turns; you do not need to notify it.


### PR DESCRIPTION
## Summary
- add a SQLite-backed queued delivery store with TTL/cap semantics
- keep live delivery first, then queue supported failures for hook/CLI polling peers
- add Stop-hook draining, CLI fallback visibility, and docs/tests for queue behavior

## Verification
- worker reported: `uv run pytest` 1380 passed, 1 xfailed
- worker reported: `uv run ruff check repowire tests/test_queued_deliveries.py tests/test_sqlite_state_schedules.py`
- worker reported: `uv run ty check repowire/`
- worker reported: `python3 scripts/pre_pr_hygiene.py` clean for ledger churn

Tracks repowire-sip.5.
