### PR TITLE
[codex] Fix docs and marketing landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,11 @@ Repowire runs locally by default through a daemon on your machine. The hosted re
 **1. Install Repowire and wire your agents.**
 
 ```bash
-uv tool install repowire    # or: pipx install repowire / pip install repowire
+curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
 repowire setup
 ```
 
-Or use the interactive installer:
-
-```bash
-curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
-```
+The installer detects `uv`, `pipx`, and `pip` in that order.
 
 **2. Open your normal agent CLIs.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,14 +46,10 @@ Use it when one repo needs a concrete answer from another repo, when you want a 
 ## Install
 
 ```bash
-uv tool install repowire
-```
-
-Requires macOS or Linux, Python 3.10+, and tmux. Alternatives: `pipx install repowire`, `pip install repowire`, or the interactive installer:
-
-```bash
 curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
 ```
+
+Requires macOS or Linux, Python 3.10+, and tmux. The installer detects `uv`, `pipx`, and `pip` in that order. Prefer a package manager directly? See [Install](start/install.md).
 
 ## First ask
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -2,32 +2,23 @@
 
 Repowire runs on macOS and Linux with Python 3.10+ and tmux.
 
-## Recommended: uv
-
-```bash
-uv tool install repowire
-```
-
-Fast, isolated, and the way the project itself is developed.
-
-## Alternatives
-
-```bash
-pipx install repowire
-pip install repowire
-```
-
-Use `pipx` if you want isolation without uv. Use plain `pip` only inside a virtualenv you control.
-
-## Interactive installer
-
-Use this when you want setup to choose the available package manager for you.
+## Recommended
 
 ```bash
 curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh
 ```
 
-The installer detects `uv`, `pipx`, and `pip` in that order and falls through to whichever it finds. It then drops you into [setup](setup.md).
+The installer detects `uv`, `pipx`, and `pip` in that order, installs Repowire with the first available package manager, then drops you into [setup](setup.md).
+
+## Alternatives
+
+```bash
+uv tool install repowire
+pipx install repowire
+pip install repowire
+```
+
+Use `uv` for the fastest isolated install. Use `pipx` if you want isolation without uv. Use plain `pip` only inside a virtualenv you control.
 
 ## What gets installed
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,20 +21,18 @@ theme:
   logo: assets/logo-mark.svg
   favicon: assets/favicon.ico
   palette:
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: custom
-      accent: custom
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.instant
     - navigation.tracking
@@ -79,6 +77,9 @@ markdown_extensions:
 
 extra:
   social:
+    - icon: material/transit-connection-variant
+      link: https://repowire.io/dashboard
+      name: Relay dashboard
     - icon: fontawesome/brands/github
       link: https://github.com/prassanna-ravishankar/repowire
     - icon: fontawesome/brands/python

--- a/web/app/marketing.css
+++ b/web/app/marketing.css
@@ -288,7 +288,7 @@
 
 /* =========================  DASHBOARD SHOT  ========================= */
 .rw-marketing .dashboard-shot {
-  max-width: var(--container-xl); margin: 0 auto; padding: 8px 24px 104px;
+  max-width: var(--container-xl); margin: 0 auto; padding: 0 24px 104px;
 }
 .rw-marketing .shot-frame {
   border: 1px solid var(--rds-border);
@@ -347,6 +347,7 @@
 .rw-marketing .feature-hero-visual .mesh-log-row:last-child { border-bottom: 0; }
 
 .rw-marketing .feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.rw-marketing .feature-grid-six .feature { min-height: 190px; }
 .rw-marketing .feature {
   background: var(--surface); border: 1px solid var(--rds-border);
   border-radius: var(--rds-radius-lg); padding: 28px;
@@ -364,26 +365,20 @@
 .rw-marketing .feature p { margin: 0; font-size: 14.5px; color: var(--fg-muted); line-height: 1.55; }
 
 /* =========================  HOW IT WORKS  ========================= */
-.rw-marketing .how { max-width: var(--container-xl); margin: 0 auto; padding: 0 24px 96px; }
-.rw-marketing .how-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-.rw-marketing .how-step {
-  background: var(--surface); border: 1px solid var(--rds-border);
-  border-radius: var(--rds-radius-lg); padding: 28px;
+.rw-marketing .how { max-width: var(--container-xl); margin: 0 auto; padding: 0 24px 104px; }
+.rw-marketing .arch-frame {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+  background: var(--surface);
+  border: 1px solid var(--rds-border);
+  border-radius: var(--rds-radius-xl);
+  box-shadow: var(--shadow-md);
 }
-.rw-marketing .how-num { font: 500 12px var(--rds-font-mono); color: var(--accent); letter-spacing: 0.08em; margin-bottom: 16px; }
-.rw-marketing .how-step h3 { margin: 0 0 8px; font-size: 18px; font-weight: 600; }
-.rw-marketing .how-step .optional { font-size: 13px; color: var(--fg-subtle); font-weight: 400; margin-left: 4px; }
-.rw-marketing .how-step p { margin: 0 0 16px; color: var(--fg-muted); font-size: 14.5px; line-height: 1.55; }
-.rw-marketing .how-code {
-  background: var(--surface-sunken); border: 1px solid var(--rds-border);
-  border-radius: 8px; padding: 10px 14px;
-  font-family: var(--rds-font-mono); font-size: 13px; color: var(--fg);
-}
-.rw-marketing .how-code .prompt { color: var(--fg-subtle); margin-right: 6px; }
-.rw-marketing .how-code .hl { color: var(--accent); }
+.rw-marketing .arch-img { display: block; width: 100%; height: auto; border-radius: var(--rds-radius); }
 
 /* =========================  CODE SHOWCASE  ========================= */
-.rw-marketing .showcase { max-width: var(--container-xl); margin: 0 auto; padding: 0 24px 120px; }
+.rw-marketing .showcase { max-width: var(--container-xl); margin: 0 auto; padding: 0 24px 96px; }
 .rw-marketing .showcase-grid {
   display: grid; grid-template-columns: minmax(0, 1fr);
   max-width: 860px; margin: 0 auto;
@@ -406,7 +401,7 @@
   font-family: var(--rds-font-mono); font-size: 13px; line-height: 1.7;
   color: #efece4; background: transparent; overflow-x: auto;
 }
-.rw-marketing .term-body div { white-space: pre; }
+.rw-marketing .term-body div { white-space: nowrap; }
 .rw-marketing .term-blank { height: 1.7em; }
 .rw-marketing .t-d { color: #807c74; }
 .rw-marketing .t-c { color: var(--cobalt-300); font-weight: 500; }
@@ -466,7 +461,10 @@
   .rw-marketing .mobile-menu { display: flex; }
   .rw-marketing .cta { display: none; }
   .rw-marketing .hero { padding: 48px 20px 40px; }
-  .rw-marketing .features, .rw-marketing .how { padding: 56px 20px; }
+  .rw-marketing .features { padding: 56px 20px; }
+  .rw-marketing .how { padding: 0 20px 64px; }
+  .rw-marketing .showcase { padding: 0 20px 64px; }
+  .rw-marketing .arch-frame { padding: 12px; }
   .rw-marketing .feature-hero { padding: 24px; }
   .rw-marketing .feature-grid { grid-template-columns: 1fr; }
   .rw-marketing .features { padding-bottom: 56px; }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -14,10 +14,10 @@ export default function Home() {
       <TopBar />
       <main>
         <Hero />
-        <DashboardShot />
+        <CodeShowcase />
         <Features />
         <HowItWorks />
-        <CodeShowcase />
+        <DashboardShot />
         <CTA />
       </main>
       <Footer />

--- a/web/components/marketing/CTA.tsx
+++ b/web/components/marketing/CTA.tsx
@@ -1,6 +1,6 @@
 import CopyButton from "./CopyButton";
 
-const INSTALL_CMD = "uv tool install repowire && repowire up";
+const INSTALL_CMD = "curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh";
 
 export default function CTA() {
   return (

--- a/web/components/marketing/CodeShowcase.tsx
+++ b/web/components/marketing/CodeShowcase.tsx
@@ -1,12 +1,33 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const terminalLines = [
+  { text: "$ claude", className: "t-c" },
+  { text: "You: I just built the pricing card. Ask Codex to review the component.", className: "t-row" },
+  {
+    text: 'Claude: mcp__repowire.ask({ peer_name: "ui-codex", query: "Review web/components/PricingCard.tsx. Focus on accessibility, responsive layout, and state handling." })',
+    className: "t-row",
+  },
+  { text: "Repowire: ask-c91f2b sent to @ui-codex", className: "t-g" },
+  { text: "[ask #ask-c91f2b from @site-claude] Review web/components/PricingCard.tsx...", className: "t-m" },
+  { text: "Codex: reading component, styles, and tests", className: "t-row" },
+  {
+    text: '[ack #ask-c91f2b from @ui-codex] Two fixes: button label wraps at 360px, and loading state needs aria-busy. The props contract looks clean.',
+    className: "t-g",
+  },
+  { text: "Claude: applying the responsive label and aria-busy fixes now.", className: "t-row" },
+];
+
 export default function CodeShowcase() {
   return (
     <section className="showcase">
       <div className="section-head">
-        <span className="eyebrow">The CLI</span>
+        <span className="eyebrow">The terminal</span>
         <h2>The terminal is the source of truth.</h2>
         <p className="section-sub">
-          Everything the dashboard shows starts here. List peers, ask a question, wait on the ack —
-          the mesh is a few commands away.
+          Claude can ask a Codex peer for a real review, Codex closes the thread with an ack,
+          and the whole exchange stays visible to the mesh.
         </p>
       </div>
       <div className="showcase-grid">
@@ -17,32 +38,22 @@ export default function CodeShowcase() {
               <span />
               <span />
             </div>
-            <div className="term-title">repowire — tmux:main</div>
+            <div className="term-title">claude ↔ repowire ↔ codex</div>
           </div>
-          <pre className="term-body">
-            <div>
-              <span className="t-d">$ </span>
-              <span className="t-c">repowire peer ls</span>
-            </div>
-            <div className="t-m">NAME            AGENT          STATUS    LAST SEEN</div>
-            <div className="t-row">backend         claude-code    online    4s</div>
-            <div className="t-row">frontend        codex          online    22s</div>
-            <div className="t-row t-stale">db-migrations   gemini-cli     stale     4m</div>
-            <div className="t-row t-off">e2e-runner      opencode       offline   2h</div>
-            <div className="term-blank">&nbsp;</div>
-            <div>
-              <span className="t-d">$ </span>
-              <span className="t-c">repowire</span>
-              <span> ask </span>
-              <span className="t-arg">@frontend</span>
-              <span> &quot;auth response shape?&quot;</span>
-            </div>
-            <div className="t-g">→ sent · waiting on ack</div>
-            <div>
-              <span className="t-g">← @frontend ack</span>
-              <span> {`{ user, session }`} — no wrapper.</span>
-            </div>
-          </pre>
+          <div className="term-body" role="img" aria-label="Animated terminal showing Claude asking Codex to review a React component and receiving an ack">
+            {terminalLines.map((line, index) => (
+              <motion.div
+                key={line.text}
+                className={line.className}
+                initial={{ opacity: 0, y: 6 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.8 }}
+                transition={{ delay: index * 0.12, duration: 0.28, ease: "easeOut" }}
+              >
+                {line.text}
+              </motion.div>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/web/components/marketing/DashboardShot.tsx
+++ b/web/components/marketing/DashboardShot.tsx
@@ -18,7 +18,7 @@ export default function DashboardShot() {
             <span />
             <span />
           </div>
-          <span className="shot-url">relay.repowire.io/dashboard</span>
+          <span className="shot-url">repowire.io/dashboard</span>
         </div>
         <Image
           src="/screenshots/dashboard.png"

--- a/web/components/marketing/Features.tsx
+++ b/web/components/marketing/Features.tsx
@@ -1,30 +1,35 @@
-type IconName = "ask" | "local" | "agents" | "tmux" | "human" | "audit";
+type IconName = "ask" | "review" | "handoff" | "context" | "checkpoint" | "compare" | "escalate";
 
 const secondary: { icon: IconName; title: string; body: string }[] = [
   {
-    icon: "local",
-    title: "Local by default",
-    body: "A single daemon on port 8377 is the hub. The hosted relay is opt-in, and it's only there for browser and phone access.",
+    icon: "review",
+    title: "Cross-agent review",
+    body: "Ask the peer nearest the code to review a component, migration, prompt, or PR branch before you merge it.",
   },
   {
-    icon: "agents",
-    title: "Agent-agnostic",
-    body: "Claude Code, Codex, Gemini CLI, OpenCode, Pi — anything that can hit an HTTP endpoint can register as a peer.",
+    icon: "handoff",
+    title: "Repo-to-repo handoff",
+    body: "Ask the API repo what changed, then let the frontend peer adapt against the answer it acks back.",
   },
   {
-    icon: "tmux",
-    title: "Tmux-native",
-    body: "Sessions are named, persistent, and steerable. Repowire never owns the agent's process; it just helps them talk.",
+    icon: "context",
+    title: "Live context lookup",
+    body: "Ask another session for the exact file, endpoint, schema, or command output from its own checkout.",
   },
   {
-    icon: "human",
-    title: "Human in the loop",
-    body: "Watch the mesh from the dashboard. Pause an agent, redirect a question, or step in mid-conversation.",
+    icon: "checkpoint",
+    title: "Checkpoint with closure",
+    body: "Use ask when a status update must close cleanly. Open threads keep resurfacing until the peer acks.",
   },
   {
-    icon: "audit",
-    title: "Audit trail by default",
-    body: "Every ask / ack / notify is logged with provenance. Replay a run, export a transcript, or git-commit it.",
+    icon: "compare",
+    title: "Divergent second opinion",
+    body: "Ask a different backend to critique an approach while the first agent keeps the original thread moving.",
+  },
+  {
+    icon: "escalate",
+    title: "Human escalation",
+    body: "Route the same ask shape through Telegram, Slack, or the dashboard when a person needs to decide.",
   },
 ];
 
@@ -44,7 +49,7 @@ export default function Features() {
           <h3>Ask across repos</h3>
           <p>
             Send a question to the peer that&apos;s already working in another checkout. It answers
-            from its live tree and sends back an explicit ack — never a vibes-based reply, never a
+            from its live tree and sends back an explicit ack, never a vibes-based reply or a
             copy-paste handoff.
           </p>
         </div>
@@ -57,7 +62,7 @@ export default function Features() {
         </div>
       </div>
 
-      <div className="feature-grid">
+      <div className="feature-grid feature-grid-six">
         {secondary.map((it) => (
           <div className="feature" key={it.title}>
             <div className="feature-icon">
@@ -122,46 +127,53 @@ function FeatureIcon({ name }: { name: IconName }) {
           <path d="M16 18l6-6-6-6M8 6l-6 6 6 6" />
         </svg>
       );
-    case "local":
+    case "review":
       return (
         <svg {...props}>
-          <rect x="3" y="4" width="18" height="12" rx="2" />
-          <line x1="8" y1="20" x2="16" y2="20" />
-          <line x1="12" y1="16" x2="12" y2="20" />
+          <path d="M4 5h16v12H7l-3 3z" />
+          <path d="M8 10h8" />
+          <path d="M8 13h5" />
         </svg>
       );
-    case "agents":
+    case "handoff":
       return (
         <svg {...props}>
-          <circle cx="9" cy="9" r="2.5" />
-          <circle cx="17" cy="13" r="2" />
-          <circle cx="7" cy="17" r="2" />
-          <line x1="10.5" y1="10.5" x2="15.5" y2="12.5" />
-          <line x1="8" y1="15" x2="10" y2="11" />
+          <path d="M7 7h10" />
+          <path d="M14 4l3 3-3 3" />
+          <path d="M17 17H7" />
+          <path d="M10 14l-3 3 3 3" />
         </svg>
       );
-    case "tmux":
+    case "context":
       return (
         <svg {...props}>
-          <rect x="3" y="3" width="18" height="18" rx="2" />
-          <line x1="12" y1="3" x2="12" y2="21" />
-          <line x1="3" y1="12" x2="12" y2="12" />
+          <circle cx="11" cy="11" r="7" />
+          <path d="M16.5 16.5 21 21" />
+          <path d="M8 11h6" />
+          <path d="M11 8v6" />
         </svg>
       );
-    case "human":
+    case "checkpoint":
+      return (
+        <svg {...props}>
+          <path d="M20 6 9 17l-5-5" />
+          <path d="M4 20h16" />
+        </svg>
+      );
+    case "compare":
+      return (
+        <svg {...props}>
+          <path d="M5 7h14" />
+          <path d="M7 7l3 12" />
+          <path d="M17 7l-3 12" />
+          <path d="M3 19h18" />
+        </svg>
+      );
+    case "escalate":
       return (
         <svg {...props}>
           <circle cx="12" cy="8" r="4" />
           <path d="M4 21a8 8 0 0 1 16 0" />
-        </svg>
-      );
-    case "audit":
-      return (
-        <svg {...props}>
-          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-          <polyline points="14 2 14 8 20 8" />
-          <line x1="8" y1="13" x2="16" y2="13" />
-          <line x1="8" y1="17" x2="13" y2="17" />
         </svg>
       );
   }

--- a/web/components/marketing/Footer.tsx
+++ b/web/components/marketing/Footer.tsx
@@ -22,6 +22,7 @@ export default function Footer() {
             <div className="footer-col-title">Developers</div>
             <a href="https://docs.repowire.io">Docs</a>
             <a href="https://docs.repowire.io/start/install/">Install</a>
+            <a href="https://repowire.io/dashboard">Relay dashboard</a>
             <a href="https://github.com/prassanna-ravishankar/repowire">GitHub</a>
             <a href="https://docs.repowire.io/reference/mcp-tools/">API reference</a>
           </div>

--- a/web/components/marketing/Hero.tsx
+++ b/web/components/marketing/Hero.tsx
@@ -2,7 +2,7 @@ import { ArrowRight } from "lucide-react";
 import CopyButton from "./CopyButton";
 import MeshDemo from "./MeshDemo";
 
-const INSTALL_CMD = "uv tool install repowire && repowire up";
+const INSTALL_CMD = "curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh";
 
 export default function Hero() {
   return (
@@ -21,7 +21,7 @@ export default function Hero() {
             Install Repowire
             <ArrowRight width={16} height={16} strokeWidth={1.75} />
           </a>
-          <a className="btn secondary" href="https://docs.repowire.io">Read the docs</a>
+          <a className="btn secondary" href="https://repowire.io/dashboard">Open relay</a>
         </div>
         <div className="install-strip">
           <div className="install-cmd">

--- a/web/components/marketing/HowItWorks.tsx
+++ b/web/components/marketing/HowItWorks.tsx
@@ -1,37 +1,25 @@
+import Image from "next/image";
+
 export default function HowItWorks() {
   return (
     <section className="how" id="how">
       <div className="section-head">
         <span className="eyebrow">How it works</span>
-        <h2>Three pieces. Nothing else to install.</h2>
+        <h2>One daemon, many peers, optional relay.</h2>
+        <p className="section-sub">
+          The same architecture from the README: agents and human surfaces connect to the local
+          daemon, and the hosted relay only appears when you opt into remote access.
+        </p>
       </div>
-      <div className="how-grid">
-        <div className="how-step">
-          <div className="how-num">01</div>
-          <h3>The daemon</h3>
-          <p>A small process on port 8377. It registers peers, routes messages, and writes the audit log to disk.</p>
-          <div className="how-code">
-            <span className="prompt">$</span> repowire up
-          </div>
-        </div>
-        <div className="how-step">
-          <div className="how-num">02</div>
-          <h3>The peers</h3>
-          <p>Each agent session registers a name and a tmux pane. They poll for messages and post replies.</p>
-          <div className="how-code">
-            <span className="prompt">$</span> repowire peer add <span className="hl">backend</span>
-          </div>
-        </div>
-        <div className="how-step">
-          <div className="how-num">03</div>
-          <h3>
-            The relay <span className="optional">(optional)</span>
-          </h3>
-          <p>A hosted endpoint that lets you reach the same mesh from a browser or phone. End-to-end encrypted.</p>
-          <div className="how-code">
-            <span className="prompt">$</span> repowire relay link
-          </div>
-        </div>
+      <div className="arch-frame">
+        <Image
+          src="/brand/repowire-arch.webp"
+          width={1400}
+          height={886}
+          alt="Repowire architecture diagram showing agent transports, the local daemon, and optional relay surfaces"
+          sizes="(max-width: 980px) 100vw, 1100px"
+          className="arch-img"
+        />
       </div>
     </section>
   );

--- a/web/components/marketing/TopBar.tsx
+++ b/web/components/marketing/TopBar.tsx
@@ -11,6 +11,7 @@ const GITHUB_URL = "https://github.com/prassanna-ravishankar/repowire";
 const NAV_LINKS = [
   { label: "Product", href: "#features" },
   { label: "Docs", href: "https://docs.repowire.io" },
+  { label: "Relay", href: "https://repowire.io/dashboard" },
   { label: "Changelog", href: "https://github.com/prassanna-ravishankar/repowire/releases" },
 ];
 


### PR DESCRIPTION
## Summary

- Adds explicit relay entry points on the marketing page and docs chrome.
- Makes the curl installer the primary install command in README and docs.
- Reorders the landing page so the terminal-first Claude-to-Codex ask/ack example appears immediately after the hero.
- Replaces generic feature cards with six ask-derived workflow patterns and swaps the How it works section to the README architecture image.
- Moves the dashboard section later in the page and keeps the dashboard URL on `repowire.io/dashboard`.

## Why

The post-merge public surface had a few product-story regressions: no obvious relay link, docs theme switching depended on media-only palette entries, install commands led with package-manager-specific commands, and the landing page emphasized dashboard/features before the terminal ask/ack workflow.

## Validation

- `uv run --no-project --with zensical zensical build --strict`
- `npm run lint`
- `npm run build`
- Browser smoke checked desktop and mobile at `http://localhost:3008`
- Ran `python3 scripts/pre_pr_hygiene.py --restore-beads-ledgers`; remaining advisory items are reviewed as not requiring extra capability/operations docs because this changes public landing/docs positioning, not product behavior.

## Notes

`bd dolt push` failed because this worktree's Beads Dolt database has no `origin` remote configured. Git branch push succeeded.