### PR TITLE
feat: add lightweight session handoff

### DIFF
--- a/repowire/hooks/handoff.py
+++ b/repowire/hooks/handoff.py
@@ -1,0 +1,188 @@
+"""Bounded session handoff summaries for hook-level resume context."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HANDOFF_WORD_LIMIT = 300
+HANDOFF_TURN_LIMIT = 12
+
+
+def _cache_dir() -> Path:
+    from repowire.config import models
+
+    return models.CACHE_DIR / "handoffs"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _identity_key(cwd: str | None, backend: str, session_id: str | None) -> str | None:
+    if not cwd or not session_id:
+        return None
+    try:
+        normalized_cwd = str(Path(cwd).expanduser().resolve())
+    except OSError:
+        normalized_cwd = str(Path(cwd).expanduser())
+    raw = json.dumps(
+        {"backend": backend, "cwd": normalized_cwd, "session_id": session_id},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _handoff_path(cwd: str | None, backend: str, session_id: str | None) -> Path | None:
+    key = _identity_key(cwd, backend, session_id)
+    if key is None:
+        return None
+    return _cache_dir() / f"{key}.json"
+
+
+def _text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                block_type = block.get("type")
+                if block_type == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                elif block_type == "tool_use":
+                    name = block.get("name") or "tool"
+                    parts.append(f"[tool: {name}]")
+                elif block_type == "tool_result":
+                    parts.append("[tool result]")
+            elif isinstance(block, str):
+                parts.append(block)
+        return " ".join(parts)
+    return ""
+
+
+def _entry_turn(entry: dict[str, Any]) -> tuple[str, str] | None:
+    role = entry.get("type") or entry.get("role")
+    message = entry.get("message")
+    content: Any = None
+    if isinstance(message, dict):
+        role = message.get("role") or role
+        content = message.get("content")
+    elif isinstance(entry.get("content"), (str, list)):
+        content = entry.get("content")
+    if role not in {"user", "assistant"}:
+        return None
+    text = _clean_text(_text_from_content(content))
+    if not text:
+        return None
+    return str(role), text
+
+
+def _clean_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _cap_words(text: str, limit: int = HANDOFF_WORD_LIMIT) -> str:
+    words = text.split()
+    if len(words) <= limit:
+        return text
+    return " ".join(words[:limit]).rstrip(".,;:") + "..."
+
+
+def build_handoff_summary(
+    *,
+    transcript_path: Path | None = None,
+    user_text: str | None = None,
+    assistant_text: str | None = None,
+) -> str | None:
+    """Build a compact resume summary from source-owned turn data."""
+    turns: list[tuple[str, str]] = []
+    if transcript_path and transcript_path.exists():
+        try:
+            with open(transcript_path) as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(entry, dict) and (turn := _entry_turn(entry)):
+                        turns.append(turn)
+        except OSError:
+            turns = []
+
+    if not turns:
+        if user_text:
+            turns.append(("user", _clean_text(user_text)))
+        if assistant_text:
+            turns.append(("assistant", _clean_text(assistant_text)))
+
+    turns = [(role, text) for role, text in turns if text][-HANDOFF_TURN_LIMIT:]
+    if not turns:
+        return None
+
+    parts = [f"{role}: {text}" for role, text in turns]
+    return _cap_words("Recent session context: " + " ".join(parts))
+
+
+def write_handoff_summary(
+    *,
+    cwd: str | None,
+    backend: str,
+    session_id: str | None,
+    transcript_path: Path | None = None,
+    user_text: str | None = None,
+    assistant_text: str | None = None,
+) -> None:
+    """Persist only a bounded summary for exact same-session resume injection."""
+    path = _handoff_path(cwd, backend, session_id)
+    if path is None:
+        return
+    summary = build_handoff_summary(
+        transcript_path=transcript_path,
+        user_text=user_text,
+        assistant_text=assistant_text,
+    )
+    if not summary:
+        return
+    payload = {
+        "backend": backend,
+        "cwd": str(Path(cwd or "").expanduser()),
+        "session_id": session_id,
+        "summary": summary,
+        "word_limit": HANDOFF_WORD_LIMIT,
+        "updated_at": _now(),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    except OSError:
+        return
+
+
+def load_handoff_context(
+    *,
+    cwd: str | None,
+    backend: str,
+    session_id: str | None,
+) -> str | None:
+    """Return a clearly labeled handoff block for the same session identity."""
+    path = _handoff_path(cwd, backend, session_id)
+    if path is None or not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    summary = payload.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    return "\n".join([
+        "[Repowire Session Handoff]",
+        "Summary from the previous turn of this same cwd/session identity:",
+        _cap_words(_clean_text(summary)),
+    ])

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -15,6 +15,7 @@ from urllib.parse import quote
 
 from repowire.config.models import AgentType
 from repowire.hooks._tmux import get_tmux_info
+from repowire.hooks.handoff import load_handoff_context, write_handoff_summary
 from repowire.hooks.utils import (
     clear_pane_runtime_state,
     daemon_get,
@@ -593,7 +594,15 @@ def main(backend: str = "claude-code") -> int:
                     file=sys.stderr,
                 )
 
-        sections = [s for s in (self_context, peers_context, persona_context) if s]
+        handoff_context = load_handoff_context(
+            cwd=cwd,
+            backend=backend,
+            session_id=hook_session_id or None,
+        )
+
+        sections = [
+            s for s in (self_context, peers_context, handoff_context, persona_context) if s
+        ]
         if sections:
             output = {
                 "hookSpecificOutput": {
@@ -606,7 +615,16 @@ def main(backend: str = "claude-code") -> int:
     elif event == "SessionEnd":
         # Don't mark peer offline here - SessionEnd fires frequently during
         # agentic loops and tool use cycles, not just at true session end.
-        pass
+        transcript_path = input_data.get("transcript_path")
+        write_handoff_summary(
+            cwd=cwd,
+            backend=backend,
+            session_id=hook_session_id or None,
+            transcript_path=(
+                Path(transcript_path).expanduser().resolve()
+                if isinstance(transcript_path, str) and transcript_path else None
+            ),
+        )
 
     return 0
 

--- a/repowire/hooks/stop_handler.py
+++ b/repowire/hooks/stop_handler.py
@@ -17,6 +17,7 @@ from repowire.hooks.ask_lifecycle import (
     format_reminder_block,
 )
 from repowire.hooks.chat_delta_streamer import streamer_pid_path
+from repowire.hooks.handoff import write_handoff_summary
 from repowire.hooks.utils import (
     daemon_post,
     get_display_name,
@@ -117,6 +118,18 @@ def main(backend: str = "claude-code") -> int:
         user_text = None
     if assistant_text and not assistant_text.strip():
         assistant_text = None
+
+    write_handoff_summary(
+        cwd=payload.cwd or input_data.get("cwd"),
+        backend=backend,
+        session_id=payload.session_id or None,
+        transcript_path=(
+            Path(payload.transcript_path).expanduser().resolve()
+            if payload.transcript_path else None
+        ),
+        user_text=user_text,
+        assistant_text=assistant_text,
+    )
 
     # Signal the per-turn delta streamer (if running) to exit before posting
     # the final chat_turn. Order matters only weakly — the dashboard reconciles

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,75 @@
+"""Tests for hook-level session handoff summaries."""
+
+import json
+from pathlib import Path
+
+from repowire.hooks.handoff import (
+    HANDOFF_WORD_LIMIT,
+    build_handoff_summary,
+    load_handoff_context,
+    write_handoff_summary,
+)
+
+
+def _make_transcript(tmp_path: Path, user_text: str, assistant_text: str) -> Path:
+    path = tmp_path / "transcript.jsonl"
+    path.write_text(
+        "\n".join([
+            json.dumps({"type": "user", "message": {"content": user_text}}),
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": assistant_text}]},
+            }),
+        ]) + "\n",
+    )
+    return path
+
+
+def test_summary_is_capped(tmp_path):
+    transcript = _make_transcript(
+        tmp_path,
+        "hello",
+        " ".join(f"word{i}" for i in range(HANDOFF_WORD_LIMIT + 50)),
+    )
+
+    summary = build_handoff_summary(transcript_path=transcript)
+
+    assert summary is not None
+    assert len(summary.split()) <= HANDOFF_WORD_LIMIT
+
+
+def test_write_persists_summary_only_for_matching_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr("repowire.config.models.CACHE_DIR", tmp_path)
+    transcript = _make_transcript(tmp_path, "raw user prompt", "raw assistant answer")
+
+    write_handoff_summary(
+        cwd=str(tmp_path / "repo"),
+        backend="claude-code",
+        session_id="session-1",
+        transcript_path=transcript,
+    )
+
+    files = list((tmp_path / "handoffs").glob("*.json"))
+    assert len(files) == 1
+    payload = json.loads(files[0].read_text())
+    assert sorted(payload) == [
+        "backend",
+        "cwd",
+        "session_id",
+        "summary",
+        "updated_at",
+        "word_limit",
+    ]
+    assert "raw user prompt" in payload["summary"]
+    assert "raw assistant answer" in payload["summary"]
+
+    assert load_handoff_context(
+        cwd=str(tmp_path / "repo"),
+        backend="claude-code",
+        session_id="session-1",
+    ).startswith("[Repowire Session Handoff]")
+    assert load_handoff_context(
+        cwd=str(tmp_path / "repo"),
+        backend="claude-code",
+        session_id="different-session",
+    ) is None

--- a/tests/test_session_handler.py
+++ b/tests/test_session_handler.py
@@ -1,10 +1,13 @@
 """Tests for the session hook handler."""
 
+import io
 import json
 import signal
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
+from repowire.hooks.handoff import write_handoff_summary
 from repowire.hooks.session_handler import (
     _find_self_peer,
     format_peers_context,
@@ -272,6 +275,91 @@ class TestSessionMain:
             # First positional arg is now path (cwd), not display_name
             assert call_args[0][0] == str(tmp_path)
             assert call_args.kwargs["circle_source"] == "tmux"
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.spawn_ws_hook")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    def test_session_start_injects_matching_handoff(
+        self, mock_branch, mock_status, mock_spawn, mock_tmux, mock_register, mock_fetch, tmp_path,
+    ):
+        with patch("repowire.config.models.CACHE_DIR", tmp_path / "cache"):
+            write_handoff_summary(
+                cwd=str(tmp_path),
+                backend="claude-code",
+                session_id="abc12345-rest",
+                user_text="Finish session handoff tests",
+                assistant_text="Stop hook writes the bounded handoff.",
+            )
+            buf = io.StringIO()
+            with patch("sys.stdin") as mock_stdin, redirect_stdout(buf):
+                mock_stdin.read.return_value = json.dumps({
+                    "hook_event_name": "SessionStart",
+                    "cwd": str(tmp_path),
+                    "session_id": "abc12345-rest",
+                })
+                result = main()
+
+        assert result == 0
+        output = json.loads(buf.getvalue())
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "[Repowire Session Handoff]" in context
+        assert "Finish session handoff tests" in context
+        assert "bounded handoff" in context
+
+    @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
+    @patch(
+        "repowire.hooks.session_handler._register_peer_http",
+        return_value=("repow-default-abc12345", "test-claude-code", False, True),
+    )
+    @patch(
+        "repowire.hooks.session_handler.get_tmux_info",
+        return_value={
+            "pane_id": "%1",
+            "session_name": "default",
+            "window_name": "test",
+        },
+    )
+    @patch("repowire.hooks.session_handler.spawn_ws_hook")
+    @patch("repowire.hooks.session_handler.compute_git_status", return_value=None)
+    @patch("repowire.hooks.session_handler.get_git_branch", return_value=None)
+    def test_session_start_does_not_inject_mismatched_handoff(
+        self, mock_branch, mock_status, mock_spawn, mock_tmux, mock_register, mock_fetch, tmp_path,
+    ):
+        with patch("repowire.config.models.CACHE_DIR", tmp_path / "cache"):
+            write_handoff_summary(
+                cwd=str(tmp_path),
+                backend="claude-code",
+                session_id="old-session",
+                user_text="Do not inject this",
+                assistant_text="Wrong session identity.",
+            )
+            buf = io.StringIO()
+            with patch("sys.stdin") as mock_stdin, redirect_stdout(buf):
+                mock_stdin.read.return_value = json.dumps({
+                    "hook_event_name": "SessionStart",
+                    "cwd": str(tmp_path),
+                    "session_id": "new-session",
+                })
+                result = main()
+
+        assert result == 0
+        output = json.loads(buf.getvalue())
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "[Repowire Session Handoff]" not in context
+        assert "Do not inject this" not in context
 
     @patch("repowire.hooks.session_handler.fetch_peers", return_value=None)
     @patch(

--- a/tests/test_stop_handler.py
+++ b/tests/test_stop_handler.py
@@ -94,6 +94,31 @@ class TestStopHandler:
     @patch("repowire.hooks.stop_handler.daemon_post")
     @patch("repowire.hooks.stop_handler.update_status", return_value=True)
     @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
+    def test_writes_handoff_summary(self, mock_pane, mock_status, mock_post, tmp_path, monkeypatch):
+        monkeypatch.setattr("repowire.config.models.CACHE_DIR", tmp_path / "cache")
+        tp = _make_transcript(tmp_path, [
+            {"type": "user", "message": {"content": "Continue the parser work"}},
+            {"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "Parser tests are green."},
+            ]}},
+        ])
+
+        _run_hook({
+            "cwd": str(tmp_path),
+            "session_id": "abc12345-rest",
+            "transcript_path": str(tp),
+        })
+
+        handoff_files = list((tmp_path / "cache" / "handoffs").glob("*.json"))
+        assert len(handoff_files) == 1
+        payload = json.loads(handoff_files[0].read_text())
+        assert payload["session_id"] == "abc12345-rest"
+        assert "Continue the parser work" in payload["summary"]
+        assert "Parser tests are green" in payload["summary"]
+
+    @patch("repowire.hooks.stop_handler.daemon_post")
+    @patch("repowire.hooks.stop_handler.update_status", return_value=True)
+    @patch("repowire.hooks.stop_handler.get_pane_id", return_value="%42")
     @patch("repowire.hooks.stop_handler.get_display_name", return_value="myproject-claude-code")
     def test_uses_display_name_as_peer_name(
         self, mock_name, mock_pane, mock_status, mock_post, tmp_path,


### PR DESCRIPTION
## Summary
- write a bounded handoff summary from existing Stop/session transcript data
- inject a labelled handoff block on matching SessionStart resume context
- avoid raw transcript persistence and keep the first slice hook-local

## Verification
- worker reported: `uv run pytest` 1380 passed, 1 xfailed
- worker reported: targeted ruff passed
- worker reported: `uv run ty check repowire/` passed

Tracks repowire-sip.6.
