### PR TITLE
Default one-shot path/backend jobs to fresh per-fire executors

### DIFF
--- a/docs/capabilities/jobs.md
+++ b/docs/capabilities/jobs.md
@@ -13,7 +13,7 @@ Jobs are durable tracked work records. They let agents and humans create work, i
 ## Common flows
 
 - Create a one-off job when an orchestrator needs to track a piece of work across turns.
-- Use recurring jobs for durable worker folders such as `.repowire/agents/daily-brief`; path/backend recurring jobs use per-fire executors by default and can resume backend-native context between fires.
+- Use path/backend jobs for durable worker folders such as `.repowire/agents/daily-brief`; they use per-fire executors by default, and recurring jobs can resume backend-native context between fires.
 - Update progress while work is running, then record a final result.
 - Cancel stale or superseded jobs instead of leaving them ambiguous.
 

--- a/docs/concepts/jobs-and-schedules.md
+++ b/docs/concepts/jobs-and-schedules.md
@@ -21,10 +21,11 @@ Jobs are durable work records. They are useful when an orchestrator or human nee
 repowire jobs create "Daily brief" --path .repowire/agents/daily-brief --backend codex --cron "@daily" --prompt "Prepare the brief."
 ```
 
-For unassigned path/backend jobs, each run uses a short-lived executor process.
-`continuity=resume` keeps the backend-native runtime session id as the
-continuity handle for later compatible runs; `continuity=fresh` starts without
-that resume handle. The process is released after terminal job completion.
+For unassigned path/backend jobs, each run uses a short-lived executor process
+by default. Recurring jobs use `continuity=resume` to keep the backend-native
+runtime session id as the continuity handle for the next fire; one-shot jobs
+default to `continuity=fresh`. The process is released after terminal job
+completion.
 
 ## Related
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -159,12 +159,13 @@ creation. Existing child jobs are not cancelled automatically. Recurring Codex
 jobs preserve the latest observed runtime binding for the same calendar/path
 and can launch `codex resume <runtime-session-id>` when compatible resume
 metadata exists; otherwise the runner falls back to normal spawn behavior.
-Unassigned path/backend jobs default to `process_scope=per_fire` and
-`continuity=resume`: each run uses a short-lived executor process, terminal
-completion releases that process, and later runs can use the backend-native
-runtime session id when available. Pass `--continuity fresh` to start without
-backend-native resume, or `--process-scope persistent` for the older live-peer
-reuse behavior.
+Unassigned path/backend jobs default to `process_scope=per_fire`: each run uses
+a short-lived executor process and terminal completion releases that process.
+One-shot jobs default to `continuity=fresh`; recurring jobs default to
+`continuity=resume` so the next fire uses the backend-native runtime session id
+when available. Pass `--continuity fresh` on recurring jobs to start each fire
+without backend-native resume, or `--process-scope persistent` for the older
+live-peer reuse behavior.
 
 Use `--assigned-peer` for an exact peer id/name. Ambiguous display names are
 rejected before persistence. Without an assigned peer, pass `--path` and

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -16,10 +16,12 @@ The daemon exposes HTTP routes for the dashboard, hooks, CLI helpers, and client
 ## Jobs Execution Policy
 
 `POST /jobs` accepts `process_scope` and `continuity` for path/backend durable
-jobs. Unassigned path/backend jobs default to `process_scope=per_fire` and
-`continuity=resume`, so each run uses a short-lived executor process and later
-runs can resume backend-native runtime context when a compatible runtime session
-id is available. Use `continuity=fresh` to avoid backend resume.
+jobs. Unassigned path/backend jobs default to `process_scope=per_fire`, so each
+run uses a short-lived executor process that is released after terminal
+completion. One-shot jobs default to `continuity=fresh`; recurring jobs default
+to `continuity=resume`, so the next fire resumes backend-native runtime context
+when a runtime session id is available. Use `continuity=fresh` to avoid backend
+resume.
 
 ## Jobs List Views
 

--- a/repowire/daemon/routes/work.py
+++ b/repowire/daemon/routes/work.py
@@ -198,7 +198,7 @@ def _merge_execution_request(
         execution["process_scope"] = process_scope
     continuity = request.continuity or execution.get("continuity")
     if continuity is None and process_scope == "per_fire":
-        continuity = "resume"
+        continuity = "resume" if request.cron else "fresh"
     if continuity is not None:
         if continuity not in {"resume", "fresh"}:
             raise HTTPException(

--- a/repowire/daemon/session_control.py
+++ b/repowire/daemon/session_control.py
@@ -736,7 +736,7 @@ class SessionControlService:
             process_scope = "per_fire"
         continuity = execution.get("continuity")
         if continuity is None and process_scope == "per_fire":
-            continuity = "resume"
+            continuity = "resume" if work.source_kind == "calendar" else "fresh"
         continuity = str(continuity or "resume")
         return {"process_scope": process_scope, "continuity": continuity}
 

--- a/tests/test_durable_job_runner.py
+++ b/tests/test_durable_job_runner.py
@@ -398,7 +398,7 @@ async def test_manual_run_future_due_dispatches_once_and_records_correlation(tmp
 
 
 @pytest.mark.anyio
-async def test_path_backend_job_persistent_policy_reuses_live_matching_peer_without_spawning(
+async def test_path_backend_persistent_policy_reuses_live_matching_peer_without_spawning(
     tmp_path,
 ):
     _cfg, registry, db, store, _calendar, _session_bindings, delivery, spawn, runner = _env(

--- a/tests/test_work_routes.py
+++ b/tests/test_work_routes.py
@@ -186,7 +186,7 @@ async def test_jobs_create_path_backend_defaults_to_per_fire(env) -> None:
     execution = created.json()["status"]["request"]["execution"]
     assert execution["target"] == {"path": "/tmp/brief", "backend": "codex"}
     assert execution["process_scope"] == "per_fire"
-    assert execution["continuity"] == "resume"
+    assert execution["continuity"] == "fresh"
 
 
 async def test_jobs_create_assigned_peer_keeps_persistent_default(env) -> None:


### PR DESCRIPTION
## Summary
- default unassigned one-shot path/backend jobs to per_fire + fresh continuity
- keep recurring calendar jobs on per_fire + resume continuity for native backend context
- update job docs/reference examples to describe fresh vs resume defaults

## Validation
- uv run pytest tests/test_work_routes.py tests/test_durable_job_runner.py
- uv run pytest tests/test_work_routes.py tests/test_durable_job_runner.py -k "per_fire or persistent_policy or path_backend or continuity or release"
- uv run ruff check repowire/daemon/routes/work.py repowire/daemon/session_control.py tests/test_work_routes.py tests/test_durable_job_runner.py
- uv run ty check repowire/daemon/routes/work.py repowire/daemon/session_control.py
- uv run --extra docs zensical build --strict
- python3 scripts/pre_pr_hygiene.py