### PR TITLE
Add daemon jobs lifecycle skeleton

### DIFF
--- a/docs/concepts/tracked-work-lifecycle.md
+++ b/docs/concepts/tracked-work-lifecycle.md
@@ -1,10 +1,10 @@
 # Tracked work lifecycle
 
-Status: architecture contract for future daemon-backed tracked work. This
-document defines the lifecycle Repowire should implement separately from
-conversational `ask`/`ack`. It does not claim that a durable job store, new
-dashboard workflow, ACP/channel health model, or backend resume execution is
-shipped today.
+Status: architecture contract plus first daemon skeleton for tracked work. The
+daemon now has a durable tracked-work store and HTTP status/result/cancel
+surface separately from conversational `ask`/`ack`. Executor delivery,
+dashboard workflows, ACP/channel health handling, transport cancel, and backend
+resume execution are still future slices.
 
 ## Problem
 
@@ -35,6 +35,43 @@ Tracked work and ask/ack must remain separate primitives:
   state.
 - Ask reminder, pending reply, TTL, and reply-routing behavior remain owned by
   `AskTracker`.
+
+## Current daemon skeleton
+
+The first shipped daemon slice provides a neutral tracked-work record and HTTP
+API. It is intentionally not tied to Anya, a default orchestrator persona, or a
+specific backend.
+
+- `POST /jobs` / `POST /work` creates a durable work record and returns a
+  `job_id` / `work_id` with initial `queued` status.
+- `GET /jobs` / `GET /work` lists status records with optional filters for
+  state, owner, creator, Repowire session, and circle.
+- `GET /jobs/{job_id}` / `GET /work/{work_id}/status` returns the current
+  status read model.
+- `PATCH /jobs/{job_id}` / `PATCH /work/{work_id}` updates lifecycle state and
+  can append a progress note.
+- `GET /jobs/{job_id}/result` / `GET /work/{work_id}/result` returns terminal
+  result data, or
+  `result_state=not_ready` plus status while work is non-terminal.
+- `POST /jobs/{job_id}/cancel` / `POST /work/{work_id}/cancel` records an
+  audit-visible cancel request.
+
+The record includes job-facing and owner/source/scope fields such as `title`,
+`kind`, `created_by_peer_id`, `owner_peer_id`, `assigned_peer_id`,
+`source_kind`, `source_id`, `correlation_id`, `scope`, `circle`,
+`repowire_session_id`, `visibility`, and progress events. This API is a
+lifecycle foundation: it does not select executors, deliver work to transports,
+cancel live runtime sessions, expose MCP job tools, or update
+dashboard/Telegram/Slack UI yet.
+
+Use jobs when work needs durable status, progress history, result metadata, or
+cancellation. Use `ask` for a conversational request that another peer should
+close with `ack`. Use `schedule` for future delivery of a notify or ask.
+
+Terminal jobs cannot be moved back to non-terminal states in this slice. A
+terminal job may be updated with the same terminal state to add bounded
+metadata or progress notes, and omitted result fields preserve their existing
+values.
 
 ## State model
 
@@ -67,13 +104,18 @@ Recommended fields:
 
 | Field | Purpose |
 | --- | --- |
-| `work_id` | Daemon-generated stable identifier. |
+| `job_id` / `work_id` | Daemon-generated stable identifier. |
+| `title` | Short human-readable job title. |
+| `kind` | Small type label such as `verification`, `research`, or `handoff`. |
 | `state` | One state from the lifecycle table. |
 | `state_reason` | Short machine-readable reason such as `executor_busy`, `permission_required`, `deadline_elapsed`, `capability_missing`, or `cancel_requested`. |
 | `phase` | Optional executor-defined phase label for display. |
 | `progress` | Optional bounded progress object, for example `{"current": 2, "total": 5, "unit": "checks"}`. |
+| `progress_events` | Bounded operator history of progress notes and state observations. |
 | `owner_peer_id` | Peer that owns or last owned execution, when known. |
+| `assigned_peer_id` | Peer assigned to execute the job, when known. |
 | `repowire_session_id` | Durable session/workstream binding when known. |
+| `correlation_id` | Related ask/query correlation id, when known. |
 | `circle` | Visibility and routing scope. |
 | `created_by_peer_id` | Peer or service that created the work. |
 | `created_at` | Daemon acceptance time. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,6 +127,30 @@ Create one-shot or recurring scheduled mesh messages. Without `--cron`, `WHEN_OR
 
 `schedule self` targets the current CLI peer identity by default and is the easiest way to wake the same session later. `schedule create` targets another peer and requires `--from-peer` so the daemon knows who the scheduled message is from. `--kind ask` opens an ask thread when the schedule fires; `notify` is fire-and-forget.
 
+## `repowire jobs`
+
+```bash
+repowire jobs create TITLE [--kind KIND] [--owner PEER_ID] [--assigned-peer PEER_ID] [--session SESSION_ID] [--correlation-id CORR_ID] [--circle CIRCLE] [--json]
+repowire jobs list [--state STATE] [--owner PEER_ID] [--created-by PEER_ID] [--session SESSION_ID] [--circle CIRCLE] [--json]
+repowire jobs show JOB_ID [--json]
+repowire jobs update JOB_ID --state STATE [--reason REASON] [--phase PHASE] [--note NOTE] [--result-summary TEXT] [--json]
+repowire jobs cancel JOB_ID [--requested-by PEER_ID] [--reason REASON] [--json]
+repowire jobs result JOB_ID [--json]
+```
+
+Create and inspect daemon-owned tracked work records. Jobs are durable control
+state in `state.db`; they can exist without a live peer, ask thread, schedule,
+or session. This first slice is an operator surface and API skeleton, not an
+execution engine: creating a job does not dispatch work to an agent.
+
+Use jobs when work needs durable status, progress notes, result metadata, or
+cancellation. Use `ask` for a conversational request that another peer should
+close with `ack`. Use `schedule` for future delivery of a notify or ask.
+
+Jobs commands are script-safe: daemon connection failures, missing jobs, and
+HTTP errors exit non-zero. Pass `--json` when scripts need the status, list, or
+result payload.
+
 ## `repowire orchestrator persona`
 
 ```bash

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -1957,6 +1957,287 @@ def _current_cli_peer_name(client: Any | None = None) -> str:
 
 
 @main.group()
+def jobs() -> None:
+    """Create and inspect durable tracked work jobs."""
+    pass
+
+
+@jobs.command(name="create")
+@click.argument("title")
+@click.option("--kind", default="general", show_default=True)
+@click.option("--created-by", "created_by_peer_id", help="Creator/requester peer id")
+@click.option("--owner", "owner_peer_id", help="Owning peer or operator id")
+@click.option("--assigned-peer", "assigned_peer_id", help="Assigned executor peer id")
+@click.option("--session", "repowire_session_id", help="Related Repowire session id")
+@click.option("--correlation-id", help="Related ask/query correlation id")
+@click.option("--circle", "-c", help="Visibility/routing circle")
+@click.option("--source-kind", default="cli", show_default=True)
+@click.option("--source-id", help="Source-local identifier")
+@click.option("--scope", help="Small routing/display scope label")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_create_cmd(
+    title: str,
+    kind: str,
+    created_by_peer_id: str | None,
+    owner_peer_id: str | None,
+    assigned_peer_id: str | None,
+    repowire_session_id: str | None,
+    correlation_id: str | None,
+    circle: str | None,
+    source_kind: str,
+    source_id: str | None,
+    scope: str | None,
+    as_json: bool,
+) -> None:
+    """Create a durable job without dispatching it to an executor."""
+    import httpx
+
+    body = {
+        "title": title,
+        "kind": kind,
+        "source_kind": source_kind,
+    }
+    for key, value in {
+        "created_by_peer_id": created_by_peer_id,
+        "owner_peer_id": owner_peer_id,
+        "assigned_peer_id": assigned_peer_id,
+        "repowire_session_id": repowire_session_id,
+        "correlation_id": correlation_id,
+        "circle": circle,
+        "source_id": source_id,
+        "scope": scope,
+    }.items():
+        if value:
+            body[key] = value
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(f"{_get_daemon_url()}/jobs", json=body)
+            resp.raise_for_status()
+            status = resp.json()["status"]
+            if as_json:
+                console.print_json(data=status)
+            else:
+                _print_job_status(status, created=True)
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to create job: {_http_error_detail(e)}") from e
+
+
+@jobs.command(name="list")
+@click.option("--state", help="Filter by lifecycle state")
+@click.option("--owner", "owner_peer_id", help="Filter by owner peer id")
+@click.option("--created-by", "created_by_peer_id", help="Filter by creator peer id")
+@click.option("--session", "repowire_session_id", help="Filter by Repowire session id")
+@click.option("--circle", "-c", help="Filter by circle")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON list instead of table")
+def jobs_list_cmd(
+    state: str | None,
+    owner_peer_id: str | None,
+    created_by_peer_id: str | None,
+    repowire_session_id: str | None,
+    circle: str | None,
+    as_json: bool,
+) -> None:
+    """List durable jobs."""
+    import httpx
+
+    params = {
+        key: value
+        for key, value in {
+            "state": state,
+            "owner_peer_id": owner_peer_id,
+            "created_by_peer_id": created_by_peer_id,
+            "repowire_session_id": repowire_session_id,
+            "circle": circle,
+        }.items()
+        if value
+    }
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{_get_daemon_url()}/jobs", params=params or None)
+            resp.raise_for_status()
+            items = resp.json().get("work", [])
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to list jobs: {_http_error_detail(e)}") from e
+
+    if as_json:
+        console.print_json(data={"work": items})
+        return
+
+    if not items:
+        console.print("[yellow]No jobs.[/]")
+        return
+    table = Table(title="Repowire Jobs")
+    table.add_column("ID", style="cyan")
+    table.add_column("State")
+    table.add_column("Title")
+    table.add_column("Kind")
+    table.add_column("Owner")
+    table.add_column("Updated")
+    for item in items:
+        table.add_row(
+            item.get("job_id") or item.get("work_id", ""),
+            item.get("state", ""),
+            item.get("title", ""),
+            item.get("kind", ""),
+            item.get("owner_peer_id") or "-",
+            item.get("updated_at", ""),
+        )
+    console.print(table)
+
+
+@jobs.command(name="show")
+@click.argument("job_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_show_cmd(job_id: str, as_json: bool) -> None:
+    """Show a job status record."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{_get_daemon_url()}/jobs/{job_id}/status")
+            if resp.status_code == 404:
+                raise click.ClickException(f"No job: {job_id}")
+            resp.raise_for_status()
+            status = resp.json()["status"]
+            if as_json:
+                console.print_json(data=status)
+            else:
+                _print_job_status(status)
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to show job: {_http_error_detail(e)}") from e
+
+
+@jobs.command(name="update")
+@click.argument("job_id")
+@click.option("--state", required=True, help="New lifecycle state")
+@click.option("--reason", "state_reason", help="Machine-readable state reason")
+@click.option("--phase", help="Display phase")
+@click.option("--note", "progress_note", help="Append a progress note")
+@click.option("--result-summary", help="Terminal result summary")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_update_cmd(
+    job_id: str,
+    state: str,
+    state_reason: str | None,
+    phase: str | None,
+    progress_note: str | None,
+    result_summary: str | None,
+    as_json: bool,
+) -> None:
+    """Update job lifecycle status and optionally append a progress note."""
+    import httpx
+
+    body = {"state": state}
+    for key, value in {
+        "state_reason": state_reason,
+        "phase": phase,
+        "progress_note": progress_note,
+        "result_summary": result_summary,
+    }.items():
+        if value:
+            body[key] = value
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.patch(f"{_get_daemon_url()}/jobs/{job_id}", json=body)
+            if resp.status_code == 404:
+                raise click.ClickException(f"No job: {job_id}")
+            resp.raise_for_status()
+            status = resp.json()["status"]
+            if as_json:
+                console.print_json(data=status)
+            else:
+                _print_job_status(status)
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to update job: {_http_error_detail(e)}") from e
+
+
+@jobs.command(name="cancel")
+@click.argument("job_id")
+@click.option("--requested-by", "requested_by_peer_id", help="Peer id requesting cancel")
+@click.option("--reason", default="cancel_requested", show_default=True)
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_cancel_cmd(
+    job_id: str,
+    requested_by_peer_id: str | None,
+    reason: str,
+    as_json: bool,
+) -> None:
+    """Request cancellation for a job."""
+    import httpx
+
+    body = {"reason": reason}
+    if requested_by_peer_id:
+        body["requested_by_peer_id"] = requested_by_peer_id
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(f"{_get_daemon_url()}/jobs/{job_id}/cancel", json=body)
+            if resp.status_code == 404:
+                raise click.ClickException(f"No job: {job_id}")
+            resp.raise_for_status()
+            status = resp.json()["status"]
+            if as_json:
+                console.print_json(data=status)
+            else:
+                _print_job_status(status)
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to cancel job: {_http_error_detail(e)}") from e
+
+
+@jobs.command(name="result")
+@click.argument("job_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON result")
+def jobs_result_cmd(job_id: str, as_json: bool) -> None:
+    """Show terminal job result, or current status if not ready."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{_get_daemon_url()}/jobs/{job_id}/result")
+            if resp.status_code == 404:
+                raise click.ClickException(f"No job: {job_id}")
+            resp.raise_for_status()
+            result = resp.json()["result"]
+            if as_json:
+                console.print_json(data=result)
+            elif result.get("result_state") == "not_ready":
+                _print_job_status(result.get("status", {}))
+            else:
+                console.print(f"[green]Job {result.get('job_id') or result.get('work_id')}[/]")
+                console.print(f"  state: {result.get('state')}")
+                if result.get("summary"):
+                    console.print(f"  summary: {result.get('summary')}")
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to get job result: {_http_error_detail(e)}") from e
+
+
+def _print_job_status(status: dict[str, Any], *, created: bool = False) -> None:
+    prefix = "Created job" if created else "Job"
+    console.print(f"[green]{prefix} {status.get('job_id') or status.get('work_id')}[/]")
+    console.print(f"  title: [cyan]{status.get('title') or ''}[/]")
+    console.print(f"  state: {status.get('state')}")
+    console.print(f"  kind:  {status.get('kind')}")
+    if status.get("owner_peer_id"):
+        console.print(f"  owner: {status.get('owner_peer_id')}")
+    if status.get("result_summary"):
+        console.print(f"  result: {status.get('result_summary')}")
+    if status.get("cancellation_reason"):
+        console.print(f"  cancel: {status.get('cancellation_reason')}")
+
+
+@main.group()
 def schedule() -> None:
     """Schedule one-time or recurring mesh messages."""
     pass

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -47,6 +47,7 @@ from repowire.daemon.routes import (
     schedules,
     sessions,
     websocket,
+    work,
 )
 from repowire.daemon.routes import spawn as spawn_routes
 from repowire.daemon.scheduler import Scheduler
@@ -58,6 +59,7 @@ from repowire.daemon.state.session_bindings import (
     SQLiteSessionBindingStore,
     resolve_repowire_session_id,
 )
+from repowire.daemon.state.work import SQLiteWorkStore
 from repowire.daemon.websocket_transport import WebSocketTransport
 
 logger = logging.getLogger(__name__)
@@ -254,6 +256,7 @@ def create_app(
             ttl_seconds=cfg.daemon.delivery_queue_ttl_seconds,
             max_per_peer=cfg.daemon.delivery_queue_max_per_peer,
         )
+        work_store = SQLiteWorkStore(state_db)
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -268,6 +271,7 @@ def create_app(
             Path.home() / ".repowire" / "review_queue.json"
         )
         app.state.schedule_store = schedule_store
+        app.state.work_store = work_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         app.state.queued_delivery_store = queued_delivery_store
@@ -438,6 +442,7 @@ def create_app(
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
     app.include_router(sessions.router)
+    app.include_router(work.router)
 
     _mount_http_mcp(app, _config or load_config())
 
@@ -557,6 +562,7 @@ def create_test_app(
             ttl_seconds=cfg.daemon.delivery_queue_ttl_seconds,
             max_per_peer=cfg.daemon.delivery_queue_max_per_peer,
         )
+        work_store = SQLiteWorkStore(state_db)
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -569,6 +575,7 @@ def create_test_app(
         rq_dir = persistence_path.parent if persistence_path else Path.home() / ".repowire"
         app.state.review_queue_store = ReviewQueueStore(rq_dir / "review_queue.json")
         app.state.schedule_store = schedule_store
+        app.state.work_store = work_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         app.state.queued_delivery_store = queued_delivery_store
@@ -651,6 +658,7 @@ def create_test_app(
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
     app.include_router(sessions.router)
+    app.include_router(work.router)
 
     _mount_http_mcp(app, config or Config())
 

--- a/repowire/daemon/deps.py
+++ b/repowire/daemon/deps.py
@@ -23,6 +23,7 @@ class AppState(Protocol):
     config: Config
     schedule_store: Any
     scheduler: Any
+    work_store: Any
 
 
 # Global state - initialized by lifespan

--- a/repowire/daemon/routes/work.py
+++ b/repowire/daemon/routes/work.py
@@ -1,0 +1,207 @@
+"""Tracked work lifecycle HTTP routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state
+from repowire.daemon.work_store import TrackedWork
+
+router = APIRouter(tags=["work"])
+
+
+class WorkCreateRequest(BaseModel):
+    title: str = ""
+    kind: str = "general"
+    created_by_peer_id: str | None = None
+    owner_peer_id: str | None = None
+    assigned_peer_id: str | None = None
+    repowire_session_id: str | None = None
+    correlation_id: str | None = None
+    circle: str | None = None
+    source_kind: str | None = Field(None, description="Origin type, e.g. mcp, cli, dashboard")
+    source_id: str | None = Field(None, description="Origin-local identifier")
+    scope: str | None = Field(None, description="Small routing/display scope label")
+    visibility: str = "circle"
+    request: dict[str, Any] = Field(default_factory=dict)
+    deadline_at: str | None = None
+    expires_at: str | None = None
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkCancelRequest(BaseModel):
+    requested_by_peer_id: str | None = None
+    reason: str = "cancel_requested"
+
+
+class WorkUpdateRequest(BaseModel):
+    state: str
+    state_reason: str | None = None
+    phase: str | None = None
+    progress: dict[str, Any] | None = None
+    progress_note: str | None = None
+    result_summary: str | None = None
+    result_data: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    artifacts: list[Any] | None = None
+    provenance: dict[str, Any] | None = None
+
+
+class WorkStatusResponse(BaseModel):
+    status: dict[str, Any]
+
+    @classmethod
+    def from_work(cls, work: TrackedWork) -> WorkStatusResponse:
+        return cls(status=work.status())
+
+
+class WorkCreateResponse(BaseModel):
+    job_id: str
+    work_id: str
+    status: dict[str, Any]
+
+    @classmethod
+    def from_work(cls, work: TrackedWork) -> WorkCreateResponse:
+        return cls(job_id=work.work_id, work_id=work.work_id, status=work.status())
+
+
+class WorkListResponse(BaseModel):
+    work: list[dict[str, Any]]
+
+
+class WorkResultResponse(BaseModel):
+    result: dict[str, Any]
+
+
+def _store():
+    state = get_app_state()
+    store = getattr(state, "work_store", None)
+    if store is None:
+        raise RuntimeError("work_store not initialized")
+    return store
+
+
+@router.post("/work", response_model=WorkCreateResponse)
+@router.post("/jobs", response_model=WorkCreateResponse)
+async def create_work(
+    request: WorkCreateRequest,
+    _: str | None = Depends(require_auth),
+) -> WorkCreateResponse:
+    store = _store()
+    work = store.create(
+        title=request.title,
+        kind=request.kind,
+        created_by_peer_id=request.created_by_peer_id,
+        owner_peer_id=request.owner_peer_id,
+        assigned_peer_id=request.assigned_peer_id,
+        repowire_session_id=request.repowire_session_id,
+        correlation_id=request.correlation_id,
+        circle=request.circle,
+        source_kind=request.source_kind,
+        source_id=request.source_id,
+        scope=request.scope,
+        visibility=request.visibility,
+        request=request.request,
+        deadline_at=request.deadline_at,
+        expires_at=request.expires_at,
+        provenance=request.provenance,
+    )
+    return WorkCreateResponse.from_work(work)
+
+
+@router.get("/work", response_model=WorkListResponse)
+@router.get("/jobs", response_model=WorkListResponse)
+async def list_work(
+    state: str | None = None,
+    owner_peer_id: str | None = None,
+    created_by_peer_id: str | None = None,
+    repowire_session_id: str | None = None,
+    circle: str | None = None,
+    _: str | None = Depends(require_auth),
+) -> WorkListResponse:
+    store = _store()
+    try:
+        items = store.list_all(
+            state=state,
+            owner_peer_id=owner_peer_id,
+            created_by_peer_id=created_by_peer_id,
+            repowire_session_id=repowire_session_id,
+            circle=circle,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return WorkListResponse(work=[item.status() for item in items])
+
+
+@router.get("/work/{work_id}/status", response_model=WorkStatusResponse)
+@router.get("/jobs/{work_id}", response_model=WorkStatusResponse)
+@router.get("/jobs/{work_id}/status", response_model=WorkStatusResponse)
+async def get_work_status(
+    work_id: str,
+    _: str | None = Depends(require_auth),
+) -> WorkStatusResponse:
+    work = _store().get(work_id)
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkStatusResponse.from_work(work)
+
+
+@router.patch("/work/{work_id}", response_model=WorkStatusResponse)
+@router.patch("/jobs/{work_id}", response_model=WorkStatusResponse)
+async def update_work(
+    work_id: str,
+    request: WorkUpdateRequest,
+    _: str | None = Depends(require_auth),
+) -> WorkStatusResponse:
+    try:
+        work = _store().update_state(
+            work_id,
+            state=request.state,
+            state_reason=request.state_reason,
+            phase=request.phase,
+            progress=request.progress,
+            progress_note=request.progress_note,
+            result_summary=request.result_summary,
+            result_data=request.result_data,
+            error=request.error,
+            artifacts=request.artifacts,
+            provenance=request.provenance,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkStatusResponse.from_work(work)
+
+
+@router.get("/work/{work_id}/result", response_model=WorkResultResponse)
+@router.get("/jobs/{work_id}/result", response_model=WorkResultResponse)
+async def get_work_result(
+    work_id: str,
+    _: str | None = Depends(require_auth),
+) -> WorkResultResponse:
+    work = _store().get(work_id)
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkResultResponse(result=work.result())
+
+
+@router.post("/work/{work_id}/cancel", response_model=WorkStatusResponse)
+@router.post("/jobs/{work_id}/cancel", response_model=WorkStatusResponse)
+async def cancel_work(
+    work_id: str,
+    request: WorkCancelRequest,
+    _: str | None = Depends(require_auth),
+) -> WorkStatusResponse:
+    work = _store().cancel(
+        work_id,
+        requested_by_peer_id=request.requested_by_peer_id,
+        reason=request.reason,
+    )
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkStatusResponse.from_work(work)

--- a/repowire/daemon/state/__init__.py
+++ b/repowire/daemon/state/__init__.py
@@ -6,10 +6,12 @@ from repowire.daemon.state.queued_deliveries import (
     SQLiteQueuedDeliveryStore,
 )
 from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
+from repowire.daemon.state.work import SQLiteWorkStore
 
 __all__ = [
     "QueuedDelivery",
     "SQLiteQueuedDeliveryStore",
+    "SQLiteWorkStore",
     "SessionBinding",
     "SQLiteSessionBindingStore",
     "StateDatabase",

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 class StateDatabase:
@@ -238,6 +238,45 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS tracked_work (
+                    work_id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL DEFAULT '',
+                    kind TEXT NOT NULL DEFAULT 'general',
+                    state TEXT NOT NULL,
+                    state_reason TEXT,
+                    phase TEXT,
+                    progress_json TEXT NOT NULL DEFAULT '{}',
+                    progress_events_json TEXT NOT NULL DEFAULT '[]',
+                    owner_peer_id TEXT,
+                    assigned_peer_id TEXT,
+                    repowire_session_id TEXT,
+                    correlation_id TEXT,
+                    circle TEXT,
+                    created_by_peer_id TEXT,
+                    source_kind TEXT,
+                    source_id TEXT,
+                    scope TEXT,
+                    visibility TEXT NOT NULL DEFAULT 'circle',
+                    request_json TEXT NOT NULL DEFAULT '{}',
+                    deadline_at TEXT,
+                    expires_at TEXT,
+                    result_summary TEXT,
+                    result_data_json TEXT NOT NULL DEFAULT '{}',
+                    error_json TEXT NOT NULL DEFAULT '{}',
+                    artifacts_json TEXT NOT NULL DEFAULT '[]',
+                    provenance_json TEXT NOT NULL DEFAULT '{}',
+                    cancel_requested INTEGER NOT NULL DEFAULT 0,
+                    cancel_requested_at TEXT,
+                    cancel_requested_by_peer_id TEXT,
+                    cancellation_reason TEXT,
+                    completed_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """,
+            )
+            self.conn.execute(
+                """
                 CREATE INDEX IF NOT EXISTS idx_queued_deliveries_peer_created
                 ON queued_deliveries(peer_id, created_at)
                 """,
@@ -246,6 +285,27 @@ class StateDatabase:
                 """
                 CREATE INDEX IF NOT EXISTS idx_queued_deliveries_expires
                 ON queued_deliveries(expires_at)
+                """,
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tracked_work_state ON tracked_work(state)",
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tracked_work_owner_updated
+                ON tracked_work(owner_peer_id, updated_at)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tracked_work_session_updated
+                ON tracked_work(repowire_session_id, updated_at)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tracked_work_circle_updated
+                ON tracked_work(circle, updated_at)
                 """,
             )
             self.conn.execute(
@@ -289,6 +349,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (6, "queued deliveries for polling peers"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (7, "tracked work lifecycle records"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/work.py
+++ b/repowire/daemon/state/work.py
@@ -1,0 +1,352 @@
+"""SQLite-backed tracked work persistence adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.work_store import (
+    TrackedWork,
+    WorkState,
+    is_terminal_state,
+    json_dumps,
+    json_loads,
+    new_work_id,
+    now_iso,
+    validate_state,
+)
+
+
+class SQLiteWorkStore:
+    """Tracked work store backed by daemon state DB."""
+
+    def __init__(self, db: StateDatabase) -> None:
+        self._db = db
+        self._conn = db.conn
+
+    @staticmethod
+    def _row_to_work(row: sqlite3.Row | None) -> TrackedWork | None:
+        if row is None:
+            return None
+        return TrackedWork(
+            work_id=row["work_id"],
+            title=row["title"],
+            kind=row["kind"],
+            state=validate_state(row["state"]),
+            state_reason=row["state_reason"],
+            phase=row["phase"],
+            progress=json_loads(row["progress_json"], {}),
+            progress_events=json_loads(row["progress_events_json"], []),
+            owner_peer_id=row["owner_peer_id"],
+            assigned_peer_id=row["assigned_peer_id"],
+            repowire_session_id=row["repowire_session_id"],
+            correlation_id=row["correlation_id"],
+            circle=row["circle"],
+            created_by_peer_id=row["created_by_peer_id"],
+            source_kind=row["source_kind"],
+            source_id=row["source_id"],
+            scope=row["scope"],
+            visibility=row["visibility"],
+            request=json_loads(row["request_json"], {}),
+            deadline_at=row["deadline_at"],
+            expires_at=row["expires_at"],
+            result_summary=row["result_summary"],
+            result_data=json_loads(row["result_data_json"], {}),
+            error=json_loads(row["error_json"], {}),
+            artifacts=json_loads(row["artifacts_json"], []),
+            provenance=json_loads(row["provenance_json"], {}),
+            cancel_requested=bool(row["cancel_requested"]),
+            cancel_requested_at=row["cancel_requested_at"],
+            cancel_requested_by_peer_id=row["cancel_requested_by_peer_id"],
+            cancellation_reason=row["cancellation_reason"],
+            completed_at=row["completed_at"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def create(
+        self,
+        *,
+        title: str = "",
+        kind: str = "general",
+        created_by_peer_id: str | None = None,
+        owner_peer_id: str | None = None,
+        assigned_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        correlation_id: str | None = None,
+        circle: str | None = None,
+        source_kind: str | None = None,
+        source_id: str | None = None,
+        scope: str | None = None,
+        visibility: str = "circle",
+        request: dict[str, Any] | None = None,
+        deadline_at: str | None = None,
+        expires_at: str | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> TrackedWork:
+        now = now_iso()
+        work = TrackedWork(
+            work_id=new_work_id(),
+            title=title,
+            kind=kind,
+            state="queued",
+            state_reason=None,
+            phase=None,
+            progress={},
+            progress_events=[],
+            owner_peer_id=owner_peer_id,
+            assigned_peer_id=assigned_peer_id,
+            repowire_session_id=repowire_session_id,
+            correlation_id=correlation_id,
+            circle=circle,
+            created_by_peer_id=created_by_peer_id,
+            source_kind=source_kind,
+            source_id=source_id,
+            scope=scope,
+            visibility=visibility,
+            request=request or {},
+            deadline_at=deadline_at,
+            expires_at=expires_at,
+            provenance=provenance or {},
+            created_at=now,
+            updated_at=now,
+        )
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO tracked_work(
+                    work_id, title, kind, state, state_reason, phase, progress_json,
+                    progress_events_json, owner_peer_id, assigned_peer_id,
+                    repowire_session_id, correlation_id, circle, created_by_peer_id,
+                    source_kind, source_id, scope, visibility, request_json,
+                    deadline_at, expires_at, result_summary, result_data_json,
+                    error_json, artifacts_json, provenance_json, cancel_requested,
+                    cancel_requested_at, cancel_requested_by_peer_id,
+                    cancellation_reason, completed_at,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+                """,
+                (
+                    work.work_id,
+                    work.title,
+                    work.kind,
+                    work.state,
+                    work.state_reason,
+                    work.phase,
+                    json_dumps(work.progress),
+                    json_dumps(work.progress_events),
+                    work.owner_peer_id,
+                    work.assigned_peer_id,
+                    work.repowire_session_id,
+                    work.correlation_id,
+                    work.circle,
+                    work.created_by_peer_id,
+                    work.source_kind,
+                    work.source_id,
+                    work.scope,
+                    work.visibility,
+                    json_dumps(work.request),
+                    work.deadline_at,
+                    work.expires_at,
+                    work.result_summary,
+                    json_dumps(work.result_data),
+                    json_dumps(work.error),
+                    json_dumps(work.artifacts),
+                    json_dumps(work.provenance),
+                    int(work.cancel_requested),
+                    work.cancel_requested_at,
+                    work.cancel_requested_by_peer_id,
+                    work.cancellation_reason,
+                    work.completed_at,
+                    work.created_at,
+                    work.updated_at,
+                ),
+            )
+        return work
+
+    def get(self, work_id: str) -> TrackedWork | None:
+        row = self._conn.execute(
+            "SELECT * FROM tracked_work WHERE work_id = ?",
+            (work_id,),
+        ).fetchone()
+        return self._row_to_work(row)
+
+    def list_all(
+        self,
+        *,
+        state: str | None = None,
+        owner_peer_id: str | None = None,
+        created_by_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        circle: str | None = None,
+    ) -> list[TrackedWork]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if state is not None:
+            validate_state(state)
+            clauses.append("state = ?")
+            params.append(state)
+        if owner_peer_id is not None:
+            clauses.append("owner_peer_id = ?")
+            params.append(owner_peer_id)
+        if created_by_peer_id is not None:
+            clauses.append("created_by_peer_id = ?")
+            params.append(created_by_peer_id)
+        if repowire_session_id is not None:
+            clauses.append("repowire_session_id = ?")
+            params.append(repowire_session_id)
+        if circle is not None:
+            clauses.append("circle = ?")
+            params.append(circle)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._conn.execute(
+            f"SELECT * FROM tracked_work {where} ORDER BY updated_at DESC",
+            params,
+        ).fetchall()
+        return [work for row in rows if (work := self._row_to_work(row)) is not None]
+
+    def update_state(
+        self,
+        work_id: str,
+        *,
+        state: WorkState,
+        state_reason: str | None = None,
+        phase: str | None = None,
+        progress: dict[str, Any] | None = None,
+        progress_note: str | None = None,
+        result_summary: str | None = None,
+        result_data: dict[str, Any] | None = None,
+        error: dict[str, Any] | None = None,
+        artifacts: list[Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> TrackedWork | None:
+        validate_state(state)
+        existing = self.get(work_id)
+        if existing is None:
+            return None
+        if existing.terminal and state != existing.state:
+            raise ValueError(
+                f"terminal work {work_id} is already {existing.state}; "
+                "terminal state cannot be changed",
+            )
+        completed_at = existing.completed_at
+        if is_terminal_state(state) and completed_at is None:
+            completed_at = datetime.now(timezone.utc).isoformat()
+        progress_events = list(existing.progress_events)
+        if progress_note:
+            progress_events.append(
+                {
+                    "at": now_iso(),
+                    "note": progress_note,
+                    "state": state,
+                    "phase": phase if phase is not None else existing.phase,
+                },
+            )
+        with self._conn:
+            self._conn.execute(
+                """
+                UPDATE tracked_work SET
+                    state = ?,
+                    state_reason = ?,
+                    phase = ?,
+                    progress_json = ?,
+                    progress_events_json = ?,
+                    result_summary = ?,
+                    result_data_json = ?,
+                    error_json = ?,
+                    artifacts_json = ?,
+                    provenance_json = ?,
+                    completed_at = ?,
+                    updated_at = ?
+                WHERE work_id = ?
+                """,
+                (
+                    state,
+                    state_reason,
+                    phase,
+                    json_dumps(progress if progress is not None else existing.progress),
+                    json_dumps(progress_events),
+                    result_summary if result_summary is not None else existing.result_summary,
+                    json_dumps(result_data if result_data is not None else existing.result_data),
+                    json_dumps(error if error is not None else existing.error),
+                    json_dumps(artifacts if artifacts is not None else existing.artifacts),
+                    json_dumps(provenance if provenance is not None else existing.provenance),
+                    completed_at,
+                    now_iso(),
+                    work_id,
+                ),
+            )
+        return self.get(work_id)
+
+    def cancel(
+        self,
+        work_id: str,
+        *,
+        requested_by_peer_id: str | None = None,
+        reason: str = "cancel_requested",
+    ) -> TrackedWork | None:
+        existing = self.get(work_id)
+        if existing is None:
+            return None
+        requested_at = now_iso()
+        if existing.terminal:
+            with self._conn:
+                self._conn.execute(
+                    """
+                    UPDATE tracked_work SET
+                        cancel_requested = 1,
+                        cancel_requested_at = COALESCE(cancel_requested_at, ?),
+                        cancel_requested_by_peer_id = COALESCE(cancel_requested_by_peer_id, ?),
+                        cancellation_reason = COALESCE(cancellation_reason, ?),
+                        updated_at = ?
+                    WHERE work_id = ?
+                    """,
+                    (requested_at, requested_by_peer_id, reason, requested_at, work_id),
+                )
+            return self.get(work_id)
+        if existing.state == "queued":
+            with self._conn:
+                self._conn.execute(
+                    """
+                    UPDATE tracked_work SET
+                        state = 'cancelled',
+                        state_reason = ?,
+                        cancel_requested = 1,
+                        cancel_requested_at = ?,
+                        cancel_requested_by_peer_id = ?,
+                        cancellation_reason = ?,
+                        completed_at = ?,
+                        updated_at = ?
+                    WHERE work_id = ?
+                    """,
+                    (
+                        reason,
+                        requested_at,
+                        requested_by_peer_id,
+                        reason,
+                        requested_at,
+                        requested_at,
+                        work_id,
+                    ),
+                )
+            return self.get(work_id)
+        with self._conn:
+            self._conn.execute(
+                """
+                UPDATE tracked_work SET
+                    state_reason = ?,
+                    cancel_requested = 1,
+                    cancel_requested_at = ?,
+                    cancel_requested_by_peer_id = ?,
+                    cancellation_reason = ?,
+                    updated_at = ?
+                WHERE work_id = ?
+                """,
+                (reason, requested_at, requested_by_peer_id, reason, requested_at, work_id),
+            )
+        return self.get(work_id)

--- a/repowire/daemon/work_store.py
+++ b/repowire/daemon/work_store.py
@@ -1,0 +1,229 @@
+"""Tracked work lifecycle model and store interface."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal, Protocol
+from uuid import uuid4
+
+WorkState = Literal[
+    "queued",
+    "delivered",
+    "running",
+    "awaiting_input",
+    "completed",
+    "failed",
+    "cancelled",
+    "blocked",
+    "expired",
+    "unavailable",
+]
+TerminalWorkState = Literal["completed", "failed", "cancelled", "expired", "unavailable"]
+
+WORK_STATES: frozenset[str] = frozenset(
+    {
+        "queued",
+        "delivered",
+        "running",
+        "awaiting_input",
+        "completed",
+        "failed",
+        "cancelled",
+        "blocked",
+        "expired",
+        "unavailable",
+    },
+)
+TERMINAL_WORK_STATES: frozenset[str] = frozenset(
+    {"completed", "failed", "cancelled", "expired", "unavailable"},
+)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_work_id() -> str:
+    return f"work-{uuid4().hex[:12]}"
+
+
+def is_terminal_state(state: str) -> bool:
+    return state in TERMINAL_WORK_STATES
+
+
+def validate_state(state: str) -> WorkState:
+    if state not in WORK_STATES:
+        raise ValueError(f"state must be one of {sorted(WORK_STATES)}; got {state!r}")
+    return state  # type: ignore[return-value]
+
+
+def json_dumps(value: dict[str, Any] | list[Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def json_loads(raw: str | None, default: dict[str, Any] | list[Any]) -> Any:
+    if not raw:
+        return default.copy() if isinstance(default, dict) else list(default)
+    data = json.loads(raw)
+    if isinstance(default, dict):
+        return data if isinstance(data, dict) else {}
+    return data if isinstance(data, list) else []
+
+
+@dataclass
+class TrackedWork:
+    """Daemon-owned lifecycle record for durable tracked work."""
+
+    work_id: str
+    state: WorkState
+    created_at: str
+    updated_at: str
+    title: str = ""
+    kind: str = "general"
+    state_reason: str | None = None
+    phase: str | None = None
+    progress: dict[str, Any] = field(default_factory=dict)
+    progress_events: list[Any] = field(default_factory=list)
+    owner_peer_id: str | None = None
+    assigned_peer_id: str | None = None
+    repowire_session_id: str | None = None
+    correlation_id: str | None = None
+    circle: str | None = None
+    created_by_peer_id: str | None = None
+    source_kind: str | None = None
+    source_id: str | None = None
+    scope: str | None = None
+    visibility: str = "circle"
+    request: dict[str, Any] = field(default_factory=dict)
+    deadline_at: str | None = None
+    expires_at: str | None = None
+    result_summary: str | None = None
+    result_data: dict[str, Any] = field(default_factory=dict)
+    error: dict[str, Any] = field(default_factory=dict)
+    artifacts: list[Any] = field(default_factory=list)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    cancel_requested: bool = False
+    cancel_requested_at: str | None = None
+    cancel_requested_by_peer_id: str | None = None
+    cancellation_reason: str | None = None
+    completed_at: str | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return is_terminal_state(self.state)
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "job_id": self.work_id,
+            "work_id": self.work_id,
+            "title": self.title,
+            "kind": self.kind,
+            "state": self.state,
+            "state_reason": self.state_reason,
+            "phase": self.phase,
+            "progress": self.progress,
+            "progress_events": self.progress_events,
+            "owner_peer_id": self.owner_peer_id,
+            "assigned_peer_id": self.assigned_peer_id,
+            "repowire_session_id": self.repowire_session_id,
+            "correlation_id": self.correlation_id,
+            "circle": self.circle,
+            "created_by_peer_id": self.created_by_peer_id,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "scope": self.scope,
+            "visibility": self.visibility,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "deadline_at": self.deadline_at,
+            "expires_at": self.expires_at,
+            "result_summary": self.result_summary,
+            "cancel_requested": self.cancel_requested,
+            "cancel_requested_at": self.cancel_requested_at,
+            "cancel_requested_by_peer_id": self.cancel_requested_by_peer_id,
+            "cancellation_reason": self.cancellation_reason,
+            "links": self.provenance.get("links", {}),
+        }
+
+    def result(self) -> dict[str, Any]:
+        if not self.terminal:
+            return {
+                "job_id": self.work_id,
+                "work_id": self.work_id,
+                "result_state": "not_ready",
+                "status": self.status(),
+            }
+        return {
+            "job_id": self.work_id,
+            "work_id": self.work_id,
+            "state": self.state,
+            "summary": self.result_summary,
+            "data": self.result_data,
+            "error": self.error,
+            "artifacts": self.artifacts,
+            "completed_at": self.completed_at,
+            "provenance": self.provenance,
+        }
+
+
+class WorkStoreProtocol(Protocol):
+    """Persistence adapter interface for tracked work records."""
+
+    def create(
+        self,
+        *,
+        title: str = "",
+        kind: str = "general",
+        created_by_peer_id: str | None = None,
+        owner_peer_id: str | None = None,
+        assigned_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        correlation_id: str | None = None,
+        circle: str | None = None,
+        source_kind: str | None = None,
+        source_id: str | None = None,
+        scope: str | None = None,
+        visibility: str = "circle",
+        request: dict[str, Any] | None = None,
+        deadline_at: str | None = None,
+        expires_at: str | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> TrackedWork: ...
+
+    def get(self, work_id: str) -> TrackedWork | None: ...
+
+    def list_all(
+        self,
+        *,
+        state: str | None = None,
+        owner_peer_id: str | None = None,
+        created_by_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        circle: str | None = None,
+    ) -> list[TrackedWork]: ...
+
+    def update_state(
+        self,
+        work_id: str,
+        *,
+        state: WorkState,
+        state_reason: str | None = None,
+        phase: str | None = None,
+        progress: dict[str, Any] | None = None,
+        progress_note: str | None = None,
+        result_summary: str | None = None,
+        result_data: dict[str, Any] | None = None,
+        error: dict[str, Any] | None = None,
+        artifacts: list[Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> TrackedWork | None: ...
+
+    def cancel(
+        self,
+        work_id: str,
+        *,
+        requested_by_peer_id: str | None = None,
+        reason: str = "cancel_requested",
+    ) -> TrackedWork | None: ...

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+from click.testing import CliRunner
+
+from repowire.cli import main
+
+
+def _status(job_id: str = "work-abc123") -> dict:
+    return {
+        "job_id": job_id,
+        "work_id": job_id,
+        "title": "Run checks",
+        "kind": "verification",
+        "state": "queued",
+        "owner_peer_id": "owner",
+        "updated_at": "2026-05-25T10:00:00+00:00",
+    }
+
+
+def _mock_client(monkeypatch, response_json: dict | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = response_json or {
+        "job_id": "work-abc123",
+        "work_id": "work-abc123",
+        "status": _status(),
+    }
+    response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.post.return_value = response
+    client.get.return_value = response
+    client.patch.return_value = response
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+    return client
+
+
+def test_jobs_create_posts_job_metadata(monkeypatch) -> None:
+    client = _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "jobs",
+            "create",
+            "Run checks",
+            "--kind",
+            "verification",
+            "--owner",
+            "owner",
+            "--circle",
+            "default",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    client.post.assert_called_once_with(
+        "http://127.0.0.1:8377/jobs",
+        json={
+            "title": "Run checks",
+            "kind": "verification",
+            "source_kind": "cli",
+            "owner_peer_id": "owner",
+            "circle": "default",
+        },
+    )
+    assert "work-abc123" in result.output
+
+
+def test_jobs_create_json_emits_status_json(monkeypatch) -> None:
+    _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["jobs", "create", "Run checks", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"job_id": "work-abc123"' in result.output
+    assert '"title": "Run checks"' in result.output
+
+
+def test_jobs_list_filters_and_renders_table(monkeypatch) -> None:
+    client = _mock_client(monkeypatch, response_json={"work": [_status()]})
+
+    result = CliRunner().invoke(main, ["jobs", "list", "--state", "queued"])
+
+    assert result.exit_code == 0, result.output
+    client.get.assert_called_once_with(
+        "http://127.0.0.1:8377/jobs",
+        params={"state": "queued"},
+    )
+    assert "Run checks" in result.output
+
+
+def test_jobs_list_json_emits_work_array(monkeypatch) -> None:
+    client = _mock_client(monkeypatch, response_json={"work": [_status()]})
+
+    result = CliRunner().invoke(main, ["jobs", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    client.get.assert_called_once_with("http://127.0.0.1:8377/jobs", params=None)
+    assert '"work"' in result.output
+    assert '"job_id": "work-abc123"' in result.output
+
+
+def test_jobs_show_404_exits_nonzero(monkeypatch) -> None:
+    response = MagicMock()
+    response.status_code = 404
+    client = MagicMock()
+    client.get.return_value = response
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+
+    result = CliRunner().invoke(main, ["jobs", "show", "work-missing"])
+
+    assert result.exit_code != 0
+    assert "No job: work-missing" in result.output
+
+
+def test_jobs_list_connection_error_exits_nonzero(monkeypatch) -> None:
+    client = MagicMock()
+    client.get.side_effect = httpx.ConnectError("no daemon")
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+
+    result = CliRunner().invoke(main, ["jobs", "list"])
+
+    assert result.exit_code != 0
+    assert "Cannot connect to daemon" in result.output
+
+
+def test_jobs_update_patches_status(monkeypatch) -> None:
+    client = _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["jobs", "update", "work-abc123", "--state", "running", "--note", "started"],
+    )
+
+    assert result.exit_code == 0, result.output
+    client.patch.assert_called_once_with(
+        "http://127.0.0.1:8377/jobs/work-abc123",
+        json={"state": "running", "progress_note": "started"},
+    )
+
+
+def test_jobs_update_json_emits_status(monkeypatch) -> None:
+    _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["jobs", "update", "work-abc123", "--state", "running", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"job_id": "work-abc123"' in result.output
+
+
+def test_jobs_cancel_posts_cancel_request(monkeypatch) -> None:
+    client = _mock_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["jobs", "cancel", "work-abc123", "--reason", "stale"],
+    )
+
+    assert result.exit_code == 0, result.output
+    client.post.assert_called_once_with(
+        "http://127.0.0.1:8377/jobs/work-abc123/cancel",
+        json={"reason": "stale"},
+    )
+
+
+def test_jobs_cancel_http_error_exits_nonzero(monkeypatch) -> None:
+    request = httpx.Request("POST", "http://127.0.0.1:8377/jobs/work-abc123/cancel")
+    response = httpx.Response(500, json={"detail": "boom"}, request=request)
+    client = MagicMock()
+    client.post.return_value = response
+    client.__enter__.return_value = client
+    monkeypatch.setattr("httpx.Client", MagicMock(return_value=client))
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://127.0.0.1:8377")
+
+    result = CliRunner().invoke(main, ["jobs", "cancel", "work-abc123"])
+
+    assert result.exit_code != 0
+    assert "Failed to cancel job: boom" in result.output
+
+
+def test_jobs_result_prints_json(monkeypatch) -> None:
+    client = _mock_client(
+        monkeypatch,
+        response_json={"result": {"job_id": "work-abc123", "result_state": "not_ready"}},
+    )
+
+    result = CliRunner().invoke(main, ["jobs", "result", "work-abc123", "--json"])
+
+    assert result.exit_code == 0, result.output
+    client.get.assert_called_once_with("http://127.0.0.1:8377/jobs/work-abc123/result")
+    assert "not_ready" in result.output

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -34,7 +34,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5, 6}
+        assert versions == {1, 2, 3, 4, 5, 6, 7}
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -46,6 +46,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert "peer_session_mappings" in tables
         assert "runtime_identity_certificates" in tables
         assert "queued_deliveries" in tables
+        assert "tracked_work" in tables
     finally:
         db.close()
 
@@ -58,7 +59,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5, 6}
+        assert versions == {1, 2, 3, 4, 5, 6, 7}
     finally:
         db2.close()
 

--- a/tests/test_work_routes.py
+++ b/tests/test_work_routes.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import work as work_routes
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.work import SQLiteWorkStore
+from repowire.daemon.websocket_transport import WebSocketTransport
+
+
+def _make_app(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    db = StateDatabase(tmp_path / "state.db")
+    store = SQLiteWorkStore(db)
+
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        work_store=store,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+
+    app = FastAPI()
+    app.include_router(work_routes.router)
+    return app, db
+
+
+@pytest.fixture
+async def env(tmp_path):
+    app, db = _make_app(tmp_path)
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url="http://test") as c:
+        yield c
+    cleanup_deps()
+    db.close()
+
+
+async def test_create_work_returns_queued_status(env) -> None:
+    r = await env.post(
+        "/work",
+        json={
+            "title": "Run checks",
+            "kind": "verification",
+            "created_by_peer_id": "repow-default-creator",
+            "owner_peer_id": "repow-default-owner",
+            "assigned_peer_id": "repow-default-worker",
+            "circle": "default",
+            "source_kind": "dashboard",
+            "source_id": "compose-1",
+            "request": {"title": "run checks"},
+        },
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["work_id"].startswith("work-")
+    assert body["job_id"] == body["work_id"]
+    assert body["status"]["title"] == "Run checks"
+    assert body["status"]["kind"] == "verification"
+    assert body["status"]["state"] == "queued"
+    assert body["status"]["owner_peer_id"] == "repow-default-owner"
+    assert body["status"]["assigned_peer_id"] == "repow-default-worker"
+    assert body["status"]["source_kind"] == "dashboard"
+
+
+async def test_list_work_filters_by_circle_and_state(env) -> None:
+    await env.post("/work", json={"circle": "default", "owner_peer_id": "owner-a"})
+    await env.post("/work", json={"circle": "other", "owner_peer_id": "owner-b"})
+
+    r = await env.get("/work", params={"circle": "default", "state": "queued"})
+
+    assert r.status_code == 200
+    items = r.json()["work"]
+    assert len(items) == 1
+    assert items[0]["owner_peer_id"] == "owner-a"
+
+
+async def test_result_for_non_terminal_work_returns_not_ready_status(env) -> None:
+    created = await env.post("/work", json={"created_by_peer_id": "creator"})
+    work_id = created.json()["work_id"]
+
+    r = await env.get(f"/work/{work_id}/result")
+
+    assert r.status_code == 200
+    result = r.json()["result"]
+    assert result["result_state"] == "not_ready"
+    assert result["status"]["work_id"] == work_id
+    assert result["status"]["job_id"] == work_id
+
+
+async def test_jobs_alias_can_update_progress_and_return_result(env) -> None:
+    created = await env.post("/jobs", json={"title": "Investigate", "kind": "research"})
+    job_id = created.json()["job_id"]
+
+    updated = await env.patch(
+        f"/jobs/{job_id}",
+        json={
+            "state": "completed",
+            "phase": "done",
+            "progress_note": "wrote summary",
+            "result_summary": "root cause found",
+            "result_data": {"root_cause": "missing config"},
+        },
+    )
+
+    assert updated.status_code == 200
+    status = updated.json()["status"]
+    assert status["state"] == "completed"
+    assert status["progress_events"][0]["note"] == "wrote summary"
+
+    result = await env.get(f"/jobs/{job_id}/result")
+    assert result.status_code == 200
+    assert result.json()["result"]["summary"] == "root cause found"
+
+
+async def test_terminal_job_cannot_move_back_to_non_terminal(env) -> None:
+    created = await env.post("/jobs", json={"title": "Terminal guard"})
+    job_id = created.json()["job_id"]
+    completed = await env.patch(
+        f"/jobs/{job_id}",
+        json={"state": "completed", "result_summary": "done"},
+    )
+    assert completed.status_code == 200
+
+    reverted = await env.patch(f"/jobs/{job_id}", json={"state": "running"})
+
+    assert reverted.status_code == 400
+    assert "terminal state cannot be changed" in reverted.json()["detail"]
+
+
+async def test_terminal_same_state_update_preserves_result_fields(env) -> None:
+    created = await env.post("/jobs", json={"title": "Preserve result"})
+    job_id = created.json()["job_id"]
+    failed = await env.patch(
+        f"/jobs/{job_id}",
+        json={
+            "state": "failed",
+            "result_summary": "failed",
+            "result_data": {"step": "setup"},
+            "error": {"message": "missing config"},
+            "artifacts": [{"path": "logs/setup.txt"}],
+        },
+    )
+    assert failed.status_code == 200
+
+    enriched = await env.patch(
+        f"/jobs/{job_id}",
+        json={"state": "failed", "progress_note": "triaged"},
+    )
+
+    assert enriched.status_code == 200
+    result = await env.get(f"/jobs/{job_id}/result")
+    body = result.json()["result"]
+    assert body["summary"] == "failed"
+    assert body["data"] == {"step": "setup"}
+    assert body["error"] == {"message": "missing config"}
+    assert body["artifacts"] == [{"path": "logs/setup.txt"}]
+
+
+async def test_cancel_queued_work_returns_cancelled_status(env) -> None:
+    created = await env.post("/work", json={"owner_peer_id": "owner"})
+    work_id = created.json()["work_id"]
+
+    r = await env.post(
+        f"/work/{work_id}/cancel",
+        json={"requested_by_peer_id": "creator"},
+    )
+
+    assert r.status_code == 200
+    status = r.json()["status"]
+    assert status["state"] == "cancelled"
+    assert status["state_reason"] == "cancel_requested"
+    assert status["cancel_requested_by_peer_id"] == "creator"
+    assert status["cancellation_reason"] == "cancel_requested"
+
+
+async def test_unknown_work_returns_404(env) -> None:
+    r = await env.get("/work/work-missing/status")
+
+    assert r.status_code == 404

--- a/tests/test_work_store.py
+++ b/tests/test_work_store.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.work import SQLiteWorkStore
+
+
+def test_sqlite_work_store_create_list_and_reload(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create(
+            title="Run checks",
+            kind="verification",
+            created_by_peer_id="repow-default-creator",
+            owner_peer_id="repow-default-owner",
+            assigned_peer_id="repow-default-worker",
+            repowire_session_id="rw-session-1",
+            correlation_id="ask-1",
+            circle="default",
+            source_kind="mcp",
+            source_id="tool-call-1",
+            scope="repo",
+            request={"task": "run checks"},
+            provenance={"links": {"ask_id": "ask-1"}},
+        )
+
+        assert work.work_id.startswith("work-")
+        assert work.status()["job_id"] == work.work_id
+        assert work.title == "Run checks"
+        assert work.kind == "verification"
+        assert work.state == "queued"
+        assert work.status()["links"] == {"ask_id": "ask-1"}
+        assert [item.work_id for item in store.list_all(owner_peer_id="repow-default-owner")] == [
+            work.work_id,
+        ]
+    finally:
+        db.close()
+
+    reopened = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(reopened)
+        loaded = store.list_all(repowire_session_id="rw-session-1")[0]
+        assert loaded.work_id == work.work_id
+        assert loaded.request == {"task": "run checks"}
+        assert loaded.source_kind == "mcp"
+        assert loaded.assigned_peer_id == "repow-default-worker"
+        assert loaded.correlation_id == "ask-1"
+    finally:
+        reopened.close()
+
+
+def test_sqlite_work_store_result_not_ready_until_terminal(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create(created_by_peer_id="repow-default-creator")
+
+        assert store.get(work.work_id).result()["result_state"] == "not_ready"  # type: ignore[union-attr]
+
+        completed = store.update_state(
+            work.work_id,
+            state="completed",
+            progress_note="checks finished",
+            result_summary="checks passed",
+            result_data={"passed": 12},
+            artifacts=[{"path": "logs/checks.txt"}],
+        )
+
+        assert completed is not None
+        result = completed.result()
+        assert result["state"] == "completed"
+        assert result["job_id"] == work.work_id
+        assert result["summary"] == "checks passed"
+        assert result["data"] == {"passed": 12}
+        assert result["completed_at"] is not None
+        assert completed.progress_events[0]["note"] == "checks finished"
+    finally:
+        db.close()
+
+
+def test_sqlite_work_store_cancel_queued_work_is_terminal(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create(owner_peer_id="repow-default-owner")
+
+        cancelled = store.cancel(
+            work.work_id,
+            requested_by_peer_id="repow-default-creator",
+        )
+
+        assert cancelled is not None
+        assert cancelled.state == "cancelled"
+        assert cancelled.state_reason == "cancel_requested"
+        assert cancelled.cancel_requested is True
+        assert cancelled.cancel_requested_by_peer_id == "repow-default-creator"
+        assert cancelled.cancellation_reason == "cancel_requested"
+        assert cancelled.completed_at is not None
+    finally:
+        db.close()
+
+
+def test_sqlite_work_store_cancel_running_work_records_pending_cancel(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create(owner_peer_id="repow-default-owner")
+        running = store.update_state(work.work_id, state="running", phase="tests")
+        assert running is not None
+
+        cancelled = store.cancel(work.work_id, reason="user_requested")
+
+        assert cancelled is not None
+        assert cancelled.state == "running"
+        assert cancelled.state_reason == "user_requested"
+        assert cancelled.cancel_requested is True
+        assert cancelled.completed_at is None
+    finally:
+        db.close()
+
+
+def test_sqlite_work_store_terminal_state_cannot_move_back_to_non_terminal(
+    tmp_path: Path,
+) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create()
+        completed = store.update_state(
+            work.work_id,
+            state="completed",
+            result_summary="done",
+            result_data={"ok": True},
+            error={"code": "none"},
+            artifacts=[{"path": "artifact.txt"}],
+        )
+        assert completed is not None
+
+        try:
+            store.update_state(work.work_id, state="running")
+        except ValueError as e:
+            assert "terminal state cannot be changed" in str(e)
+        else:
+            raise AssertionError("expected terminal state guard")
+
+        still_completed = store.get(work.work_id)
+        assert still_completed is not None
+        assert still_completed.state == "completed"
+    finally:
+        db.close()
+
+
+def test_sqlite_work_store_terminal_metadata_update_preserves_omitted_result_fields(
+    tmp_path: Path,
+) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteWorkStore(db)
+        work = store.create()
+        completed = store.update_state(
+            work.work_id,
+            state="failed",
+            result_summary="failed in setup",
+            result_data={"step": "setup"},
+            error={"message": "missing config"},
+            artifacts=[{"path": "logs/setup.txt"}],
+        )
+        assert completed is not None
+
+        enriched = store.update_state(
+            work.work_id,
+            state="failed",
+            progress_note="triaged",
+        )
+
+        assert enriched is not None
+        assert enriched.state == "failed"
+        assert enriched.result_summary == "failed in setup"
+        assert enriched.result_data == {"step": "setup"}
+        assert enriched.error == {"message": "missing config"}
+        assert enriched.artifacts == [{"path": "logs/setup.txt"}]
+        assert enriched.progress_events[-1]["note"] == "triaged"
+    finally:
+        db.close()

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -74,7 +74,7 @@ export default function Concepts() {
           Agents use Repowire tools for mesh peers: <Mono>ask</Mono> for tracked work, <Mono>notify_peer</Mono> for fire-and-forget updates, and <Mono>ack</Mono> to close inbound asks. <Mono>SendMessage</Mono> is only for same-session harness teammates.
         </p>
         <p>
-          <Mono>timeline</Mono> and <Mono>result</Mono> are views over existing peer, ask, schedule, event, and session-history data until a separate tracked-work lifecycle exists. ACP/channel broker health is reserved for the channel health work rather than claimed by this command contract.
+          <Mono>timeline</Mono> and general mesh <Mono>result</Mono> views still draw from existing peer, ask, schedule, event, session-history, and tracked-work data. ACP/channel broker health is reserved for the channel health work rather than claimed by this command contract.
         </p>
         <p>
           Future Claude Code marketplace plugin packaging may expose these commands as slash commands, skills, docs, and an MCP bootstrap, but it remains optional. The plugin manifest should map to the same command ids and check drift against the installed Repowire package, <Mono>repowire mcp</Mono>, hook snippets, Claude Code version, and the declared compatible Repowire range. It does not replace <Mono>repowire setup</Mono> or install a second daemon.
@@ -83,10 +83,16 @@ export default function Concepts() {
 
       <Section title="Tracked work lifecycle">
         <p>
-          Durable tracked work is a separate daemon-backed lifecycle from conversational <Mono>ask</Mono>/<Mono>ack</Mono>. The design reserves <Mono>work_id</Mono> records with states such as <Mono>queued</Mono>, <Mono>delivered</Mono>, <Mono>running</Mono>, <Mono>awaiting_input</Mono>, <Mono>completed</Mono>, <Mono>failed</Mono>, <Mono>cancelled</Mono>, <Mono>blocked</Mono>, <Mono>expired</Mono>, and <Mono>unavailable</Mono>.
+          Durable tracked work is a separate daemon-backed lifecycle from conversational <Mono>ask</Mono>/<Mono>ack</Mono>. The daemon has a first HTTP and CLI skeleton for durable <Mono>job_id</Mono>/<Mono>work_id</Mono> records with states such as <Mono>queued</Mono>, <Mono>delivered</Mono>, <Mono>running</Mono>, <Mono>awaiting_input</Mono>, <Mono>completed</Mono>, <Mono>failed</Mono>, <Mono>cancelled</Mono>, <Mono>blocked</Mono>, <Mono>expired</Mono>, and <Mono>unavailable</Mono>.
         </p>
         <p>
           Status, result, and cancel semantics belong to that work lifecycle. Acks may close related conversation threads, but they do not complete work. Session and circle visibility should resolve by exact ids where possible, and protocol cancel should be attempted before transport teardown when a live backend connection can still accept it.
+        </p>
+        <p>
+          The current slice covers <Mono>POST /jobs</Mono>, <Mono>GET /jobs</Mono>, <Mono>GET /jobs/:id</Mono>, <Mono>PATCH /jobs/:id</Mono>, <Mono>GET /jobs/:id/result</Mono>, <Mono>POST /jobs/:id/cancel</Mono>, and matching <Mono>repowire jobs</Mono> commands. Use jobs for durable status/progress/result/cancel, ask for closeable conversations, and schedule for future delivery. Executor selection, transport delivery, live runtime cancel, and dashboard controls remain future work.
+        </p>
+        <p>
+          Terminal jobs cannot be moved back to non-terminal states. Same-terminal updates may add bounded metadata or progress notes without clearing omitted result fields. MCP job tools remain a follow-up.
         </p>
       </Section>
 

--- a/web/app/docs/reference/cli/page.tsx
+++ b/web/app/docs/reference/cli/page.tsx
@@ -84,6 +84,26 @@ repowire schedule delete SCHEDULE_ID`}
       </Cmd>
 
       <Cmd
+        name="repowire jobs"
+        usage={`repowire jobs create TITLE [--kind KIND] [--owner PEER_ID] [--assigned-peer PEER_ID] [--session SESSION_ID] [--json]
+repowire jobs list [--state STATE] [--owner PEER_ID] [--created-by PEER_ID] [--session SESSION_ID] [--json]
+repowire jobs show JOB_ID [--json]
+repowire jobs update JOB_ID --state STATE [--reason REASON] [--phase PHASE] [--note NOTE] [--result-summary TEXT] [--json]
+repowire jobs cancel JOB_ID [--requested-by PEER_ID] [--reason REASON] [--json]
+repowire jobs result JOB_ID [--json]`}
+      >
+        <p>
+          Create and inspect daemon-owned tracked work records. Jobs are durable control state in <Mono>state.db</Mono>; they can exist without a live peer, ask thread, schedule, or session. Creating a job does not dispatch work to an agent.
+        </p>
+        <p>
+          Use jobs for durable status, progress notes, result metadata, and cancellation. Use <Mono>ask</Mono> for a conversational request that another peer closes with <Mono>ack</Mono>. Use <Mono>schedule</Mono> for future delivery of a notify or ask.
+        </p>
+        <p>
+          Jobs commands exit non-zero on daemon connection failures, missing jobs, and HTTP errors. Pass <Mono>--json</Mono> for scriptable status, list, and result output.
+        </p>
+      </Cmd>
+
+      <Cmd
         name="repowire orchestrator persona"
         usage={`repowire orchestrator persona list
 repowire orchestrator persona show [NAME]


### PR DESCRIPTION
## Summary

Adds a neutral daemon-owned jobs/tracked-work lifecycle primitive, separate from ask/ack and schedules.

- adds a durable SQLite-backed tracked work store with `job_id`/`work_id`, title/kind, owner/source/session/correlation metadata, progress events, terminal result metadata, and cancellation metadata
- exposes additive `/jobs` routes plus `/work` compatibility routes for create/list/show/update/result/cancel
- adds `repowire jobs create/list/show/update/cancel/result` operator commands with non-zero failures and JSON output options for scripting
- documents when to use jobs vs asks vs schedules in concept and CLI docs, including mirrored web docs

## Notes

This was rebased after #305, #307, and #308. State schema is now linearized as v7: v5 runtime identity certificates, v6 queued deliveries, v7 tracked work lifecycle records.

This PR intentionally does not implement executor dispatch, auto job creation, Telegram UI, persona/Anya behavior, session handoff/resume semantics, identity source-of-truth changes, store-forward queue changes, or MCP job tools. `repowire-sip.1` should remain open for MCP/status JSON acceptance and any execution/status integration beyond this first slice.

Terminal jobs cannot move back to non-terminal states. Same-terminal updates may add bounded metadata/progress notes while preserving omitted result fields.

Graphify and Beads ledger churn are intentionally excluded from the product diff.

## Validation

- `uv run --extra dev pytest tests/test_work_store.py tests/test_work_routes.py tests/test_cli_jobs.py tests/test_sqlite_state_schedules.py tests/test_tracked_work_lifecycle_contract.py` passed: 42 passed
- `uv run --extra dev ruff check repowire/ tests/test_work_store.py tests/test_work_routes.py tests/test_cli_jobs.py tests/test_sqlite_state_schedules.py tests/test_tracked_work_lifecycle_contract.py` passed
- `uv run --extra dev ty check repowire/` passed
- `uv run --extra dev pytest` passed: 1412 passed, 1 warning
- `python3 scripts/pre_pr_hygiene.py` passed advisory checks