### PR TITLE
fix(web): terminal renders blank — switch to pure-CSS fade-in

### DIFF
--- a/web/app/marketing.css
+++ b/web/app/marketing.css
@@ -402,6 +402,19 @@
   color: #efece4; background: transparent; overflow-x: auto;
 }
 .rw-marketing .term-body div { white-space: nowrap; }
+/* Lines are visible by default; the entrance is a pure-CSS progressive
+   enhancement so the terminal can never render blank (no JS/hydration/viewport
+   dependency, unlike the prior framer-motion approach). */
+.rw-marketing .term-line {
+  animation: term-line-in 0.28s ease-out both;
+}
+@keyframes term-line-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .rw-marketing .term-line { animation: none; }
+}
 .rw-marketing .term-blank { height: 1.7em; }
 .rw-marketing .t-d { color: #807c74; }
 .rw-marketing .t-c { color: var(--cobalt-300); font-weight: 500; }

--- a/web/components/marketing/CodeShowcase.tsx
+++ b/web/components/marketing/CodeShowcase.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
-
 const terminalLines = [
   { text: "$ claude", className: "t-c" },
   { text: "You: I just built the pricing card. Ask Codex to review the component.", className: "t-row" },
@@ -40,31 +36,17 @@ export default function CodeShowcase() {
             </div>
             <div className="term-title">claude ↔ repowire ↔ codex</div>
           </div>
-          <motion.div
-            className="term-body"
-            role="img"
-            aria-label="Animated terminal showing Claude asking Codex to review a React component and receiving an ack"
-            initial="hidden"
-            animate="shown"
-            variants={{
-              hidden: {},
-              shown: { transition: { staggerChildren: 0.12 } },
-            }}
-          >
-            {terminalLines.map((line) => (
-              <motion.div
+          <div className="term-body" role="img" aria-label="Animated terminal showing Claude asking Codex to review a React component and receiving an ack">
+            {terminalLines.map((line, index) => (
+              <div
                 key={line.text}
-                className={line.className}
-                variants={{
-                  hidden: { opacity: 0, y: 6 },
-                  shown: { opacity: 1, y: 0 },
-                }}
-                transition={{ duration: 0.28, ease: "easeOut" }}
+                className={`${line.className} term-line`}
+                style={{ animationDelay: `${index * 0.12}s` }}
               >
                 {line.text}
-              </motion.div>
+              </div>
             ))}
-          </motion.div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Third and final fix for the blank terminal. Browser-verified the previous framer-motion approaches (#320 whileInView, #321 animate-on-mount) did NOT work on the live site: identical bundle deployed and confirmed live, but framer's SSR initial='hidden' (opacity:0 inline) was never replaced on hydration — lines stayed opacity:0. (Reproduced on localhost it worked; on Cloudflare-served live it didn't — a framer-motion v12 SSR/hydration mount-animation gotcha.)

Real fix: drop framer-motion from the terminal entirely. Lines are plain divs, **visible by default** (CSS colors, no opacity:0 base), with a pure-CSS @keyframes entrance + per-line animation-delay for the stagger, and prefers-reduced-motion respected. No JS, hydration, or viewport dependency — the terminal can never render blank.

Verified: built static export, served locally, agent-browser confirmed all 8 lines opacity:1 WITH animation AND with animation:none (the no-JS fallback). SSR HTML no longer ships opacity:0 inline on the term lines. Screenshot confirms the full Claude↔Codex conversation renders. Lint + build clean.

Will verify on the LIVE site post-deploy before calling done.