### PR TITLE
Centralize agent backends and session acquisition

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -8,3 +8,7 @@
 - [Antigravity CLI (`agy`)](antigravity.md) — plugin-based; hook firing and MCP pending upstream verification.
 - [OpenCode](opencode.md) — TypeScript plugin with persistent WebSocket.
 - Pi — extension path installed when the `pi` CLI or config is detected.
+
+Contributor note: backend behavior is centralized in the agent backend registry.
+See [Adding a backend](../reference/adding-a-backend.md) before adding another
+runtime or changing spawn/resume/setup behavior.

--- a/docs/concepts/session-binding-contract.md
+++ b/docs/concepts/session-binding-contract.md
@@ -161,6 +161,13 @@ Rules:
 - `repowire/daemon/state/session_bindings.py` persists binding metadata,
   source locators, cursors, provenance, resume capability, and lifecycle
   status without storing raw runtime transcript bodies.
+- `repowire/daemon/session_control.py` is the first session-acquisition service
+  used by durable jobs. It records a `session.acquire_executor` operation,
+  then resolves a live peer, backend-native resume, or fresh spawn.
+- `repowire/daemon/state/operations.py` stores internal operation lifecycle
+  records for acquisition attempts, strategies, results, and structured
+  failures. Operations are audit/control records; they do not replace peer,
+  session, or job identity.
 
 ## Migration path
 

--- a/docs/reference/adding-a-backend.md
+++ b/docs/reference/adding-a-backend.md
@@ -1,0 +1,91 @@
+# Adding a backend
+
+Repowire keeps backend identity and backend behavior separate:
+
+- `repowire/agent_types.py` defines `AgentType`, the serialized enum used in
+  config, APIs, peer state, jobs, and session bindings.
+- `repowire/agent_backends.py` defines `AgentBackend`, the behavior registry
+  for setup, spawn defaults, resume commands, MCP config, and post-spawn
+  warmup.
+
+Add a backend by updating both layers. Avoid scattering backend-specific
+`if backend == ...` checks through routes, jobs, or CLI commands; put runtime
+differences on the backend class and call through the registry.
+
+## Backend class
+
+Create an `AgentBackend` subclass in `repowire/agent_backends.py`:
+
+```python
+class ExampleBackend(AgentBackend):
+    agent_type = AgentType.EXAMPLE
+    display_name = "Example"
+    cli_names = ("example",)
+    default_command = "example"
+    supports_resume = True
+    resume_strategy = "example_resume"
+    resume_flag = "--resume"
+```
+
+Register it in `AGENT_BACKENDS`. The registry must cover every `AgentType`, even
+non-local backends that cannot be spawned. Use `supports_local_spawn = False`
+and `default_command = None` for transport-only entries.
+
+## Required decisions
+
+| Decision | Where it lives | Notes |
+| --- | --- | --- |
+| Serialized name | `AgentType` | This is persisted state, so changing it is a migration. |
+| Default spawn command | `AgentBackend.default_command` | Re-exported as `DEFAULT_SPAWN_COMMANDS` for config compatibility. |
+| CLI detection | `cli_names` and `config_markers` | Used by `repowire setup` auto-detection. |
+| Setup behavior | `install()` | Delegate heavy work to `repowire/installers/<backend>.py`. |
+| Resume shape | `supports_resume`, `resume_flag`, `resume_subcommand` | Used by durable jobs and session acquisition to build backend-native resume commands. |
+| MCP config support | `mcp_config_scope` and MCP methods | Only set this when Repowire can list/add/remove MCP servers for that backend. |
+| Post-spawn warmup | `post_spawn_strategy` or `post_spawn_warmup()` | Use this for runtime-specific first-message or seed behavior. |
+
+## Resume contract
+
+Runtime resume is a backend capability, not a jobs-only special case.
+
+When hooks or runtime registration expose a backend session ID, Repowire records
+that ID in session/job provenance and asks the backend for `resume_capability`.
+Later, session acquisition chooses in order:
+
+1. reuse a suitable live peer;
+2. spawn a backend-native resume command for the recorded runtime session;
+3. spawn a fresh peer when no binding is usable.
+
+For simple CLIs, set one of:
+
+- `resume_flag = "--resume"` to run `<command> --resume <runtime-session-id>`;
+- `resume_subcommand = "resume"` to run `<command> resume <runtime-session-id>`.
+
+If the backend supports resume but needs more than a flag or subcommand,
+override `build_resume_command()`.
+
+## MCP config
+
+Backends with MCP configuration support should define `mcp_config_scope` and
+implement:
+
+- `list_mcp_servers()`;
+- `add_mcp_server()`;
+- `remove_mcp_server()`.
+
+Backends without MCP support should leave `mcp_config_scope = None`; the base
+class returns a typed unsupported error.
+
+## Tests
+
+At minimum, add or update tests for:
+
+- the registry invariant: `set(AGENT_BACKENDS) == set(AgentType)`;
+- default command compatibility through `DEFAULT_SPAWN_COMMANDS`;
+- setup auto-detection and installer dispatch;
+- resume capability and resume command construction;
+- spawn/session acquisition behavior for reuse, resume, and fresh spawn;
+- MCP config behavior if the backend supports MCP edits;
+- post-spawn warmup if the backend needs runtime-specific seeding.
+
+Use focused tests for the backend class and one integration-level test for the
+daemon or CLI path that consumes it.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -24,11 +24,13 @@ The daemon is the single routing hub. It does not care whether a peer arrived th
 
 | Area | Files | Responsibility |
 | --- | --- | --- |
+| Agent backends | `repowire/agent_types.py`, `repowire/agent_backends.py` | Serialized backend identity plus setup, spawn, resume, MCP config, and post-spawn behavior dispatch |
 | Daemon app | `repowire/daemon/app.py`, `repowire/daemon/deps.py` | FastAPI app factory, dependency wiring, dashboard/static serving |
 | Peer state | `repowire/daemon/peer_registry.py` | Registration, liveness, circles, roles, lazy repair |
 | Message routing | `repowire/daemon/peer_delivery.py`, `repowire/daemon/transport_router.py`, `repowire/daemon/message_router.py`, `repowire/daemon/websocket_transport.py` | Delivery orchestration, ACP-before-WebSocket transport selection, and wire delivery over connected peers |
 | Ask lifecycle | `repowire/daemon/ask_tracker.py`, `repowire/daemon/routes/asks.py` | Open ask state, pending reminders, close/ack handling |
 | Session controls | `repowire/daemon/session_controls.py`, `repowire/daemon/routes/sessions.py` | Session-binding resolution and session-targeted control capability routes |
+| Session acquisition | `repowire/daemon/session_control.py`, `repowire/daemon/state/operations.py` | Durable operation records and live-executor acquisition for session/job work |
 | Schedules | `repowire/daemon/scheduler.py`, `repowire/daemon/schedule_store.py`, `repowire/daemon/routes/schedules.py` | One-shot and recurring cron deliveries |
 | Jobs | `repowire/daemon/job_runner.py`, `repowire/daemon/state/work.py`, `repowire/daemon/state/calendar.py`, `repowire/daemon/routes/work.py` | Durable tracked work, recurring calendar templates, and spawned job dispatch |
 | Hooks | `repowire/hooks/` | Runtime event adapters, tmux injection, transcript/chat extraction |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - CLI: reference/cli.md
       - Configuration: reference/configuration.md
       - Architecture: reference/architecture.md
+      - Adding a backend: reference/adding-a-backend.md
   - Troubleshooting:
       - troubleshooting/index.md
       - Hooks not firing: troubleshooting/hooks.md

--- a/repowire/agent_backends.py
+++ b/repowire/agent_backends.py
@@ -1,0 +1,447 @@
+"""Agent backend behavior registry.
+
+AgentType is the serialized identity used in config, APIs, and state. AgentBackend
+owns backend-specific behavior and delegates heavyweight implementation to the
+runtime-specific installer/config modules.
+
+Keep this module independent of repowire.config.models at import time. Config
+models re-export DEFAULT_SPAWN_COMMANDS for compatibility, so module-level
+config imports would create a cycle.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+from abc import ABC
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+from repowire.agent_types import AgentType
+
+
+@dataclass(frozen=True)
+class AgentResumePlan:
+    backend: AgentType
+    runtime_session_id: str
+    repowire_session_id: str | None = None
+    capability: dict | None = None
+
+
+@dataclass(frozen=True)
+class BackendInstallOptions:
+    use_channels: bool = False
+
+
+@dataclass(frozen=True)
+class BackendInstallMessage:
+    level: str
+    text: str
+
+
+@dataclass(frozen=True)
+class McpConfigScope:
+    owner: str
+    effective_scope: str
+    label: str
+    description: str
+    supported_scopes: tuple[str, ...] = ("user",)
+    default_scope: str = "user"
+    is_global: bool = True
+
+    def as_dict(self, backend: AgentType) -> dict[str, Any]:
+        return {
+            "backend": backend.value,
+            "owner": self.owner,
+            "effective_scope": self.effective_scope,
+            "label": self.label,
+            "description": self.description,
+            "supported_scopes": list(self.supported_scopes),
+            "default_scope": self.default_scope,
+            "is_global": self.is_global,
+        }
+
+
+class AgentBackend(ABC):
+    agent_type: ClassVar[AgentType]
+    display_name: ClassVar[str]
+    cli_names: ClassVar[tuple[str, ...]] = ()
+    config_markers: ClassVar[tuple[Path, ...]] = ()
+    default_command: ClassVar[str | None] = None
+    local_cli: ClassVar[bool] = True
+    supports_local_spawn: ClassVar[bool] = True
+    supports_resume: ClassVar[bool] = False
+    resume_strategy: ClassVar[str] = "unsupported"
+    resume_flag: ClassVar[str | None] = None
+    resume_subcommand: ClassVar[str | None] = None
+    mcp_config_scope: ClassVar[McpConfigScope | None] = None
+    post_spawn_strategy: ClassVar[str] = "seed_message"
+
+    def detect_installed(self) -> bool:
+        return any(shutil.which(name) for name in self.cli_names) or any(
+            marker.exists() for marker in self.config_markers
+        )
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        raise NotImplementedError(f"Setup is not implemented for {self.agent_type.value}")
+
+    def resume_capability(self, runtime_session_id: str | None) -> dict:
+        if not runtime_session_id:
+            return {}
+        if not self.supports_resume:
+            return {
+                "supported": False,
+                "strategy": self.resume_strategy,
+                "reason": "backend_resume_not_implemented",
+            }
+        return {
+            "supported": True,
+            "strategy": self.resume_strategy,
+            "runtime_session_id_arg": runtime_session_id,
+        }
+
+    def can_resume(self, runtime_session_id: str | None) -> bool:
+        return self.supports_resume and bool(runtime_session_id)
+
+    def build_resume_command(self, command: str, runtime_session_id: str) -> str:
+        if not self.supports_resume:
+            raise ValueError(
+                f"Backend-native resume is not available for {self.agent_type.value}"
+            )
+        quoted_session = shlex.quote(runtime_session_id)
+        if self.resume_subcommand:
+            return f"{command} {self.resume_subcommand} {quoted_session}"
+        return f"{command} {self.resume_flag} {quoted_session}"
+
+    async def post_spawn_warmup(
+        self,
+        pane_id: str,
+        *,
+        path: str,
+        circle: str,
+        message: str | None = None,
+    ) -> None:
+        if self.post_spawn_strategy == "codex_warmup":
+            from repowire.installers.post_spawn import DEFAULT_WARMUP_TEMPLATE, _codex_warmup
+
+            text = message or DEFAULT_WARMUP_TEMPLATE.format(path=path, circle=circle)
+            await _codex_warmup(pane_id, text)
+        elif message:
+            from repowire.installers.post_spawn import _claude_code_family_seed
+
+            await _claude_code_family_seed(pane_id, message)
+
+    def list_mcp_servers(self, peer):
+        if self.mcp_config_scope is None:
+            self._raise_mcp_unsupported()
+        raise NotImplementedError
+
+    def add_mcp_server(self, peer, spec) -> None:
+        if self.mcp_config_scope is None:
+            self._raise_mcp_unsupported()
+        raise NotImplementedError
+
+    def remove_mcp_server(self, peer, name: str) -> None:
+        if self.mcp_config_scope is None:
+            self._raise_mcp_unsupported()
+        raise NotImplementedError
+
+    def _raise_mcp_unsupported(self) -> None:
+        from repowire.peer_mcp import NotSupportedError
+
+        raise NotSupportedError(f"MCP config not supported for backend {self.agent_type.value}")
+
+
+class ClaudeCodeBackend(AgentBackend):
+    agent_type = AgentType.CLAUDE_CODE
+    display_name = "Claude Code"
+    cli_names = ("claude",)
+    default_command = "claude --dangerously-skip-permissions"
+    supports_resume = True
+    resume_strategy = "claude_resume"
+    resume_flag = "--resume"
+    mcp_config_scope = McpConfigScope(
+        owner="peer/project",
+        effective_scope="peer_project",
+        label="Claude Code peer/project config",
+        description=(
+            "Claude Code MCP edits can target user/global config or the peer's "
+            "project/worktree via the selected add scope."
+        ),
+        supported_scopes=("user", "project"),
+        is_global=False,
+    )
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        import subprocess
+
+        from repowire.installers.claude_code import install_channel, install_hooks
+
+        options = options or BackendInstallOptions()
+        messages: list[BackendInstallMessage] = []
+        if options.use_channels:
+            channel_ok, channel_msg = install_channel()
+            if channel_ok:
+                install_hooks(channel_mode=True)
+                messages.append(BackendInstallMessage("success", channel_msg))
+            else:
+                install_hooks()
+                messages.append(BackendInstallMessage("warning", channel_msg))
+                messages.append(
+                    BackendInstallMessage(
+                        "success",
+                        "Claude Code hooks installed (fallback)",
+                    )
+                )
+        else:
+            install_hooks()
+            messages.append(BackendInstallMessage("success", "Claude Code hooks installed"))
+
+        try:
+            subprocess.run(["claude", "mcp", "remove", "repowire"], capture_output=True)
+            cmd = ["claude", "mcp", "add", "-s", "user", "repowire", "--", "repowire", "mcp"]
+            subprocess.run(cmd, check=True)
+            messages.append(BackendInstallMessage("success", "MCP server added to Claude"))
+        except subprocess.CalledProcessError as e:
+            messages.append(
+                BackendInstallMessage(
+                    "error",
+                    f"Failed to configure Claude MCP server: {e}",
+                )
+            )
+        return messages
+
+    def list_mcp_servers(self, peer):
+        from repowire import peer_mcp
+
+        return peer_mcp._claude_list(peer)
+
+    def add_mcp_server(self, peer, spec) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._claude_add(peer, spec)
+
+    def remove_mcp_server(self, peer, name: str) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._claude_remove(peer, name)
+
+
+class CodexBackend(AgentBackend):
+    agent_type = AgentType.CODEX
+    display_name = "Codex"
+    cli_names = ("codex",)
+    default_command = "codex --dangerously-bypass-approvals-and-sandbox"
+    supports_resume = True
+    resume_strategy = "codex_resume"
+    resume_subcommand = "resume"
+    post_spawn_strategy = "codex_warmup"
+    mcp_config_scope = McpConfigScope(
+        owner="backend",
+        effective_scope="backend_global",
+        label="Codex global backend config",
+        description=(
+            "Codex MCP edits target the user-level Codex config shared by "
+            "Codex sessions on this host."
+        ),
+    )
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        from repowire.installers.codex import install_hooks, install_mcp
+
+        messages: list[BackendInstallMessage] = []
+        try:
+            install_hooks()
+            messages.append(BackendInstallMessage("success", "Codex hooks installed"))
+        except Exception as e:
+            messages.append(BackendInstallMessage("error", f"Failed to install Codex hooks: {e}"))
+        try:
+            install_mcp()
+            messages.append(BackendInstallMessage("success", "Codex MCP server configured"))
+        except Exception as e:
+            messages.append(BackendInstallMessage("error", f"Failed to configure Codex MCP: {e}"))
+        return messages
+
+    def list_mcp_servers(self, peer):
+        from repowire import peer_mcp
+
+        return peer_mcp._codex_list()
+
+    def add_mcp_server(self, peer, spec) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._codex_add(spec)
+
+    def remove_mcp_server(self, peer, name: str) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._codex_remove(name)
+
+
+class GeminiBackend(AgentBackend):
+    agent_type = AgentType.GEMINI
+    display_name = "Gemini"
+    cli_names = ("gemini",)
+    default_command = "gemini --yolo"
+    supports_resume = True
+    resume_strategy = "gemini_resume"
+    resume_flag = "--resume"
+    mcp_config_scope = McpConfigScope(
+        owner="backend",
+        effective_scope="backend_global",
+        label="Gemini global backend config",
+        description=(
+            "Gemini MCP edits target the user-level Gemini settings shared by "
+            "Gemini sessions on this host."
+        ),
+    )
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        from repowire.installers.gemini import install_hooks, install_mcp
+
+        messages: list[BackendInstallMessage] = []
+        try:
+            install_hooks()
+            messages.append(BackendInstallMessage("success", "Gemini hooks installed"))
+        except Exception as e:
+            messages.append(BackendInstallMessage("error", f"Failed to install Gemini hooks: {e}"))
+        try:
+            install_mcp()
+            messages.append(BackendInstallMessage("success", "Gemini MCP server configured"))
+        except Exception as e:
+            messages.append(BackendInstallMessage("error", f"Failed to configure Gemini MCP: {e}"))
+        return messages
+
+    def list_mcp_servers(self, peer):
+        from repowire import peer_mcp
+
+        return peer_mcp._gemini_list()
+
+    def add_mcp_server(self, peer, spec) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._gemini_add(spec)
+
+    def remove_mcp_server(self, peer, name: str) -> None:
+        from repowire import peer_mcp
+
+        peer_mcp._gemini_remove(name)
+
+
+class OpenCodeBackend(AgentBackend):
+    agent_type = AgentType.OPENCODE
+    display_name = "OpenCode"
+    cli_names = ("opencode",)
+    config_markers = (Path.home() / ".config" / "opencode",)
+    default_command = "opencode"
+    supports_resume = True
+    resume_strategy = "opencode_session"
+    resume_flag = "--session"
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        from repowire.installers.opencode import install_plugin
+
+        try:
+            install_plugin()
+            return [BackendInstallMessage("success", "OpenCode plugin installed")]
+        except Exception as e:
+            return [BackendInstallMessage("error", f"Failed to install OpenCode plugin: {e}")]
+
+
+class AntigravityBackend(AgentBackend):
+    agent_type = AgentType.ANTIGRAVITY
+    display_name = "Antigravity"
+    cli_names = ("agy",)
+    config_markers = (Path.home() / ".gemini" / "antigravity-cli",)
+    default_command = "agy --dangerously-skip-permissions"
+    supports_resume = True
+    resume_strategy = "antigravity_conversation"
+    resume_flag = "--conversation"
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        from repowire.installers.antigravity import install_hooks
+
+        try:
+            install_hooks()
+            return [
+                BackendInstallMessage("success", "Antigravity plugin installed"),
+                BackendInstallMessage(
+                    "info",
+                    "Hook firing and MCP registration via `agy` plugins are "
+                    "pending upstream verification.",
+                ),
+            ]
+        except Exception as e:
+            return [BackendInstallMessage("error", f"Failed to install Antigravity plugin: {e}")]
+
+
+class PiBackend(AgentBackend):
+    agent_type = AgentType.PI
+    display_name = "Pi"
+    cli_names = ("pi",)
+    config_markers = (Path.home() / ".pi",)
+    default_command = "pi"
+    supports_resume = True
+    resume_strategy = "pi_session"
+    resume_flag = "--session"
+
+    def install(self, options: BackendInstallOptions | None = None) -> list[BackendInstallMessage]:
+        from repowire.installers.pi import install_extension
+
+        try:
+            install_extension()
+            return [BackendInstallMessage("success", "Pi extension installed")]
+        except Exception as e:
+            return [BackendInstallMessage("error", f"Failed to install Pi extension: {e}")]
+
+
+class McpHttpBackend(AgentBackend):
+    agent_type = AgentType.MCP_HTTP
+    display_name = "HTTP MCP"
+    local_cli = False
+    supports_local_spawn = False
+    default_command = None
+
+
+AGENT_BACKENDS: dict[AgentType, AgentBackend] = {
+    AgentType.CLAUDE_CODE: ClaudeCodeBackend(),
+    AgentType.OPENCODE: OpenCodeBackend(),
+    AgentType.CODEX: CodexBackend(),
+    AgentType.GEMINI: GeminiBackend(),
+    AgentType.ANTIGRAVITY: AntigravityBackend(),
+    AgentType.PI: PiBackend(),
+    AgentType.MCP_HTTP: McpHttpBackend(),
+}
+
+DEFAULT_SPAWN_COMMANDS: dict[AgentType, str] = {
+    backend_type: backend.default_command
+    for backend_type, backend in AGENT_BACKENDS.items()
+    if backend.default_command is not None
+}
+
+
+def agent_backend_for(backend: AgentType) -> AgentBackend:
+    return AGENT_BACKENDS[backend]
+
+
+def resume_capability_for_registration(
+    backend: AgentType,
+    runtime_session_id: str | None,
+) -> dict:
+    return agent_backend_for(backend).resume_capability(runtime_session_id)
+
+
+def can_resume_backend(
+    backend: AgentType,
+    *,
+    runtime_session_id: str | None = None,
+) -> bool:
+    return agent_backend_for(backend).can_resume(runtime_session_id)
+
+
+def build_resume_command(command: str, plan: AgentResumePlan) -> str:
+    return agent_backend_for(plan.backend).build_resume_command(
+        command,
+        plan.runtime_session_id,
+    )

--- a/repowire/agent_types.py
+++ b/repowire/agent_types.py
@@ -1,0 +1,17 @@
+"""Serialized agent runtime identities."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class AgentType(str, Enum):
+    """Type of AI coding agent a peer is running."""
+
+    CLAUDE_CODE = "claude-code"
+    OPENCODE = "opencode"
+    CODEX = "codex"
+    GEMINI = "gemini"
+    ANTIGRAVITY = "antigravity"
+    PI = "pi"
+    MCP_HTTP = "mcp-http"

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -265,77 +265,18 @@ def setup(
     non_interactive: bool,
 ) -> None:
     """One-time setup: install hooks/plugins, MCP server, and daemon service."""
-    import shutil
-
-    from repowire.config.models import DEFAULT_SPAWN_COMMANDS, AgentType, load_config
+    from repowire.config.models import load_config
 
     interactive = _is_interactive(non_interactive)
     config = load_config()
 
     _cleanup_legacy_artifacts()
 
-    agents_setup: list[str] = []
-
-    # Detect and set up Claude Code if claude CLI available
-    if shutil.which("claude"):
-        # Channel transport: flag or interactive prompt
-        use_channels = experimental_channels
-        if not use_channels and interactive:
-            use_channels = click.confirm(
-                "Use experimental channel transport? (claude.ai login + bun)",
-                default=False,
-            )
-        _setup_claude_code(use_channels=use_channels)
-        agents_setup.append("claude-code")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.CLAUDE_CODE,
-            DEFAULT_SPAWN_COMMANDS[AgentType.CLAUDE_CODE],
-        )
-
-    # Detect and set up OpenCode if opencode CLI or config exists
-    if shutil.which("opencode") or (Path.home() / ".config" / "opencode").exists():
-        _setup_opencode()
-        agents_setup.append("opencode")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.OPENCODE,
-            DEFAULT_SPAWN_COMMANDS[AgentType.OPENCODE],
-        )
-
-    # Detect and set up Codex if codex CLI available
-    if shutil.which("codex"):
-        _setup_codex()
-        agents_setup.append("codex")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.CODEX,
-            DEFAULT_SPAWN_COMMANDS[AgentType.CODEX],
-        )
-
-    # Detect and set up Gemini if gemini CLI available
-    if shutil.which("gemini"):
-        _setup_gemini()
-        agents_setup.append("gemini")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.GEMINI,
-            DEFAULT_SPAWN_COMMANDS[AgentType.GEMINI],
-        )
-
-    # Detect and set up Antigravity CLI (`agy`) if installed
-    if shutil.which("agy") or (Path.home() / ".gemini" / "antigravity-cli").exists():
-        _setup_antigravity()
-        agents_setup.append("antigravity")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.ANTIGRAVITY,
-            DEFAULT_SPAWN_COMMANDS[AgentType.ANTIGRAVITY],
-        )
-
-    # Detect and set up Pi if pi CLI or config exists
-    if shutil.which("pi") or (Path.home() / ".pi").exists():
-        _setup_pi()
-        agents_setup.append("pi")
-        config.daemon.spawn.commands.setdefault(
-            AgentType.PI,
-            DEFAULT_SPAWN_COMMANDS[AgentType.PI],
-        )
+    agents_setup = _install_detected_backends(
+        config,
+        interactive=interactive,
+        experimental_channels=experimental_channels,
+    )
 
     if not agents_setup:
         console.print("[yellow]No agent types detected.[/]")
@@ -705,7 +646,6 @@ def update(post_upgrade: bool) -> None:
     import subprocess
 
     from repowire.config.models import load_config
-    from repowire.installers.claude_code import check_channel_installed
 
     if not post_upgrade:
         config = load_config()
@@ -738,21 +678,14 @@ def update(post_upgrade: bool) -> None:
         console.print("[dim]Continuing with upgraded repowire...[/]")
         os.execv(repowire_bin, [repowire_bin, "update", "--post-upgrade"])
 
-    # Reinstall hooks (non-interactive, preserving current channel mode)
-    if shutil.which("claude"):
-        _setup_claude_code(use_channels=check_channel_installed())
-    if shutil.which("opencode") or (Path.home() / ".config" / "opencode").exists():
-        _setup_opencode()
-    if shutil.which("codex"):
-        _setup_codex()
-    if shutil.which("gemini"):
-        _setup_gemini()
-    if shutil.which("agy") or (Path.home() / ".gemini" / "antigravity-cli").exists():
-        _setup_antigravity()
-    if shutil.which("pi") or (Path.home() / ".pi").exists():
-        _setup_pi()
-
+    # Reinstall hooks/plugins non-interactively, preserving current channel mode.
     config = load_config()
+    _install_detected_backends(
+        config,
+        interactive=False,
+        experimental_channels=False,
+        preserve_channel_mode=True,
+    )
     config.save()
     console.print("[green]✓[/] SQLite state enabled")
     console.print("  State migrations run automatically when the daemon restarts.")
@@ -987,112 +920,50 @@ def _cleanup_legacy_artifacts() -> None:
             console.print(f"[green]\u2713[/] Removed legacy {dirname}/ directory")
 
 
-def _setup_claude_code(use_channels: bool = False) -> None:
-    """Setup for Claude Code agent type."""
-    import subprocess
-
-    from repowire.installers.claude_code import install_channel, install_hooks
-
-    if use_channels:
-        channel_ok, channel_msg = install_channel()
-        if channel_ok:
-            install_hooks(channel_mode=True)  # minimal Stop hook for dashboard
-            console.print(f"[green]✓[/] {channel_msg}")
-        else:
-            install_hooks()
-            console.print(f"[yellow]![/] {channel_msg}")
-            console.print("[green]✓[/] Claude Code hooks installed (fallback)")
-    else:
-        install_hooks()
-        console.print("[green]✓[/] Claude Code hooks installed")
-
-    try:
-        # Remove existing repowire MCP server if present
-        subprocess.run(["claude", "mcp", "remove", "repowire"], capture_output=True)
-
-        cmd = ["claude", "mcp", "add", "-s", "user", "repowire", "--", "repowire", "mcp"]
-        subprocess.run(cmd, check=True)
-        console.print("[green]✓[/] MCP server added to Claude")
-    except subprocess.CalledProcessError as e:
-        console.print(f"[red]Failed to configure Claude MCP server: {e}[/]")
-
-
-def _setup_opencode() -> None:
-    """Setup for OpenCode agent type."""
-    from repowire.installers.opencode import install_plugin
-
-    try:
-        install_plugin()
-        console.print("[green]✓[/] OpenCode plugin installed")
-    except Exception as e:
-        console.print(f"[red]Failed to install OpenCode plugin: {e}[/]")
-
-
-def _setup_codex() -> None:
-    """Setup for OpenAI Codex agent type."""
-    from repowire.installers.codex import install_hooks, install_mcp
-
-    try:
-        install_hooks()
-        console.print("[green]✓[/] Codex hooks installed")
-    except Exception as e:
-        console.print(f"[red]Failed to install Codex hooks: {e}[/]")
-
-    try:
-        install_mcp()
-        console.print("[green]✓[/] Codex MCP server configured")
-    except Exception as e:
-        console.print(f"[red]Failed to configure Codex MCP: {e}[/]")
-
-
-def _setup_gemini() -> None:
-    """Setup for Google Gemini CLI agent type."""
-    from repowire.installers.gemini import install_hooks, install_mcp
-
-    try:
-        install_hooks()
-        console.print("[green]✓[/] Gemini hooks installed")
-    except Exception as e:
-        console.print(f"[red]Failed to install Gemini hooks: {e}[/]")
-
-    try:
-        install_mcp()
-        console.print("[green]✓[/] Gemini MCP server configured")
-    except Exception as e:
-        console.print(f"[red]Failed to configure Gemini MCP: {e}[/]")
-
-
-def _setup_antigravity() -> None:
-    """Setup for Antigravity CLI (`agy`) agent type.
-
-    Installs a Repowire plugin into the Antigravity plugins directory. The
-    plugin layout (plugin.json + hooks/hooks.json) is verified via
-    `agy plugin validate`. End-to-end hook firing and MCP registration via
-    the plugin system are pending upstream verification — `repowire status`
-    and `repowire doctor` report that gap explicitly.
-    """
-    from repowire.installers.antigravity import install_hooks
-
-    try:
-        install_hooks()
-        console.print("[green]✓[/] Antigravity plugin installed")
-        console.print(
-            "  [dim]Hook firing and MCP registration via `agy` plugins are"
-            " pending upstream verification.[/]"
+def _print_backend_install_messages(messages) -> None:
+    for message in messages:
+        style = {"success": "green", "warning": "yellow", "error": "red"}.get(
+            message.level,
+            "dim",
         )
-    except Exception as e:
-        console.print(f"[red]Failed to install Antigravity plugin: {e}[/]")
+        marker = {"success": "✓", "warning": "!", "error": "✗"}.get(message.level, " ")
+        console.print(f"[{style}]{marker}[/] {message.text}")
 
 
-def _setup_pi() -> None:
-    """Setup for Pi (pi.dev) agent type."""
-    from repowire.installers.pi import install_extension
+def _install_detected_backends(
+    config,
+    *,
+    interactive: bool,
+    experimental_channels: bool,
+    preserve_channel_mode: bool = False,
+) -> list[str]:
+    from repowire.agent_backends import AGENT_BACKENDS, BackendInstallOptions
+    from repowire.agent_types import AgentType
 
-    try:
-        install_extension()
-        console.print("[green]✓[/] Pi extension installed")
-    except Exception as e:
-        console.print(f"[red]Failed to install Pi extension: {e}[/]")
+    agents_setup: list[str] = []
+    for backend_type, backend in AGENT_BACKENDS.items():
+        if not backend.supports_local_spawn or not backend.detect_installed():
+            continue
+        use_channels = False
+        if backend_type is AgentType.CLAUDE_CODE:
+            if preserve_channel_mode:
+                from repowire.installers.claude_code import check_channel_installed
+
+                use_channels = check_channel_installed()
+            else:
+                use_channels = experimental_channels
+                if not use_channels and interactive:
+                    use_channels = click.confirm(
+                        "Use experimental channel transport? (claude.ai login + bun)",
+                        default=False,
+                    )
+        _print_backend_install_messages(
+            backend.install(BackendInstallOptions(use_channels=use_channels))
+        )
+        agents_setup.append(backend_type.value)
+        if backend.default_command is not None:
+            config.daemon.spawn.commands.setdefault(backend_type, backend.default_command)
+    return agents_setup
 
 
 @main.command()
@@ -2210,7 +2081,7 @@ def agents_create_cmd(
             "  [yellow]note:[/] this path is not under daemon.spawn.allowed_paths; "
             "add an allowed path before daemon-spawned jobs can run it"
         )
-    console.print(f"  job: [cyan]{suggested}[/]")
+    click.echo(f"  job: {suggested}")
 
 
 @main.group()

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import os
 import shlex
-from enum import Enum
 from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from repowire.agent_backends import DEFAULT_SPAWN_COMMANDS as _DEFAULT_SPAWN_COMMANDS
+from repowire.agent_types import AgentType
+
+DEFAULT_SPAWN_COMMANDS = _DEFAULT_SPAWN_COMMANDS
 
 DEFAULT_QUERY_TIMEOUT: float = 300.0
 """Default timeout in seconds for peer-to-peer queries (5 minutes)."""
@@ -20,28 +24,6 @@ DEFAULT_HOST: str = "127.0.0.1"
 DEFAULT_PORT: int = 8377
 DEFAULT_DAEMON_URL: str = f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
 """Default daemon URL used by hooks and MCP server."""
-
-
-class AgentType(str, Enum):
-    """Type of AI coding agent a peer is running."""
-
-    CLAUDE_CODE = "claude-code"
-    OPENCODE = "opencode"
-    CODEX = "codex"
-    GEMINI = "gemini"
-    ANTIGRAVITY = "antigravity"
-    PI = "pi"
-    MCP_HTTP = "mcp-http"
-
-
-DEFAULT_SPAWN_COMMANDS: dict[AgentType, str] = {
-    AgentType.CLAUDE_CODE: "claude --dangerously-skip-permissions",
-    AgentType.OPENCODE: "opencode",
-    AgentType.CODEX: "codex --dangerously-bypass-approvals-and-sandbox",
-    AgentType.GEMINI: "gemini --yolo",
-    AgentType.ANTIGRAVITY: "agy --dangerously-skip-permissions",
-    AgentType.PI: "pi",
-}
 
 
 class SpawnProfile(BaseModel):
@@ -189,14 +171,13 @@ class SpawnSettings(BaseModel):
         """Migrate legacy allowed_commands into runtime command profiles on load."""
         if self.commands or not self.allowed_commands:
             return self
+        from repowire.agent_backends import AGENT_BACKENDS
+
         inferred: dict[AgentType, str] = {}
         command_to_backend = {
-            "claude": AgentType.CLAUDE_CODE,
-            "opencode": AgentType.OPENCODE,
-            "codex": AgentType.CODEX,
-            "gemini": AgentType.GEMINI,
-            "agy": AgentType.ANTIGRAVITY,
-            "pi": AgentType.PI,
+            cli_name: backend_type
+            for backend_type, backend in AGENT_BACKENDS.items()
+            for cli_name in backend.cli_names
         }
         for command in self.allowed_commands:
             head = command.split(None, 1)[0] if command else ""

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -52,10 +52,12 @@ from repowire.daemon.routes import (
 )
 from repowire.daemon.routes import spawn as spawn_routes
 from repowire.daemon.scheduler import Scheduler
+from repowire.daemon.session_control import SessionControlService
 from repowire.daemon.spawn_service import SpawnService
 from repowire.daemon.state import StateDatabase
 from repowire.daemon.state.calendar import SQLiteCalendarStore
 from repowire.daemon.state.events import SQLiteEventStore
+from repowire.daemon.state.operations import SQLiteOperationStore
 from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
 from repowire.daemon.state.schedules import SQLiteScheduleStore
 from repowire.daemon.state.session_bindings import (
@@ -261,6 +263,7 @@ def create_app(
         )
         work_store = SQLiteWorkStore(state_db)
         calendar_store = SQLiteCalendarStore(state_db, work_store)
+        operation_store = SQLiteOperationStore(state_db)
         # Store in app state for route handlers
         app.state.config = cfg
         app.state.transport = transport
@@ -277,6 +280,7 @@ def create_app(
         app.state.schedule_store = schedule_store
         app.state.work_store = work_store
         app.state.calendar_store = calendar_store
+        app.state.operation_store = operation_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         app.state.queued_delivery_store = queued_delivery_store
@@ -309,6 +313,14 @@ def create_app(
             background_tasks=spawn_routes._BACKGROUND_TASKS,
         )
         app.state.spawn_service = spawn_service
+        session_control = SessionControlService(
+            peer_registry=peer_registry,
+            spawn_service=spawn_service,
+            operation_store=operation_store,
+            session_binding_store=session_binding_store,
+            calendar_store=calendar_store,
+        )
+        app.state.session_control = session_control
         job_runner = JobRunner(
             config=cfg,
             work_store=work_store,
@@ -317,6 +329,7 @@ def create_app(
             peer_delivery=peer_delivery,
             spawn_service=spawn_service,
             session_binding_store=session_binding_store,
+            session_control=session_control,
         )
         app.state.job_runner = job_runner
         scheduler = Scheduler(
@@ -587,6 +600,7 @@ def create_test_app(
         )
         work_store = SQLiteWorkStore(state_db)
         calendar_store = SQLiteCalendarStore(state_db, work_store)
+        operation_store = SQLiteOperationStore(state_db)
         app.state.config = cfg
         app.state.transport = transport
         app.state.query_tracker = query_tracker
@@ -601,6 +615,7 @@ def create_test_app(
         app.state.schedule_store = schedule_store
         app.state.work_store = work_store
         app.state.calendar_store = calendar_store
+        app.state.operation_store = operation_store
         app.state.state_db = state_db
         app.state.session_binding_store = session_binding_store
         app.state.queued_delivery_store = queued_delivery_store
@@ -627,6 +642,31 @@ def create_test_app(
             queued_delivery_store=queued_delivery_store,
         )
         app.state.peer_delivery = peer_delivery
+        spawn_service = SpawnService(
+            config=cfg,
+            spawned_pane_ids=spawn_routes._SPAWNED_PANE_IDS,
+            background_tasks=spawn_routes._BACKGROUND_TASKS,
+        )
+        app.state.spawn_service = spawn_service
+        session_control = SessionControlService(
+            peer_registry=registry,
+            spawn_service=spawn_service,
+            operation_store=operation_store,
+            session_binding_store=session_binding_store,
+            calendar_store=calendar_store,
+        )
+        app.state.session_control = session_control
+        job_runner = JobRunner(
+            config=cfg,
+            work_store=work_store,
+            calendar_store=calendar_store,
+            peer_registry=registry,
+            peer_delivery=peer_delivery,
+            spawn_service=spawn_service,
+            session_binding_store=session_binding_store,
+            session_control=session_control,
+        )
+        app.state.job_runner = job_runner
         scheduler = Scheduler(
             store=schedule_store,
             peer_registry=registry,

--- a/repowire/daemon/job_runner.py
+++ b/repowire/daemon/job_runner.py
@@ -10,10 +10,15 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from repowire.agent_backends import AgentResumePlan, can_resume_backend
 from repowire.config.models import AgentType, Config
 from repowire.daemon.peer_delivery import PeerDeliveryService
 from repowire.daemon.peer_registry import PeerRegistry
-from repowire.daemon.spawn_service import RuntimeResumePlan, SpawnService
+from repowire.daemon.session_control import (
+    ExecutorAcquisitionUnavailableError,
+    SessionControlService,
+)
+from repowire.daemon.spawn_service import SpawnService
 from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 from repowire.daemon.work_store import TrackedWork, now_iso
 from repowire.protocol.peers import Peer, PeerStatus
@@ -49,6 +54,7 @@ class JobRunner:
         peer_delivery: PeerDeliveryService,
         spawn_service: SpawnService,
         session_binding_store: SQLiteSessionBindingStore | None = None,
+        session_control: SessionControlService | None = None,
         runner_owner_id: str = "daemon-job-runner",
         lease_seconds: int = 300,
         poll_interval: float | None = None,
@@ -60,6 +66,7 @@ class JobRunner:
         self._delivery = peer_delivery
         self._spawn = spawn_service
         self._session_bindings = session_binding_store
+        self._session_control = session_control
         self._runner_owner_id = runner_owner_id
         self._lease_seconds = lease_seconds
         self._task: asyncio.Task | None = None
@@ -271,6 +278,48 @@ class JobRunner:
     async def _resolve_or_spawn_peer(self, work: TrackedWork, attempt_id: str) -> Peer | None:
         execution = (work.request or {}).get("execution") or {}
         target = execution.get("target") or {}
+        if self._session_control is not None:
+            try:
+                acquisition = await self._session_control.acquire_executor_for_work(
+                    work,
+                    target=target,
+                    runner_owner_id=self._runner_owner_id,
+                )
+            except ExecutorAcquisitionUnavailableError as e:
+                self._store.update_attempt(
+                    work.work_id,
+                    attempt_id=attempt_id,
+                    status=e.status,
+                    phase=e.phase,
+                    assigned_peer_id=e.assigned_peer_id,
+                    operation_id=e.operation_id,
+                    error=e.error,
+                )
+                return None
+            peer = acquisition.peer
+            phase_by_strategy = {
+                "assigned_peer": "resolved_peer",
+                "reused_peer": "reused_peer",
+                "backend_resume": "resumed_peer_registered",
+                "spawned_peer": "spawned_peer_registered",
+            }
+            self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                phase=phase_by_strategy.get(acquisition.strategy, "resolved_peer"),
+                assigned_peer_id=peer.peer_id,
+                assigned_peer_info=self._peer_info(peer, work=work),
+                tmux={"tmux_session": peer.tmux_session, "pane_id": peer.pane_id},
+                resume_plan=self._resume_plan_info(acquisition.resume_plan),
+                operation_id=acquisition.operation_id,
+                acquisition_strategy=acquisition.strategy,
+                acquisition={
+                    "operation_id": acquisition.operation_id,
+                    "strategy": acquisition.strategy,
+                    "runtime_binding": acquisition.runtime_binding,
+                },
+            )
+            return peer
         assigned = target.get("assigned_peer_id") or work.assigned_peer_id
         if assigned:
             resolved = await self._registry.resolve_peer_strict(str(assigned), circle=work.circle)
@@ -472,7 +521,7 @@ class JobRunner:
         *,
         path: str,
         backend: AgentType,
-    ) -> RuntimeResumePlan | None:
+    ) -> AgentResumePlan | None:
         if self._calendar is None or work.source_kind != "calendar" or not work.source_id:
             return None
         entry = self._calendar.get(work.source_id)
@@ -492,10 +541,12 @@ class JobRunner:
         if not isinstance(runtime_session_id, str) or not runtime_session_id:
             return None
         capability = binding.get("resume_capability") or {}
-        if not self._can_resume_backend(backend, capability):
+        if isinstance(capability, dict) and capability.get("supported") is False:
+            return None
+        if not can_resume_backend(backend, runtime_session_id=runtime_session_id):
             return None
         repowire_session_id = binding.get("repowire_session_id")
-        return RuntimeResumePlan(
+        return AgentResumePlan(
             backend=backend,
             runtime_session_id=runtime_session_id,
             repowire_session_id=(
@@ -505,17 +556,7 @@ class JobRunner:
         )
 
     @staticmethod
-    def _can_resume_backend(backend: AgentType, capability: Any) -> bool:
-        if backend != AgentType.CODEX or not isinstance(capability, dict):
-            return False
-        if capability.get("strategy") == "codex_resume":
-            return True
-        if capability.get("supported") is True or capability.get("can_resume") is True:
-            return True
-        return capability.get("status") in {"supported", "available", "resume_available"}
-
-    @staticmethod
-    def _resume_plan_info(plan: RuntimeResumePlan | None) -> dict[str, Any] | None:
+    def _resume_plan_info(plan: AgentResumePlan | None) -> dict[str, Any] | None:
         if plan is None:
             return None
         return {

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 
 from repowire import peer_mcp
+from repowire.agent_backends import agent_backend_for, resume_capability_for_registration
 from repowire.config.models import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
@@ -62,22 +63,16 @@ def _binding_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
     return {key: metadata[key] for key in allowed_keys if metadata.get(key) is not None}
 
 
-def _resume_capability_for_registration(
+def _resume_capability_from_metadata(
     backend: AgentType,
     metadata: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    if backend != AgentType.CODEX:
-        return {}
     if not metadata:
         return {}
     runtime_session_id = metadata.get("hook_session_id")
     if not isinstance(runtime_session_id, str) or not runtime_session_id:
         return {}
-    return {
-        "supported": True,
-        "strategy": "codex_resume",
-        "runtime_session_id_arg": runtime_session_id,
-    }
+    return resume_capability_for_registration(backend, runtime_session_id)
 
 
 class PeerInfo(BaseModel):
@@ -425,7 +420,7 @@ async def _register_peer_impl(
                     "runtime_session_id": request.metadata.get("hook_session_id"),
                     "observed_by_peer_id": peer_id,
                 },
-                resume_capability=_resume_capability_for_registration(
+                resume_capability=_resume_capability_from_metadata(
                     request.backend,
                     request.metadata,
                 ),
@@ -1114,53 +1109,13 @@ async def _resolve_peer_or_404(name: str, circle: str | None) -> Peer:
 
 def _mcp_scope_metadata(peer: Peer) -> McpConfigScopeResponse:
     self_machine = socket.gethostname()
-    backend = peer.backend
-    if backend == AgentType.CLAUDE_CODE:
-        scope = {
-            "backend": backend.value,
-            "owner": "peer/project",
-            "effective_scope": "peer_project",
-            "label": "Claude Code peer/project config",
-            "description": (
-                "Claude Code MCP edits can target user/global config or the peer's "
-                "project/worktree via the selected add scope."
-            ),
-            "supported_scopes": ["user", "project"],
-            "default_scope": "user",
-            "is_global": False,
-        }
-    elif backend == AgentType.CODEX:
-        scope = {
-            "backend": backend.value,
-            "owner": "backend",
-            "effective_scope": "backend_global",
-            "label": "Codex global backend config",
-            "description": (
-                "Codex MCP edits target the user-level Codex config shared by "
-                "Codex sessions on this host."
-            ),
-            "supported_scopes": ["user"],
-            "default_scope": "user",
-            "is_global": True,
-        }
-    elif backend == AgentType.GEMINI:
-        scope = {
-            "backend": backend.value,
-            "owner": "backend",
-            "effective_scope": "backend_global",
-            "label": "Gemini global backend config",
-            "description": (
-                "Gemini MCP edits target the user-level Gemini settings shared by "
-                "Gemini sessions on this host."
-            ),
-            "supported_scopes": ["user"],
-            "default_scope": "user",
-            "is_global": True,
-        }
-    else:
-        raise peer_mcp.NotSupportedError(f"MCP config not supported for backend {backend.value}")
+    backend = agent_backend_for(peer.backend)
+    if backend.mcp_config_scope is None:
+        raise peer_mcp.NotSupportedError(
+            f"MCP config not supported for backend {peer.backend.value}"
+        )
     return McpConfigScopeResponse(
-        **scope,
+        **backend.mcp_config_scope.as_dict(peer.backend),
         peer_id=peer.peer_id,
         peer_name=peer.display_name,
         project_path=peer.path,

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -62,6 +62,24 @@ def _binding_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
     return {key: metadata[key] for key in allowed_keys if metadata.get(key) is not None}
 
 
+def _resume_capability_for_registration(
+    backend: AgentType,
+    metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if backend != AgentType.CODEX:
+        return {}
+    if not metadata:
+        return {}
+    runtime_session_id = metadata.get("hook_session_id")
+    if not isinstance(runtime_session_id, str) or not runtime_session_id:
+        return {}
+    return {
+        "supported": True,
+        "strategy": "codex_resume",
+        "runtime_session_id_arg": runtime_session_id,
+    }
+
+
 class PeerInfo(BaseModel):
     """Peer information for API responses."""
 
@@ -407,6 +425,10 @@ async def _register_peer_impl(
                     "runtime_session_id": request.metadata.get("hook_session_id"),
                     "observed_by_peer_id": peer_id,
                 },
+                resume_capability=_resume_capability_for_registration(
+                    request.backend,
+                    request.metadata,
+                ),
                 status="active",
                 metadata=_binding_metadata(request.metadata),
             )

--- a/repowire/daemon/session_control.py
+++ b/repowire/daemon/session_control.py
@@ -1,0 +1,506 @@
+"""Session-first executor acquisition for jobs and future controls."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException
+
+from repowire.agent_backends import AgentResumePlan, can_resume_backend
+from repowire.config.models import AgentType
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.spawn_service import SpawnService
+from repowire.daemon.state.operations import SQLiteOperationStore
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
+from repowire.daemon.work_store import TrackedWork, now_iso
+from repowire.protocol.peers import Peer, PeerStatus
+
+SPAWN_REGISTRATION_TIMEOUT_SECONDS = 45.0
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class ExecutorAcquisition:
+    peer: Peer
+    strategy: str
+    operation_id: str
+    resume_plan: AgentResumePlan | None = None
+    runtime_binding: dict[str, Any] | None = None
+
+
+class ExecutorAcquisitionUnavailableError(Exception):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        operation_id: str,
+        status: str = "unavailable",
+        phase: str = "resolve_peer",
+        error: dict[str, Any] | None = None,
+        assigned_peer_id: str | None = None,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.operation_id = operation_id
+        self.status = status
+        self.phase = phase
+        self.error = error or {"reason": reason}
+        self.assigned_peer_id = assigned_peer_id
+
+
+class SessionControlService:
+    """Acquire a live executor for durable session/job work."""
+
+    def __init__(
+        self,
+        *,
+        peer_registry: PeerRegistry,
+        spawn_service: SpawnService,
+        operation_store: SQLiteOperationStore,
+        session_binding_store: SQLiteSessionBindingStore | None = None,
+        calendar_store: Any | None = None,
+    ) -> None:
+        self._registry = peer_registry
+        self._spawn = spawn_service
+        self._operations = operation_store
+        self._session_bindings = session_binding_store
+        self._calendar = calendar_store
+
+    async def acquire_executor_for_work(
+        self,
+        work: TrackedWork,
+        *,
+        target: dict[str, Any],
+        runner_owner_id: str,
+    ) -> ExecutorAcquisition:
+        operation = self._operations.create(
+            kind="session.acquire_executor",
+            target={
+                "work_id": work.work_id,
+                "repowire_session_id": work.repowire_session_id,
+                "source_kind": work.source_kind,
+                "source_id": work.source_id,
+                "circle": work.circle,
+                "target": target,
+            },
+            provenance={"requested_by": runner_owner_id},
+        )
+        assigned = target.get("assigned_peer_id") or work.assigned_peer_id
+        if assigned:
+            return await self._acquire_assigned_peer(work, operation.operation_id, str(assigned))
+
+        path = target.get("path")
+        backend_raw = target.get("backend")
+        if not path or not backend_raw:
+            self._operations.fail(
+                operation.operation_id,
+                state="unavailable",
+                error={"reason": "missing_target"},
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "missing_target",
+                operation_id=operation.operation_id,
+            )
+        try:
+            backend = AgentType(str(backend_raw))
+        except ValueError:
+            self._operations.fail(
+                operation.operation_id,
+                state="unavailable",
+                error={"reason": "invalid_backend"},
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "invalid_backend",
+                operation_id=operation.operation_id,
+            )
+
+        circle = work.circle or "default"
+        reusable = await self._find_live_peer(path=str(path), backend=backend, circle=circle)
+        if reusable is not None:
+            runtime_binding = self._record_runtime_binding(
+                work, reusable, source="reused_peer"
+            )
+            self._operations.start_attempt(
+                operation.operation_id,
+                strategy="reused_peer",
+                detail={"peer_id": reusable.peer_id},
+            )
+            self._operations.complete(
+                operation.operation_id,
+                strategy="reused_peer",
+                result={
+                    "peer_id": reusable.peer_id,
+                    "runtime_binding": runtime_binding,
+                },
+            )
+            return ExecutorAcquisition(
+                peer=reusable,
+                strategy="reused_peer",
+                operation_id=operation.operation_id,
+                runtime_binding=runtime_binding,
+            )
+
+        resume_plan = self._resume_plan_for(work, path=str(path), backend=backend)
+        strategy = "backend_resume" if resume_plan is not None else "spawned_peer"
+        self._operations.start_attempt(
+            operation.operation_id,
+            strategy=strategy,
+            detail={
+                "path": str(path),
+                "backend": backend.value,
+                "resume_plan": self.resume_plan_info(resume_plan),
+            },
+        )
+        warmup = (
+            "Repowire spawned this session for a durable job. "
+            "Please register with the mesh; the job request will arrive as an ask."
+        )
+        try:
+            spawn_result = self._spawn.spawn(
+                path=str(path),
+                backend=backend,
+                profile=target.get("profile"),
+                circle=circle,
+                message=warmup,
+                resume_plan=resume_plan,
+            )
+        except HTTPException as e:
+            error = {
+                "reason": "spawn_failed",
+                "status_code": e.status_code,
+                "detail": e.detail,
+            }
+            self._operations.fail(
+                operation.operation_id,
+                strategy=strategy,
+                error=error,
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "spawn_failed",
+                operation_id=operation.operation_id,
+                status="failed",
+                phase="spawn",
+                error=error,
+            ) from e
+        except Exception as e:
+            error = {
+                "reason": "spawn_failed",
+                "message": str(e),
+                "type": type(e).__name__,
+            }
+            self._operations.fail(
+                operation.operation_id,
+                strategy=strategy,
+                error=error,
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "spawn_failed",
+                operation_id=operation.operation_id,
+                status="failed",
+                phase="spawn",
+                error=error,
+            ) from e
+
+        resolved = await self._await_spawned_peer(
+            spawn_result.display_name,
+            circle,
+            path=str(path),
+            backend=backend,
+            pane_id=spawn_result.pane_id,
+        )
+        if resolved is None:
+            error = {"reason": "spawned_peer_not_registered"}
+            self._operations.fail(
+                operation.operation_id,
+                state="unavailable",
+                strategy=strategy,
+                error=error,
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "spawned_peer_not_registered",
+                operation_id=operation.operation_id,
+                error=error,
+            )
+        runtime_binding = self._record_runtime_binding(
+            work,
+            resolved,
+            source="backend_resume" if resume_plan is not None else "spawned_peer",
+        )
+        self._operations.complete(
+            operation.operation_id,
+            strategy=strategy,
+            result={
+                "peer_id": resolved.peer_id,
+                "tmux": {
+                    "tmux_session": resolved.tmux_session,
+                    "pane_id": resolved.pane_id,
+                },
+                "runtime_binding": runtime_binding,
+            },
+        )
+        return ExecutorAcquisition(
+            peer=resolved,
+            strategy=strategy,
+            operation_id=operation.operation_id,
+            resume_plan=resume_plan,
+            runtime_binding=runtime_binding,
+        )
+
+    async def _acquire_assigned_peer(
+        self,
+        work: TrackedWork,
+        operation_id: str,
+        assigned: str,
+    ) -> ExecutorAcquisition:
+        resolved = await self._registry.resolve_peer_strict(assigned, circle=work.circle)
+        if isinstance(resolved, list):
+            reason = "assigned_peer_not_found" if not resolved else "ambiguous_assigned_peer"
+            self._operations.fail(operation_id, state="unavailable", error={"reason": reason})
+            raise ExecutorAcquisitionUnavailableError(reason, operation_id=operation_id)
+        if resolved.status == PeerStatus.OFFLINE:
+            self._operations.fail(
+                operation_id,
+                state="unavailable",
+                error={"reason": "assigned_peer_offline"},
+            )
+            raise ExecutorAcquisitionUnavailableError(
+                "assigned_peer_offline",
+                operation_id=operation_id,
+                assigned_peer_id=resolved.peer_id,
+            )
+        runtime_binding = self._record_runtime_binding(work, resolved, source="assigned_peer")
+        self._operations.start_attempt(
+            operation_id,
+            strategy="assigned_peer",
+            detail={"peer_id": resolved.peer_id},
+        )
+        self._operations.complete(
+            operation_id,
+            strategy="assigned_peer",
+            result={"peer_id": resolved.peer_id, "runtime_binding": runtime_binding},
+        )
+        return ExecutorAcquisition(
+            peer=resolved,
+            strategy="assigned_peer",
+            operation_id=operation_id,
+            runtime_binding=runtime_binding,
+        )
+
+    async def _find_live_peer(
+        self,
+        *,
+        path: str,
+        backend: AgentType,
+        circle: str,
+    ) -> Peer | None:
+        target_path = self._normalize_path(path)
+        candidates: list[Peer] = []
+        for peer in await self._registry.get_all_peers():
+            if peer.status not in (PeerStatus.ONLINE, PeerStatus.BUSY):
+                continue
+            if peer.circle != circle or peer.backend != backend:
+                continue
+            if self._normalize_path(peer.path) != target_path:
+                continue
+            candidates.append(peer)
+        if not candidates:
+            return None
+        return max(
+            candidates,
+            key=lambda peer: (
+                peer.status == PeerStatus.ONLINE,
+                peer.last_seen or datetime.min.replace(tzinfo=timezone.utc),
+            ),
+        )
+
+    async def _await_spawned_peer(
+        self,
+        display_name: str,
+        circle: str | None,
+        *,
+        path: str,
+        backend: AgentType,
+        pane_id: str | None,
+        timeout_seconds: float = SPAWN_REGISTRATION_TIMEOUT_SECONDS,
+    ) -> Peer | None:
+        target_path = self._normalize_path(path)
+        deadline = _utcnow() + timedelta(seconds=timeout_seconds)
+        while True:
+            if pane_id:
+                pane_peer = await self._registry.get_peer_by_pane(pane_id)
+                if pane_peer is not None and pane_peer.status != PeerStatus.OFFLINE:
+                    return pane_peer
+            resolved = await self._registry.resolve_peer_strict(display_name, circle=circle)
+            if not isinstance(resolved, list) and resolved.status != PeerStatus.OFFLINE:
+                return resolved
+            path_peer = await self._find_registered_spawned_peer(
+                path=target_path,
+                backend=backend,
+                circle=circle or "default",
+            )
+            if path_peer is not None:
+                return path_peer
+            if _utcnow() >= deadline:
+                return None
+            await asyncio.sleep(0.25)
+
+    async def _find_registered_spawned_peer(
+        self,
+        *,
+        path: str,
+        backend: AgentType,
+        circle: str,
+    ) -> Peer | None:
+        candidates: list[Peer] = []
+        for peer in await self._registry.get_all_peers():
+            if peer.status not in (PeerStatus.ONLINE, PeerStatus.BUSY):
+                continue
+            if peer.circle != circle or peer.backend != backend:
+                continue
+            if self._normalize_path(peer.path) != path:
+                continue
+            candidates.append(peer)
+        if not candidates:
+            return None
+        return max(
+            candidates,
+            key=lambda peer: (
+                bool(peer.pane_id),
+                peer.last_seen or datetime.min.replace(tzinfo=timezone.utc),
+            ),
+        )
+
+    def _resume_plan_for(
+        self,
+        work: TrackedWork,
+        *,
+        path: str,
+        backend: AgentType,
+    ) -> AgentResumePlan | None:
+        if self._calendar is None or work.source_kind != "calendar" or not work.source_id:
+            return None
+        entry = self._calendar.get(work.source_id)
+        if entry is None:
+            return None
+        binding = (entry.provenance or {}).get("runtime_binding") or {}
+        if not isinstance(binding, dict):
+            return None
+        if binding.get("backend") != backend.value:
+            return None
+        if self._normalize_path(binding.get("path")) != self._normalize_path(path):
+            return None
+        circle = work.circle or "default"
+        if binding.get("circle") and binding.get("circle") != circle:
+            return None
+        runtime_session_id = binding.get("runtime_session_id")
+        if not isinstance(runtime_session_id, str) or not runtime_session_id:
+            return None
+        capability = binding.get("resume_capability") or {}
+        if isinstance(capability, dict) and capability.get("supported") is False:
+            return None
+        if not can_resume_backend(backend, runtime_session_id=runtime_session_id):
+            return None
+        repowire_session_id = binding.get("repowire_session_id")
+        return AgentResumePlan(
+            backend=backend,
+            runtime_session_id=runtime_session_id,
+            repowire_session_id=(
+                repowire_session_id if isinstance(repowire_session_id, str) else None
+            ),
+            capability=capability if isinstance(capability, dict) else {},
+        )
+
+    @staticmethod
+    def resume_plan_info(plan: AgentResumePlan | None) -> dict[str, Any] | None:
+        if plan is None:
+            return None
+        return {
+            "backend": plan.backend.value,
+            "runtime_session_id": plan.runtime_session_id,
+            "repowire_session_id": plan.repowire_session_id,
+            "capability": plan.capability or {},
+        }
+
+    def _record_runtime_binding(
+        self,
+        work: TrackedWork,
+        peer: Peer,
+        *,
+        source: str,
+    ) -> dict[str, Any]:
+        binding = self.runtime_binding_for_peer(peer, work=work)
+        binding["source"] = source
+        binding["recorded_at"] = now_iso()
+        if self._calendar is not None and work.source_kind == "calendar" and work.source_id:
+            self._calendar.update_runtime_binding(work.source_id, binding=binding)
+        return binding
+
+    def runtime_binding_for_peer(
+        self,
+        peer: Peer,
+        *,
+        work: TrackedWork | None = None,
+    ) -> dict[str, Any]:
+        runtime_session_id = self._runtime_session_id_for_peer(peer)
+        session_binding = None
+        if self._session_bindings is not None:
+            if runtime_session_id:
+                session_binding = self._session_bindings.get_by_runtime_session(
+                    runtime_session_id,
+                    backend=peer.backend.value,
+                    project_path=peer.path,
+                )
+            if session_binding is None:
+                bindings = self._session_bindings.list_by_peer(peer.peer_id)
+                if bindings:
+                    session_binding = bindings[0]
+        binding: dict[str, Any] = {
+            "peer_id": peer.peer_id,
+            "display_name": peer.display_name,
+            "backend": peer.backend.value,
+            "path": peer.path,
+            "circle": peer.circle,
+            "status": peer.status.value,
+            "tmux": {"tmux_session": peer.tmux_session, "pane_id": peer.pane_id},
+        }
+        if work is not None:
+            binding["work_id"] = work.work_id
+        if runtime_session_id:
+            binding["runtime_session_id"] = runtime_session_id
+        if peer.metadata:
+            binding["metadata"] = dict(peer.metadata)
+        if session_binding is not None:
+            binding.update(
+                {
+                    "repowire_session_id": session_binding.repowire_session_id,
+                    "runtime_session_id": session_binding.runtime_session_id
+                    or binding.get("runtime_session_id"),
+                    "runtime_source_uri": session_binding.runtime_source_uri,
+                    "source_cursor": session_binding.source_cursor,
+                    "resume_capability": session_binding.resume_capability,
+                    "binding_status": session_binding.status,
+                }
+            )
+        return binding
+
+    @staticmethod
+    def _runtime_session_id_for_peer(peer: Peer) -> str | None:
+        metadata = peer.metadata or {}
+        for key in ("runtime_session_id", "hook_session_id", "session_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    @staticmethod
+    def _normalize_path(path: str | None) -> str:
+        if not path:
+            return ""
+        return str(Path(path).expanduser().resolve())

--- a/repowire/daemon/session_controls.py
+++ b/repowire/daemon/session_controls.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal
 
+from repowire.agent_backends import can_resume_backend
+from repowire.config.models import AgentType
 from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
 from repowire.protocol.peers import Peer, PeerStatus
 
@@ -86,12 +88,23 @@ def resume_capability_for(resolution: SessionResolution) -> tuple[ResumeStatus, 
             f"Session binding status is {binding.status}; resume is not available.",
         )
 
-    capability = binding.resume_capability or {}
-    if _capability_supported(capability):
+    try:
+        backend = AgentType(binding.backend)
+    except ValueError:
+        backend = None
+    can_resume = (
+        can_resume_backend(
+            backend,
+            runtime_session_id=binding.runtime_session_id,
+        )
+        if backend is not None
+        else False
+    )
+    if can_resume:
         return (
             "resume_available",
             "supported",
-            "Backend resume metadata is present; callers can use this capability record.",
+            "Backend resume is available for this runtime session.",
         )
 
     return (
@@ -99,10 +112,3 @@ def resume_capability_for(resolution: SessionResolution) -> tuple[ResumeStatus, 
         "unsupported",
         "No compatible backend resume capability is recorded for this session.",
     )
-
-
-def _capability_supported(capability: dict[str, Any]) -> bool:
-    if capability.get("supported") is True or capability.get("can_resume") is True:
-        return True
-    status = capability.get("status")
-    return isinstance(status, str) and status in {"supported", "available", "resume_available"}

--- a/repowire/daemon/spawn_service.py
+++ b/repowire/daemon/spawn_service.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from fastapi import HTTPException, status
 
+from repowire.agent_backends import AgentResumePlan, build_resume_command
 from repowire.config.models import AgentType, Config, apply_spawn_profile
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import PeerRole
@@ -24,14 +23,6 @@ class SpawnServiceResult:
     tmux_session: str
     pane_id: str | None
     message: str | None
-
-
-@dataclass(frozen=True)
-class RuntimeResumePlan:
-    backend: AgentType
-    runtime_session_id: str
-    repowire_session_id: str | None = None
-    capability: dict[str, Any] | None = None
 
 
 class SpawnService:
@@ -118,7 +109,7 @@ class SpawnService:
         message: str | None = None,
         role: PeerRole = PeerRole.AGENT,
         peer_id: str | None = None,
-        resume_plan: RuntimeResumePlan | None = None,
+        resume_plan: AgentResumePlan | None = None,
     ) -> SpawnServiceResult:
         resolved_path = self.validate_path(path)
         command = self.resolve_command(backend, profile)
@@ -176,20 +167,9 @@ class SpawnService:
         command: str,
         *,
         backend: AgentType,
-        resume_plan: RuntimeResumePlan,
+        resume_plan: AgentResumePlan,
     ) -> str:
         """Return a backend-native resume command for a recorded runtime session."""
-        # The configured Codex command is expected to be the binary plus global
-        # flags only; the backend subcommand and session id are appended here.
-        if backend != AgentType.CODEX:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail={
-                    "error": "backend_resume_unavailable",
-                    "backend": backend.value,
-                    "hint": "Backend-native resume is currently implemented for Codex only.",
-                },
-            )
         if resume_plan.backend != backend:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -199,4 +179,14 @@ class SpawnService:
                     "resume_backend": resume_plan.backend.value,
                 },
             )
-        return f"{command} resume {shlex.quote(resume_plan.runtime_session_id)}"
+        try:
+            return build_resume_command(command, resume_plan)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "error": "backend_resume_unavailable",
+                    "backend": backend.value,
+                    "hint": str(e),
+                },
+            ) from e

--- a/repowire/daemon/state/__init__.py
+++ b/repowire/daemon/state/__init__.py
@@ -2,6 +2,7 @@
 
 from repowire.daemon.state.calendar import CalendarEntry, SQLiteCalendarStore
 from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.operations import Operation, SQLiteOperationStore
 from repowire.daemon.state.queued_deliveries import (
     QueuedDelivery,
     SQLiteQueuedDeliveryStore,
@@ -11,7 +12,9 @@ from repowire.daemon.state.work import SQLiteWorkStore
 
 __all__ = [
     "QueuedDelivery",
+    "Operation",
     "CalendarEntry",
+    "SQLiteOperationStore",
     "SQLiteQueuedDeliveryStore",
     "SQLiteCalendarStore",
     "SQLiteWorkStore",

--- a/repowire/daemon/state/database.py
+++ b/repowire/daemon/state/database.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 
 class StateDatabase:
@@ -348,6 +348,36 @@ class StateDatabase:
             )
             self.conn.execute(
                 """
+                CREATE TABLE IF NOT EXISTS operations (
+                    operation_id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    target_json TEXT NOT NULL DEFAULT '{}',
+                    strategy TEXT,
+                    attempts_json TEXT NOT NULL DEFAULT '[]',
+                    result_json TEXT NOT NULL DEFAULT '{}',
+                    error_json TEXT NOT NULL DEFAULT '{}',
+                    provenance_json TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    completed_at TEXT
+                )
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_operations_kind_updated
+                ON operations(kind, updated_at)
+                """,
+            )
+            self.conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_operations_state_updated
+                ON operations(state, updated_at)
+                """,
+            )
+            self.conn.execute(
+                """
                 INSERT OR IGNORE INTO schema_migrations(version, description)
                 VALUES (?, ?)
                 """,
@@ -401,6 +431,13 @@ class StateDatabase:
                 VALUES (?, ?)
                 """,
                 (8, "recurring durable job calendar entries"),
+            )
+            self.conn.execute(
+                """
+                INSERT OR IGNORE INTO schema_migrations(version, description)
+                VALUES (?, ?)
+                """,
+                (9, "durable operation lifecycle records"),
             )
             self.conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
 

--- a/repowire/daemon/state/operations.py
+++ b/repowire/daemon/state/operations.py
@@ -1,0 +1,261 @@
+"""SQLite-backed durable operation lifecycle records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.work_store import json_dumps, json_loads, now_iso
+
+
+def new_operation_id() -> str:
+    return f"op-{uuid4().hex[:12]}"
+
+
+@dataclass(frozen=True)
+class Operation:
+    operation_id: str
+    kind: str
+    state: str
+    target: dict[str, Any] = field(default_factory=dict)
+    strategy: str | None = None
+    attempts: list[dict[str, Any]] = field(default_factory=list)
+    result: dict[str, Any] = field(default_factory=dict)
+    error: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+    updated_at: str = ""
+    completed_at: str | None = None
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "operation_id": self.operation_id,
+            "kind": self.kind,
+            "state": self.state,
+            "target": self.target,
+            "strategy": self.strategy,
+            "attempts": self.attempts,
+            "result": self.result,
+            "error": self.error,
+            "provenance": self.provenance,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "completed_at": self.completed_at,
+        }
+
+
+class SQLiteOperationStore:
+    """Repository for internal command/operation audit state."""
+
+    def __init__(self, db: StateDatabase) -> None:
+        self._conn = db.conn
+
+    @staticmethod
+    def _row_to_operation(row) -> Operation | None:
+        if row is None:
+            return None
+        return Operation(
+            operation_id=row["operation_id"],
+            kind=row["kind"],
+            state=row["state"],
+            target=json_loads(row["target_json"], {}),
+            strategy=row["strategy"],
+            attempts=json_loads(row["attempts_json"], []),
+            result=json_loads(row["result_json"], {}),
+            error=json_loads(row["error_json"], {}),
+            provenance=json_loads(row["provenance_json"], {}),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            completed_at=row["completed_at"],
+        )
+
+    def create(
+        self,
+        *,
+        kind: str,
+        target: dict[str, Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> Operation:
+        now = now_iso()
+        operation = Operation(
+            operation_id=new_operation_id(),
+            kind=kind,
+            state="queued",
+            target=target or {},
+            provenance=provenance or {},
+            created_at=now,
+            updated_at=now,
+        )
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO operations(
+                    operation_id, kind, state, target_json, strategy,
+                    attempts_json, result_json, error_json, provenance_json,
+                    created_at, updated_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    operation.operation_id,
+                    operation.kind,
+                    operation.state,
+                    json_dumps(operation.target),
+                    operation.strategy,
+                    json_dumps(operation.attempts),
+                    json_dumps(operation.result),
+                    json_dumps(operation.error),
+                    json_dumps(operation.provenance),
+                    operation.created_at,
+                    operation.updated_at,
+                    operation.completed_at,
+                ),
+            )
+        return operation
+
+    def get(self, operation_id: str) -> Operation | None:
+        row = self._conn.execute(
+            "SELECT * FROM operations WHERE operation_id = ?",
+            (operation_id,),
+        ).fetchone()
+        return self._row_to_operation(row)
+
+    def list_all(self, *, kind: str | None = None, state: str | None = None) -> list[Operation]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if kind is not None:
+            clauses.append("kind = ?")
+            params.append(kind)
+        if state is not None:
+            clauses.append("state = ?")
+            params.append(state)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = self._conn.execute(
+            f"SELECT * FROM operations {where} ORDER BY updated_at DESC",
+            params,
+        ).fetchall()
+        return [
+            operation
+            for row in rows
+            if (operation := self._row_to_operation(row)) is not None
+        ]
+
+    def start_attempt(
+        self,
+        operation_id: str,
+        *,
+        strategy: str | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> Operation | None:
+        operation = self.get(operation_id)
+        if operation is None:
+            return None
+        attempts = list(operation.attempts)
+        attempts.append(
+            {
+                "attempt_id": f"op-attempt-{uuid4().hex[:12]}",
+                "state": "running",
+                "strategy": strategy,
+                "detail": detail or {},
+                "started_at": now_iso(),
+                "completed_at": None,
+                "error": {},
+            }
+        )
+        return self._update(
+            operation,
+            state="running",
+            strategy=strategy if strategy is not None else operation.strategy,
+            attempts=attempts,
+        )
+
+    def complete(
+        self,
+        operation_id: str,
+        *,
+        strategy: str | None = None,
+        result: dict[str, Any] | None = None,
+    ) -> Operation | None:
+        operation = self.get(operation_id)
+        if operation is None:
+            return None
+        now = now_iso()
+        attempts = list(operation.attempts)
+        if attempts:
+            attempts[-1] = {
+                **attempts[-1],
+                "state": "completed",
+                "completed_at": now,
+                "result": result or {},
+            }
+        return self._update(
+            operation,
+            state="completed",
+            strategy=strategy if strategy is not None else operation.strategy,
+            attempts=attempts,
+            result=result or {},
+            completed_at=now,
+        )
+
+    def fail(
+        self,
+        operation_id: str,
+        *,
+        state: str = "failed",
+        strategy: str | None = None,
+        error: dict[str, Any] | None = None,
+    ) -> Operation | None:
+        operation = self.get(operation_id)
+        if operation is None:
+            return None
+        now = now_iso()
+        attempts = list(operation.attempts)
+        if attempts:
+            attempts[-1] = {
+                **attempts[-1],
+                "state": state,
+                "completed_at": now,
+                "error": error or {},
+            }
+        return self._update(
+            operation,
+            state=state,
+            strategy=strategy if strategy is not None else operation.strategy,
+            attempts=attempts,
+            error=error or {},
+            completed_at=now,
+        )
+
+    def _update(
+        self,
+        operation: Operation,
+        *,
+        state: str,
+        strategy: str | None,
+        attempts: list[dict[str, Any]] | None = None,
+        result: dict[str, Any] | None = None,
+        error: dict[str, Any] | None = None,
+        completed_at: str | None = None,
+    ) -> Operation | None:
+        now = now_iso()
+        with self._conn:
+            self._conn.execute(
+                """
+                UPDATE operations
+                SET state = ?, strategy = ?, attempts_json = ?, result_json = ?,
+                    error_json = ?, updated_at = ?, completed_at = ?
+                WHERE operation_id = ?
+                """,
+                (
+                    state,
+                    strategy,
+                    json_dumps(attempts if attempts is not None else operation.attempts),
+                    json_dumps(result if result is not None else operation.result),
+                    json_dumps(error if error is not None else operation.error),
+                    now,
+                    completed_at,
+                    operation.operation_id,
+                ),
+            )
+        return self.get(operation.operation_id)

--- a/repowire/daemon/state/work.py
+++ b/repowire/daemon/state/work.py
@@ -415,6 +415,9 @@ class SQLiteWorkStore:
         correlation_id: str | None = None,
         delivery_state: str | None = None,
         resume_plan: dict[str, Any] | None = None,
+        operation_id: str | None = None,
+        acquisition_strategy: str | None = None,
+        acquisition: dict[str, Any] | None = None,
         error: dict[str, Any] | None = None,
     ) -> TrackedWork | None:
         with self._conn:
@@ -446,6 +449,12 @@ class SQLiteWorkStore:
                     attempt["delivery_state"] = delivery_state
                 if resume_plan is not None:
                     attempt["resume_plan"] = resume_plan
+                if operation_id is not None:
+                    attempt["operation_id"] = operation_id
+                if acquisition_strategy is not None:
+                    attempt["acquisition_strategy"] = acquisition_strategy
+                if acquisition is not None:
+                    attempt["acquisition"] = acquisition
                 if error is not None:
                     attempt["error"] = error
                 if status in {"delivered", "failed", "unavailable", "interrupted", "cancelled"}:

--- a/repowire/installers/post_spawn.py
+++ b/repowire/installers/post_spawn.py
@@ -19,7 +19,8 @@ import asyncio
 import logging
 import shutil
 
-from repowire.config.models import AgentType
+from repowire.agent_backends import agent_backend_for
+from repowire.agent_types import AgentType
 
 logger = logging.getLogger(__name__)
 
@@ -50,18 +51,12 @@ async def post_spawn_warmup(
     block the spawn flow or any other peer's work.
     """
     try:
-        if backend == AgentType.CODEX:
-            text = message or DEFAULT_WARMUP_TEMPLATE.format(path=path, circle=circle)
-            await _codex_warmup(pane_id, text)
-        elif message:
-            # claude-code, opencode, gemini: SessionStart fires at boot so the
-            # peer self-registers without a nudge, but the per-spawn seed
-            # message was previously dropped on the floor. Deliver it via
-            # tmux send-keys after a short settle delay so the agent has a
-            # prompt to receive into. This closes the
-            # `pending_first_turn` drop where spawn brief silently vanished.
-            await _claude_code_family_seed(pane_id, message)
-        # else: no seed message — registration via SessionStart is enough.
+        await agent_backend_for(backend).post_spawn_warmup(
+            pane_id,
+            path=path,
+            circle=circle,
+            message=message,
+        )
     except Exception as e:
         logger.warning("post_spawn_warmup failed for %s pane %s: %s", backend, pane_id, e)
 

--- a/repowire/peer_mcp.py
+++ b/repowire/peer_mcp.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from repowire.config.models import AgentType
+from repowire.agent_backends import agent_backend_for
 from repowire.protocol.peers import Peer
 
 # Subprocess timeout for `claude mcp` calls. Surfaces as 504 in the route.
@@ -172,14 +172,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
 
 
 def list_servers(peer: Peer) -> list[McpServerEntry]:
-    backend = peer.backend
-    if backend == AgentType.CLAUDE_CODE:
-        return _claude_list(peer)
-    if backend == AgentType.CODEX:
-        return _codex_list()
-    if backend == AgentType.GEMINI:
-        return _gemini_list()
-    raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+    return agent_backend_for(peer.backend).list_mcp_servers(peer)
 
 
 def add_server(peer: Peer, spec: McpServerSpec) -> None:
@@ -189,15 +182,7 @@ def add_server(peer: Peer, spec: McpServerSpec) -> None:
     if spec.name in existing:
         raise DuplicateServerError(f"server {spec.name!r} already exists")
 
-    backend = peer.backend
-    if backend == AgentType.CLAUDE_CODE:
-        _claude_add(peer, spec)
-    elif backend == AgentType.CODEX:
-        _codex_add(spec)
-    elif backend == AgentType.GEMINI:
-        _gemini_add(spec)
-    else:
-        raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+    agent_backend_for(peer.backend).add_mcp_server(peer, spec)
 
 
 def remove_server(peer: Peer, name: str) -> None:
@@ -206,15 +191,7 @@ def remove_server(peer: Peer, name: str) -> None:
     if name not in existing:
         raise ServerNotFoundError(f"server {name!r} not configured")
 
-    backend = peer.backend
-    if backend == AgentType.CLAUDE_CODE:
-        _claude_remove(peer, name)
-    elif backend == AgentType.CODEX:
-        _codex_remove(name)
-    elif backend == AgentType.GEMINI:
-        _gemini_remove(name)
-    else:
-        raise NotSupportedError(f"MCP config not supported for backend {backend.value}")
+    agent_backend_for(peer.backend).remove_mcp_server(peer, name)
 
 
 # ---------------------------------------------------------------------------

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import libtmux
 from libtmux.exc import LibTmuxException, ObjectDoesNotExist
 
-from repowire.config.models import DEFAULT_SPAWN_COMMANDS, AgentType
+from repowire.agent_backends import DEFAULT_SPAWN_COMMANDS
+from repowire.agent_types import AgentType
 from repowire.spawn_hints import write_hint
 
 # Default commands for each agent type

--- a/tests/test_durable_job_runner.py
+++ b/tests/test_durable_job_runner.py
@@ -10,6 +10,13 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from repowire.agent_backends import (
+    AGENT_BACKENDS,
+    DEFAULT_SPAWN_COMMANDS,
+    AgentResumePlan,
+    can_resume_backend,
+    resume_capability_for_registration,
+)
 from repowire.config.models import AgentType, Config
 from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.deps import cleanup_deps, init_deps
@@ -18,9 +25,11 @@ from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.routes import work as work_routes
-from repowire.daemon.spawn_service import RuntimeResumePlan, SpawnService, SpawnServiceResult
+from repowire.daemon.session_control import SessionControlService
+from repowire.daemon.spawn_service import SpawnService, SpawnServiceResult
 from repowire.daemon.state.calendar import SQLiteCalendarStore
 from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.operations import SQLiteOperationStore
 from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 from repowire.daemon.state.work import SQLiteWorkStore
 from repowire.daemon.websocket_transport import WebSocketTransport
@@ -77,9 +86,17 @@ def _env(tmp_path: Path):
     db = StateDatabase(tmp_path / "state.db")
     store = SQLiteWorkStore(db)
     calendar = SQLiteCalendarStore(db, store)
+    operations = SQLiteOperationStore(db)
     session_bindings = SQLiteSessionBindingStore(db)
     delivery = FakeDelivery()
     spawn = FakeSpawn()
+    session_control = SessionControlService(
+        peer_registry=registry,
+        spawn_service=spawn,  # type: ignore[arg-type]
+        operation_store=operations,
+        session_binding_store=session_bindings,
+        calendar_store=calendar,
+    )
     runner = JobRunner(
         config=cfg,
         work_store=store,
@@ -88,6 +105,7 @@ def _env(tmp_path: Path):
         peer_delivery=delivery,  # type: ignore[arg-type]
         spawn_service=spawn,  # type: ignore[arg-type]
         session_binding_store=session_bindings,
+        session_control=session_control,
         poll_interval=0.01,
     )
     state = SimpleNamespace(
@@ -99,7 +117,9 @@ def _env(tmp_path: Path):
         peer_registry=registry,
         work_store=store,
         calendar_store=calendar,
+        operation_store=operations,
         session_binding_store=session_bindings,
+        session_control=session_control,
         job_runner=runner,
         relay_mode=False,
     )
@@ -909,6 +929,48 @@ async def test_recurring_job_uses_recorded_codex_resume_binding(tmp_path):
     cleanup_deps()
 
 
+def test_recurring_job_does_not_resume_when_binding_marks_resume_unsupported(tmp_path):
+    _cfg, _registry, db, store, calendar, _session_bindings, _delivery, _spawn, runner = _env(
+        tmp_path
+    )
+    worker_path = str(tmp_path / "daily-email-brief")
+    calendar.create(
+        title="daily brief",
+        kind="brief",
+        cron="*/2 * * * *",
+        circle="default",
+        request={"execution": {"target": {"path": worker_path, "backend": "codex"}}},
+        provenance={
+            "runtime_binding": {
+                "peer_id": "repow-default-old",
+                "backend": "codex",
+                "path": worker_path,
+                "circle": "default",
+                "runtime_session_id": "codex-runtime-old",
+                "resume_capability": {
+                    "supported": False,
+                    "strategy": "codex_resume",
+                    "reason": "runtime_marked_unresumable",
+                },
+            }
+        },
+        now=datetime(2026, 5, 25, 8, 0, tzinfo=timezone.utc),
+    )
+    [child] = calendar.materialize_due(now=datetime(2026, 5, 25, 8, 2, tzinfo=timezone.utc))
+
+    assert runner._resume_plan_for(child, path=worker_path, backend=AgentType.CODEX) is None
+    assert (
+        runner._session_control._resume_plan_for(
+            child,
+            path=worker_path,
+            backend=AgentType.CODEX,
+        )
+        is None
+    )
+    db.close()
+    cleanup_deps()
+
+
 def _parse_iso_for_test(value: str) -> datetime:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
@@ -920,7 +982,7 @@ def test_spawn_service_builds_codex_resume_command() -> None:
     command = SpawnService.resume_command(
         "codex --dangerously-bypass-approvals-and-sandbox",
         backend=AgentType.CODEX,
-        resume_plan=RuntimeResumePlan(
+        resume_plan=AgentResumePlan(
             backend=AgentType.CODEX,
             runtime_session_id="codex-runtime-1",
             capability={"supported": True, "strategy": "codex_resume"},
@@ -928,6 +990,88 @@ def test_spawn_service_builds_codex_resume_command() -> None:
     )
 
     assert command == "codex --dangerously-bypass-approvals-and-sandbox resume codex-runtime-1"
+
+
+def test_agent_backend_registry_covers_every_agent_type() -> None:
+    assert set(AGENT_BACKENDS) == set(AgentType)
+    for backend_type, backend in AGENT_BACKENDS.items():
+        assert backend.agent_type == backend_type
+        if backend.supports_local_spawn:
+            assert backend.default_command
+            assert DEFAULT_SPAWN_COMMANDS[backend_type] == backend.default_command
+
+
+def test_agent_backends_make_codex_resume_first_class() -> None:
+    capability = resume_capability_for_registration(AgentType.CODEX, "runtime-123")
+
+    assert capability == {
+        "supported": True,
+        "strategy": "codex_resume",
+        "runtime_session_id_arg": "runtime-123",
+    }
+    assert can_resume_backend(AgentType.CODEX, runtime_session_id="runtime-123")
+    assert not can_resume_backend(AgentType.CODEX, runtime_session_id=None)
+
+
+@pytest.mark.parametrize(
+    ("backend", "base_command", "expected"),
+    [
+        (
+            AgentType.CLAUDE_CODE,
+            "claude --dangerously-skip-permissions",
+            "claude --dangerously-skip-permissions --resume runtime-123",
+        ),
+        (
+            AgentType.GEMINI,
+            "gemini --yolo",
+            "gemini --yolo --resume runtime-123",
+        ),
+        (
+            AgentType.OPENCODE,
+            "opencode",
+            "opencode --session runtime-123",
+        ),
+        (
+            AgentType.ANTIGRAVITY,
+            "agy --dangerously-skip-permissions",
+            "agy --dangerously-skip-permissions --conversation runtime-123",
+        ),
+        (
+            AgentType.PI,
+            "pi",
+            "pi --session runtime-123",
+        ),
+    ],
+)
+def test_agent_backends_build_resume_commands_for_cli_backends(
+    backend: AgentType,
+    base_command: str,
+    expected: str,
+) -> None:
+    capability = resume_capability_for_registration(backend, "runtime-123")
+
+    assert capability["supported"] is True
+    assert can_resume_backend(backend, runtime_session_id="runtime-123")
+    assert (
+        SpawnService.resume_command(
+            base_command,
+            backend=backend,
+            resume_plan=AgentResumePlan(
+                backend=backend,
+                runtime_session_id="runtime-123",
+                capability=capability,
+            ),
+        )
+        == expected
+    )
+
+
+def test_agent_backends_cover_unsupported_mcp_http_explicitly() -> None:
+    capability = resume_capability_for_registration(AgentType.MCP_HTTP, "runtime-123")
+
+    assert capability["supported"] is False
+    assert capability["reason"] == "backend_resume_not_implemented"
+    assert not can_resume_backend(AgentType.MCP_HTTP, runtime_session_id="runtime-123")
 
 
 @pytest.mark.anyio
@@ -961,7 +1105,7 @@ async def test_spawn_service_passes_codex_resume_command_to_spawn(tmp_path, monk
         path=str(tmp_path),
         backend=AgentType.CODEX,
         message="warm",
-        resume_plan=RuntimeResumePlan(
+        resume_plan=AgentResumePlan(
             backend=AgentType.CODEX,
             runtime_session_id="codex-runtime-1",
             capability={"supported": True, "strategy": "codex_resume"},

--- a/tests/test_durable_job_runner.py
+++ b/tests/test_durable_job_runner.py
@@ -931,6 +931,50 @@ def test_spawn_service_builds_codex_resume_command() -> None:
 
 
 @pytest.mark.anyio
+async def test_spawn_service_passes_codex_resume_command_to_spawn(tmp_path, monkeypatch):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CODEX] = "codex --dangerously-bypass-approvals-and-sandbox"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    tasks: set[asyncio.Task] = set()
+    spawn_impl = Mock(
+        return_value=SimpleNamespace(
+            display_name="daily-email-brief",
+            tmux_session="default:daily-email-brief",
+            pane_id="%661",
+            message="warm",
+        )
+    )
+    monkeypatch.setattr("repowire.daemon.spawn_service.record_spawn_ownership", Mock())
+
+    async def warmup(*_args, **_kwargs):
+        return None
+
+    service = SpawnService(
+        config=cfg,
+        spawned_pane_ids=set(),
+        background_tasks=tasks,
+        spawn_impl=spawn_impl,
+        warmup_impl=warmup,
+    )
+
+    service.spawn(
+        path=str(tmp_path),
+        backend=AgentType.CODEX,
+        message="warm",
+        resume_plan=RuntimeResumePlan(
+            backend=AgentType.CODEX,
+            runtime_session_id="codex-runtime-1",
+            capability={"supported": True, "strategy": "codex_resume"},
+        ),
+    )
+
+    spawn_config = spawn_impl.call_args.args[0]
+    assert spawn_config.command == (
+        "codex --dangerously-bypass-approvals-and-sandbox resume codex-runtime-1"
+    )
+
+
+@pytest.mark.anyio
 async def test_spawn_service_records_ownership_and_warmup(tmp_path, monkeypatch):
     cfg = Config()
     cfg.daemon.spawn.commands[AgentType.CLAUDE_CODE] = "claude"

--- a/tests/test_session_controls_routes.py
+++ b/tests/test_session_controls_routes.py
@@ -115,9 +115,9 @@ async def test_session_resume_reports_unsupported_fallback(tmp_path):
     async with app.router.lifespan_context(app):
         binding = app.state.session_binding_store.upsert_observation(
             peer_id=None,
-            backend="gemini",
+            backend="mcp-http",
             project_path="/repo",
-            runtime_session_id="gemini-runtime-1",
+            runtime_session_id="mcp-http-runtime-1",
             status="detached",
         )
         transport = ASGITransport(app=app)

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 from repowire.config.models import Config
 from repowire.daemon.schedule_store import Schedule, ScheduleStore
 from repowire.daemon.state.database import SCHEMA_VERSION, StateDatabase
+from repowire.daemon.state.operations import SQLiteOperationStore
 from repowire.daemon.state.schedules import SQLiteScheduleStore
 from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 
@@ -34,7 +35,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5, 6, 7, 8}
+        assert versions == {1, 2, 3, 4, 5, 6, 7, 8, 9}
         tables = {
             row[0]
             for row in db.conn.execute(
@@ -48,6 +49,7 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
         assert "queued_deliveries" in tables
         assert "tracked_work" in tables
         assert "calendar_entries" in tables
+        assert "operations" in tables
     finally:
         db.close()
 
@@ -60,9 +62,42 @@ def test_state_database_migration_idempotent_and_pragmas(tmp_path: Path) -> None
                 "SELECT version FROM schema_migrations",
             ).fetchall()
         }
-        assert versions == {1, 2, 3, 4, 5, 6, 7, 8}
+        assert versions == {1, 2, 3, 4, 5, 6, 7, 8, 9}
     finally:
         db2.close()
+
+
+def test_sqlite_operation_store_records_lifecycle(tmp_path: Path) -> None:
+    db = StateDatabase(tmp_path / "state.db")
+    try:
+        store = SQLiteOperationStore(db)
+        operation = store.create(
+            kind="session.acquire_executor",
+            target={"work_id": "work-1"},
+            provenance={"requested_by": "runner"},
+        )
+
+        running = store.start_attempt(
+            operation.operation_id,
+            strategy="backend_resume",
+            detail={"backend": "codex"},
+        )
+        assert running is not None
+        assert running.state == "running"
+        assert running.strategy == "backend_resume"
+        assert running.attempts[-1]["state"] == "running"
+
+        completed = store.complete(
+            operation.operation_id,
+            result={"peer_id": "repow-default-worker"},
+        )
+        assert completed is not None
+        assert completed.state == "completed"
+        assert completed.result["peer_id"] == "repow-default-worker"
+        assert completed.attempts[-1]["state"] == "completed"
+        assert completed.completed_at is not None
+    finally:
+        db.close()
 
 
 def test_sqlite_schedule_store_create_list_delete_parity(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_schedules.py
+++ b/tests/test_sqlite_state_schedules.py
@@ -369,6 +369,32 @@ async def test_test_app_wires_session_binding_store_and_observes_hooks(tmp_path:
             assert validated.status_code == 200
             assert validated.json()["peer_id"] == peer_id
 
+            codex_reg = await client.post(
+                "/peers",
+                json={
+                    "name": "daily-email-brief",
+                    "path": "/repo/daily-email-brief",
+                    "circle": "default",
+                    "backend": "codex",
+                    "pane_id": "%78",
+                    "metadata": {
+                        "hook_session_id": "codex-runtime-1",
+                    },
+                },
+            )
+            assert codex_reg.status_code == 200
+            codex_binding = app.state.session_binding_store.get_by_runtime_session(
+                "codex-runtime-1",
+                backend="codex",
+                project_path="/repo/daily-email-brief",
+            )
+            assert codex_binding is not None
+            assert codex_binding.resume_capability == {
+                "supported": True,
+                "strategy": "codex_resume",
+                "runtime_session_id_arg": "codex-runtime-1",
+            }
+
             app.state.peer_registry._peers.clear()
             rehydrated = await client.post(
                 "/peers/identity/validate",


### PR DESCRIPTION
## Summary
- centralizes backend-specific behavior in `AgentBackend` classes while keeping `AgentType` as the serialized identity
- adds durable session acquisition operations for jobs to choose live reuse, backend-native resume, or fresh spawn with auditable operation state
- documents the backend extension path with a new `docs/reference/adding-a-backend.md` page and architecture/session-binding updates
- addresses review feedback by consolidating setup/post-upgrade backend install flow, avoiding the peer route helper shadow, honoring `resume_capability.supported == false`, and applying the valid bot review nits

## Validation
- `uv run ruff check repowire/agent_backends.py repowire/cli.py repowire/daemon/job_runner.py repowire/daemon/routes/peers.py repowire/daemon/session_control.py repowire/daemon/state/operations.py tests/test_durable_job_runner.py`
- `uv run ty check repowire/`
- `uv run pytest tests/test_durable_job_runner.py tests/test_cli_agents.py tests/test_peer_mcp_backends.py tests/test_peer_mcp_routes.py tests/test_sqlite_state_schedules.py -q` (`90 passed`)
- `uv run pytest -q` (`1456 passed`)
- earlier before review feedback: `uv run mkdocs build --strict`, `python3 scripts/pre_pr_hygiene.py`

## Notes
- README and CLI/MCP reference docs were not changed because this slice does not add user-facing commands or flags; it moves backend behavior behind existing surfaces and adds contributor-facing backend docs.
- The plain `agents create` job suggestion output is intentional so CLI tests and scripts see a copyable command without Rich markup.
- No merge or tag performed.