### PR TITLE
Add durable job runner

### DIFF
--- a/docs/concepts/tracked-work-lifecycle.md
+++ b/docs/concepts/tracked-work-lifecycle.md
@@ -1,10 +1,12 @@
 # Tracked work lifecycle
 
-Status: architecture contract plus first daemon skeleton for tracked work. The
-daemon now has a durable tracked-work store and HTTP status/result/cancel
-surface separately from conversational `ask`/`ack`. Executor delivery,
-dashboard workflows, ACP/channel health handling beyond the narrow cancel hook,
-and backend resume execution are still future slices.
+Status: architecture contract plus first durable job-runner slice. The daemon
+now has a durable tracked-work store and lifecycle surface separately from
+conversational `ask`/`ack`, persisted execution spec, HTTP/CLI
+create-run-retry-cancel surfaces, and a daemon `JobRunner` that dispatches work
+via `ask`. Dashboard workflows, MCP mirroring of run/retry, ACP/channel health
+handling beyond the narrow cancel hook, and backend resume execution remain
+future slices.
 
 ## Problem
 
@@ -36,20 +38,28 @@ Tracked work and ask/ack must remain separate primitives:
 - Ask reminder, pending reply, TTL, and reply-routing behavior remain owned by
   `AskTracker`.
 
-## Current daemon skeleton
+## Current daemon slice
 
-The first shipped daemon slice provides a neutral tracked-work record and HTTP
-API. It is intentionally not tied to Anya, a default orchestrator persona, or a
-specific backend.
+The current daemon slice provides a neutral tracked-work record, HTTP API, CLI,
+and daemon runner. It is intentionally not tied to Anya, a default orchestrator
+persona, or a specific backend.
 
-- `POST /jobs` / `POST /work` creates a durable work record and returns a
-  `job_id` / `work_id` with initial `queued` status.
+- `POST /jobs` / `POST /work` creates a durable work record, persists
+  `request.execution`, and returns a `job_id` / `work_id` with initial
+  `queued` status.
 - `GET /jobs` / `GET /work` lists status records with optional filters for
   state, owner, creator, Repowire session, and circle.
 - `GET /jobs/{job_id}` / `GET /work/{work_id}/status` returns the current
   status read model.
+- `POST /jobs/{job_id}/run` ignores `due_at` and manually dispatches queued,
+  failed, or unavailable work.
+- `POST /jobs/{job_id}/retry` dispatches failed, unavailable, or delivered
+  work and preserves previous attempt records. Delivered retry is an explicit
+  operator recovery path for a worker that received the ask but died before
+  reporting status.
 - `PATCH /jobs/{job_id}` / `PATCH /work/{work_id}` updates lifecycle state and
-  can append a progress note.
+  can append a progress note. Runner-managed terminal updates must include the
+  current `attempt_id`; stale attempt ids return conflict.
 - `GET /jobs/{job_id}/result` / `GET /work/{work_id}/result` returns terminal
   result data, or
   `result_state=not_ready` plus status while work is non-terminal.
@@ -62,10 +72,22 @@ specific backend.
 The record includes job-facing and owner/source/scope fields such as `title`,
 `kind`, `created_by_peer_id`, `owner_peer_id`, `assigned_peer_id`,
 `source_kind`, `source_id`, `correlation_id`, `scope`, `circle`,
-`repowire_session_id`, `visibility`, and progress events. This API is a
-lifecycle foundation: it does not select executors, deliver work to transports,
-cancel live runtime sessions outside the explicit ACP-client case, or update
-dashboard/Telegram/Slack UI yet.
+`repowire_session_id`, `visibility`, and progress events. Execution metadata is
+persisted under `request.execution` with prompt, target, schedule, and delivery
+subkeys. Runner provenance is persisted under `provenance.runner`, including the
+current attempt id, lease, attempt count, and bounded attempt records. The
+runner uses wake-on-create plus sleep-until-next-due behavior; it does not scan
+continuously when no job is due.
+
+Executor selection is deliberately small: an exact assigned peer id wins; an
+ambiguous display name is rejected before create/run; otherwise `path` +
+`backend` + optional `profile` spawns a new peer through the shared spawn
+guardrails. Delivery uses `ask` and records a correlation id. Ack confirms only receipt.
+The worker prompt requires an immediate `state=running` update with the current
+attempt id before longer work, then a terminal lifecycle update with the same
+attempt id on completion. If a delivered job never sends that start heartbeat
+before its dispatch lease expires, the runner may mark it unavailable so it can
+be retried or inspected.
 
 Use jobs when work needs durable status, progress history, result metadata, or
 cancellation. Use `ask` for a conversational request that another peer should
@@ -83,6 +105,7 @@ The daemon should expose these states as the canonical tracked-work lifecycle:
 | State | Meaning | Terminal |
 | --- | --- | --- |
 | `queued` | The daemon accepted the work, stored it, and has not yet selected or reached an executor. | No |
+| `dispatching` | A runner atomically acquired the work and is within its visible dispatch lease. | No |
 | `delivered` | The daemon delivered the work request to the selected peer/session/transport, but the executor has not reported active execution. | No |
 | `running` | The executor has accepted the work and is actively working. | No |
 | `awaiting_input` | Execution is paused waiting for user, peer, approval, credential, or external input. | No |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -130,22 +130,29 @@ Create one-shot or recurring scheduled mesh messages. Without `--cron`, `WHEN_OR
 ## `repowire jobs`
 
 ```bash
-repowire jobs create TITLE [--kind KIND] [--owner PEER_ID] [--assigned-peer PEER_ID] [--session SESSION_ID] [--correlation-id CORR_ID] [--circle CIRCLE] [--json]
+repowire jobs create TITLE [--kind KIND] [--prompt TEXT | --prompt-file PATH] [--assigned-peer PEER] [--path PATH --backend BACKEND] [--profile NAME] [--due-at ISO_TIME] [--result-surface NAME] [--json]
+repowire jobs run JOB_ID [--json]
+repowire jobs retry JOB_ID [--json]
 repowire jobs list [--state STATE] [--owner PEER_ID] [--created-by PEER_ID] [--session SESSION_ID] [--circle CIRCLE] [--json]
 repowire jobs show JOB_ID [--json]
-repowire jobs update JOB_ID --state STATE [--reason REASON] [--phase PHASE] [--note NOTE] [--result-summary TEXT] [--json]
+repowire jobs update JOB_ID --state STATE [--attempt-id ATTEMPT_ID] [--reason REASON] [--phase PHASE] [--note NOTE] [--result-summary TEXT] [--json]
 repowire jobs cancel JOB_ID [--requested-by PEER_ID] [--reason REASON] [--json]
 repowire jobs result JOB_ID [--json]
 ```
 
-Create and inspect daemon-owned tracked work records. Jobs are durable control
-state in `state.db`; they can exist without a live peer, ask thread, schedule,
-or session. This first slice is an operator surface and API skeleton, not an
-execution engine: creating a job does not dispatch work to an agent.
+Create, run, retry, and inspect daemon-owned tracked work records. Jobs are
+durable control state in `state.db`; they can exist without a live peer, ask
+thread, schedule, or session. Creating a job persists an execution spec but does
+not dispatch it until the daemon runner reaches `due_at` or you call
+`repowire jobs run JOB_ID`.
 
-Use jobs when work needs durable status, progress notes, result metadata, or
-cancellation. Use `ask` for a conversational request that another peer should
-close with `ack`. Use `schedule` for future delivery of a notify or ask.
+Use `--assigned-peer` for an exact peer id/name. Ambiguous display names are
+rejected before persistence. Without an assigned peer, pass `--path` and
+`--backend` (plus optional `--profile`) so the daemon can spawn a worker through
+the same guardrails as `/spawn`. Delivery is an `ask`; ack is only receipt, and
+workers should first mark receipt/start with the current attempt id, for example
+`repowire jobs update JOB_ID --state running --attempt-id ATTEMPT_ID`, then
+complete with a terminal update using the same attempt id.
 
 Jobs commands are script-safe: daemon connection failures, missing jobs, and
 HTTP errors exit non-zero. Pass `--json` when scripts need the status, list, or

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -214,10 +214,10 @@ Return one job's current status JSON. `job_show` is an alias for `job_status`.
 ### `job_update`
 
 ```python
-job_update(job_id: str, state: str, state_reason: str | None = None, phase: str | None = None, progress: dict | None = None, progress_note: str | None = None, result_summary: str | None = None, result_data: dict | None = None, error: dict | None = None, artifacts: list | None = None, provenance: dict | None = None) -> str
+job_update(job_id: str, state: str, state_reason: str | None = None, phase: str | None = None, progress: dict | None = None, progress_note: str | None = None, result_summary: str | None = None, result_data: dict | None = None, error: dict | None = None, artifacts: list | None = None, provenance: dict | None = None, attempt_id: str | None = None) -> str
 ```
 
-Update a job lifecycle state through `PATCH /jobs/{job_id}`. Returns the updated status JSON. Terminal jobs cannot move back to non-terminal states; same-terminal updates may add bounded metadata.
+Update a job lifecycle state through `PATCH /jobs/{job_id}`. Returns the updated status JSON. Terminal jobs cannot move back to non-terminal states; same-terminal updates may add bounded metadata. Runner-managed updates should include the current `attempt_id` from the job prompt/status. Workers should immediately mark `state="running"` with that attempt id before longer work, then send the terminal update with the same attempt id.
 
 ### `job_result`
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -64,7 +64,10 @@ def serve(host: str, port: int, relay: bool, no_install_hooks: bool) -> None:
         config.save()
 
     env_disable = os.environ.get("REPOWIRE_DISABLE_HOOK_INSTALL", "").strip().lower() in (
-        "1", "true", "yes", "on",
+        "1",
+        "true",
+        "yes",
+        "on",
     )
     install_hooks = not (no_install_hooks or env_disable)
     app = create_app(config=config, install_tmux_hooks=install_hooks)
@@ -184,9 +187,14 @@ def _prompt_bot_config(
     if not has_config and click.confirm(f"Configure {name} bot?", default=False):
         for field_name, prompt_text in fields:
             hide = "token" in field_name
-            setattr(config_section, field_name, click.prompt(
-                f"  {prompt_text}", hide_input=hide,
-            ))
+            setattr(
+                config_section,
+                field_name,
+                click.prompt(
+                    f"  {prompt_text}",
+                    hide_input=hide,
+                ),
+            )
         console.print(f"[green]✓[/] {name} configured")
 
 
@@ -238,7 +246,8 @@ def _daemon_health_ok(host: str, port: int, *, attempts: int = 10) -> bool:
     ),
 )
 @click.option(
-    "--experimental-channels", is_flag=True,
+    "--experimental-channels",
+    is_flag=True,
     help="Use channel transport (experimental, requires claude.ai login and bun)",
 )
 @click.option(
@@ -279,7 +288,8 @@ def setup(
         _setup_claude_code(use_channels=use_channels)
         agents_setup.append("claude-code")
         config.daemon.spawn.commands.setdefault(
-            AgentType.CLAUDE_CODE, DEFAULT_SPAWN_COMMANDS[AgentType.CLAUDE_CODE],
+            AgentType.CLAUDE_CODE,
+            DEFAULT_SPAWN_COMMANDS[AgentType.CLAUDE_CODE],
         )
 
     # Detect and set up OpenCode if opencode CLI or config exists
@@ -287,7 +297,8 @@ def setup(
         _setup_opencode()
         agents_setup.append("opencode")
         config.daemon.spawn.commands.setdefault(
-            AgentType.OPENCODE, DEFAULT_SPAWN_COMMANDS[AgentType.OPENCODE],
+            AgentType.OPENCODE,
+            DEFAULT_SPAWN_COMMANDS[AgentType.OPENCODE],
         )
 
     # Detect and set up Codex if codex CLI available
@@ -295,7 +306,8 @@ def setup(
         _setup_codex()
         agents_setup.append("codex")
         config.daemon.spawn.commands.setdefault(
-            AgentType.CODEX, DEFAULT_SPAWN_COMMANDS[AgentType.CODEX],
+            AgentType.CODEX,
+            DEFAULT_SPAWN_COMMANDS[AgentType.CODEX],
         )
 
     # Detect and set up Gemini if gemini CLI available
@@ -303,7 +315,8 @@ def setup(
         _setup_gemini()
         agents_setup.append("gemini")
         config.daemon.spawn.commands.setdefault(
-            AgentType.GEMINI, DEFAULT_SPAWN_COMMANDS[AgentType.GEMINI],
+            AgentType.GEMINI,
+            DEFAULT_SPAWN_COMMANDS[AgentType.GEMINI],
         )
 
     # Detect and set up Antigravity CLI (`agy`) if installed
@@ -311,7 +324,8 @@ def setup(
         _setup_antigravity()
         agents_setup.append("antigravity")
         config.daemon.spawn.commands.setdefault(
-            AgentType.ANTIGRAVITY, DEFAULT_SPAWN_COMMANDS[AgentType.ANTIGRAVITY],
+            AgentType.ANTIGRAVITY,
+            DEFAULT_SPAWN_COMMANDS[AgentType.ANTIGRAVITY],
         )
 
     # Detect and set up Pi if pi CLI or config exists
@@ -319,7 +333,8 @@ def setup(
         _setup_pi()
         agents_setup.append("pi")
         config.daemon.spawn.commands.setdefault(
-            AgentType.PI, DEFAULT_SPAWN_COMMANDS[AgentType.PI],
+            AgentType.PI,
+            DEFAULT_SPAWN_COMMANDS[AgentType.PI],
         )
 
     if not agents_setup:
@@ -336,7 +351,8 @@ def setup(
 
         if is_tmux_available():
             installed = install_hooks(
-                config.daemon.host, config.daemon.port,
+                config.daemon.host,
+                config.daemon.port,
             )
             if installed:
                 console.print(f"[green]✓[/] Tmux lifecycle hooks ({len(installed)} hooks)")
@@ -395,19 +411,27 @@ def setup(
     if config.telegram.bot_token:
         console.print("[green]✓[/] Telegram configured (existing config)")
     elif interactive:
-        _prompt_bot_config("Telegram", config.telegram, [
-            ("bot_token", "Bot token"),
-            ("chat_id", "Chat ID"),
-        ])
+        _prompt_bot_config(
+            "Telegram",
+            config.telegram,
+            [
+                ("bot_token", "Bot token"),
+                ("chat_id", "Chat ID"),
+            ],
+        )
 
     if config.slack.bot_token:
         console.print("[green]✓[/] Slack configured (existing config)")
     elif interactive:
-        _prompt_bot_config("Slack", config.slack, [
-            ("bot_token", "Bot token (xoxb-...)"),
-            ("app_token", "App token (xapp-...)"),
-            ("channel_id", "Channel ID (C...)"),
-        ])
+        _prompt_bot_config(
+            "Slack",
+            config.slack,
+            [
+                ("bot_token", "Bot token (xoxb-...)"),
+                ("app_token", "App token (xapp-...)"),
+                ("channel_id", "Channel ID (C...)"),
+            ],
+        )
 
     # Save config
     console.print("[green]✓[/] SQLite state enabled")
@@ -696,7 +720,9 @@ def update(post_upgrade: bool) -> None:
         package_spec = _repowire_package_spec(config)
         console.print(f"[cyan]Upgrading {package_spec} via {pkg_mgr}...[/]")
         result = subprocess.run(
-            _upgrade_command(pkg_mgr, config), capture_output=True, text=True,
+            _upgrade_command(pkg_mgr, config),
+            capture_output=True,
+            text=True,
         )
         if result.returncode != 0:
             console.print(f"[red]Upgrade failed:[/] {result.stderr[:200]}")
@@ -706,8 +732,7 @@ def update(post_upgrade: bool) -> None:
         repowire_bin = shutil.which("repowire")
         if not repowire_bin:
             console.print(
-                "[yellow]![/] repowire is no longer on PATH; "
-                "run repowire setup manually."
+                "[yellow]![/] repowire is no longer on PATH; run repowire setup manually."
             )
             return
         console.print("[dim]Continuing with upgraded repowire...[/]")
@@ -791,6 +816,7 @@ def status() -> None:
 
     if shutil.which("codex") or (Path.home() / ".codex").exists():
         from repowire.installers.codex import check_hooks_installed as check_codex_hooks
+
         if check_codex_hooks():
             console.print("  [green]✓[/] codex (hooks installed)")
         else:
@@ -802,6 +828,7 @@ def status() -> None:
         from repowire.installers.antigravity import (
             check_hooks_installed as check_agy_hooks,
         )
+
         if check_agy_hooks():
             console.print(
                 "  [green]✓[/] antigravity (plugin installed; hook firing pending upstream)"
@@ -813,6 +840,7 @@ def status() -> None:
 
     if shutil.which("pi") or (Path.home() / ".pi").exists():
         from repowire.installers.pi import check_extension_installed as check_pi_ext
+
         if check_pi_ext():
             console.print("  [green]✓[/] pi (extension installed)")
         else:
@@ -1430,18 +1458,20 @@ def orchestrator_diff() -> None:
             # differs — show a short diff
             local_lines = local.read_text().splitlines(keepends=True)
             shipped_lines = shipped.read_text().splitlines(keepends=True)
-            diff = list(difflib.unified_diff(
-                local_lines, shipped_lines,
-                fromfile=f"local:{rel}", tofile=f"shipped:{rel}", n=2,
-            ))
+            diff = list(
+                difflib.unified_diff(
+                    local_lines,
+                    shipped_lines,
+                    fromfile=f"local:{rel}",
+                    tofile=f"shipped:{rel}",
+                    n=2,
+                )
+            )
             for line in diff[:30]:
                 console.print(line.rstrip(), highlight=False)
             if len(diff) > 30:
                 console.print(f"  [dim]... {len(diff) - 30} more lines; diff truncated[/]")
-            console.print(
-                "  [dim]To accept upstream: cp the file from "
-                f"{shipped} → {local}[/]"
-            )
+            console.print(f"  [dim]To accept upstream: cp the file from {shipped} → {local}[/]")
 
 
 @orchestrator.command(name="start")
@@ -1467,10 +1497,10 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
         validate_workspace,
         workspace_path,
     )
+
     if service:
         console.print(
-            "[yellow]--service mode is planned for v2; "
-            "falling back to manual tmux launch.[/]"
+            "[yellow]--service mode is planned for v2; falling back to manual tmux launch.[/]"
         )
 
     ws = workspace_path()
@@ -1478,8 +1508,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
     # Preflight 1: workspace
     if not (ws / "AGENTS.md").exists():
         console.print(
-            "[yellow]Workspace not initialized at "
-            f"{ws}.[/] Running [cyan]orchestrator init[/]..."
+            f"[yellow]Workspace not initialized at {ws}.[/] Running [cyan]orchestrator init[/]..."
         )
         rendered, msg = init_workspace()
         if rendered:
@@ -1500,9 +1529,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
         console.print("[red]Workspace validation failed:[/]")
         for e in errors:
             console.print(f"  [red]✗[/] {e}")
-        console.print(
-            "Try [cyan]repowire orchestrator init --force[/] to recreate."
-        )
+        console.print("Try [cyan]repowire orchestrator init --force[/] to recreate.")
         return
 
     # Preflight 2: daemon reachable
@@ -1547,8 +1574,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
         suggested = _ORCHESTRATOR_RUNTIME_COMMANDS[selected_runtime]
         if selected_profile:
             console.print(
-                "[red]✗[/] Orchestrator spawn profile is not configured for "
-                f"{selected_runtime!r}."
+                f"[red]✗[/] Orchestrator spawn profile is not configured for {selected_runtime!r}."
             )
             console.print(
                 f"Add [cyan]daemon.spawn.profiles.{selected_runtime}.{selected_profile}[/] "
@@ -1556,8 +1582,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
             )
         else:
             console.print(
-                "[red]✗[/] Orchestrator runtime is not configured in "
-                "daemon.spawn.commands."
+                "[red]✗[/] Orchestrator runtime is not configured in daemon.spawn.commands."
             )
             console.print(
                 f"Add [cyan]daemon.spawn.commands.{selected_runtime}: "
@@ -1565,11 +1590,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
             )
         return
 
-    profile_label = (
-        "n/a (command override)"
-        if yaml_command
-        else selected_profile or "default"
-    )
+    profile_label = "n/a (command override)" if yaml_command else selected_profile or "default"
     console.print(
         f"[cyan]Spawning orchestrator[/] "
         f"(runtime={selected_runtime}, circle={circle}, "
@@ -1608,8 +1629,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
         soul = load_active_soul()
         if soul is not None:
             console.print(
-                f"  Persona: [cyan]{soul.name}[/] "
-                f"([dim]{soul.source}[/], sha256:{soul.short_hash})"
+                f"  Persona: [cyan]{soul.name}[/] ([dim]{soul.source}[/], sha256:{soul.short_hash})"
             )
     except Exception:
         pass
@@ -1633,8 +1653,7 @@ def orchestrator_persona_list() -> None:
     if not rows:
         console.print("[dim]No personas found.[/]")
         console.print(
-            "Drop a SOUL.md at "
-            "[cyan]~/.repowire/personas/<name>/SOUL.md[/] to get started."
+            "Drop a SOUL.md at [cyan]~/.repowire/personas/<name>/SOUL.md[/] to get started."
         )
         return
     for row in rows:
@@ -1660,9 +1679,7 @@ def orchestrator_persona_show(name: str | None) -> None:
     if soul is None:
         console.print(f"[red]✗[/] No SOUL.md found for persona {target!r}")
         return
-    console.print(
-        f"[cyan]{soul.name}[/] [dim]({soul.source}, sha256:{soul.short_hash})[/]"
-    )
+    console.print(f"[cyan]{soul.name}[/] [dim]({soul.source}, sha256:{soul.short_hash})[/]")
     console.print(f"[dim]{soul.path}[/]")
     console.print()
     console.print(soul.content.strip())
@@ -1981,6 +1998,13 @@ def jobs() -> None:
 @click.option("--source-kind", default="cli", show_default=True)
 @click.option("--source-id", help="Source-local identifier")
 @click.option("--scope", help="Small routing/display scope label")
+@click.option("--prompt", help="Inline prompt to dispatch")
+@click.option("--prompt-file", help="Read prompt from file")
+@click.option("--path", help="Target project path for spawned peer")
+@click.option("--backend", help="Backend to spawn when no assigned peer is provided")
+@click.option("--profile", help="Spawn profile")
+@click.option("--due-at", help="Schedule due time (ISO-8601)")
+@click.option("--result-surface", help="Metadata-only result surface")
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
 def jobs_create_cmd(
     title: str,
@@ -1994,6 +2018,13 @@ def jobs_create_cmd(
     source_kind: str,
     source_id: str | None,
     scope: str | None,
+    prompt: str | None,
+    prompt_file: str | None,
+    path: str | None,
+    backend: str | None,
+    profile: str | None,
+    due_at: str | None,
+    result_surface: str | None,
     as_json: bool,
 ) -> None:
     """Create a durable job without dispatching it to an executor."""
@@ -2013,6 +2044,13 @@ def jobs_create_cmd(
         "circle": circle,
         "source_id": source_id,
         "scope": scope,
+        "prompt": prompt,
+        "prompt_file": prompt_file,
+        "path": path,
+        "backend": backend,
+        "profile": profile,
+        "due_at": due_at,
+        "result_surface": result_surface,
     }.items():
         if value:
             body[key] = value
@@ -2084,6 +2122,7 @@ def jobs_list_cmd(
     table.add_column("Title")
     table.add_column("Kind")
     table.add_column("Owner")
+    table.add_column("Due")
     table.add_column("Updated")
     for item in items:
         table.add_row(
@@ -2092,6 +2131,7 @@ def jobs_list_cmd(
             item.get("title", ""),
             item.get("kind", ""),
             item.get("owner_peer_id") or "-",
+            item.get("due_at") or "-",
             item.get("updated_at", ""),
         )
     console.print(table)
@@ -2128,6 +2168,7 @@ def jobs_show_cmd(job_id: str, as_json: bool) -> None:
 @click.option("--phase", help="Display phase")
 @click.option("--note", "progress_note", help="Append a progress note")
 @click.option("--result-summary", help="Terminal result summary")
+@click.option("--attempt-id", help="Current runner attempt id for runner-managed jobs")
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
 def jobs_update_cmd(
     job_id: str,
@@ -2136,6 +2177,7 @@ def jobs_update_cmd(
     phase: str | None,
     progress_note: str | None,
     result_summary: str | None,
+    attempt_id: str | None,
     as_json: bool,
 ) -> None:
     """Update job lifecycle status and optionally append a progress note."""
@@ -2147,6 +2189,7 @@ def jobs_update_cmd(
         "phase": phase,
         "progress_note": progress_note,
         "result_summary": result_summary,
+        "attempt_id": attempt_id,
     }.items():
         if value:
             body[key] = value
@@ -2165,6 +2208,42 @@ def jobs_update_cmd(
         raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
     except httpx.HTTPStatusError as e:
         raise click.ClickException(f"Failed to update job: {_http_error_detail(e)}") from e
+
+
+def _post_job_action(job_id: str, action: str, *, as_json: bool) -> None:
+    import httpx
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(f"{_get_daemon_url()}/jobs/{job_id}/{action}", json={})
+            if resp.status_code == 404:
+                raise click.ClickException(f"No job: {job_id}")
+            resp.raise_for_status()
+            status = resp.json()["status"]
+            if as_json:
+                console.print_json(data=status)
+            else:
+                _print_job_status(status)
+    except httpx.ConnectError:
+        raise click.ClickException("Cannot connect to daemon. Run 'repowire serve' first.")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(f"Failed to {action} job: {_http_error_detail(e)}") from e
+
+
+@jobs.command(name="run")
+@click.argument("job_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_run_cmd(job_id: str, as_json: bool) -> None:
+    """Run a queued/future or failed/unavailable job immediately."""
+    _post_job_action(job_id, "run", as_json=as_json)
+
+
+@jobs.command(name="retry")
+@click.argument("job_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON status instead of text")
+def jobs_retry_cmd(job_id: str, as_json: bool) -> None:
+    """Retry a failed or unavailable job with a new attempt."""
+    _post_job_action(job_id, "retry", as_json=as_json)
 
 
 @jobs.command(name="cancel")
@@ -2238,6 +2317,13 @@ def _print_job_status(status: dict[str, Any], *, created: bool = False) -> None:
     console.print(f"  kind:  {status.get('kind')}")
     if status.get("owner_peer_id"):
         console.print(f"  owner: {status.get('owner_peer_id')}")
+    if status.get("assigned_peer_id"):
+        console.print(f"  assigned: {status.get('assigned_peer_id')}")
+    if status.get("due_at"):
+        console.print(f"  due_at: {status.get('due_at')}")
+    runner = status.get("runner") or {}
+    if runner.get("current_attempt_id"):
+        console.print(f"  attempt: {runner.get('current_attempt_id')}")
     if status.get("result_summary"):
         console.print(f"  result: {status.get('result_summary')}")
     if status.get("cancellation_reason"):
@@ -2504,7 +2590,9 @@ def peer_list(show_offline: bool) -> None:
 @peer.command(name="describe")
 @click.argument("identifier")
 @click.option(
-    "--circle", "-c", default=None,
+    "--circle",
+    "-c",
+    default=None,
     help="Circle to scope lookup when a display_name is ambiguous across circles.",
 )
 def peer_describe(identifier: str, circle: str | None) -> None:
@@ -2542,8 +2630,7 @@ def peer_describe(identifier: str, circle: str | None) -> None:
             snapshot = build_snapshot(client, daemon_url, outcome)
     except httpx.ConnectError:
         console.print(
-            f"[red]Cannot connect to daemon at {daemon_url}.[/] "
-            "Run 'repowire serve' first.",
+            f"[red]Cannot connect to daemon at {daemon_url}.[/] Run 'repowire serve' first.",
         )
         sys.exit(1)
     except httpx.HTTPStatusError as e:
@@ -2580,8 +2667,7 @@ def peer_claim_role(role: str, peer_name: str | None, circle: str | None, force:
             if resp.status_code == 404:
                 console.print(f"[red]Peer not found:[/] {target}")
                 console.print(
-                    "[dim]Pass --peer with an existing peer from "
-                    "`repowire peer list -a`.[/]"
+                    "[dim]Pass --peer with an existing peer from `repowire peer list -a`.[/]"
                 )
                 sys.exit(1)
             if resp.status_code == 409:
@@ -2643,14 +2729,14 @@ def _render_peer_snapshot(snapshot: object) -> None:
         snippet = a.text if len(a.text) <= 60 else a.text[:57] + "..."
         console.print(
             f"  [green]inbound[/]   {a.correlation_id}  from [cyan]@{a.from_peer}[/]  "
-            f"{when}  [dim]\"{snippet}\"[/]",
+            f'{when}  [dim]"{snippet}"[/]',
         )
     for a in snapshot.outbound_asks:
         when = humanize_last_seen(a.created_at)
         snippet = a.text if len(a.text) <= 60 else a.text[:57] + "..."
         console.print(
             f"  [yellow]outbound[/]  {a.correlation_id}  to [cyan]@{a.to_peer}[/]  "
-            f"{when}  [dim]\"{snippet}\"[/]",
+            f'{when}  [dim]"{snippet}"[/]',
         )
 
     console.print("")
@@ -2665,15 +2751,17 @@ def _render_peer_snapshot(snapshot: object) -> None:
         snippet = ev.text if len(ev.text) <= 60 else ev.text[:57] + "..."
         line = f"  [dim]{ts}[/]  {arrow} [cyan]{ev.event_type}[/] {cp}"
         if snippet:
-            line += f"  [dim]\"{snippet}\"[/]"
+            line += f'  [dim]"{snippet}"[/]'
         console.print(line)
 
 
 @peer.command(name="new")
 @click.argument("path", type=click.Path(exists=True), default=".")
 @click.option(
-    "--backend", "-b", default="claude-code",
-    type=click.Choice(["claude-code", "opencode", "codex", "gemini", "antigravity", "pi"])
+    "--backend",
+    "-b",
+    default="claude-code",
+    type=click.Choice(["claude-code", "opencode", "codex", "gemini", "antigravity", "pi"]),
 )
 @click.option("--command", "-c", "cmd", help="Deprecated: explicit command override")
 @click.option("--profile", help="Named spawn profile to apply to the backend command")
@@ -2963,6 +3051,7 @@ def _auth_headers() -> dict[str, str]:
     """
     try:
         from repowire.config.models import load_config
+
         token = load_config().daemon.auth_token
     except Exception:
         return {}
@@ -3087,18 +3176,21 @@ def peer_whoami(
                     console.print(f"[red]Register failed: {resp.status_code} {resp.text}[/]")
                     sys.exit(1)
                 data = resp.json()
-                _emit({
-                    "peer_id": data.get("peer_id"),
-                    "display_name": data.get("display_name"),
-                    "backend": backend,
-                    "circle": circle or "default",
-                })
+                _emit(
+                    {
+                        "peer_id": data.get("peer_id"),
+                        "display_name": data.get("display_name"),
+                        "backend": backend,
+                        "circle": circle or "default",
+                    }
+                )
                 return
 
             # Read-only lookup
             if pane_id and not name:
                 resp = client.get(
-                    f"{daemon}/peers/by-pane/{quote(pane_id, safe='')}", headers=headers,
+                    f"{daemon}/peers/by-pane/{quote(pane_id, safe='')}",
+                    headers=headers,
                 )
                 if resp.status_code == 200:
                     _emit(resp.json())
@@ -3147,7 +3239,10 @@ def peer_asks(
     try:
         with httpx.Client(timeout=5.0) as client:
             resolved, err = _resolve_peer_id_for_asks(
-                client, peer_id=peer_id, pane_id=pane_id, peer_name=peer_name,
+                client,
+                peer_id=peer_id,
+                pane_id=pane_id,
+                peer_name=peer_name,
             )
             if err:
                 console.print(f"[red]{err}[/]")
@@ -3204,7 +3299,10 @@ def peer_deliveries(
     try:
         with httpx.Client(timeout=5.0) as client:
             resolved, err = _resolve_peer_id_for_asks(
-                client, peer_id=peer_id, pane_id=pane_id, peer_name=peer_name,
+                client,
+                peer_id=peer_id,
+                pane_id=pane_id,
+                peer_name=peer_name,
             )
             if err:
                 console.print(f"[red]{err}[/]")
@@ -3215,9 +3313,7 @@ def peer_deliveries(
                 headers=_auth_headers(),
             )
             if resp.status_code >= 400:
-                console.print(
-                    f"[red]/deliveries/pending failed: {resp.status_code} {resp.text}[/]"
-                )
+                console.print(f"[red]/deliveries/pending failed: {resp.status_code} {resp.text}[/]")
                 sys.exit(1)
             deliveries = resp.json().get("deliveries", [])
     except httpx.ConnectError:
@@ -3267,9 +3363,7 @@ def peer_ack(correlation_id: str, message: str | None, from_peer: str | None) ->
         sys.exit(1)
 
     if resp.status_code == 200:
-        console.print(
-            f"[green]Acked #{correlation_id}{' with reply' if message else ''}[/]"
-        )
+        console.print(f"[green]Acked #{correlation_id}{' with reply' if message else ''}[/]")
         return
     if resp.status_code == 404:
         console.print(f"[red]No open ask with correlation_id: {correlation_id}[/]")

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -28,6 +28,7 @@ from repowire.daemon.auth import require_localhost
 from repowire.daemon.deps import cleanup_deps, init_deps
 from repowire.daemon.event_bus import EventBus
 from repowire.daemon.event_log import EventLog
+from repowire.daemon.job_runner import JobRunner
 from repowire.daemon.lifecycle_handler import LifecycleHandler
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_delivery import PeerDeliveryService
@@ -51,6 +52,7 @@ from repowire.daemon.routes import (
 )
 from repowire.daemon.routes import spawn as spawn_routes
 from repowire.daemon.scheduler import Scheduler
+from repowire.daemon.spawn_service import SpawnService
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.events import SQLiteEventStore
 from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
@@ -298,6 +300,20 @@ def create_app(
             queued_delivery_store=queued_delivery_store,
         )
         app.state.peer_delivery = peer_delivery
+        spawn_service = SpawnService(
+            config=cfg,
+            spawned_pane_ids=spawn_routes._SPAWNED_PANE_IDS,
+            background_tasks=spawn_routes._BACKGROUND_TASKS,
+        )
+        app.state.spawn_service = spawn_service
+        job_runner = JobRunner(
+            config=cfg,
+            work_store=work_store,
+            peer_registry=peer_registry,
+            peer_delivery=peer_delivery,
+            spawn_service=spawn_service,
+        )
+        app.state.job_runner = job_runner
         scheduler = Scheduler(
             store=schedule_store,
             peer_registry=peer_registry,
@@ -314,6 +330,7 @@ def create_app(
 
         await peer_registry.start()
         await scheduler.start()
+        await job_runner.start()
         init_deps(
             cfg, peer_registry, app.state,
             lifecycle_handler=lifecycle_handler,
@@ -393,6 +410,7 @@ def create_app(
         if relay_client:
             await relay_client.stop()
         await acp_manager.close()
+        await job_runner.stop()
         await scheduler.stop()
         event_log.save()
         peer_registry._persist_mappings()

--- a/repowire/daemon/job_runner.py
+++ b/repowire/daemon/job_runner.py
@@ -1,0 +1,372 @@
+"""Durable autonomous job dispatch runner."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import HTTPException
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.peer_delivery import PeerDeliveryService
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.spawn_service import SpawnService
+from repowire.daemon.work_store import TrackedWork, now_iso
+from repowire.protocol.peers import Peer, PeerStatus
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_due(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class JobRunner:
+    """Acquires queued jobs and dispatches them exactly once per attempt."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        work_store: Any,
+        peer_registry: PeerRegistry,
+        peer_delivery: PeerDeliveryService,
+        spawn_service: SpawnService,
+        runner_owner_id: str = "daemon-job-runner",
+        lease_seconds: int = 300,
+        poll_interval: float | None = None,
+    ) -> None:
+        self._config = config
+        self._store = work_store
+        self._registry = peer_registry
+        self._delivery = peer_delivery
+        self._spawn = spawn_service
+        self._runner_owner_id = runner_owner_id
+        self._lease_seconds = lease_seconds
+        self._task: asyncio.Task | None = None
+        self._stopped = asyncio.Event()
+        self._wake = asyncio.Event()
+
+    async def start(self) -> None:
+        self.recover_stale()
+        self._stopped.clear()
+        self._wake.clear()
+        self._task = asyncio.create_task(self._loop())
+
+    def wake(self) -> None:
+        """Wake the runner after job create/update instead of polling."""
+        self._wake.set()
+
+    async def stop(self) -> None:
+        self._stopped.set()
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    def recover_stale(self) -> list[TrackedWork]:
+        return self._store.recover_stale_dispatching(
+            now=now_iso(), runner_owner_id=self._runner_owner_id
+        )
+
+    async def _loop(self) -> None:
+        try:
+            while not self._stopped.is_set():
+                # Clear before inspecting state so a create/update that races
+                # with deadline computation remains set and wakes the wait.
+                self._wake.clear()
+                try:
+                    self.recover_stale()
+                    await self.run_due_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("job runner tick failed")
+                delay = self._seconds_until_next_deadline()
+                waiters = [
+                    asyncio.create_task(self._stopped.wait()),
+                    asyncio.create_task(self._wake.wait()),
+                ]
+                try:
+                    done, pending = await asyncio.wait(
+                        waiters,
+                        timeout=delay,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in pending:
+                        task.cancel()
+                    for task in done:
+                        task.result()
+                finally:
+                    for task in waiters:
+                        if not task.done():
+                            task.cancel()
+        except asyncio.CancelledError:
+            raise
+
+    def _seconds_until_next_deadline(self) -> float | None:
+        """Return seconds until next concrete due/lease deadline, or None.
+
+        None means there is no known future job deadline, so the runner sleeps
+        indefinitely until create/update wakes it or the daemon stops.
+        """
+        soonest: datetime | None = None
+        now = _utcnow()
+        for work in self._store.list_all(state="queued"):
+            execution = (work.request or {}).get("execution") or {}
+            due_at = (execution.get("schedule") or {}).get("due_at")
+            due = _parse_due(due_at) or now
+            if soonest is None or due < soonest:
+                soonest = due
+        for state in ("dispatching", "delivered"):
+            for work in self._store.list_all(state=state):
+                runner = (work.provenance or {}).get("runner") or {}
+                lease_until = _parse_due(runner.get("lease_until"))
+                if lease_until is not None and (soonest is None or lease_until < soonest):
+                    soonest = lease_until
+        if soonest is None:
+            return None
+        return max(0.0, (soonest - now).total_seconds())
+
+    async def run_due_once(self) -> list[str]:
+        dispatched: list[str] = []
+        for work in self._store.list_all(state="queued"):
+            execution = (work.request or {}).get("execution") or {}
+            due_at = (execution.get("schedule") or {}).get("due_at")
+            due = _parse_due(due_at)
+            if due is not None and due > _utcnow():
+                continue
+            result = await self.run_job(work.work_id, ignore_due_at=False)
+            if result is not None:
+                dispatched.append(work.work_id)
+        return dispatched
+
+    async def run_job(
+        self, work_id: str, *, ignore_due_at: bool = True, retry: bool = False
+    ) -> TrackedWork | None:
+        lease_until = (_utcnow() + timedelta(seconds=self._lease_seconds)).isoformat()
+        acquired = self._store.acquire_for_dispatch(
+            work_id,
+            runner_owner_id=self._runner_owner_id,
+            lease_until=lease_until,
+            ignore_due_at=ignore_due_at,
+            retry=retry,
+        )
+        if acquired is None:
+            return None
+        attempt_id = (acquired.provenance.get("runner") or {}).get("current_attempt_id")
+        if not attempt_id:
+            return acquired
+        try:
+            return await self._dispatch(acquired, attempt_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # keep dispatch audit-visible
+            return self._store.update_attempt(
+                work_id,
+                attempt_id=attempt_id,
+                status="failed",
+                phase="dispatch",
+                error={"reason": "dispatch_failed", "message": str(e), "type": type(e).__name__},
+            )
+
+    async def _dispatch(self, work: TrackedWork, attempt_id: str) -> TrackedWork | None:
+        current = self._store.get(work.work_id)
+        if current is None:
+            return None
+        if current.cancel_requested:
+            return self._store.update_attempt(
+                work.work_id, attempt_id=attempt_id, status="cancelled", phase="cancelled"
+            )
+
+        peer = await self._resolve_or_spawn_peer(current, attempt_id)
+        if peer is None:
+            return self._store.get(work.work_id)
+
+        current = self._store.get(work.work_id)
+        if current is None:
+            return None
+        if current.cancel_requested:
+            return self._store.update_attempt(
+                work.work_id, attempt_id=attempt_id, status="cancelled", phase="cancelled"
+            )
+
+        text = self._build_prompt(current, attempt_id)
+        self._store.update_attempt(
+            work.work_id,
+            attempt_id=attempt_id,
+            phase="delivery",
+            assigned_peer_id=peer.peer_id,
+            assigned_peer_info={
+                "peer_id": peer.peer_id,
+                "display_name": peer.display_name,
+                "backend": peer.backend.value,
+                "path": peer.path,
+                "status": peer.status.value,
+            },
+            tmux={"tmux_session": peer.tmux_session, "pane_id": peer.pane_id},
+            delivery_state="pending",
+        )
+        try:
+            cid = await self._delivery.open_scheduled_ask(
+                from_peer=self._runner_owner_id,
+                to_peer=peer.peer_id,
+                text=text,
+                circle=peer.circle,
+            )
+        except Exception as e:
+            return self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                status="failed",
+                phase="delivery",
+                delivery_state="failed",
+                error={
+                    "reason": "ask_delivery_failed",
+                    "message": str(e),
+                    "type": type(e).__name__,
+                },
+            )
+        return self._store.update_attempt(
+            work.work_id,
+            attempt_id=attempt_id,
+            status="delivered",
+            phase="delivered",
+            delivery_state="delivered",
+            correlation_id=cid,
+        )
+
+    async def _resolve_or_spawn_peer(self, work: TrackedWork, attempt_id: str) -> Peer | None:
+        execution = (work.request or {}).get("execution") or {}
+        target = execution.get("target") or {}
+        assigned = target.get("assigned_peer_id") or work.assigned_peer_id
+        if assigned:
+            resolved = await self._registry.resolve_peer_strict(str(assigned), circle=work.circle)
+            if isinstance(resolved, list):
+                return self._mark_unavailable(
+                    work,
+                    attempt_id,
+                    "assigned_peer_not_found" if not resolved else "ambiguous_assigned_peer",
+                )
+            if resolved.status == PeerStatus.OFFLINE:
+                return self._mark_unavailable(
+                    work, attempt_id, "assigned_peer_offline", assigned_peer_id=resolved.peer_id
+                )
+            self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                phase="resolved_peer",
+                assigned_peer_id=resolved.peer_id,
+            )
+            return resolved
+
+        path = target.get("path")
+        backend_raw = target.get("backend")
+        if not path or not backend_raw:
+            return self._mark_unavailable(work, attempt_id, "missing_target")
+        try:
+            backend = AgentType(str(backend_raw))
+        except ValueError:
+            return self._mark_unavailable(work, attempt_id, "invalid_backend")
+        warmup = (
+            "Repowire spawned this session for a durable job. "
+            "Please register with the mesh; the job request will arrive as an ask."
+        )
+        try:
+            spawn_result = self._spawn.spawn(
+                path=str(path),
+                backend=backend,
+                profile=target.get("profile"),
+                circle=work.circle or "default",
+                message=warmup,
+            )
+        except HTTPException as e:
+            return self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                status="failed",
+                phase="spawn",
+                error={"reason": "spawn_failed", "status_code": e.status_code, "detail": e.detail},
+            )
+        except Exception as e:
+            return self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                status="failed",
+                phase="spawn",
+                error={"reason": "spawn_failed", "message": str(e), "type": type(e).__name__},
+            )
+        self._store.update_attempt(
+            work.work_id,
+            attempt_id=attempt_id,
+            phase="spawned",
+            tmux={"tmux_session": spawn_result.tmux_session, "pane_id": spawn_result.pane_id},
+        )
+        resolved = await self._await_spawned_peer(spawn_result.display_name, work.circle)
+        if resolved is None:
+            return self._mark_unavailable(work, attempt_id, "spawned_peer_not_registered")
+        return resolved
+
+    async def _await_spawned_peer(
+        self,
+        display_name: str,
+        circle: str | None,
+        *,
+        timeout_seconds: float = 10.0,
+    ) -> Peer | None:
+        deadline = _utcnow() + timedelta(seconds=timeout_seconds)
+        while True:
+            resolved = await self._registry.resolve_peer_strict(display_name, circle=circle)
+            if not isinstance(resolved, list):
+                return resolved
+            if _utcnow() >= deadline:
+                return None
+            await asyncio.sleep(0.25)
+
+    def _mark_unavailable(
+        self,
+        work: TrackedWork,
+        attempt_id: str,
+        reason: str,
+        *,
+        assigned_peer_id: str | None = None,
+    ) -> None:
+        self._store.update_attempt(
+            work.work_id,
+            attempt_id=attempt_id,
+            status="unavailable",
+            phase="resolve_peer",
+            assigned_peer_id=assigned_peer_id,
+            error={"reason": reason},
+        )
+        return None
+
+    @staticmethod
+    def _build_prompt(work: TrackedWork, attempt_id: str) -> str:
+        execution = (work.request or {}).get("execution") or {}
+        prompt = execution.get("prompt") or {}
+        body = prompt.get("body") or work.title
+        return (
+            f"[Repowire durable job]\n"
+            f"job_id: {work.work_id}\n"
+            f"attempt_id: {attempt_id}\n\n"
+            f"{body}\n\n"
+            "First, immediately PATCH /jobs/{job_id} to state=running with this "
+            "attempt_id before doing longer work. When complete, PATCH /jobs/{job_id} "
+            "with a terminal state and the same attempt_id. Ack only confirms receipt."
+        )

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -14,6 +14,7 @@ from repowire.daemon.ask_tracker import QuiesceFailedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_config, get_peer_registry
 from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.spawn_service import SpawnService
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import Peer, PeerRole
 from repowire.spawn import SpawnConfig, SpawnResult, kill_pane, spawn_peer
@@ -145,6 +146,7 @@ def _resolve_spawn_command(
         detail="Either backend or legacy command is required.",
     )
 
+
 router = APIRouter(tags=["spawn"])
 
 
@@ -183,7 +185,8 @@ class SpawnRequest(BaseModel):
     backend: AgentType | None = Field(None, description="Backend/runtime profile to spawn")
     profile: str | None = Field(None, description="Optional named model/profile for backend")
     command: str | None = Field(
-        None, description="Deprecated: command/profile name for compatibility",
+        None,
+        description="Deprecated: command/profile name for compatibility",
     )
     circle: str = Field(default="default", description="Circle to spawn into")
     message: str | None = Field(
@@ -317,59 +320,29 @@ async def spawn(
     allowed_paths in ~/.repowire/config.yaml.
     The spawned agent self-registers via its SessionStart hook once it starts.
     """
-    _validate_spawn_path(request.path)
-    backend, command = _resolve_spawn_command(
-        backend=request.backend,
-        legacy_command=request.command,
-        profile=request.profile,
+    if request.backend is None:
+        backend, _command = _resolve_spawn_command(
+            backend=request.backend,
+            legacy_command=request.command,
+            profile=request.profile,
+        )
+    else:
+        backend = request.backend
+    service = getattr(get_app_state(), "spawn_service", None) or SpawnService(
+        config=get_config(),
+        spawned_pane_ids=_SPAWNED_PANE_IDS,
+        background_tasks=_BACKGROUND_TASKS,
+        spawn_impl=spawn_peer,
+        warmup_impl=post_spawn_warmup,
     )
-
-    resolved_path = str(Path(request.path).expanduser().resolve())
-
-    try:
-        result: SpawnResult = spawn_peer(
-            SpawnConfig(
-                path=resolved_path,
-                circle=request.circle,
-                backend=backend,
-                command=command,
-                message=request.message,
-                role=request.role.value,
-            )
-        )
-    except (ValueError, RuntimeError) as e:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
-
-    # Record that we own this pane so /kill-peer can safely kill it later.
-    # Externally-attached agents (notably OpenCode) also report tmux_session,
-    # so tmux_session alone is NOT a daemon-spawn signal — pane_id ownership is.
-    if result.pane_id:
-        _SPAWNED_PANE_IDS.add(result.pane_id)
-        _record_daemon_spawn_ownership(
-            result,
-            path=resolved_path,
-            backend=backend,
-            circle=request.circle,
-            role=request.role,
-        )
-
-    # Schedule post-spawn warmup in the background -- the codex case sleeps
-    # ~10s and would otherwise stall the /spawn response. claude/opencode/gemini
-    # warmups are no-ops and return immediately. Hold a strong ref to the task
-    # in a module-level set so asyncio doesn't GC it mid-sleep.
-    if result.pane_id:
-        task = asyncio.create_task(
-            post_spawn_warmup(
-                backend,
-                result.pane_id,
-                path=resolved_path,
-                circle=request.circle,
-                message=result.message,
-            )
-        )
-        _BACKGROUND_TASKS.add(task)
-        task.add_done_callback(_BACKGROUND_TASKS.discard)
-
+    result = service.spawn(
+        path=request.path,
+        backend=backend,
+        profile=request.profile,
+        circle=request.circle,
+        message=request.message,
+        role=request.role,
+    )
     return SpawnResponse(display_name=result.display_name, tmux_session=result.tmux_session)
 
 
@@ -445,7 +418,8 @@ async def kill_registered_peer(
     await peer_registry.lazy_repair()
     await _authorize_kill(peer_registry, request.from_peer)
     resolved = await peer_registry.resolve_peer_strict(
-        request.peer_identifier, circle=request.circle,
+        request.peer_identifier,
+        circle=request.circle,
     )
 
     if isinstance(resolved, list):
@@ -714,7 +688,8 @@ async def restart_peer(
             )
         except (ValueError, RuntimeError) as e:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(e),
             ) from e
 
         if result.pane_id:
@@ -873,10 +848,7 @@ async def switch_peer_backend(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "error": "switch_in_progress",
-                    "hint": (
-                        "Another switch is in progress for this peer. "
-                        "Retry shortly."
-                    ),
+                    "hint": ("Another switch is in progress for this peer. Retry shortly."),
                 },
             ) from e
         raise HTTPException(
@@ -931,7 +903,8 @@ async def switch_peer_backend(
             )
         except (ValueError, RuntimeError) as e:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(e),
             ) from e
 
         if result.pane_id:

--- a/repowire/daemon/routes/work.py
+++ b/repowire/daemon/routes/work.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state
 from repowire.daemon.work_store import TrackedWork
@@ -32,6 +33,15 @@ class WorkCreateRequest(BaseModel):
     deadline_at: str | None = None
     expires_at: str | None = None
     provenance: dict[str, Any] = Field(default_factory=dict)
+    prompt: str | None = Field(None, description="Inline durable job prompt")
+    prompt_file: str | None = Field(None, description="Read durable job prompt from file")
+    path: str | None = Field(None, description="Target working directory for spawned peer")
+    backend: AgentType | None = Field(
+        None, description="Backend to spawn when assigned_peer_id is absent"
+    )
+    profile: str | None = Field(None, description="Optional backend profile")
+    due_at: str | None = Field(None, description="Optional scheduled due time")
+    result_surface: str | None = Field(None, description="Metadata-only result surface")
 
 
 class WorkCancelRequest(BaseModel):
@@ -39,8 +49,13 @@ class WorkCancelRequest(BaseModel):
     reason: str = "cancel_requested"
 
 
+class WorkRunRequest(BaseModel):
+    requested_by_peer_id: str | None = None
+
+
 class WorkUpdateRequest(BaseModel):
     state: str
+    attempt_id: str | None = None
     state_reason: str | None = None
     phase: str | None = None
     progress: dict[str, Any] | None = None
@@ -86,6 +101,87 @@ def _store():
     return store
 
 
+def _job_runner():
+    state = get_app_state()
+    runner = getattr(state, "job_runner", None)
+    if runner is None:
+        raise RuntimeError("job_runner not initialized")
+    return runner
+
+
+def _read_prompt_file(path: str) -> str:
+    from pathlib import Path
+
+    return Path(path).expanduser().read_text(encoding="utf-8")
+
+
+def _merge_execution_request(
+    request: WorkCreateRequest, assigned_peer_id: str | None
+) -> dict[str, Any]:
+    body = dict(request.request)
+    execution = dict(body.get("execution") or {})
+    prompt = dict(execution.get("prompt") or {})
+    if request.prompt_file:
+        prompt.update(
+            {
+                "body": _read_prompt_file(request.prompt_file),
+                "source": "file",
+                "source_path": request.prompt_file,
+            }
+        )
+    elif request.prompt is not None:
+        prompt.update({"body": request.prompt, "source": "inline"})
+    elif not prompt:
+        prompt.update({"body": request.title, "source": "title"})
+    target = dict(execution.get("target") or {})
+    if request.path is not None:
+        target["path"] = request.path
+    if request.backend is not None:
+        target["backend"] = request.backend.value
+    if request.profile is not None:
+        target["profile"] = request.profile
+    if assigned_peer_id is not None:
+        target["assigned_peer_id"] = assigned_peer_id
+    schedule = dict(execution.get("schedule") or {})
+    if request.due_at is not None:
+        schedule["due_at"] = request.due_at
+    delivery = dict(execution.get("delivery") or {})
+    delivery.setdefault("kind", "ask")
+    if request.result_surface is not None:
+        delivery["result_surface"] = request.result_surface
+    execution.update(
+        {"prompt": prompt, "target": target, "schedule": schedule, "delivery": delivery}
+    )
+    body["execution"] = execution
+    return body
+
+
+async def _canonical_assigned_peer(identifier: str | None, circle: str | None) -> str | None:
+    if not identifier:
+        return None
+    if identifier.startswith("repow-"):
+        return identifier
+    registry = get_app_state().peer_registry
+    resolved = await registry.resolve_peer_strict(identifier, circle=circle)
+    if isinstance(resolved, list):
+        if not resolved:
+            raise HTTPException(
+                status_code=404, detail={"error": "assigned_peer_not_found", "peer": identifier}
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "ambiguous_assigned_peer",
+                "peer": identifier,
+                "candidates": [
+                    {"peer_id": p.peer_id, "display_name": p.display_name, "circle": p.circle}
+                    for p in resolved
+                ],
+            },
+        )
+    return resolved.peer_id
+
+
 async def _attempt_protocol_cancel(work: TrackedWork) -> dict[str, Any]:
     """Try a bounded runtime-level cancel for the current architecture slice.
 
@@ -120,12 +216,16 @@ async def _attempt_protocol_cancel(work: TrackedWork) -> dict[str, Any]:
             manager.cancel_existing(work.assigned_peer_id),
             timeout=2.0,
         )
-        return result if isinstance(result, dict) else {
-            "attempted": True,
-            "status": "sent",
-            "reason": "session_cancel_sent",
-            "peer_id": work.assigned_peer_id,
-        }
+        return (
+            result
+            if isinstance(result, dict)
+            else {
+                "attempted": True,
+                "status": "sent",
+                "reason": "session_cancel_sent",
+                "peer_id": work.assigned_peer_id,
+            }
+        )
     except TimeoutError:
         return {
             "attempted": True,
@@ -162,12 +262,14 @@ async def create_work(
     _: str | None = Depends(require_auth),
 ) -> WorkCreateResponse:
     store = _store()
+    assigned_peer_id = await _canonical_assigned_peer(request.assigned_peer_id, request.circle)
+    merged_request = _merge_execution_request(request, assigned_peer_id)
     work = store.create(
         title=request.title,
         kind=request.kind,
         created_by_peer_id=request.created_by_peer_id,
         owner_peer_id=request.owner_peer_id,
-        assigned_peer_id=request.assigned_peer_id,
+        assigned_peer_id=assigned_peer_id,
         repowire_session_id=request.repowire_session_id,
         correlation_id=request.correlation_id,
         circle=request.circle,
@@ -175,11 +277,14 @@ async def create_work(
         source_id=request.source_id,
         scope=request.scope,
         visibility=request.visibility,
-        request=request.request,
+        request=merged_request,
         deadline_at=request.deadline_at,
         expires_at=request.expires_at,
         provenance=request.provenance,
     )
+    runner = getattr(get_app_state(), "job_runner", None)
+    if runner is not None and hasattr(runner, "wake"):
+        runner.wake()
     return WorkCreateResponse.from_work(work)
 
 
@@ -240,9 +345,58 @@ async def update_work(
             error=request.error,
             artifacts=request.artifacts,
             provenance=request.provenance,
+            attempt_id=request.attempt_id,
         )
+    except RuntimeError as e:
+        if str(e) == "stale_attempt":
+            raise HTTPException(status_code=409, detail="stale attempt_id") from e
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkStatusResponse.from_work(work)
+
+
+@router.post("/work/{work_id}/run", response_model=WorkStatusResponse)
+@router.post("/jobs/{work_id}/run", response_model=WorkStatusResponse)
+async def run_work(
+    work_id: str,
+    request: WorkRunRequest | None = None,
+    _: str | None = Depends(require_auth),
+) -> WorkStatusResponse:
+    existing = _store().get(work_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    if existing.state not in {"queued", "failed", "unavailable"}:
+        raise HTTPException(
+            status_code=409, detail=f"Job cannot be run from state {existing.state}"
+        )
+    work = await _job_runner().run_job(work_id, ignore_due_at=True)
+    if work is None:
+        work = _store().get(work_id)
+    if work is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    return WorkStatusResponse.from_work(work)
+
+
+@router.post("/work/{work_id}/retry", response_model=WorkStatusResponse)
+@router.post("/jobs/{work_id}/retry", response_model=WorkStatusResponse)
+async def retry_work(
+    work_id: str,
+    request: WorkRunRequest | None = None,
+    _: str | None = Depends(require_auth),
+) -> WorkStatusResponse:
+    existing = _store().get(work_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail=f"No work: {work_id}")
+    if existing.state not in {"failed", "unavailable", "delivered"}:
+        raise HTTPException(
+            status_code=409, detail=f"Job cannot be retried from state {existing.state}"
+        )
+    work = await _job_runner().run_job(work_id, ignore_due_at=True, retry=True)
+    if work is None:
+        work = _store().get(work_id)
     if work is None:
         raise HTTPException(status_code=404, detail=f"No work: {work_id}")
     return WorkStatusResponse.from_work(work)

--- a/repowire/daemon/spawn_service.py
+++ b/repowire/daemon/spawn_service.py
@@ -1,0 +1,159 @@
+"""Shared daemon spawn service used by HTTP routes and durable job runner."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import HTTPException, status
+
+from repowire.config.models import AgentType, Config, apply_spawn_profile
+from repowire.installers.post_spawn import post_spawn_warmup
+from repowire.protocol.peers import PeerRole
+from repowire.spawn import SpawnConfig, SpawnResult, spawn_peer
+from repowire.spawn_ownership import record_spawn_ownership
+
+
+@dataclass(frozen=True)
+class SpawnServiceResult:
+    display_name: str
+    tmux_session: str
+    pane_id: str | None
+    message: str | None
+
+
+class SpawnService:
+    """Spawn peers while preserving /spawn validation and ownership semantics."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        spawned_pane_ids: set[str] | None = None,
+        background_tasks: set[asyncio.Task] | None = None,
+        spawn_impl: Callable[[SpawnConfig], SpawnResult] = spawn_peer,
+        warmup_impl=post_spawn_warmup,
+    ) -> None:
+        self._config = config
+        self._spawned_pane_ids = spawned_pane_ids if spawned_pane_ids is not None else set()
+        self._background_tasks = background_tasks if background_tasks is not None else set()
+        self._spawn_impl = spawn_impl
+        self._warmup_impl = warmup_impl
+
+    def validate_path(self, path: str) -> str:
+        allowed_paths = self._config.daemon.spawn.allowed_paths
+        commands = self._config.daemon.spawn.commands
+        if not commands or not allowed_paths:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "Spawn is disabled. Set daemon.spawn.commands and "
+                    "daemon.spawn.allowed_paths in ~/.repowire/config.yaml"
+                ),
+            )
+        resolved = Path(path).expanduser().resolve()
+        if not resolved.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Path does not exist: {path}"
+            )
+        roots = [Path(p).expanduser().resolve() for p in allowed_paths]
+        if not any(resolved == root or root in resolved.parents for root in roots):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Path not under any allowed_paths: {path}",
+            )
+        return str(resolved)
+
+    def resolve_command(self, backend: AgentType, profile: str | None = None) -> str:
+        command = self._config.daemon.spawn.commands.get(backend)
+        if not command:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error": "command_unavailable",
+                    "hint": (
+                        f"No daemon.spawn.commands entry for {backend.value!r}. "
+                        "Add it to ~/.repowire/config.yaml."
+                    ),
+                    "backend": backend.value,
+                },
+            )
+        if profile:
+            selected_profile = self._config.daemon.spawn.profiles.get(backend, {}).get(profile)
+            if selected_profile is None:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail={
+                        "error": "profile_unavailable",
+                        "hint": (
+                            f"No daemon.spawn.profiles.{backend.value}.{profile} "
+                            "entry in ~/.repowire/config.yaml."
+                        ),
+                        "backend": backend.value,
+                        "profile": profile,
+                    },
+                )
+            command = apply_spawn_profile(command, selected_profile)
+        return command
+
+    def spawn(
+        self,
+        *,
+        path: str,
+        backend: AgentType,
+        profile: str | None = None,
+        circle: str = "default",
+        message: str | None = None,
+        role: PeerRole = PeerRole.AGENT,
+        peer_id: str | None = None,
+    ) -> SpawnServiceResult:
+        resolved_path = self.validate_path(path)
+        command = self.resolve_command(backend, profile)
+        try:
+            result = self._spawn_impl(
+                SpawnConfig(
+                    path=resolved_path,
+                    circle=circle,
+                    backend=backend,
+                    command=command,
+                    message=message,
+                    role=role.value,
+                )
+            )
+        except (ValueError, RuntimeError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+            ) from e
+
+        if result.pane_id:
+            self._spawned_pane_ids.add(result.pane_id)
+            record_spawn_ownership(
+                pane_id=result.pane_id,
+                path=resolved_path,
+                backend=backend,
+                circle=circle,
+                role=role,
+                display_name=result.display_name,
+                tmux_session=result.tmux_session,
+                peer_id=peer_id,
+            )
+            task = asyncio.create_task(
+                self._warmup_impl(
+                    backend,
+                    result.pane_id,
+                    path=resolved_path,
+                    circle=circle,
+                    message=result.message,
+                )
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
+        return SpawnServiceResult(
+            display_name=result.display_name,
+            tmux_session=result.tmux_session,
+            pane_id=result.pane_id,
+            message=result.message,
+        )

--- a/repowire/daemon/state/work.py
+++ b/repowire/daemon/state/work.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 from repowire.daemon.state.database import StateDatabase
 from repowire.daemon.work_store import (
@@ -17,6 +18,30 @@ from repowire.daemon.work_store import (
     now_iso,
     validate_state,
 )
+
+
+def _runner_provenance(work: TrackedWork) -> dict[str, Any]:
+    provenance = dict(work.provenance)
+    runner = dict(provenance.get("runner") or {})
+    runner.setdefault("attempt_count", len(runner.get("attempts") or []))
+    runner.setdefault("attempts", [])
+    provenance["runner"] = runner
+    return provenance
+
+
+def _runner_current_attempt(work: TrackedWork) -> str | None:
+    runner = (work.provenance or {}).get("runner") or {}
+    current = runner.get("current_attempt_id")
+    return current if isinstance(current, str) and current else None
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 class SQLiteWorkStore:
@@ -210,6 +235,266 @@ class SQLiteWorkStore:
         ).fetchall()
         return [work for row in rows if (work := self._row_to_work(row)) is not None]
 
+    def _replace_work_json(
+        self,
+        work_id: str,
+        *,
+        state: str,
+        state_reason: str | None,
+        phase: str | None,
+        assigned_peer_id: str | None,
+        correlation_id: str | None,
+        provenance: dict[str, Any],
+        error: dict[str, Any] | None = None,
+        completed_at: str | None = None,
+    ) -> None:
+        now = now_iso()
+        self._conn.execute(
+            """
+            UPDATE tracked_work SET
+                state = ?, state_reason = ?, phase = ?, assigned_peer_id = ?,
+                correlation_id = ?, provenance_json = ?, error_json = ?,
+                completed_at = ?, updated_at = ?
+            WHERE work_id = ?
+            """,
+            (
+                state,
+                state_reason,
+                phase,
+                assigned_peer_id,
+                correlation_id,
+                json_dumps(provenance),
+                json_dumps(error or {}),
+                completed_at,
+                now,
+                work_id,
+            ),
+        )
+
+    def acquire_for_dispatch(
+        self,
+        work_id: str,
+        *,
+        runner_owner_id: str,
+        lease_until: str,
+        attempt_id: str | None = None,
+        ignore_due_at: bool = False,
+        retry: bool = False,
+    ) -> TrackedWork | None:
+        now = now_iso()
+        attempt_id = attempt_id or f"attempt-{uuid4().hex[:12]}"
+        with self._conn:
+            existing = self.get(work_id)
+            if existing is None or existing.cancel_requested:
+                return None
+            allowed = (
+                {"queued", "failed", "unavailable"}
+                if not retry
+                else {"failed", "unavailable", "delivered"}
+            )
+            if existing.state not in allowed:
+                return None
+            if retry and existing.state not in {"failed", "unavailable", "delivered"}:
+                return None
+            due_at = (((existing.request or {}).get("execution") or {}).get("schedule") or {}).get(
+                "due_at"
+            )
+            due = _parse_iso(due_at)
+            if due and not ignore_due_at and due > datetime.now(timezone.utc):
+                return None
+            provenance = _runner_provenance(existing)
+            runner = provenance["runner"]
+            attempts = list(runner.get("attempts") or [])
+            attempt = {
+                "attempt_id": attempt_id,
+                "status": "dispatching",
+                "phase": "acquired",
+                "started_at": now,
+                "completed_at": None,
+                "runner_owner_id": runner_owner_id,
+                "lease_until": lease_until,
+                "assigned_peer_id": existing.assigned_peer_id,
+                "assigned_peer_info": {},
+                "tmux": {},
+                "correlation_id": None,
+                "delivery_state": None,
+                "error": {},
+            }
+            attempts.append(attempt)
+            runner.update(
+                {
+                    "attempt_count": len(attempts),
+                    "current_attempt_id": attempt_id,
+                    "runner_owner_id": runner_owner_id,
+                    "acquired_at": now,
+                    "lease_until": lease_until,
+                    "attempts": attempts,
+                }
+            )
+            provenance["runner"] = runner
+            self._replace_work_json(
+                work_id,
+                state="dispatching",
+                state_reason="dispatching",
+                phase="acquired",
+                assigned_peer_id=existing.assigned_peer_id,
+                correlation_id=existing.correlation_id,
+                provenance=provenance,
+            )
+        return self.get(work_id)
+
+    def recover_stale_dispatching(
+        self,
+        *,
+        now: str,
+        runner_owner_id: str | None = None,
+    ) -> list[TrackedWork]:
+        recovered: list[TrackedWork] = []
+        rows = self._conn.execute(
+            "SELECT * FROM tracked_work WHERE state IN ('dispatching', 'delivered')"
+        ).fetchall()
+        with self._conn:
+            for row in rows:
+                work = self._row_to_work(row)
+                if work is None:
+                    continue
+                provenance = _runner_provenance(work)
+                runner = provenance["runner"]
+                lease_until = runner.get("lease_until")
+                lease = _parse_iso(lease_until)
+                current_time = _parse_iso(now) or datetime.now(timezone.utc)
+                if lease and lease > current_time:
+                    continue
+                attempt_id = runner.get("current_attempt_id")
+                attempts = list(runner.get("attempts") or [])
+                for attempt in attempts:
+                    if attempt.get("attempt_id") == attempt_id:
+                        attempt.update(
+                            {
+                                "status": "unavailable",
+                                "phase": "runner_interrupted",
+                                "completed_at": now,
+                                "error": {"reason": "runner_interrupted"},
+                            }
+                        )
+                        break
+                runner.update(
+                    {
+                        "attempts": attempts,
+                        "last_error": {"reason": "runner_interrupted"},
+                        "current_attempt_id": attempt_id,
+                    }
+                )
+                provenance["runner"] = runner
+                self._replace_work_json(
+                    work.work_id,
+                    state="unavailable",
+                    state_reason="runner_interrupted",
+                    phase="runner_interrupted",
+                    assigned_peer_id=work.assigned_peer_id,
+                    correlation_id=work.correlation_id,
+                    provenance=provenance,
+                    error={"reason": "runner_interrupted"},
+                    completed_at=now,
+                )
+                refreshed = self.get(work.work_id)
+                if refreshed is not None:
+                    recovered.append(refreshed)
+        return recovered
+
+    def update_attempt(
+        self,
+        work_id: str,
+        *,
+        attempt_id: str,
+        status: str | None = None,
+        phase: str | None = None,
+        assigned_peer_id: str | None = None,
+        assigned_peer_info: dict[str, Any] | None = None,
+        tmux: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        delivery_state: str | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> TrackedWork | None:
+        with self._conn:
+            existing = self.get(work_id)
+            if existing is None:
+                return None
+            provenance = _runner_provenance(existing)
+            runner = provenance["runner"]
+            attempts = list(runner.get("attempts") or [])
+            found = False
+            completed_at = existing.completed_at
+            for attempt in attempts:
+                if attempt.get("attempt_id") != attempt_id:
+                    continue
+                found = True
+                if status is not None:
+                    attempt["status"] = status
+                if phase is not None:
+                    attempt["phase"] = phase
+                if assigned_peer_id is not None:
+                    attempt["assigned_peer_id"] = assigned_peer_id
+                if assigned_peer_info is not None:
+                    attempt["assigned_peer_info"] = assigned_peer_info
+                if tmux is not None:
+                    attempt["tmux"] = tmux
+                if correlation_id is not None:
+                    attempt["correlation_id"] = correlation_id
+                if delivery_state is not None:
+                    attempt["delivery_state"] = delivery_state
+                if error is not None:
+                    attempt["error"] = error
+                if status in {"delivered", "failed", "unavailable", "interrupted", "cancelled"}:
+                    attempt["completed_at"] = now_iso()
+                break
+            if not found:
+                return None
+            runner["attempts"] = attempts
+            if error:
+                runner["last_error"] = error
+            provenance["runner"] = runner
+            is_current = runner.get("current_attempt_id") == attempt_id
+            if not is_current:
+                self._conn.execute(
+                    """
+                    UPDATE tracked_work SET provenance_json = ?, updated_at = ?
+                    WHERE work_id = ?
+                    """,
+                    (json_dumps(provenance), now_iso(), work_id),
+                )
+                return self.get(work_id)
+            state = existing.state
+            reason = existing.state_reason
+            new_phase = phase if phase is not None else existing.phase
+            if status == "delivered":
+                state, reason = "delivered", "ask_delivered"
+            elif status == "failed":
+                state, reason = "failed", (error or {}).get("reason", "dispatch_failed")
+                completed_at = completed_at or now_iso()
+            elif status == "unavailable":
+                state, reason = "unavailable", (error or {}).get("reason", "unavailable")
+                completed_at = completed_at or now_iso()
+            elif status == "cancelled":
+                state, reason = "cancelled", "cancel_requested"
+                completed_at = completed_at or now_iso()
+            self._replace_work_json(
+                work_id,
+                state=state,
+                state_reason=reason,
+                phase=new_phase,
+                assigned_peer_id=assigned_peer_id
+                if assigned_peer_id is not None
+                else existing.assigned_peer_id,
+                correlation_id=correlation_id
+                if correlation_id is not None
+                else existing.correlation_id,
+                provenance=provenance,
+                error=error if error is not None else existing.error,
+                completed_at=completed_at,
+            )
+        return self.get(work_id)
+
     def update_state(
         self,
         work_id: str,
@@ -224,11 +509,18 @@ class SQLiteWorkStore:
         error: dict[str, Any] | None = None,
         artifacts: list[Any] | None = None,
         provenance: dict[str, Any] | None = None,
+        attempt_id: str | None = None,
     ) -> TrackedWork | None:
         validate_state(state)
         existing = self.get(work_id)
         if existing is None:
             return None
+        current_attempt_id = _runner_current_attempt(existing)
+        if current_attempt_id and state in {"completed", "failed", "cancelled"}:
+            if not attempt_id:
+                raise ValueError("attempt_id is required for runner-managed job updates")
+            if attempt_id != current_attempt_id:
+                raise RuntimeError("stale_attempt")
         if existing.terminal and state != existing.state:
             raise ValueError(
                 f"terminal work {work_id} is already {existing.state}; "

--- a/repowire/daemon/work_store.py
+++ b/repowire/daemon/work_store.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 WorkState = Literal[
     "queued",
+    "dispatching",
     "delivered",
     "running",
     "awaiting_input",
@@ -25,6 +26,7 @@ TerminalWorkState = Literal["completed", "failed", "cancelled", "expired", "unav
 WORK_STATES: frozenset[str] = frozenset(
     {
         "queued",
+        "dispatching",
         "delivered",
         "running",
         "awaiting_input",
@@ -145,6 +147,11 @@ class TrackedWork:
             "cancel_requested_by_peer_id": self.cancel_requested_by_peer_id,
             "cancellation_reason": self.cancellation_reason,
             "protocol_cancel": self.provenance.get("protocol_cancel"),
+            "request": self.request,
+            "provenance": self.provenance,
+            "execution": self.request.get("execution", {}),
+            "runner": self.provenance.get("runner", {}),
+            "due_at": ((self.request.get("execution", {}).get("schedule", {}) or {}).get("due_at")),
             "links": self.provenance.get("links", {}),
         }
 
@@ -205,6 +212,39 @@ class WorkStoreProtocol(Protocol):
         circle: str | None = None,
     ) -> list[TrackedWork]: ...
 
+    def acquire_for_dispatch(
+        self,
+        work_id: str,
+        *,
+        runner_owner_id: str,
+        lease_until: str,
+        attempt_id: str | None = None,
+        ignore_due_at: bool = False,
+        retry: bool = False,
+    ) -> TrackedWork | None: ...
+
+    def recover_stale_dispatching(
+        self,
+        *,
+        now: str,
+        runner_owner_id: str | None = None,
+    ) -> list[TrackedWork]: ...
+
+    def update_attempt(
+        self,
+        work_id: str,
+        *,
+        attempt_id: str,
+        status: str | None = None,
+        phase: str | None = None,
+        assigned_peer_id: str | None = None,
+        assigned_peer_info: dict[str, Any] | None = None,
+        tmux: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        delivery_state: str | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> TrackedWork | None: ...
+
     def update_state(
         self,
         work_id: str,
@@ -219,6 +259,7 @@ class WorkStoreProtocol(Protocol):
         error: dict[str, Any] | None = None,
         artifacts: list[Any] | None = None,
         provenance: dict[str, Any] | None = None,
+        attempt_id: str | None = None,
     ) -> TrackedWork | None: ...
 
     def cancel(

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -799,8 +799,13 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         error: dict | None = None,
         artifacts: list | None = None,
         provenance: dict | None = None,
+        attempt_id: str | None = None,
     ) -> str:
-        """[Repowire mesh] Update a tracked work job lifecycle state as JSON."""
+        """[Repowire mesh] Update a tracked work job lifecycle state as JSON.
+
+        Runner-managed terminal updates must pass the current attempt_id from
+        the job prompt/status so stale attempts cannot complete newer work.
+        """
         await _ensure_registered(strict=True)
         body = {
             key: value
@@ -815,6 +820,7 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
                 "error": error,
                 "artifacts": artifacts,
                 "provenance": provenance,
+                "attempt_id": attempt_id,
             }.items()
             if value is not None
         }

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -138,13 +138,23 @@ def test_jobs_update_patches_status(monkeypatch) -> None:
 
     result = CliRunner().invoke(
         main,
-        ["jobs", "update", "work-abc123", "--state", "running", "--note", "started"],
+        [
+            "jobs",
+            "update",
+            "work-abc123",
+            "--state",
+            "completed",
+            "--note",
+            "started",
+            "--attempt-id",
+            "attempt-1",
+        ],
     )
 
     assert result.exit_code == 0, result.output
     client.patch.assert_called_once_with(
         "http://127.0.0.1:8377/jobs/work-abc123",
-        json={"state": "running", "progress_note": "started"},
+        json={"state": "completed", "progress_note": "started", "attempt_id": "attempt-1"},
     )
 
 

--- a/tests/test_durable_job_runner.py
+++ b/tests/test_durable_job_runner.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.job_runner import JobRunner
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.routes import work as work_routes
+from repowire.daemon.spawn_service import SpawnService, SpawnServiceResult
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.work import SQLiteWorkStore
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import PeerRole, PeerStatus
+
+
+class FakeDelivery:
+    def __init__(self, cid: str = "ask-test") -> None:
+        self.cid = cid
+        self.calls: list[dict] = []
+        self.fail: Exception | None = None
+
+    async def open_scheduled_ask(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.fail:
+            raise self.fail
+        return self.cid
+
+
+class FakeSpawn:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.fail: Exception | None = None
+
+    def spawn(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.fail:
+            raise self.fail
+        return SpawnServiceResult(
+            display_name="worker",
+            tmux_session="jobs:worker",
+            pane_id="%9",
+            message=kwargs.get("message"),
+        )
+
+
+def _env(tmp_path: Path):
+    cfg = Config()
+    transport = WebSocketTransport()
+    qt = QueryTracker()
+    at = AskTracker(ttl_hours=24.0)
+    router = MessageRouter(transport=transport, query_tracker=qt)
+    registry = PeerRegistry(
+        config=cfg,
+        message_router=router,
+        query_tracker=qt,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+        ask_tracker=at,
+    )
+    db = StateDatabase(tmp_path / "state.db")
+    store = SQLiteWorkStore(db)
+    delivery = FakeDelivery()
+    spawn = FakeSpawn()
+    runner = JobRunner(
+        config=cfg,
+        work_store=store,
+        peer_registry=registry,
+        peer_delivery=delivery,  # type: ignore[arg-type]
+        spawn_service=spawn,  # type: ignore[arg-type]
+        poll_interval=0.01,
+    )
+    state = SimpleNamespace(
+        config=cfg,
+        transport=transport,
+        query_tracker=qt,
+        ask_tracker=at,
+        message_router=router,
+        peer_registry=registry,
+        work_store=store,
+        job_runner=runner,
+        relay_mode=False,
+    )
+    init_deps(cfg, registry, state)
+    return cfg, registry, db, store, delivery, spawn, runner
+
+
+async def _register_peer(
+    registry: PeerRegistry,
+    *,
+    peer_id: str = "repow-default-worker",
+    status=PeerStatus.ONLINE,
+):
+    pid, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/project",
+        peer_id=peer_id,
+        initial_status=status,
+        role=PeerRole.AGENT,
+    )
+    return pid
+
+
+def test_atomic_acquire_prevents_double_dispatch(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, _runner = _env(tmp_path)
+    work = store.create(title="job")
+
+    first = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+    )
+    second = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r2",
+        lease_until=(datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+    )
+
+    assert first is not None
+    assert second is None
+    assert store.get(work.work_id).state == "dispatching"
+    db.close()
+    cleanup_deps()
+
+
+def test_startup_recovery_marks_stale_dispatching_unavailable(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    work = store.create(title="job")
+    store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+
+    recovered = runner.recover_stale()
+
+    assert [w.work_id for w in recovered] == [work.work_id]
+    status = store.get(work.work_id)
+    assert status.state == "unavailable"
+    assert status.state_reason == "runner_interrupted"
+    assert status.error == {"reason": "runner_interrupted"}
+    db.close()
+    cleanup_deps()
+
+
+def test_startup_recovery_marks_stale_delivered_unavailable(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    work = store.create(title="job")
+    acquired = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+    attempt_id = acquired.provenance["runner"]["current_attempt_id"]
+    store.update_attempt(
+        work.work_id,
+        attempt_id=attempt_id,
+        status="delivered",
+        phase="delivered",
+        correlation_id="ask-1",
+    )
+
+    recovered = runner.recover_stale()
+
+    assert [w.work_id for w in recovered] == [work.work_id]
+    assert store.get(work.work_id).state == "unavailable"
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_live_runner_recovers_delivered_after_lease_without_restart(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    work = store.create(title="job")
+    acquired = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) + timedelta(milliseconds=50)).isoformat(),
+    )
+    attempt_id = acquired.provenance["runner"]["current_attempt_id"]
+    store.update_attempt(
+        work.work_id,
+        attempt_id=attempt_id,
+        status="delivered",
+        phase="delivered",
+        correlation_id="ask-1",
+    )
+
+    await runner.start()
+    try:
+        await asyncio.sleep(0.2)
+        recovered = store.get(work.work_id)
+        assert recovered.state == "unavailable"
+        assert recovered.state_reason == "runner_interrupted"
+    finally:
+        await runner.stop()
+        db.close()
+        cleanup_deps()
+
+
+def test_running_heartbeat_avoids_delivered_lease_recovery(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    work = store.create(title="job")
+    acquired = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+    attempt_id = acquired.provenance["runner"]["current_attempt_id"]
+    store.update_attempt(
+        work.work_id,
+        attempt_id=attempt_id,
+        status="delivered",
+        phase="delivered",
+        correlation_id="ask-1",
+    )
+    store.update_state(work.work_id, state="running", attempt_id=attempt_id)
+
+    recovered = runner.recover_stale()
+
+    assert recovered == []
+    assert store.get(work.work_id).state == "running"
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_wake_set_during_deadline_computation_is_not_lost(tmp_path, monkeypatch):
+    _cfg, _registry, db, _store, _delivery, _spawn, runner = _env(tmp_path)
+    calls = 0
+
+    async def fake_run_due_once():
+        nonlocal calls
+        calls += 1
+        if calls >= 2:
+            runner._stopped.set()  # noqa: SLF001
+        return []
+
+    def fake_next_deadline():
+        if calls == 1:
+            runner.wake()
+        return None
+
+    monkeypatch.setattr(runner, "run_due_once", fake_run_due_once)
+    monkeypatch.setattr(runner, "_seconds_until_next_deadline", fake_next_deadline)
+
+    await runner.start()
+    await asyncio.wait_for(runner._task, timeout=1.0)  # noqa: SLF001
+
+    assert calls >= 2
+    db.close()
+    cleanup_deps()
+
+
+def test_runner_waits_indefinitely_when_no_due_or_lease_deadline(tmp_path):
+    _cfg, _registry, db, _store, _delivery, _spawn, runner = _env(tmp_path)
+
+    assert runner._seconds_until_next_deadline() is None  # noqa: SLF001
+
+    db.close()
+    cleanup_deps()
+
+
+def test_due_at_offset_is_compared_by_instant_not_string(tmp_path):
+    _cfg, _registry, db, store, _delivery, _spawn, _runner = _env(tmp_path)
+    # Lexicographically less than a UTC now string on many days, but far in the future by instant.
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).astimezone(
+        timezone(timedelta(hours=-10))
+    )
+    work = store.create(
+        title="future",
+        request={"execution": {"schedule": {"due_at": future.isoformat()}}},
+    )
+
+    acquired = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+        ignore_due_at=False,
+    )
+
+    assert acquired is None
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_manual_run_future_due_dispatches_once_and_records_correlation(tmp_path):
+    _cfg, registry, db, store, delivery, _spawn, runner = _env(tmp_path)
+    peer_id = await _register_peer(registry)
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    work = store.create(
+        title="future",
+        assigned_peer_id=peer_id,
+        circle="default",
+        request={
+            "execution": {
+                "prompt": {"body": "do it", "source": "inline"},
+                "target": {"assigned_peer_id": peer_id},
+                "schedule": {"due_at": future},
+                "delivery": {"kind": "ask"},
+            }
+        },
+    )
+
+    skipped = await runner.run_due_once()
+    ran = await runner.run_job(work.work_id, ignore_due_at=True)
+    again = await runner.run_job(work.work_id, ignore_due_at=True)
+
+    assert skipped == []
+    assert again is None
+    assert ran.state == "delivered"
+    assert len(delivery.calls) == 1
+    assert delivery.calls[0]["to_peer"] == peer_id
+    assert "attempt_id:" in delivery.calls[0]["text"]
+    assert store.get(work.work_id).correlation_id == "ask-test"
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_cancel_during_acquired_before_delivery_records_cancelled(tmp_path):
+    _cfg, registry, db, store, delivery, _spawn, runner = _env(tmp_path)
+    peer_id = await _register_peer(registry)
+    work = store.create(
+        title="cancel",
+        assigned_peer_id=peer_id,
+        circle="default",
+        request={"execution": {"target": {"assigned_peer_id": peer_id}}},
+    )
+    acquired = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+    )
+    attempt_id = acquired.provenance["runner"]["current_attempt_id"]
+    store.cancel(work.work_id, reason="user_requested")
+
+    result = await runner._dispatch(store.get(work.work_id), attempt_id)  # noqa: SLF001
+
+    assert result.state == "cancelled"
+    assert delivery.calls == []
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_retry_preserves_attempts_and_stale_update_conflicts(tmp_path):
+    _cfg, registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    peer_id = await _register_peer(registry)
+    work = store.create(
+        title="retry",
+        assigned_peer_id=peer_id,
+        circle="default",
+        request={"execution": {"target": {"assigned_peer_id": peer_id}}},
+    )
+    first = store.acquire_for_dispatch(
+        work.work_id,
+        runner_owner_id="r1",
+        lease_until=(datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+    )
+    old_attempt = first.provenance["runner"]["current_attempt_id"]
+    store.update_attempt(
+        work.work_id,
+        attempt_id=old_attempt,
+        status="failed",
+        phase="delivery",
+        error={"reason": "ask_delivery_failed"},
+    )
+
+    retried = await runner.run_job(work.work_id, retry=True)
+    new_attempt = retried.provenance["runner"]["current_attempt_id"]
+
+    assert new_attempt != old_attempt
+    assert retried.provenance["runner"]["attempt_count"] == 2
+    with pytest.raises(RuntimeError, match="stale_attempt"):
+        store.update_state(work.work_id, state="completed", attempt_id=old_attempt)
+    stale_update = store.update_attempt(
+        work.work_id,
+        attempt_id=old_attempt,
+        status="failed",
+        phase="old-failed",
+        correlation_id="ask-old",
+        error={"reason": "old_attempt_failed"},
+    )
+    assert stale_update.state == "delivered"
+    assert stale_update.phase == "delivered"
+    assert stale_update.correlation_id != "ask-old"
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_retry_from_delivered_creates_new_attempt(tmp_path):
+    _cfg, registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    peer_id = await _register_peer(registry)
+    work = store.create(
+        title="retry delivered",
+        assigned_peer_id=peer_id,
+        circle="default",
+        request={"execution": {"target": {"assigned_peer_id": peer_id}}},
+    )
+    delivered = await runner.run_job(work.work_id)
+    old_attempt = delivered.provenance["runner"]["current_attempt_id"]
+
+    retried = await runner.run_job(work.work_id, retry=True)
+
+    assert retried.state == "delivered"
+    assert retried.provenance["runner"]["attempt_count"] == 2
+    assert retried.provenance["runner"]["current_attempt_id"] != old_attempt
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_offline_explicit_peer_becomes_unavailable(tmp_path):
+    _cfg, registry, db, store, _delivery, _spawn, runner = _env(tmp_path)
+    peer_id = await _register_peer(registry, status=PeerStatus.OFFLINE)
+    work = store.create(
+        title="offline",
+        assigned_peer_id=peer_id,
+        circle="default",
+        request={"execution": {"target": {"assigned_peer_id": peer_id}}},
+    )
+
+    result = await runner.run_job(work.work_id)
+
+    assert result.state == "unavailable"
+    assert result.error == {"reason": "assigned_peer_offline"}
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_create_ambiguous_display_name_returns_409(tmp_path):
+    _cfg, registry, db, _store, _delivery, _spawn, runner = _env(tmp_path)
+    peer_a, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/same",
+        peer_id="repow-default-a",
+        initial_status=PeerStatus.ONLINE,
+    )
+    peer_b, _ = await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path="/tmp/same",
+        peer_id="repow-default-b",
+        initial_status=PeerStatus.ONLINE,
+    )
+    # Force ambiguity; allocator normally suffixes display names.
+    registry._peers[peer_a].display_name = "same"  # noqa: SLF001
+    registry._peers[peer_b].display_name = "same"  # noqa: SLF001
+    app = FastAPI()
+    app.include_router(work_routes.router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/jobs", json={"title": "x", "assigned_peer_id": "same"})
+
+    assert response.status_code == 409
+    await runner.stop()
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_spawn_service_records_ownership_and_warmup(tmp_path, monkeypatch):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CLAUDE_CODE] = "claude"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    spawned: set[str] = set()
+    tasks: set[asyncio.Task] = set()
+
+    async def warmup(*_args, **_kwargs):
+        return None
+
+    result_obj = SimpleNamespace(
+        display_name="proj",
+        tmux_session="jobs:proj",
+        pane_id="%1",
+        message="warm",
+    )
+    spawn_impl = Mock(return_value=result_obj)
+    monkeypatch.setattr("repowire.daemon.spawn_service.record_spawn_ownership", Mock())
+    service = SpawnService(
+        config=cfg,
+        spawned_pane_ids=spawned,
+        background_tasks=tasks,
+        spawn_impl=spawn_impl,
+        warmup_impl=warmup,
+    )
+
+    result = service.spawn(path=str(tmp_path), backend=AgentType.CLAUDE_CODE, message="warm")
+
+    assert result.pane_id == "%1"
+    assert "%1" in spawned
+    assert tasks

--- a/tests/test_mcp_jobs.py
+++ b/tests/test_mcp_jobs.py
@@ -81,8 +81,9 @@ async def test_job_status_show_result_update_and_cancel_wrap_jobs_api() -> None:
         await _tool("job_show")("work-abc123")
         await _tool("job_update")(
             "work-abc123",
-            state="running",
+            state="completed",
             progress_note="started",
+            attempt_id="attempt-1",
         )
         await _tool("job_result")("work-abc123")
         cancel_result = await _tool("job_cancel")("work-abc123", reason="stale")
@@ -93,7 +94,7 @@ async def test_job_status_show_result_update_and_cancel_wrap_jobs_api() -> None:
         (
             "PATCH",
             "/jobs/work-abc123",
-            {"state": "running", "progress_note": "started"},
+            {"state": "completed", "progress_note": "started", "attempt_id": "attempt-1"},
             None,
         ),
         ("GET", "/jobs/work-abc123/result", None, None),

--- a/tests/test_peer_describe.py
+++ b/tests/test_peer_describe.py
@@ -1,4 +1,5 @@
 """Tests for repowire.peer_describe (pure-function module + resolver)."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -162,22 +163,29 @@ class TestFetchPendingAsks:
             assert request.url.path == "/asks/pending"
             assert request.url.params["peer_id"] == "p-1"
             assert request.url.params["direction"] == "both"
-            return httpx.Response(200, json={
-                "asks": [
-                    {
-                        "correlation_id": "ask-a",
-                        "from_peer": "alice", "to_peer": "bob",
-                        "text": "hello", "created_at": "2026-05-15T14:53:00+00:00",
-                        "direction": "inbound",
-                    },
-                    {
-                        "correlation_id": "ask-b",
-                        "from_peer": "bob", "to_peer": "carol",
-                        "text": "out", "created_at": "2026-05-15T14:54:00+00:00",
-                        "direction": "outbound",
-                    },
-                ],
-            })
+            return httpx.Response(
+                200,
+                json={
+                    "asks": [
+                        {
+                            "correlation_id": "ask-a",
+                            "from_peer": "alice",
+                            "to_peer": "bob",
+                            "text": "hello",
+                            "created_at": "2026-05-15T14:53:00+00:00",
+                            "direction": "inbound",
+                        },
+                        {
+                            "correlation_id": "ask-b",
+                            "from_peer": "bob",
+                            "to_peer": "carol",
+                            "text": "out",
+                            "created_at": "2026-05-15T14:54:00+00:00",
+                            "direction": "outbound",
+                        },
+                    ],
+                },
+            )
 
         with _client(handler) as client:
             asks = fetch_pending_asks(client, "http://test", "p-1")
@@ -202,32 +210,44 @@ class TestFetchPendingAsks:
 class TestFetchRecentActivity:
     def test_filters_by_peer_id_or_name(self):
         def handler(_request):
-            return httpx.Response(200, json=[
-                # Inbound (notification to p-1)
-                {
-                    "id": "1", "type": "notification",
-                    "timestamp": "2026-05-15T14:50:00+00:00",
-                    "from": "alice", "to": "bob",
-                    "from_peer_id": "p-a", "to_peer_id": "p-1",
-                    "text": "hi bob",
-                },
-                # Outbound (p-1 -> someone)
-                {
-                    "id": "2", "type": "notification",
-                    "timestamp": "2026-05-15T14:51:00+00:00",
-                    "from": "bob", "to": "carol",
-                    "from_peer_id": "p-1", "to_peer_id": "p-c",
-                    "text": "bye carol",
-                },
-                # Irrelevant
-                {
-                    "id": "3", "type": "notification",
-                    "timestamp": "2026-05-15T14:52:00+00:00",
-                    "from": "alice", "to": "carol",
-                    "from_peer_id": "p-a", "to_peer_id": "p-c",
-                    "text": "nope",
-                },
-            ])
+            return httpx.Response(
+                200,
+                json=[
+                    # Inbound (notification to p-1)
+                    {
+                        "id": "1",
+                        "type": "notification",
+                        "timestamp": "2026-05-15T14:50:00+00:00",
+                        "from": "alice",
+                        "to": "bob",
+                        "from_peer_id": "p-a",
+                        "to_peer_id": "p-1",
+                        "text": "hi bob",
+                    },
+                    # Outbound (p-1 -> someone)
+                    {
+                        "id": "2",
+                        "type": "notification",
+                        "timestamp": "2026-05-15T14:51:00+00:00",
+                        "from": "bob",
+                        "to": "carol",
+                        "from_peer_id": "p-1",
+                        "to_peer_id": "p-c",
+                        "text": "bye carol",
+                    },
+                    # Irrelevant
+                    {
+                        "id": "3",
+                        "type": "notification",
+                        "timestamp": "2026-05-15T14:52:00+00:00",
+                        "from": "alice",
+                        "to": "carol",
+                        "from_peer_id": "p-a",
+                        "to_peer_id": "p-c",
+                        "text": "nope",
+                    },
+                ],
+            )
 
         with _client(handler) as client:
             events = fetch_recent_activity(client, "http://test", "p-1", "bob")
@@ -249,16 +269,22 @@ class TestFetchRecentActivity:
 
     def test_limit_caps_results(self):
         def handler(_request):
-            return httpx.Response(200, json=[
-                {
-                    "id": str(i), "type": "notification",
-                    "timestamp": f"2026-05-15T14:{50 + i:02d}:00+00:00",
-                    "from": "alice", "to": "bob",
-                    "from_peer_id": "p-a", "to_peer_id": "p-1",
-                    "text": f"msg {i}",
-                }
-                for i in range(10)
-            ])
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": str(i),
+                        "type": "notification",
+                        "timestamp": f"2026-05-15T14:{50 + i:02d}:00+00:00",
+                        "from": "alice",
+                        "to": "bob",
+                        "from_peer_id": "p-a",
+                        "to_peer_id": "p-1",
+                        "text": f"msg {i}",
+                    }
+                    for i in range(10)
+                ],
+            )
 
         with _client(handler) as client:
             events = fetch_recent_activity(client, "http://test", "p-1", "bob", limit=3)
@@ -277,26 +303,37 @@ class TestBuildSnapshot:
         def handler(request):
             path = request.url.path
             if path == "/asks/pending":
-                return httpx.Response(200, json={
-                    "asks": [
+                return httpx.Response(
+                    200,
+                    json={
+                        "asks": [
+                            {
+                                "correlation_id": "ask-in",
+                                "from_peer": "alice",
+                                "to_peer": "bob",
+                                "text": "?",
+                                "created_at": "2026-05-15T14:53:00+00:00",
+                                "direction": "inbound",
+                            },
+                        ],
+                    },
+                )
+            if path == "/events":
+                return httpx.Response(
+                    200,
+                    json=[
                         {
-                            "correlation_id": "ask-in",
-                            "from_peer": "alice", "to_peer": "bob",
-                            "text": "?", "created_at": "2026-05-15T14:53:00+00:00",
-                            "direction": "inbound",
+                            "id": "1",
+                            "type": "notification",
+                            "timestamp": "2026-05-15T14:54:00+00:00",
+                            "from": "alice",
+                            "to": "bob",
+                            "from_peer_id": "p-a",
+                            "to_peer_id": "p-1",
+                            "text": "hi",
                         },
                     ],
-                })
-            if path == "/events":
-                return httpx.Response(200, json=[
-                    {
-                        "id": "1", "type": "notification",
-                        "timestamp": "2026-05-15T14:54:00+00:00",
-                        "from": "alice", "to": "bob",
-                        "from_peer_id": "p-a", "to_peer_id": "p-1",
-                        "text": "hi",
-                    },
-                ])
+                )
             return httpx.Response(404)
 
         with _client(handler) as client:
@@ -373,14 +410,21 @@ class TestHumanizeLastSeen:
 
 def test_dataclass_construct_smoke():
     a = PendingAsk(
-        correlation_id="ask-1", direction="inbound",
-        from_peer="alice", to_peer="bob", text="?", created_at="now",
+        correlation_id="ask-1",
+        direction="inbound",
+        from_peer="alice",
+        to_peer="bob",
+        text="?",
+        created_at="now",
     )
     assert a.direction == "inbound"
 
     e = ActivityEvent(
-        event_type="notification", timestamp="now",
-        direction="outbound", counterparty="alice", text="hi",
+        event_type="notification",
+        timestamp="now",
+        direction="outbound",
+        counterparty="alice",
+        text="hi",
     )
     assert e.event_type == "notification"
 
@@ -473,6 +517,7 @@ def test_compute_git_status_non_git_dir(tmp_path):
 
 def _git(cwd, *args):
     import subprocess
+
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
 
@@ -493,9 +538,9 @@ def test_compute_git_status_dirty_and_untracked(tmp_path):
     _git(tmp_path, "add", "a.txt")
     _git(tmp_path, "commit", "-m", "init")
     (tmp_path / "a.txt").write_text("changed")  # unstaged
-    (tmp_path / "b.txt").write_text("new")       # untracked
+    (tmp_path / "b.txt").write_text("new")  # untracked
     (tmp_path / "c.txt").write_text("staged")
-    _git(tmp_path, "add", "c.txt")               # staged
+    _git(tmp_path, "add", "c.txt")  # staged
     res = compute_git_status(str(tmp_path))
     assert res is not None
     assert res["dirty"] == 2  # a.txt modified + b.txt untracked
@@ -504,11 +549,18 @@ def test_compute_git_status_dirty_and_untracked(tmp_path):
 
 def test_compute_git_status_ahead(tmp_path):
     import subprocess
+
     # Create a bare upstream, clone, commit ahead.
     upstream = tmp_path / "upstream.git"
     work = tmp_path / "work"
-    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
-    subprocess.run(["git", "clone", "-q", str(upstream), str(work)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", str(upstream)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work)], check=True, capture_output=True
+    )
     _git(work, "config", "user.email", "t@t")
     _git(work, "config", "user.name", "t")
     _git(work, "commit", "--allow-empty", "-m", "first")
@@ -522,16 +574,25 @@ def test_compute_git_status_ahead(tmp_path):
 
 def test_compute_git_status_behind(tmp_path):
     import subprocess
+
     upstream = tmp_path / "upstream.git"
     work_a = tmp_path / "a"
     work_b = tmp_path / "b"
-    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
-    subprocess.run(["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", str(upstream)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True
+    )
     _git(work_a, "config", "user.email", "t@t")
     _git(work_a, "config", "user.name", "t")
     _git(work_a, "commit", "--allow-empty", "-m", "first")
     _git(work_a, "push", "-q", "origin", "main")
-    subprocess.run(["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True
+    )
     _git(work_b, "config", "user.email", "t@t")
     _git(work_b, "config", "user.name", "t")
     # Now push more from A so B is behind.
@@ -545,16 +606,25 @@ def test_compute_git_status_behind(tmp_path):
 
 def test_compute_git_status_ahead_and_behind(tmp_path):
     import subprocess
+
     upstream = tmp_path / "upstream.git"
     work_a = tmp_path / "a"
     work_b = tmp_path / "b"
-    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(upstream)], check=True, capture_output=True)
-    subprocess.run(["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", str(upstream)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work_a)], check=True, capture_output=True
+    )
     _git(work_a, "config", "user.email", "t@t")
     _git(work_a, "config", "user.name", "t")
     _git(work_a, "commit", "--allow-empty", "-m", "first")
     _git(work_a, "push", "-q", "origin", "main")
-    subprocess.run(["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work_b)], check=True, capture_output=True
+    )
     _git(work_b, "config", "user.email", "t@t")
     _git(work_b, "config", "user.name", "t")
     # A pushes ahead by 1.

--- a/web/app/docs/concepts/page.tsx
+++ b/web/app/docs/concepts/page.tsx
@@ -1,0 +1,22 @@
+export default function ConceptsPage() {
+  return (
+    <main>
+      <h1>Repowire mesh command concepts</h1>
+      <p>
+        Core commands include status, peers, pending-asks, ask, notify,
+        schedule, timeline, result, and doctor. Machine responses carry a
+        schema_version field where applicable.
+      </p>
+      <p>
+        Agents must use Repowire ask/ack/notify tools rather than SendMessage
+        for mesh peers. The tracked-work lifecycle is separate from ask
+        receipt, and ACP/channel broker health remains a distinct readiness
+        concern.
+      </p>
+      <p>
+        Claude Code marketplace plugin packaging is only a convenience layer;
+        it does not replace repowire setup.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a daemon `JobRunner` for durable jobs with persisted execution specs, atomic dispatch acquisition, leases, stale startup/live recovery, and ask-based delivery
- add shared `SpawnService` so job dispatch reuses `/spawn` path/backend/profile validation, ownership recording, and warmup behavior
- extend `/jobs` and CLI/MCP surfaces for create/run/retry/cancel/update with `attempt_id`, assigned-peer canonicalization, due-at handling, and retry from delivered/unavailable/failed
- update tracked-work/CLI/MCP docs and focused tests for durable autonomous job-runner semantics

## Tests
- `python3 scripts/pre_pr_hygiene.py` (clean; no Beads ledger churn)
- `git diff --check`
- `uv run --extra dev ruff check repowire tests`
- `uv run pytest tests/test_durable_job_runner.py tests/test_work_store.py tests/test_work_routes.py tests/test_cli_jobs.py tests/test_mcp_jobs.py tests/test_daemon_app.py::TestSpawnConfig tests/test_restart_peer_route.py::TestRestartPeerRoute::test_daemon_spawn_records_durable_ownership tests/test_tracked_work_lifecycle_contract.py tests/test_mesh_command_ux_contract.py::test_web_docs_mirror_core_command_contract` (58 passed, 1 warning)
- `uv run pytest` (1433 passed, 1 warning: existing FastAPI `HTTP_422_UNPROCESSABLE_ENTITY` deprecation warning in spawn profile test)
- `graphify update .` ran; it updated graph artifacts and generated cache churn, so those advisory outputs were reverted/cleaned and not included in this PR

## Hygiene notes
- Beads ledger churn was removed from the PR.
- `tests/test_peer_describe.py` is formatting-only. It is included because the requested broad gate `uv run --extra dev ruff check repowire tests` fails on existing long lines without it.
- `web/app/docs/concepts/page.tsx` is included because full `uv run pytest` fails at `tests/test_mesh_command_ux_contract.py::test_web_docs_mirror_core_command_contract` when that expected web docs page is absent.

## Reviewer notes / residual risk
- Running jobs have no later liveness/deadline recovery in this slice once a worker sends the required `running` heartbeat; future heartbeat/deadline semantics should cover that.
- `result_surface` remains metadata-only.
- MCP mirroring is limited to `job_update(attempt_id=...)`; run/retry MCP tools are intentionally deferred.
- No advanced peer reuse knobs: exact assigned peer id wins, otherwise path + backend (+ profile) spawns a peer.
