### PR TITLE
fix(web): landing dashboard links point to relay.repowire.io

### DIFF
--- a/web/components/marketing/DashboardShot.tsx
+++ b/web/components/marketing/DashboardShot.tsx
@@ -18,7 +18,7 @@ export default function DashboardShot() {
             <span />
             <span />
           </div>
-          <span className="shot-url">repowire.io/dashboard</span>
+          <span className="shot-url">relay.repowire.io/dashboard</span>
         </div>
         <Image
           src="/screenshots/dashboard.png"

--- a/web/components/marketing/Footer.tsx
+++ b/web/components/marketing/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { RELAY_DASHBOARD_URL } from "./links";
 
 export default function Footer() {
   return (
@@ -22,7 +23,7 @@ export default function Footer() {
             <div className="footer-col-title">Developers</div>
             <a href="https://docs.repowire.io">Docs</a>
             <a href="https://docs.repowire.io/start/install/">Install</a>
-            <a href="https://repowire.io/dashboard">Relay dashboard</a>
+            <a href={RELAY_DASHBOARD_URL}>Relay dashboard</a>
             <a href="https://github.com/prassanna-ravishankar/repowire">GitHub</a>
             <a href="https://docs.repowire.io/reference/mcp-tools/">API reference</a>
           </div>

--- a/web/components/marketing/Hero.tsx
+++ b/web/components/marketing/Hero.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from "lucide-react";
 import CopyButton from "./CopyButton";
 import MeshDemo from "./MeshDemo";
+import { RELAY_DASHBOARD_URL } from "./links";
 
 const INSTALL_CMD = "curl -sSf https://raw.githubusercontent.com/prassanna-ravishankar/repowire/main/install.sh | sh";
 
@@ -21,7 +22,7 @@ export default function Hero() {
             Install Repowire
             <ArrowRight width={16} height={16} strokeWidth={1.75} />
           </a>
-          <a className="btn secondary" href="https://repowire.io/dashboard">Open relay</a>
+          <a className="btn secondary" href={RELAY_DASHBOARD_URL}>Open relay</a>
         </div>
         <div className="install-strip">
           <div className="install-cmd">

--- a/web/components/marketing/TopBar.tsx
+++ b/web/components/marketing/TopBar.tsx
@@ -5,13 +5,14 @@ import Image from "next/image";
 import { Menu, X } from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 import GitHubMark from "./GitHubMark";
+import { RELAY_DASHBOARD_URL } from "./links";
 
 const GITHUB_URL = "https://github.com/prassanna-ravishankar/repowire";
 
 const NAV_LINKS = [
   { label: "Product", href: "#features" },
   { label: "Docs", href: "https://docs.repowire.io" },
-  { label: "Relay", href: "https://repowire.io/dashboard" },
+  { label: "Relay", href: RELAY_DASHBOARD_URL },
   { label: "Changelog", href: "https://github.com/prassanna-ravishankar/repowire/releases" },
 ];
 

--- a/web/components/marketing/links.ts
+++ b/web/components/marketing/links.ts
@@ -1,0 +1,7 @@
+// Shared external link targets for the marketing site.
+//
+// The hosted dashboard is served by the relay at relay.repowire.io, not at
+// repowire.io/dashboard (that path is the local daemon's dashboard). Marketing
+// links point straight at the relay so visitors don't hit the local-style path
+// and rely on a client-side hostname redirect.
+export const RELAY_DASHBOARD_URL = "https://relay.repowire.io/dashboard";


### PR DESCRIPTION
The landing page's dashboard links pointed at `https://repowire.io/dashboard` — but that path is the **local daemon's** dashboard. On the hosted site it only worked via a clunky double-hop: load the static dashboard bundle on `repowire.io`, run JS, detect `hostname === "repowire.io"`, then client-side redirect to `relay.repowire.io/dashboard`.

This points the marketing links straight at the relay so there's no round-trip through the local-style path.

- New shared `web/components/marketing/links.ts` → `RELAY_DASHBOARD_URL = "https://relay.repowire.io/dashboard"` (single source of truth; matches the constant already in `app/dashboard/page.tsx`).
- Updated the 3 real links: Hero "Open relay", TopBar "Relay" nav, Footer "Relay dashboard".
- Updated the cosmetic URL label in the DashboardShot screenshot frame for consistency.

Lint + `next build` clean.