### PR TITLE
Add adhd divergent-ideation orchestrator skill

### DIFF
--- a/docs/concepts/orchestrator.md
+++ b/docs/concepts/orchestrator.md
@@ -27,7 +27,7 @@ Use markdown memory only for rules that should change future behavior. Detailed 
 
 This memory is orchestrator-scoped. Other peers do not inherit it implicitly; give them the relevant context through explicit briefs, project-local agent files, native runtime skills, or future session/timeline lookup when that is the right surface.
 
-Local skills are the on-demand procedure layer. `.agents/skills/` is the canonical cross-runtime location; Claude Code also sees the same skills through `.claude/skills/` symlinks. The top-level orchestrator instructions stay compact and always-loaded. Shipped skills cover general mechanics such as coordination, delegation, durable jobs, agent folders, skill creation, memory, handover, review cycles, worktree isolation, and cleanup; user- or project-specific preferences belong in local workspace files, not the product template.
+Local skills are the on-demand procedure layer. `.agents/skills/` is the canonical cross-runtime location; Claude Code also sees the same skills through `.claude/skills/` symlinks. The top-level orchestrator instructions stay compact and always-loaded. Shipped skills cover general mechanics such as coordination, delegation, durable jobs, agent folders, skill creation, memory, handover, review cycles, worktree isolation, cleanup, and divergent ideation (adhd skill); user- or project-specific preferences belong in local workspace files, not the product template.
 
 ## Co-orchestrators
 

--- a/docs/patterns/divergent-ideation.md
+++ b/docs/patterns/divergent-ideation.md
@@ -1,0 +1,103 @@
+# Divergent ideation
+
+When the obvious answer to a design choice would be competent and forgettable, the orchestrator can run a structured brainstorm across the mesh instead of answering directly. Five frame-shifted peers diverge in parallel, the orchestrator scores and clusters their output, three deepen peers expand the survivors, and the user picks one to keep iterating on. The shipped `adhd` skill (`.agents/skills/adhd/SKILL.md`) teaches the orchestrator the full loop; this page is the operator-facing how-to.
+
+Reach for it on open-ended design choices, fuzzy bugs with no known root cause, public API or naming decisions, and any prompt of the shape *"give me a few ways to…"*. Skip it for syntax lookups, known root causes, or prompts phrased closed ("quick", "standard", "canonical").
+
+## Pre-flight gate
+
+This is expensive — about ten LLM/agent calls per run, five to ten times the cost of a single answer. The skill self-judges before running:
+
+- **Explicit invocation.** If the user typed `/adhd` or asked for "ADHD mode", skip the gate.
+- **Self-judge.** Otherwise, all three must hold: the answer space is open-ended (multiple viable answers), the cost of the obvious answer being wrong is high, and the user's phrasing is open. If any fails, the orchestrator answers directly and optionally offers `/adhd <problem>` as a follow-up.
+
+The gate exists because every run spawns eight peers. Without it, the orchestrator will over-trigger and pollute the mesh.
+
+## The loop
+
+### Phase 1 — Diverge
+
+Pick five cognitive frames from the catalog (hardware engineer, regulator, 10-year-old, biology, speedrunner, and so on — see the full table in `.agents/skills/adhd/SKILL.md`). For each frame, the orchestrator spawns one peer in parallel:
+
+```text
+spawn_peer(
+  path=cwd,
+  backend="claude-code",
+  message="<frame vantage prompt>\n\n<problem>\n\n<context>\n\n"
+          "You are in DIVERGENT mode. Generator only, no critic. "
+          "Generate 6 short distinct ideas under this frame. "
+          "The first three obvious answers everyone would give are banned. "
+          "Output a JSON array only.",
+)
+set_description("adhd-diverge: hardware-engineer")
+```
+
+The peers must run in parallel with no cross-context. If one branch sees another's output, the diverge collapses to a wider single thought. Each frame produces six short ideas; the pool is roughly thirty candidates.
+
+### Phase 2 — Focus
+
+The orchestrator does the critic work itself, in its own turn:
+
+1. **Score** every idea on `novelty / viability / fit` (0–10 each).
+2. **Cluster** the pool into three to six groups by underlying angle, not surface keywords ("remove-the-server plays", "cache-shaped plays"). Surface the *shape* of the design space, not the keywords.
+3. **Flag traps** with a one-line mechanistic reason ("shelve isn't thread-safe under multi-writer load"), not a vague risk label.
+
+Then rank by `0.35*novelty + 0.40*viability + 0.25*fit`, exclude traps, take the top three. For each, spawn one focused peer with a descriptive name:
+
+```text
+spawn_peer(
+  path=cwd,
+  backend="claude-code",
+  message="<top-3 idea>\n\n"
+          "You are in FOCUS mode. Sketch how this would work in 4-8 sentences. "
+          "Name the load-bearing risk. Name the first concrete step. "
+          "Generate 3-5 sub-ideas (variations, hybrids, unlocks). JSON only.",
+)
+set_description("adhd-deepen: cache-shaped")
+```
+
+### Cleanup and resume
+
+Once all eight acks land, `kill_peer` every spawned peer. The process is what's expensive (tmux pane, CLI runtime); the session persists in storage and can be resumed. The orchestrator's final reply names each deepen survivor's session id so the user can resume the one they want to push on:
+
+> Focus branch *cache-shaped* — session `repow-default-7d31052e`. Resume with `repowire peer resume repow-default-7d31052e` to keep iterating on it.
+
+Diverge sessions are also resumable but rarely revisited.
+
+## Frames
+
+Frames are vantage-prompt rewrites that re-pose the whole question — *"re-ask this as a hardware problem"*, *"re-ask this as a regulator"*, *"re-ask this as a 10-year-old"*. They are the load-bearing mechanism: branches diverge because the *vantage* differs, not because the next token differs.
+
+The shipped catalog has fifteen frames tagged `code`, `design`, `general`, and `wild`. For code-shaped problems, the skill picks four code/design frames plus one wild. See `.agents/skills/adhd/SKILL.md` for the full table.
+
+## Output shape
+
+The structure is the point. The orchestrator renders, in order:
+
+1. **Brief** — one or two lines confirming the problem and any reframe.
+2. **Wide set** — full pool grouped by cluster, score chips `[N7 V8 F9]` next to each idea.
+3. **Converge** — two-to-four-idea shortlist with one line each on why. The non-obvious-but-viable pick marked with ★. Traps listed separately with their one-line reasons.
+4. **Focus** — the three deepened branches: sketch, load-bearing risk, first concrete step, child ideas. Resumable session id for each.
+5. **Provocation** — one wildcard question that opens a new direction.
+
+Do not collapse to prose. The clusters and the shortlist are the value.
+
+## Cost
+
+Five diverge + one score-cluster turn + three deepen ≈ ten LLM/agent calls per run. Roughly five to ten times a single-shot answer. Not for inner-loop work; gate every run on the pre-flight check.
+
+## When to skip
+
+- Factual lookups, syntax help, anything one search query away.
+- Bugs with a known root cause.
+- Prompts phrased closed: *"quick"*, *"standard"*, *"canonical"*, *"textbook"*, *"just show me"*, *"one-line"*.
+- Per-keystroke work where the cost of the obvious answer is low.
+
+When in doubt, answer directly and offer `/adhd <problem>` as an explicit follow-up.
+
+## See also
+
+- Skill source: `.agents/skills/adhd/SKILL.md` in the orchestrator workspace.
+- Upstream ADHD project: [github.com/UditAkhourii/adhd](https://github.com/UditAkhourii/adhd) (MIT). The two-phase loop and frame catalog are from there; the mesh-side execution is repowire-specific.
+- [`spawn_peer`](../reference/mcp-tools.md#spawn_peer), [`kill_peer`](../reference/mcp-tools.md#kill_peer), [`ask`](../reference/mcp-tools.md#ask) — the primitives this pattern composes.
+- [Orchestrator coordination](orchestrator-coordination.md) — the broader dispatch loop this pattern slots into.

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -5,6 +5,7 @@ Outcome-oriented recipes for non-trivial mesh workflows.
 - [Multi-repo coordination](multi-repo.md)
 - [Cross-agent review](cross-agent-review.md)
 - [Orchestrator coordination](orchestrator-coordination.md)
+- [Divergent ideation](divergent-ideation.md)
 - [Worktree isolation](worktree-isolation.md)
 - [Mobile mesh management](mobile-mesh.md)
 - [Infrastructure-as-peer](infra-as-peer.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
       - Multi-repo coordination: patterns/multi-repo.md
       - Cross-agent review: patterns/cross-agent-review.md
       - Orchestrator coordination: patterns/orchestrator-coordination.md
+      - Divergent ideation: patterns/divergent-ideation.md
       - Worktree isolation: patterns/worktree-isolation.md
       - Mobile mesh management: patterns/mobile-mesh.md
       - Infrastructure-as-peer: patterns/infra-as-peer.md

--- a/repowire/orchestrator/template/.agents/skills/adhd/SKILL.md
+++ b/repowire/orchestrator/template/.agents/skills/adhd/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: adhd
+description: Parallel divergent ideation via mesh fan-out. Spawns N frame-shifted peers, scores results, deepens top survivors. Use on open-ended design choices, fuzzy bugs, naming, API surfaces, or explicit /adhd invocation. Skip for syntax, lookups, or closed prompts ("quick", "standard", "canonical").
+license: MIT
+metadata:
+  based-on: "ADHD by Udit Akhouri (https://github.com/UditAkhourii/adhd)"
+  author: repowire
+---
+
+# ADHD
+
+Spawn many heads thinking differently, in parallel, then pick. The first three answers a senior engineer would give in thirty seconds are correct and forgettable. The interesting answers live past number three. This skill walks there.
+
+## Pre-flight
+
+Expensive: ≈8 peer spawns plus an orchestrator critic turn (5–10x a single answer). Gate every run.
+
+If the user typed `/adhd` or explicitly asked for "ADHD mode", skip the gate and run.
+
+Otherwise, all three must hold:
+1. **Open-ended.** Multiple viable answers, not one canonical correct one.
+2. **High-stakes.** Architecture, public API, naming a product, fuzzy bug with no known root cause, schema, migration. Not throwaway work.
+3. **Open phrasing.** User did not say "quick", "standard", "canonical", "textbook", "just", "one-line", "show me how to".
+
+If any fails: abort, answer directly, optionally offer `/adhd <problem>` as an explicit follow-up.
+
+## Phase 1 — Diverge
+
+Pick 5 frames from the table below. For code-shaped problems: 4 `code` or `design` tags plus 1 `wild`. Otherwise mix.
+
+For each frame, `spawn_peer` in the user's workspace with a description like `adhd-diverge: <frame>` and a seeded message containing the frame's vantage prompt, the problem, any user-provided context, and this instruction:
+
+> You are in DIVERGENT mode. Generator only, no critic. Generate 6 short distinct ideas under this frame. Each idea is one phrase or one sentence. Do not evaluate, rank, or hedge. The first three obvious answers everyone would give are banned — push past them into the awkward middle. Output a JSON array only, no prose: `[{"text": "...", "rationale": "..."}, ...]`.
+
+Spawn the 5 peers in parallel. **Branches must not see each other.** Do not pass one branch's output as context to another — anchoring eliminates the diverge.
+
+## Phase 2 — Focus
+
+Two passes:
+
+1. **Score + cluster (inline, orchestrator does this).** For each idea, rate `novelty / viability / fit` 0–10. Flag traps with a one-line mechanistic reason (not vague risk). Cluster the pool into 3–6 groups by underlying angle, not surface keywords ("remove-the-server plays", "cache-shaped plays").
+
+2. **Deepen top 3 (spawn one peer per survivor).** Rank by `0.35*novelty + 0.40*viability + 0.25*fit`, exclude traps, take top 3. For each, `spawn_peer` with a descriptive name like `adhd-deepen: <cluster-or-idea-shorthand>` and this seeded message:
+
+> You are in FOCUS mode. Take one promising idea and connect dots. Sketch how it would work in 4–8 sentences. Name the load-bearing risk. Name the first concrete step a coder would take. Then generate 3–5 sub-ideas (variations, hybrids, unlocks). JSON only.
+
+## Cleanup and resume
+
+After all acks land, `kill_peer` all 8 (5 diverge + 3 deepen). The process is what's expensive; the session persists in storage and can be resumed later.
+
+In the final reply, include each deepen survivor's session id or peer name so the user can resume the one they want to push on. Diverge sessions are also resumable but rarely revisited.
+
+Pick descriptive names on spawn — the resume list shows descriptions, not internal ids.
+
+## Output shape
+
+Render in this order. The structure is the point — do not collapse to prose.
+
+1. **Brief.** One or two lines confirming the problem and any reframe.
+2. **Wide set.** Full pool grouped by cluster, each cluster labeled by angle. Each idea is one phrase with score chips `[N7 V8 F9]`.
+3. **Converge.** 2–4 idea shortlist with one line each on why. Mark the non-obvious-but-viable pick with ★. List traps separately, each with the one-line reason it's a trap.
+4. **Focus.** The 3 deepened branches: sketch, load-bearing risk, first concrete step, child ideas. Include the resumable session id for each.
+5. **Provocation.** One wildcard question or idea that opens a new direction.
+
+## Frames
+
+Pick 5 per run. Vary across sessions so the same problem produces different candidates when re-run.
+
+| Frame | Vantage prompt | Tags |
+|---|---|---|
+| **hardware engineer** | You think in latency, memory layout, and physical constraints. Re-ask this as a hardware/firmware problem. What does the bus topology, cache, timing budget tell you? | code, wild |
+| **regulator** | You audit systems for compliance and failure modes. What must be provable, traceable, or refusable here? | design, general |
+| **10-year-old** | You are a curious 10 year old who has never seen software. Describe naive but unencumbered approaches. Ignore convention. | general, wild |
+| **competitor trying to break it** | You are a hostile competitor or attacker. Generate approaches that exploit, fail, or sabotage the obvious solution. Then invert into ideas. | code, design |
+| **biology** | Transplant a mechanism from biology (immune systems, neural plasticity, cell signaling, evolution, gut flora). Force-fit it onto this engineering problem. | code, wild |
+| **logistics** | Steal mechanisms from logistics: queues, batching, just-in-time, hub-and-spoke, returns, last-mile. Apply them literally. | code, design |
+| **game design** | Approach this as a game designer. What are the loops, rewards, friction, save-states, speedrun tricks? Treat the user as a player. | design, general |
+| **markets** | Treat the problem as a market. Buyers, sellers, market-makers. What does an auction, a futures contract, a clearing house look like here? | design, wild |
+| **inversion** | Ask the OPPOSITE question. If goal is X, brainstorm how to guarantee NOT X. Then negate each answer back. | code, design, general |
+| **$0 budget, 1 hour** | No money, no team, one hour. What is the crudest version that still does the load-bearing thing? | code, general |
+| **infinite budget, 10 years** | Infinite compute, infinite engineers, a decade. What is the maximalist version? | design, wild |
+| **remove the load-bearing assumption** | Name the thing everyone treats as fixed (framework, database, request-response model, network). Imagine it is gone. What is possible? | code, design, wild |
+| **speedrunner** | You are a speedrunner. Find glitches, skips, out-of-bounds tricks, frame-perfect shortcuts. What is the abusive-but-legal path? | code, wild |
+| **ant colony** | No central planner. Many dumb agents, local rules, pheromone trails. How does the problem solve itself emergently? | code, wild |
+| **3am on-call** | You are the on-call engineer woken at 3am when this breaks. What design would let you not get paged? | code, design |
+
+## Anti-patterns
+
+- **Convergence disguised as divergence.** Ten variations of one idea is not breadth. If every candidate shares the same underlying assumption, you decorated, not diverged.
+- **Weird-for-weird's-sake with no convergence.** A pile of 30 unsorted absurdities is as useless as one safe answer. Always converge with a real opinion.
+- **Skipping isolation.** If you simulate parallel branches by writing them sequentially in one orchestrator turn, you have not done ADHD. Use real `spawn_peer` fan-out — each spawned peer is a fresh context.
+- **Refusing to commit.** "Here are 20 ideas, you decide" is a cop-out. Generate wide, converge with a position.
+- **Forgetting to kill.** Leaving 8 idle peers after every run pollutes the mesh. Kill on cleanup; sessions remain resumable.
+
+## Calibration
+
+Scale to stakes. Quick "name this function": 3 frames × 4 ideas. "How should we position this product": 5 frames × 8 ideas. Default 5 × 6.
+
+Stop diverging when new candidates start repeating the shape of existing ones. The space is mapped; do not pad to hit a number.

--- a/repowire/orchestrator/workspace.py
+++ b/repowire/orchestrator/workspace.py
@@ -31,6 +31,7 @@ RUNTIME_SYMLINKS = ("CLAUDE.md",)
 SOURCE_FILE = "AGENTS.md"
 
 SKILL_NAMES = (
+    "adhd",
     "cleanup",
     "coordination",
     "create-agent",
@@ -47,6 +48,7 @@ SKILL_NAMES = (
 # offers per-file diff prompts for these.
 REPOWIRE_OWNED_FILES = (
     "AGENTS.md",
+    ".agents/skills/adhd/SKILL.md",
     ".agents/skills/cleanup/SKILL.md",
     ".agents/skills/coordination/SKILL.md",
     ".agents/skills/create-agent/SKILL.md",


### PR DESCRIPTION
## Summary

- New orchestrator skill at `repowire/orchestrator/template/.agents/skills/adhd/SKILL.md` that teaches parallel divergent ideation: spawn 5 frame-shifted peers (diverge), orchestrator-side score+cluster (focus), spawn 3 deepen peers per top survivor, kill all 8 after acks (sessions remain resumable).
- Adapts the ADHD pattern (https://github.com/UditAkhourii/adhd, MIT) to repowire mesh primitives — frames become temp-peer descriptions; the generator/critic split is mechanical (separate peers vs. orchestrator's own turn) rather than promised in-prompt.
- Frontmatter follows the [agentskills.io spec](https://agentskills.io/specification#frontmatter): `name`, `description`, `license`, `metadata.based-on`, `metadata.author`. First shipped skill to use the extended fields; others can be migrated as a follow-up.
- Registers `adhd` in `SKILL_NAMES` and `REPOWIRE_OWNED_FILES` in `repowire/orchestrator/workspace.py` so the skill materialises during `repowire orchestrator init` and the `.claude/skills/adhd` symlink is created.

## Test plan

- [x] `pytest tests/test_orchestrator_workspace.py tests/test_cli_orchestrator.py tests/test_orchestrator_persona.py tests/test_orchestrator_liveness.py` — 68 passed.
- [x] `ruff check repowire/orchestrator/workspace.py` — clean.
- [x] `ty check repowire/orchestrator/workspace.py` — clean.
- [x] Bundled-template verification: `importlib.resources.files('repowire.orchestrator') / 'template' / '.agents/skills/adhd/SKILL.md'` resolves and frontmatter validates.
- [ ] End-to-end smoke on a real orchestrator: invoke `/adhd <open-ended-prompt>`, confirm 5 diverge peers spawn with frame-shifted descriptions, JSON acks land, top-3 deepen peers spawn with descriptive names, all 8 are killed and listed as resumable in the final reply.
- [ ] Negative smoke: closed-phrasing prompt ("what's the standard way to do X") should fall through the pre-flight gate without spawning anything.

## Existing-user UX

`repowire setup` does not touch the orchestrator workspace; the template is materialised by an explicit `repowire orchestrator init`. New users get the skill automatically. Existing users will see `repowire orchestrator diff` flag `.agents/skills/adhd/SKILL.md` as `missing` and can `cp` it in or `orchestrator init --force` (auto-backs up first).

## Notes

- No core code changes. No new MCP tools, no formula, no CLI surface.
- Frame catalog ported from upstream ADHD (MIT). Attribution lives in `metadata.based-on`, not prose.