### PR TITLE
Add MCP job tools and pending cancel contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Full docs: [docs.repowire.io](https://docs.repowire.io).
 
 ## How It Works
 
-All peers connect to a local daemon. The daemon keeps the registry, routes asks/notifies, tracks open asks, runs schedules, and feeds the dashboard timeline.
+All peers connect to a local daemon. The daemon keeps the registry, routes asks/notifies, tracks open asks, stores durable jobs, runs schedules, and feeds the dashboard timeline.
 
 <p align="center">
   <img src="images/repowire-arch.webp" alt="Repowire architecture" width="700" />
 </p>
 
-The stable public surface is still peers, circles, asks, notifications, broadcasts, and schedules. The v0.14 direction is session-native: sessions become the durable unit of work, while peers remain the live runtime executors. The current dashboard shows the selected peer/session view, merges Claude transcript history where available with realtime events, and is moving toward broader session commands for controls like resume, scheduling, approvals, and future backend/model changes.
+The stable public surface is peers, circles, asks, notifications, broadcasts, schedules, and the `/jobs` tracked-work API exposed through CLI and MCP JSON tools. The v0.14 direction is session-native: sessions become the durable unit of work, while peers remain the live runtime executors. The current dashboard shows the selected peer/session view, merges Claude transcript history where available with realtime events, and is moving toward broader session commands for controls like resume, scheduling, approvals, and future backend/model changes.
 
 Transport notes:
 

--- a/docs/concepts/tracked-work-lifecycle.md
+++ b/docs/concepts/tracked-work-lifecycle.md
@@ -3,8 +3,8 @@
 Status: architecture contract plus first daemon skeleton for tracked work. The
 daemon now has a durable tracked-work store and HTTP status/result/cancel
 surface separately from conversational `ask`/`ack`. Executor delivery,
-dashboard workflows, ACP/channel health handling, transport cancel, and backend
-resume execution are still future slices.
+dashboard workflows, ACP/channel health handling beyond the narrow cancel hook,
+and backend resume execution are still future slices.
 
 ## Problem
 
@@ -55,13 +55,16 @@ specific backend.
   `result_state=not_ready` plus status while work is non-terminal.
 - `POST /jobs/{job_id}/cancel` / `POST /work/{work_id}/cancel` records an
   audit-visible cancel request.
+- MCP tools `job_create`, `job_list`, `job_status` / `job_show`, `job_update`,
+  `job_result`, and `job_cancel` wrap the same `/jobs` API and return JSON
+  strings for agent callers.
 
 The record includes job-facing and owner/source/scope fields such as `title`,
 `kind`, `created_by_peer_id`, `owner_peer_id`, `assigned_peer_id`,
 `source_kind`, `source_id`, `correlation_id`, `scope`, `circle`,
 `repowire_session_id`, `visibility`, and progress events. This API is a
 lifecycle foundation: it does not select executors, deliver work to transports,
-cancel live runtime sessions, expose MCP job tools, or update
+cancel live runtime sessions outside the explicit ACP-client case, or update
 dashboard/Telegram/Slack UI yet.
 
 Use jobs when work needs durable status, progress history, result metadata, or
@@ -166,7 +169,9 @@ Expected behavior:
   without contacting a transport.
 - If work is `delivered`, `running`, `awaiting_input`, or `blocked`, the daemon
   should send the runtime/backend cancel instruction when the transport exposes
-  one.
+  one. The current implementation attempts this only for an already-live
+  daemon-owned ACP client for `assigned_peer_id`; it does not spawn a client or
+  infer a runtime session from display name, path, or circle.
 - A work item should report a pending cancel reason while cancellation is in
   flight, rather than claiming `cancelled` immediately.
 - Terminal states win over late cancel requests. Cancelling `completed`,
@@ -174,6 +179,13 @@ Expected behavior:
   and return the existing terminal status.
 - Cancel requests must be audit-visible even when best-effort transport cancel
   fails.
+
+Status includes `protocol_cancel` when a non-queued cancel request reaches the
+protocol-cancel adapter. Values such as `status=sent` mean a bounded ACP
+`session/cancel` was attempted. Values such as `status=unavailable` mean the
+daemon had no live execution/session link to cancel and the work remains in the
+pending-cancel contract until a later executor update or follow-up slice adds a
+real execution binding.
 
 ## Protocol cancel before transport teardown
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -186,6 +186,55 @@ This is a *presence check*, not a snapshot of mesh state.
 
 ## Lifecycle
 
+### `job_create`
+
+```python
+job_create(title: str = "", kind: str = "general", assigned_peer_id: str | None = None, owner_peer_id: str | None = None, repowire_session_id: str | None = None, correlation_id: str | None = None, circle: str | None = None, source_kind: str | None = None, source_id: str | None = None, scope: str | None = None, visibility: str = "circle", request: dict | None = None, deadline_at: str | None = None, expires_at: str | None = None, provenance: dict | None = None) -> str
+```
+
+Create a durable tracked work job through the daemon `/jobs` API. Returns the daemon response as a JSON string with `job_id`, `work_id`, and `status`. The MCP caller's peer ID is sent as `created_by_peer_id` when available.
+
+### `job_list`
+
+```python
+job_list(state: str | None = None, owner_peer_id: str | None = None, created_by_peer_id: str | None = None, repowire_session_id: str | None = None, circle: str | None = None) -> str
+```
+
+List durable jobs through `/jobs`. Returns a JSON string shaped like `{"work": [status, ...]}`. Filters mirror the HTTP API.
+
+### `job_status` / `job_show`
+
+```python
+job_status(job_id: str) -> str
+job_show(job_id: str) -> str
+```
+
+Return one job's current status JSON. `job_show` is an alias for `job_status`.
+
+### `job_update`
+
+```python
+job_update(job_id: str, state: str, state_reason: str | None = None, phase: str | None = None, progress: dict | None = None, progress_note: str | None = None, result_summary: str | None = None, result_data: dict | None = None, error: dict | None = None, artifacts: list | None = None, provenance: dict | None = None) -> str
+```
+
+Update a job lifecycle state through `PATCH /jobs/{job_id}`. Returns the updated status JSON. Terminal jobs cannot move back to non-terminal states; same-terminal updates may add bounded metadata.
+
+### `job_result`
+
+```python
+job_result(job_id: str) -> str
+```
+
+Return terminal result JSON for a job, or `result_state="not_ready"` with the current status while the job is non-terminal.
+
+### `job_cancel`
+
+```python
+job_cancel(job_id: str, reason: str = "cancel_requested") -> str
+```
+
+Request cancellation for a tracked work job. Returns status JSON. Queued jobs move directly to `cancelled`; running, delivered, awaiting-input, or blocked jobs record `cancel_requested` and remain pending until an executor reports a terminal state. When the daemon already owns a live ACP session for the job's assigned peer, it attempts a bounded protocol `session/cancel` and reports the result in `status.protocol_cancel`. If there is no live session/execution link, `protocol_cancel` reports `unavailable` rather than claiming runtime cancellation.
+
 ### `spawn_peer`
 
 ```python

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -143,6 +143,30 @@ class AcpClientManager:
         if client is not None:
             await client.close()
 
+    async def cancel_existing(self, peer_id: str) -> dict[str, Any]:
+        """Best-effort ``session/cancel`` for an already-live ACP client.
+
+        This never starts a subprocess. It is used by tracked-work cancel to
+        honor protocol-cancel ordering only when the daemon already has a live
+        ACP session for the assigned peer.
+        """
+        async with self._lock:
+            client = self._clients.get(peer_id)
+        if client is None:
+            return {
+                "attempted": False,
+                "status": "unavailable",
+                "reason": "no_active_acp_client",
+                "peer_id": peer_id,
+            }
+        await client.cancel()
+        return {
+            "attempted": True,
+            "status": "sent",
+            "reason": "session_cancel_sent",
+            "peer_id": peer_id,
+        }
+
     async def close(self) -> None:
         """Tear down every live client. Safe to call multiple times."""
         if self._closed:

--- a/repowire/daemon/routes/work.py
+++ b/repowire/daemon/routes/work.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -83,6 +84,75 @@ def _store():
     if store is None:
         raise RuntimeError("work_store not initialized")
     return store
+
+
+async def _attempt_protocol_cancel(work: TrackedWork) -> dict[str, Any]:
+    """Try a bounded runtime-level cancel for the current architecture slice.
+
+    Tracked work does not yet have a durable execution/session binding for
+    every transport. ACP is the only runtime with a daemon-owned live session
+    handle today, so this function only targets an existing ACP client for the
+    assigned peer and otherwise records an explicit unavailable/skipped result.
+    """
+    if work.terminal:
+        return {
+            "attempted": False,
+            "status": "skipped",
+            "reason": "terminal_work",
+        }
+    if not work.assigned_peer_id:
+        return {
+            "attempted": False,
+            "status": "unavailable",
+            "reason": "no_assigned_peer",
+        }
+    state = get_app_state()
+    manager = getattr(state, "acp_manager", None)
+    if manager is None or not hasattr(manager, "cancel_existing"):
+        return {
+            "attempted": False,
+            "status": "unavailable",
+            "reason": "no_protocol_cancel_adapter",
+            "peer_id": work.assigned_peer_id,
+        }
+    try:
+        result = await asyncio.wait_for(
+            manager.cancel_existing(work.assigned_peer_id),
+            timeout=2.0,
+        )
+        return result if isinstance(result, dict) else {
+            "attempted": True,
+            "status": "sent",
+            "reason": "session_cancel_sent",
+            "peer_id": work.assigned_peer_id,
+        }
+    except TimeoutError:
+        return {
+            "attempted": True,
+            "status": "timeout",
+            "reason": "protocol_cancel_timeout",
+            "peer_id": work.assigned_peer_id,
+        }
+    except Exception as e:  # noqa: BLE001 - cancel remains audit-visible
+        return {
+            "attempted": True,
+            "status": "failed",
+            "reason": "protocol_cancel_failed",
+            "peer_id": work.assigned_peer_id,
+            "error": str(e),
+        }
+
+
+def _merge_protocol_cancel(
+    work: TrackedWork,
+    protocol_cancel: dict[str, Any],
+) -> dict[str, Any]:
+    provenance = dict(work.provenance)
+    attempts = list(provenance.get("protocol_cancel_attempts") or [])
+    attempts.append(protocol_cancel)
+    provenance["protocol_cancel"] = protocol_cancel
+    provenance["protocol_cancel_attempts"] = attempts[-10:]
+    return provenance
 
 
 @router.post("/work", response_model=WorkCreateResponse)
@@ -197,6 +267,7 @@ async def cancel_work(
     request: WorkCancelRequest,
     _: str | None = Depends(require_auth),
 ) -> WorkStatusResponse:
+    existing = _store().get(work_id)
     work = _store().cancel(
         work_id,
         requested_by_peer_id=request.requested_by_peer_id,
@@ -204,4 +275,17 @@ async def cancel_work(
     )
     if work is None:
         raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    if existing is not None and not existing.terminal and existing.state != "queued":
+        protocol_cancel = await _attempt_protocol_cancel(work)
+        provenance = _merge_protocol_cancel(work, protocol_cancel)
+        updated = _store().update_state(
+            work.work_id,
+            state=work.state,
+            state_reason=work.state_reason,
+            phase=work.phase,
+            progress=work.progress,
+            provenance=provenance,
+        )
+        if updated is not None:
+            work = updated
     return WorkStatusResponse.from_work(work)

--- a/repowire/daemon/work_store.py
+++ b/repowire/daemon/work_store.py
@@ -144,6 +144,7 @@ class TrackedWork:
             "cancel_requested_at": self.cancel_requested_at,
             "cancel_requested_by_peer_id": self.cancel_requested_by_peer_id,
             "cancellation_reason": self.cancellation_reason,
+            "protocol_cancel": self.provenance.get("protocol_cancel"),
             "links": self.provenance.get("links", {}),
         }
 

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -223,6 +224,8 @@ async def daemon_request(
             resp = await client.get(url, params=params, headers=headers)
         elif method == "DELETE":
             resp = await client.delete(url, params=params, headers=headers)
+        elif method == "PATCH":
+            resp = await client.patch(url, json=body or {}, headers=headers)
         else:
             resp = await client.post(url, json=body or {}, headers=headers)
         resp.raise_for_status()
@@ -697,6 +700,147 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         for p in peers:
             rows.append(_peer_to_tsv_row(p))
         return "\n".join(rows)
+
+    @mcp.tool()
+    async def job_create(
+        title: str = "",
+        kind: str = "general",
+        assigned_peer_id: str | None = None,
+        owner_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        correlation_id: str | None = None,
+        circle: str | None = None,
+        source_kind: str | None = None,
+        source_id: str | None = None,
+        scope: str | None = None,
+        visibility: str = "circle",
+        request: dict | None = None,
+        deadline_at: str | None = None,
+        expires_at: str | None = None,
+        provenance: dict | None = None,
+    ) -> str:
+        """[Repowire mesh] Create a durable tracked work job.
+
+        Returns the daemon JSON response as a string. The caller's peer_id is
+        sent as created_by_peer_id when available.
+        """
+        await _ensure_registered(strict=True)
+        created_by = await _get_my_peer_identifier()
+        body: dict = {
+            "title": title,
+            "kind": kind,
+            "created_by_peer_id": created_by,
+            "visibility": visibility,
+            "request": request or {},
+        }
+        optional = {
+            "assigned_peer_id": assigned_peer_id,
+            "owner_peer_id": owner_peer_id,
+            "repowire_session_id": repowire_session_id,
+            "correlation_id": correlation_id,
+            "circle": circle,
+            "source_kind": source_kind,
+            "source_id": source_id,
+            "scope": scope,
+            "deadline_at": deadline_at,
+            "expires_at": expires_at,
+            "provenance": provenance,
+        }
+        body.update({key: value for key, value in optional.items() if value is not None})
+        result = await daemon_request("POST", "/jobs", body)
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.tool()
+    async def job_list(
+        state: str | None = None,
+        owner_peer_id: str | None = None,
+        created_by_peer_id: str | None = None,
+        repowire_session_id: str | None = None,
+        circle: str | None = None,
+    ) -> str:
+        """[Repowire mesh] List durable tracked work jobs as JSON."""
+        await _ensure_registered()
+        params = {
+            key: value
+            for key, value in {
+                "state": state,
+                "owner_peer_id": owner_peer_id,
+                "created_by_peer_id": created_by_peer_id,
+                "repowire_session_id": repowire_session_id,
+                "circle": circle,
+            }.items()
+            if value is not None
+        }
+        result = await daemon_request("GET", "/jobs", params=params or None)
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.tool()
+    async def job_status(job_id: str) -> str:
+        """[Repowire mesh] Return one tracked work job status as JSON."""
+        await _ensure_registered()
+        result = await daemon_request("GET", f"/jobs/{quote(job_id, safe='')}/status")
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.tool()
+    async def job_show(job_id: str) -> str:
+        """[Repowire mesh] Alias for job_status."""
+        return await job_status(job_id)
+
+    @mcp.tool()
+    async def job_update(
+        job_id: str,
+        state: str,
+        state_reason: str | None = None,
+        phase: str | None = None,
+        progress: dict | None = None,
+        progress_note: str | None = None,
+        result_summary: str | None = None,
+        result_data: dict | None = None,
+        error: dict | None = None,
+        artifacts: list | None = None,
+        provenance: dict | None = None,
+    ) -> str:
+        """[Repowire mesh] Update a tracked work job lifecycle state as JSON."""
+        await _ensure_registered(strict=True)
+        body = {
+            key: value
+            for key, value in {
+                "state": state,
+                "state_reason": state_reason,
+                "phase": phase,
+                "progress": progress,
+                "progress_note": progress_note,
+                "result_summary": result_summary,
+                "result_data": result_data,
+                "error": error,
+                "artifacts": artifacts,
+                "provenance": provenance,
+            }.items()
+            if value is not None
+        }
+        result = await daemon_request("PATCH", f"/jobs/{quote(job_id, safe='')}", body)
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.tool()
+    async def job_result(job_id: str) -> str:
+        """[Repowire mesh] Return a tracked work job result as JSON."""
+        await _ensure_registered()
+        result = await daemon_request("GET", f"/jobs/{quote(job_id, safe='')}/result")
+        return json.dumps(result, sort_keys=True)
+
+    @mcp.tool()
+    async def job_cancel(job_id: str, reason: str = "cancel_requested") -> str:
+        """[Repowire mesh] Request cancellation for a tracked work job as JSON."""
+        await _ensure_registered(strict=True)
+        result = await daemon_request(
+            "POST",
+            f"/jobs/{quote(job_id, safe='')}/cancel",
+            {
+                "requested_by_peer_id": await _get_my_peer_identifier(),
+                "reason": reason,
+            },
+        )
+        return json.dumps(result, sort_keys=True)
 
     @mcp.tool()
     async def ask(

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.mcp.server import create_mcp_server
+
+
+def _tool(name: str):
+    return create_mcp_server()._tool_manager._tools[name].fn
+
+
+@pytest.mark.asyncio
+async def test_job_create_posts_json_with_caller_peer_id() -> None:
+    with (
+        patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock),
+        patch("repowire.mcp.server._get_my_peer_identifier", new_callable=AsyncMock) as peer,
+        patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock) as request,
+    ):
+        peer.return_value = "repow-default-creator"
+        request.return_value = {
+            "job_id": "work-abc123",
+            "work_id": "work-abc123",
+            "status": {"state": "queued"},
+        }
+
+        result = await _tool("job_create")(
+            title="Run checks",
+            kind="verification",
+            assigned_peer_id="repow-default-worker",
+            request={"command": "pytest"},
+        )
+
+    request.assert_awaited_once()
+    method, path, body = request.await_args.args[:3]
+    assert method == "POST"
+    assert path == "/jobs"
+    assert body["created_by_peer_id"] == "repow-default-creator"
+    assert body["assigned_peer_id"] == "repow-default-worker"
+    assert body["request"] == {"command": "pytest"}
+    assert json.loads(result)["job_id"] == "work-abc123"
+
+
+@pytest.mark.asyncio
+async def test_job_list_passes_filters_and_returns_json() -> None:
+    with (
+        patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock),
+        patch("repowire.mcp.server.daemon_request", new_callable=AsyncMock) as request,
+    ):
+        request.return_value = {"work": [{"job_id": "work-abc123"}]}
+
+        result = await _tool("job_list")(state="running", circle="default")
+
+    request.assert_awaited_once_with(
+        "GET",
+        "/jobs",
+        params={"state": "running", "circle": "default"},
+    )
+    assert json.loads(result)["work"][0]["job_id"] == "work-abc123"
+
+
+@pytest.mark.asyncio
+async def test_job_status_show_result_update_and_cancel_wrap_jobs_api() -> None:
+    calls: list[tuple] = []
+
+    async def fake_request(method, path, body=None, params=None):
+        calls.append((method, path, body, params))
+        if path.endswith("/result"):
+            return {"result": {"job_id": "work-abc123", "result_state": "not_ready"}}
+        return {"status": {"job_id": "work-abc123", "state": "running"}}
+
+    with (
+        patch("repowire.mcp.server._ensure_registered", new_callable=AsyncMock),
+        patch("repowire.mcp.server._get_my_peer_identifier", new_callable=AsyncMock) as peer,
+        patch("repowire.mcp.server.daemon_request", side_effect=fake_request),
+    ):
+        peer.return_value = "repow-default-creator"
+        await _tool("job_status")("work-abc123")
+        await _tool("job_show")("work-abc123")
+        await _tool("job_update")(
+            "work-abc123",
+            state="running",
+            progress_note="started",
+        )
+        await _tool("job_result")("work-abc123")
+        cancel_result = await _tool("job_cancel")("work-abc123", reason="stale")
+
+    assert calls == [
+        ("GET", "/jobs/work-abc123/status", None, None),
+        ("GET", "/jobs/work-abc123/status", None, None),
+        (
+            "PATCH",
+            "/jobs/work-abc123",
+            {"state": "running", "progress_note": "started"},
+            None,
+        ),
+        ("GET", "/jobs/work-abc123/result", None, None),
+        (
+            "POST",
+            "/jobs/work-abc123/cancel",
+            {"requested_by_peer_id": "repow-default-creator", "reason": "stale"},
+            None,
+        ),
+    ]
+    assert json.loads(cancel_result)["status"]["state"] == "running"

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -462,7 +462,9 @@ class TestMcpToolDescriptions:
                        "spawn_peer", "kill_peer", "whoami", "set_description",
                        "claim_orchestrator_role", "schedule_create", "schedule_self",
                        "schedule_cron",
-                       "schedule_list", "schedule_delete"]
+                       "schedule_list", "schedule_delete", "job_create", "job_list",
+                       "job_status", "job_show", "job_update", "job_result",
+                       "job_cancel"]
         for name in mesh_tools:
             tool = mcp._tool_manager._tools.get(name)
             assert tool is not None, f"Tool {name} not found"

--- a/tests/test_work_routes.py
+++ b/tests/test_work_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
@@ -200,6 +201,63 @@ async def test_cancel_queued_work_returns_cancelled_status(env) -> None:
     assert status["state_reason"] == "cancel_requested"
     assert status["cancel_requested_by_peer_id"] == "creator"
     assert status["cancellation_reason"] == "cancel_requested"
+    assert status["protocol_cancel"] is None
+
+
+async def test_cancel_running_work_attempts_existing_protocol_cancel(env) -> None:
+    created = await env.post(
+        "/work",
+        json={"assigned_peer_id": "repow-default-worker"},
+    )
+    work_id = created.json()["work_id"]
+    await env.patch(f"/work/{work_id}", json={"state": "running"})
+    state = work_routes.get_app_state()
+    state.acp_manager = SimpleNamespace(
+        cancel_existing=AsyncMock(
+            return_value={
+                "attempted": True,
+                "status": "sent",
+                "reason": "session_cancel_sent",
+                "peer_id": "repow-default-worker",
+            },
+        ),
+    )
+
+    r = await env.post(
+        f"/work/{work_id}/cancel",
+        json={"requested_by_peer_id": "creator", "reason": "user_requested"},
+    )
+
+    assert r.status_code == 200
+    state.acp_manager.cancel_existing.assert_awaited_once_with("repow-default-worker")
+    status = r.json()["status"]
+    assert status["state"] == "running"
+    assert status["state_reason"] == "user_requested"
+    assert status["cancel_requested"] is True
+    assert status["protocol_cancel"] == {
+        "attempted": True,
+        "status": "sent",
+        "reason": "session_cancel_sent",
+        "peer_id": "repow-default-worker",
+    }
+
+
+async def test_cancel_running_work_without_protocol_link_stays_pending(env) -> None:
+    created = await env.post("/work", json={"owner_peer_id": "owner"})
+    work_id = created.json()["work_id"]
+    await env.patch(f"/work/{work_id}", json={"state": "running"})
+
+    r = await env.post(f"/work/{work_id}/cancel", json={})
+
+    assert r.status_code == 200
+    status = r.json()["status"]
+    assert status["state"] == "running"
+    assert status["cancel_requested"] is True
+    assert status["protocol_cancel"] == {
+        "attempted": False,
+        "status": "unavailable",
+        "reason": "no_assigned_peer",
+    }
 
 
 async def test_unknown_work_returns_404(env) -> None:

--- a/web/app/docs/reference/tools/page.tsx
+++ b/web/app/docs/reference/tools/page.tsx
@@ -106,6 +106,58 @@ ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")`}
       </Tool>
 
       <Tool
+        name="job_create"
+        signature={`job_create(title: str = "", kind: str = "general", assigned_peer_id: str | None = None, owner_peer_id: str | None = None, repowire_session_id: str | None = None, correlation_id: str | None = None, circle: str | None = None, source_kind: str | None = None, source_id: str | None = None, scope: str | None = None, visibility: str = "circle", request: dict | None = None, deadline_at: str | None = None, expires_at: str | None = None, provenance: dict | None = None) -> str`}
+      >
+        <p>
+          Create a durable tracked work job through the daemon <Mono>/jobs</Mono> API. Returns JSON with <Mono>job_id</Mono>, <Mono>work_id</Mono>, and <Mono>status</Mono>. The caller&rsquo;s peer ID is sent as <Mono>created_by_peer_id</Mono> when available.
+        </p>
+      </Tool>
+
+      <Tool
+        name="job_list"
+        signature={`job_list(state: str | None = None, owner_peer_id: str | None = None, created_by_peer_id: str | None = None, repowire_session_id: str | None = None, circle: str | None = None) -> str`}
+      >
+        <p>
+          List durable jobs through <Mono>/jobs</Mono>. Returns JSON shaped like <Mono>{`{"work": [status, ...]}`}</Mono>. Filters mirror the HTTP API.
+        </p>
+      </Tool>
+
+      <Tool
+        name="job_status / job_show"
+        signature={`job_status(job_id: str) -> str
+job_show(job_id: str) -> str`}
+      >
+        <p>
+          Return one job&rsquo;s current status JSON. <Mono>job_show</Mono> is an alias for <Mono>job_status</Mono>.
+        </p>
+      </Tool>
+
+      <Tool
+        name="job_update"
+        signature={`job_update(job_id: str, state: str, state_reason: str | None = None, phase: str | None = None, progress: dict | None = None, progress_note: str | None = None, result_summary: str | None = None, result_data: dict | None = None, error: dict | None = None, artifacts: list | None = None, provenance: dict | None = None) -> str`}
+      >
+        <p>
+          Update a job lifecycle state through <Mono>PATCH /jobs/{"{job_id}"}</Mono>. Returns the updated status JSON. Terminal jobs cannot move back to non-terminal states.
+        </p>
+      </Tool>
+
+      <Tool name="job_result" signature={`job_result(job_id: str) -> str`}>
+        <p>
+          Return terminal result JSON for a job, or <Mono>result_state=&quot;not_ready&quot;</Mono> with the current status while the job is non-terminal.
+        </p>
+      </Tool>
+
+      <Tool name="job_cancel" signature={`job_cancel(job_id: str, reason: str = "cancel_requested") -> str`}>
+        <p>
+          Request cancellation for a tracked work job. Queued jobs move directly to <Mono>cancelled</Mono>; running, delivered, awaiting-input, or blocked jobs record <Mono>cancel_requested</Mono> and remain pending until an executor reports a terminal state.
+        </p>
+        <p>
+          When the daemon already owns a live ACP session for the job&rsquo;s assigned peer, it attempts a bounded protocol <Mono>session/cancel</Mono> and reports the result in <Mono>status.protocol_cancel</Mono>. If there is no live session or execution link, <Mono>protocol_cancel</Mono> reports <Mono>unavailable</Mono> rather than claiming runtime cancellation.
+        </p>
+      </Tool>
+
+      <Tool
         name="spawn_peer"
         signature={`spawn_peer(path: str, backend: str, profile: str | None = None, circle: str | None = None, message: str | None = None) -> str`}
       >


### PR DESCRIPTION
## Summary
- add MCP JSON tools for durable jobs: create/list/status/show/update/result/cancel
- record bounded protocol-cancel attempt metadata for non-queued job cancellation, limited to already-live daemon-owned ACP clients
- document the MCP jobs surface and explicit pending-cancel contract in reference and mirrored web docs

## Validation
- `uv run --extra dev pytest` -> 1417 passed, 1 existing deprecation warning
- `uv run --extra dev pytest tests/test_mcp_jobs.py tests/test_work_routes.py tests/test_work_store.py tests/test_tracked_work_lifecycle_contract.py` -> 26 passed
- `uv run --extra dev pytest tests/test_acp_broker_client.py tests/test_spawn.py::TestMcpToolDescriptions::test_mcp_tools_have_mesh_prefix tests/test_http_mcp.py` -> 44 passed
- `uv run --extra dev pytest tests/test_mcp_jobs.py tests/test_work_routes.py tests/test_spawn.py::TestMcpToolDescriptions::test_mcp_tools_have_mesh_prefix` -> 14 passed
- `uv run --extra dev ruff check repowire/ tests/test_mcp_jobs.py tests/test_work_routes.py tests/test_spawn.py` -> passed
- `uv run --extra dev ty check repowire/` -> passed
- `cd web && npm ci && npm run lint` -> passed; npm audit reports 4 moderate vulnerabilities not introduced by this slice
- `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers` -> passed advisory

## Notes
- This deliberately does not claim broad runtime cancellation for hooks/channel/WS jobs; no tracked-work execution binding exists yet. Non-queued cancel requests stay pending when no live ACP session link exists.
- Beads/root issues JSON are excluded from the product commit.