### PR TITLE
fix(web): terminal lines stuck at opacity:0 (animate on mount)

### DIFF
--- a/web/components/marketing/CodeShowcase.tsx
+++ b/web/components/marketing/CodeShowcase.tsx
@@ -45,9 +45,11 @@ export default function CodeShowcase() {
             role="img"
             aria-label="Animated terminal showing Claude asking Codex to review a React component and receiving an ack"
             initial="hidden"
-            whileInView="shown"
-            viewport={{ once: true, amount: 0.2 }}
-            variants={{ shown: { transition: { staggerChildren: 0.12 } } }}
+            animate="shown"
+            variants={{
+              hidden: {},
+              shown: { transition: { staggerChildren: 0.12 } },
+            }}
           >
             {terminalLines.map((line) => (
               <motion.div


### PR DESCRIPTION
Follow-up to #320. Browser-verified on the LIVE site that the previous fix did NOT work: the new bundle deployed fine (staggerChildren present), but all 8 terminal lines were still computed opacity:0 even with the panel fully in view.

Root cause: the whileInView-driven variant reveal still wasn't firing — the element is at/near the viewport when the IntersectionObserver initializes, and with once:true the in-view trigger never fired, so the parent never propagated the 'shown' variant to the children.

Real fix: animate on MOUNT (initial='hidden' animate='shown') with staggerChildren, dropping viewport detection entirely. The terminal reveals + staggers unconditionally on load — no scroll-observer flakiness, simplest possible mechanism.

Verified: built the static export, served it locally, loaded in agent-browser — all 8 lines reach opacity:1 (allVisible:true) and the full Claude↔Codex conversation renders (screenshot confirmed). Lint + build clean.