### PR TITLE
fix(acp): turn_state visibility, restart reconciliation, honest notify semantics

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -107,6 +107,8 @@ responses and hook receipts may include nullable `repowire_session_id`,
 
 If the live transport is unavailable but the daemon can resolve the target peer, `/notify` may return `delivery_state="queued"` and `reason="queued_delivery"`. That means the notification was stored in the SQLite queued-delivery table for the target peer/session and will be delivered once through the recipient's Stop hook or `repowire peer deliveries`, subject to the configured TTL and per-peer cap.
 
+For an ACP-brokered peer (experimental), a fire-and-forget `/notify` returns `delivery_state="delivered"` with `reason="broker_accepted"` rather than `transport_delivered`. The broker accepted the prompt task, but the ACP reply is discarded for notify, so this is *not* a runtime receipt — the daemon never learns whether the runtime completed it. Clients that need a real receipt must not treat `broker_accepted` as one.
+
 Peer resolution mirrors `ask`: defaults to the caller's circle, except for peers whose role bypasses circles (`orchestrator`, `service`, human surfaces) which resolve mesh-wide. Pass `circle="<name>"` to target a different circle.
 
 The special peer `telegram` routes to the user's phone. The `dashboard` already sees agent turns; you do not need to notify it. Both are human-role peers and resolve mesh-wide regardless of your circle.

--- a/repowire/acp/broker.py
+++ b/repowire/acp/broker.py
@@ -105,6 +105,15 @@ Args: (correlation_id, reply_text_or_None, error_or_None).
 - error non-None: ACP path failed; close the ask with an error frame.
 """
 
+AcpStateCallback = Callable[[str], Awaitable[None]]
+"""Callback to propagate the ACP peer's turn_state.
+
+Args: (turn_state,) — "working" when a prompt starts, "idle" when it settles
+(success or failure). The daemon owns identity/lifecycle, so the broker only
+emits the transition; the wiring side maps it onto ``PeerRegistry``. Best-effort:
+a failure here must never break ask delivery.
+"""
+
 
 async def deliver_ask_via_acp(
     *,
@@ -113,6 +122,7 @@ async def deliver_ask_via_acp(
     correlation_id: str,
     text: str,
     on_complete: AcpAckCallback,
+    on_state: AcpStateCallback | None = None,
     timeout: float = DEFAULT_PROMPT_TIMEOUT,
 ) -> asyncio.Task[None]:
     """Spawn a background task that prompts the ACP peer and acks the asker.
@@ -121,9 +131,25 @@ async def deliver_ask_via_acp(
     correlation_id immediately (matching the existing non-blocking semantics).
     The task acks via ``on_complete`` regardless of success or failure so an
     open ask never silently dies.
+
+    ``on_state`` (optional) is fired with "working" before the prompt and "idle"
+    once it settles, so the mesh/dashboard can see an ACP peer is mid-turn — the
+    broker's analogue of the WS UserPromptSubmit→Stop transition. It is
+    orthogonal to ``on_complete`` (which is the ask receipt) and best-effort.
     """
 
+    async def _set_state(state: str) -> None:
+        if on_state is None:
+            return
+        try:
+            await on_state(state)
+        except Exception as e:  # noqa: BLE001 — turn_state is cosmetic, never fail the ask
+            logger.warning(
+                "ACP turn_state=%s for peer_id=%s failed: %s", state, spec.peer_id, e,
+            )
+
     async def _run() -> None:
+        await _set_state("working")
         try:
             result = await manager.prompt(spec, text, timeout=timeout)
             reply = result.text or f"[acp stop_reason={result.stop_reason}, no text]"
@@ -134,5 +160,7 @@ async def deliver_ask_via_acp(
                 correlation_id, spec.peer_id, e,
             )
             await on_complete(correlation_id, None, str(e))
+        finally:
+            await _set_state("idle")
 
     return asyncio.create_task(_run(), name=f"acp-ask-{correlation_id[:8]}")

--- a/repowire/daemon/acp_reconcile.py
+++ b/repowire/daemon/acp_reconcile.py
@@ -1,0 +1,148 @@
+"""Durable lifecycle + restart reconciliation for ACP-routed asks.
+
+An ACP ask is delivered by a daemon-owned background prompt task; its closure
+(ack reply or error frame) only fires when that task completes. The AskTracker
+is in-memory, so a daemon restart loses both the open ask and the task — and
+unlike a WS peer, an ACP peer has no Stop hook to resurface it. The asker would
+be left waiting forever.
+
+To stay fail-loud we record each ACP ask as a durable ``acp_ask`` operation
+(``SQLiteOperationStore``) created *before* the prompt task is scheduled, marked
+terminal when the ask settles. On startup any still-running ``acp_ask`` op is a
+task lost across the restart: we fail it and enqueue a single durable closure
+delivery (``SQLiteQueuedDeliveryStore``) so the asker hears "your ACP ask was
+lost, please retry" once their transport is back.
+
+This is deliberately not a second redelivery system: same-peer_id reconnect gets
+the closure via the existing queue; a changed peer_id may miss it but the
+operation audit still records the failure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ACP_ASK_OPERATION_KIND = "acp_ask"
+_NON_TERMINAL_STATES = ("queued", "running")
+_RESTART_LOST_REASON = "daemon_restart_lost_acp_task"
+
+
+def record_acp_ask_operation(
+    operation_store: Any,
+    *,
+    correlation_id: str,
+    from_peer_id: str | None,
+    from_peer_name: str,
+    to_peer_id: str,
+    to_peer_name: str,
+) -> str | None:
+    """Create a durable ``acp_ask`` operation before the prompt task is scheduled.
+
+    Returns the operation_id (or None if no store / on failure — recording must
+    never break delivery). The asker identity is persisted in ``target`` so a
+    startup sweep can enqueue closure even after the in-memory ask is gone.
+    """
+    if operation_store is None:
+        return None
+    try:
+        op = operation_store.create(
+            kind=ACP_ASK_OPERATION_KIND,
+            target={
+                "correlation_id": correlation_id,
+                "from_peer_id": from_peer_id,
+                "from_peer_name": from_peer_name,
+                "to_peer_id": to_peer_id,
+                "to_peer_name": to_peer_name,
+            },
+        )
+        # Move to running immediately: the prompt task is about to be scheduled,
+        # so a crash after this point is a "lost task" the sweep must catch.
+        operation_store.start_attempt(op.operation_id, strategy="acp_prompt")
+        return op.operation_id
+    except Exception as e:  # noqa: BLE001 — durability is best-effort, never block the ask
+        logger.warning("Failed to record acp_ask operation for cid=%s: %s", correlation_id, e)
+        return None
+
+
+def settle_acp_ask_operation(
+    operation_store: Any,
+    operation_id: str | None,
+    *,
+    error: str | None,
+) -> None:
+    """Mark an ``acp_ask`` operation terminal once the ask settles.
+
+    ``error`` None → completed; non-None → failed. Best-effort.
+    """
+    if operation_store is None or operation_id is None:
+        return
+    try:
+        if error is None:
+            operation_store.complete(operation_id, result={"outcome": "acked"})
+        else:
+            operation_store.fail(operation_id, error={"reason": "acp_error", "detail": error})
+    except Exception as e:  # noqa: BLE001 — settling is best-effort
+        logger.warning("Failed to settle acp_ask operation %s: %s", operation_id, e)
+
+
+def reconcile_acp_inflight(operation_store: Any, queued_delivery_store: Any) -> int:
+    """Fail every non-terminal ``acp_ask`` op and enqueue one closure per asker.
+
+    Called once on daemon startup, after the stores are initialised. Idempotent:
+    only ``queued``/``running`` ops are touched, and failing each op moves it to
+    a terminal state so a second startup is a no-op. Returns the count reconciled.
+    """
+    if operation_store is None:
+        return 0
+    reconciled = 0
+    for state in _NON_TERMINAL_STATES:
+        try:
+            ops = operation_store.list_all(kind=ACP_ASK_OPERATION_KIND, state=state)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("acp reconcile: list_all(%s) failed: %s", state, e)
+            continue
+        for op in ops:
+            target = op.target or {}
+            cid = target.get("correlation_id", "?")
+            from_peer_id = target.get("from_peer_id")
+            from_peer_name = target.get("from_peer_name", from_peer_id or "peer")
+            to_peer_id = target.get("to_peer_id")
+            to_peer_name = target.get("to_peer_name", "peer")
+            try:
+                operation_store.fail(op.operation_id, error={"reason": _RESTART_LOST_REASON})
+            except Exception as e:  # noqa: BLE001
+                logger.warning("acp reconcile: fail(%s) failed: %s", op.operation_id, e)
+                continue
+            reconciled += 1
+            if queued_delivery_store is None or not from_peer_id:
+                logger.warning(
+                    "acp reconcile: cid=%s lost across restart; no closure enqueued "
+                    "(queue=%s, from_peer_id=%s)",
+                    cid, queued_delivery_store is not None, bool(from_peer_id),
+                )
+                continue
+            closure = (
+                f"[ack #{cid} from @{to_peer_name}] "
+                "ACP ask lost across daemon restart; please retry."
+            )
+            try:
+                # The closure is FROM the answerer (the ACP peer that was asked)
+                # TO the original asker (peer_id = the queue key).
+                queued_delivery_store.enqueue(
+                    peer_id=from_peer_id,
+                    repowire_session_id=None,
+                    kind="notify",
+                    from_peer_id=to_peer_id,
+                    from_peer_name=to_peer_name,
+                    to_peer_name=from_peer_name,
+                    text=closure,
+                    attachments=[],
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning("acp reconcile: enqueue closure for cid=%s failed: %s", cid, e)
+    if reconciled:
+        logger.info("acp reconcile: failed + queued closure for %d lost ACP ask(s)", reconciled)
+    return reconciled

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -23,6 +23,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from repowire import __version__
 from repowire.config.models import Config, load_config
+from repowire.daemon.acp_reconcile import reconcile_acp_inflight
 from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.auth import require_localhost
 from repowire.daemon.delivery_trace import DeliveryTraceStore
@@ -309,6 +310,7 @@ def create_app(
             ask_tracker=ask_tracker,
             session_binding_store=session_binding_store,
             queued_delivery_store=queued_delivery_store,
+            operation_store=operation_store,
         )
         app.state.peer_delivery = peer_delivery
         spawn_service = SpawnService(
@@ -357,6 +359,12 @@ def create_app(
             cfg, peer_registry, app.state,
             lifecycle_handler=lifecycle_handler,
         )
+
+        # Fail-loud: an ACP ask in flight when the daemon last stopped lost its
+        # background prompt task (and the in-memory AskTracker). Reconcile those
+        # durable acp_ask operations now so the asker gets a closure rather than
+        # waiting forever.
+        reconcile_acp_inflight(operation_store, queued_delivery_store)
 
         # Install tmux lifecycle hooks if tmux is available.
         # Skipped when the caller disables it (e.g. smoke daemons under a
@@ -652,6 +660,7 @@ def create_test_app(
             ask_tracker=ask_tracker,
             session_binding_store=session_binding_store,
             queued_delivery_store=queued_delivery_store,
+            operation_store=operation_store,
         )
         app.state.peer_delivery = peer_delivery
         spawn_service = SpawnService(
@@ -696,6 +705,7 @@ def create_test_app(
         await registry.start()
         await scheduler.start()
         init_deps(cfg, registry, app.state, lifecycle_handler=lh)
+        reconcile_acp_inflight(operation_store, queued_delivery_store)
 
         mcp_session_manager = getattr(app.state, "mcp_http_session_manager", None)
         async with AsyncExitStack() as stack:

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -40,11 +40,23 @@ class NotifyDeliveryResult:
     ``status`` is the legacy compact value returned by older call sites.
     ``delivery_state`` and ``reason`` make the same outcome explicit so
     clients do not need to infer BUSY queueing or transport success.
+
+    ``reason`` is honest about what was actually proven:
+      * ``transport_delivered`` — written to the recipient's live WS transport.
+      * ``broker_accepted`` — an ACP notify was accepted by the broker (the
+        prompt task was dispatched). It is *not* a runtime-receipt: the ACP
+        reply is discarded for fire-and-forget notify, so the daemon never
+        learns whether the runtime completed it. ``delivery_state`` is still
+        ``delivered`` (the broker took ownership), but clients that want a real
+        receipt must not read ``broker_accepted`` as one.
+      * ``recipient_busy`` / ``queued_delivery`` — held for later delivery.
     """
 
     status: Literal["sent", "queued"]
     delivery_state: Literal["delivered", "queued"]
-    reason: Literal["transport_delivered", "recipient_busy", "queued_delivery"]
+    reason: Literal[
+        "transport_delivered", "broker_accepted", "recipient_busy", "queued_delivery"
+    ]
     from_peer_id: str | None
     from_peer_name: str
     to_peer_id: str
@@ -308,9 +320,18 @@ class PeerDeliveryService:
         delivery_state: Literal["delivered", "queued"] = (
             "queued" if delivery_status == "queued" else "delivered"
         )
-        reason: Literal["transport_delivered", "recipient_busy", "queued_delivery"] = (
-            "recipient_busy" if delivery_status == "queued" else "transport_delivered"
-        )
+        reason: Literal[
+            "transport_delivered", "broker_accepted", "recipient_busy", "queued_delivery"
+        ]
+        if delivery_status == "queued":
+            reason = "recipient_busy"
+        elif transport_result.transport == "acp":
+            # ACP notify is fire-and-forget: the broker accepted the prompt
+            # task but the runtime receipt is discarded, so don't claim
+            # transport_delivered (which means "written to a live WS").
+            reason = "broker_accepted"
+        else:
+            reason = "transport_delivered"
         return NotifyDeliveryResult(
             status=delivery_status,
             delivery_state=delivery_state,

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -14,6 +14,10 @@ from typing import Any, Literal, cast
 from uuid import uuid4
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT, Config
+from repowire.daemon.acp_reconcile import (
+    record_acp_ask_operation,
+    settle_acp_ask_operation,
+)
 from repowire.daemon.ask_tracker import AskerIdentity, AskTracker
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
@@ -90,6 +94,7 @@ class PeerDeliveryService:
         ask_tracker: AskTracker | None = None,
         session_binding_store: Any | None = None,
         queued_delivery_store: SQLiteQueuedDeliveryStore | None = None,
+        operation_store: Any | None = None,
     ) -> None:
         self._config = config
         self._registry = registry
@@ -98,6 +103,7 @@ class PeerDeliveryService:
         self._ask_tracker = ask_tracker
         self._session_binding_store = session_binding_store
         self._queued_delivery_store = queued_delivery_store
+        self._operation_store = operation_store
 
     def _session_id_for_peer(self, peer: Any | None) -> str | None:
         return resolve_repowire_session_id(self._session_binding_store, peer=peer)
@@ -378,6 +384,20 @@ class PeerDeliveryService:
         from_session_id = self._session_id_for_peer(from_obj)
         to_session_id = self._session_id_for_peer(target)
 
+        # ACP asks are delivered by a daemon-owned background task whose closure
+        # is lost on restart. Record a durable operation BEFORE the task is
+        # scheduled so a startup sweep can fail it and notify the asker.
+        if self._operation_store is not None and self._router().acp_route(target) is not None:
+            operation_id = record_acp_ask_operation(
+                self._operation_store,
+                correlation_id=correlation_id,
+                from_peer_id=from_peer_id,
+                from_peer_name=from_peer_name,
+                to_peer_id=target.peer_id,
+                to_peer_name=target.display_name,
+            )
+            completion = self._settling_completion(completion, operation_id)
+
         try:
             return await self._router().send_ask(
                 AskEnvelope(
@@ -500,6 +520,27 @@ class PeerDeliveryService:
         if self._transport_router is None:
             raise RuntimeError("PeerTransportRouter not configured")
         return self._transport_router
+
+    def _settling_completion(
+        self, inner: AskCompletion, operation_id: str | None,
+    ) -> AskCompletion:
+        """Wrap an ACP completion so it settles the durable operation.
+
+        Runs the real completion first (deliver the ack/error), then marks the
+        ``acp_ask`` operation terminal. Settling never raises into delivery.
+        """
+        if operation_id is None:
+            return inner
+
+        async def _settle(
+            correlation_id: str, reply: str | None, error: str | None,
+        ) -> None:
+            try:
+                await inner(correlation_id, reply, error)
+            finally:
+                settle_acp_ask_operation(self._operation_store, operation_id, error=error)
+
+        return cast(AskCompletion, _settle)
 
     def _default_acp_completion(self) -> AskCompletion:
         if self._ask_tracker is None:
@@ -631,4 +672,5 @@ def peer_delivery_from_state(
         ask_tracker=getattr(state, "ask_tracker", None),
         session_binding_store=getattr(state, "session_binding_store", None),
         queued_delivery_store=getattr(state, "queued_delivery_store", None),
+        operation_store=getattr(state, "operation_store", None),
     )

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -87,7 +87,7 @@ class NotifyResponse(BaseModel):
     delivered: bool = True
     queued: bool = False
     reason: Literal[
-        "transport_delivered", "recipient_busy", "queued_delivery",
+        "transport_delivered", "broker_accepted", "recipient_busy", "queued_delivery",
     ] = "transport_delivered"
     from_peer_id: str | None = None
     from_peer_name: str | None = None

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import uuid
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Protocol, cast
 
 from repowire.acp import AcpRouteDecision, deliver_ask_via_acp, maybe_decide_acp_route
 from repowire.config.models import Config
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.protocol.messages import AttachmentRef
-from repowire.protocol.peers import Peer, PeerStatus
+from repowire.protocol.peers import Peer, PeerStatus, TurnState
 
 
 def _text_with_attachment_fallback(text: str, attachments: tuple[AttachmentRef, ...]) -> str:
@@ -189,8 +189,9 @@ class WebSocketPeerTransport:
 class AcpPeerTransport:
     """ACP delivery mapped onto prompt calls."""
 
-    def __init__(self, manager: Any) -> None:
+    def __init__(self, manager: Any, registry: PeerRegistry | None = None) -> None:
         self._manager = manager
+        self._registry = registry
 
     def decide(self, target: Peer, *, flag_enabled: bool) -> AcpRouteDecision | None:
         return maybe_decide_acp_route(
@@ -198,6 +199,22 @@ class AcpPeerTransport:
             flag_enabled=flag_enabled,
             manager=self._manager,
         )
+
+    def _state_callback(self, peer_id: str):
+        """Build an on_state callback that maps ACP turn transitions onto turn_state.
+
+        Returns None when no registry is wired (e.g. bare transport in tests),
+        so the broker simply skips state propagation.
+        """
+        registry = self._registry
+        if registry is None:
+            return None
+
+        async def _on_state(state: str) -> None:
+            turn_state = cast("TurnState", state)
+            await registry.update_peer_turn_state(peer_id, turn_state)
+
+        return _on_state
 
     async def send_ask(
         self,
@@ -213,6 +230,7 @@ class AcpPeerTransport:
             correlation_id=envelope.correlation_id,
             text=_text_with_attachment_fallback(envelope.text, envelope.attachments),
             on_complete=on_complete,
+            on_state=self._state_callback(decision.spec.peer_id),
         )
         return AskTransportResult(transport="acp", hook_delivery=None)
 
@@ -241,6 +259,7 @@ class AcpPeerTransport:
             correlation_id=cid,
             text=_text_with_attachment_fallback(envelope.text, envelope.attachments),
             on_complete=_drop_result,
+            on_state=self._state_callback(decision.spec.peer_id),
         )
         return NotifyTransportResult(
             status="sent",
@@ -266,7 +285,9 @@ class PeerTransportRouter:
         self._config = config
         self._registry = registry
         self._ws = WebSocketPeerTransport(registry, message_router)
-        self._acp = AcpPeerTransport(acp_manager) if acp_manager is not None else None
+        self._acp = (
+            AcpPeerTransport(acp_manager, registry) if acp_manager is not None else None
+        )
 
     def _acp_decision(self, target: Peer) -> AcpRouteDecision | None:
         experiments = self._config.experiments

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -289,6 +289,14 @@ class PeerTransportRouter:
             AcpPeerTransport(acp_manager, registry) if acp_manager is not None else None
         )
 
+    def acp_route(self, target: Peer) -> AcpRouteDecision | None:
+        """Public: would this target route over ACP? (None = WS fallback).
+
+        Lets callers (e.g. PeerDeliveryService) record a durable ACP operation
+        before dispatch without duplicating the flag/metadata decision.
+        """
+        return self._acp_decision(target)
+
     def _acp_decision(self, target: Peer) -> AcpRouteDecision | None:
         experiments = self._config.experiments
         flag = bool(experiments.acp_broker_client) if experiments else False

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -461,7 +461,8 @@ async def test_public_notify_route_does_not_503_for_acp_peer(
             assert body["delivery_state"] == "delivered"
             assert body["delivered"] is True
             assert body["queued"] is False
-            assert body["reason"] == "transport_delivered"
+            # ACP notify is broker-accepted, not a runtime receipt (must-fix #3).
+            assert body["reason"] == "broker_accepted"
             assert body["from_peer_name"] == asker
             assert body["to_peer_name"] == answerer
     finally:

--- a/tests/test_acp_reconcile.py
+++ b/tests/test_acp_reconcile.py
@@ -1,0 +1,117 @@
+"""Restart reconciliation for in-flight ACP asks (codex ACP must-fix #2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowire.daemon.acp_reconcile import (
+    ACP_ASK_OPERATION_KIND,
+    reconcile_acp_inflight,
+    record_acp_ask_operation,
+    settle_acp_ask_operation,
+)
+from repowire.daemon.state import StateDatabase
+from repowire.daemon.state.operations import SQLiteOperationStore
+from repowire.daemon.state.queued_deliveries import SQLiteQueuedDeliveryStore
+
+
+def _stores(
+    tmp_path: Path,
+) -> tuple[StateDatabase, SQLiteOperationStore, SQLiteQueuedDeliveryStore]:
+    db = StateDatabase(tmp_path / "state.db")
+    queue = SQLiteQueuedDeliveryStore(db, ttl_seconds=86400, max_per_peer=100)
+    return db, SQLiteOperationStore(db), queue
+
+
+def test_record_creates_running_operation(tmp_path: Path) -> None:
+    db, ops, _queue = _stores(tmp_path)
+    try:
+        op_id = record_acp_ask_operation(
+            ops,
+            correlation_id="cid-1",
+            from_peer_id="asker-id",
+            from_peer_name="asker",
+            to_peer_id="answerer-id",
+            to_peer_name="answerer",
+        )
+        assert op_id is not None
+        op = ops.get(op_id)
+        assert op is not None
+        assert op.kind == ACP_ASK_OPERATION_KIND
+        assert op.state == "running"  # ready to be swept if the daemon dies now
+        assert op.target["correlation_id"] == "cid-1"
+        assert op.target["from_peer_id"] == "asker-id"
+    finally:
+        db.close()
+
+
+def test_settle_marks_terminal_so_sweep_ignores_it(tmp_path: Path) -> None:
+    db, ops, queue = _stores(tmp_path)
+    try:
+        op_id = record_acp_ask_operation(
+            ops, correlation_id="cid-1", from_peer_id="asker-id",
+            from_peer_name="asker", to_peer_id="answerer-id", to_peer_name="answerer",
+        )
+        settle_acp_ask_operation(ops, op_id, error=None)  # successful ack
+        assert ops.get(op_id).state == "completed"
+
+        reconciled = reconcile_acp_inflight(ops, queue)
+        assert reconciled == 0  # terminal op is not swept
+        assert queue.count_for_peer("asker-id") == 0
+    finally:
+        db.close()
+
+
+def test_reconcile_fails_inflight_and_enqueues_closure(tmp_path: Path) -> None:
+    db, ops, queue = _stores(tmp_path)
+    try:
+        op_id = record_acp_ask_operation(
+            ops, correlation_id="cid-lost", from_peer_id="asker-id",
+            from_peer_name="asker", to_peer_id="answerer-id", to_peer_name="answerer",
+        )
+        # Daemon "restarts" with this op still running.
+        reconciled = reconcile_acp_inflight(ops, queue)
+        assert reconciled == 1
+        assert ops.get(op_id).state == "failed"
+
+        # The asker gets exactly one durable closure delivery.
+        assert queue.count_for_peer("asker-id") == 1
+        drained = queue.drain_for_peer("asker-id")
+        assert len(drained) == 1
+        assert "cid-lost" in drained[0].text
+        assert "lost across daemon restart" in drained[0].text
+    finally:
+        db.close()
+
+
+def test_reconcile_is_idempotent_across_restarts(tmp_path: Path) -> None:
+    db, ops, queue = _stores(tmp_path)
+    try:
+        record_acp_ask_operation(
+            ops, correlation_id="cid-lost", from_peer_id="asker-id",
+            from_peer_name="asker", to_peer_id="answerer-id", to_peer_name="answerer",
+        )
+        first = reconcile_acp_inflight(ops, queue)
+        second = reconcile_acp_inflight(ops, queue)  # a second startup
+        assert first == 1
+        assert second == 0  # already terminal -> no duplicate closure
+        assert queue.count_for_peer("asker-id") == 1
+    finally:
+        db.close()
+
+
+def test_reconcile_without_asker_id_still_fails_op(tmp_path: Path) -> None:
+    # If we somehow lack the asker peer_id, the op must still be failed (audit),
+    # we just can't enqueue a closure.
+    db, ops, queue = _stores(tmp_path)
+    try:
+        op = ops.create(
+            kind=ACP_ASK_OPERATION_KIND,
+            target={"correlation_id": "cid-x", "to_peer_name": "answerer"},
+        )
+        ops.start_attempt(op.operation_id, strategy="acp_prompt")
+        reconciled = reconcile_acp_inflight(ops, queue)
+        assert reconciled == 1
+        assert ops.get(op.operation_id).state == "failed"
+    finally:
+        db.close()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1211,3 +1211,41 @@ class TestSessionUpdate:
 
         r = await client.get(f"/peers/{name}")
         assert r.json()["status"] == "busy"
+
+
+@pytest.mark.asyncio
+async def test_acp_notify_reason_is_broker_accepted():
+    # codex ACP must-fix #3: a fire-and-forget notify routed over ACP must report
+    # reason="broker_accepted" (the broker took the prompt task) rather than
+    # "transport_delivered" (which means written to a live WS), so clients don't
+    # mistake broker acceptance for a runtime receipt.
+    from unittest.mock import AsyncMock
+
+    from repowire.daemon.peer_delivery import PeerDeliveryService
+    from repowire.daemon.transport_router import NotifyTransportResult
+
+    sender = SimpleNamespace(peer_id="sender-id", display_name="sender-codex")
+    target = SimpleNamespace(peer_id="target-id", display_name="target-codex")
+
+    registry = SimpleNamespace(
+        check_access=AsyncMock(return_value=(sender, target)),
+        add_event=lambda *a, **k: None,
+    )
+    transport_router = SimpleNamespace(
+        send_notify=AsyncMock(
+            return_value=NotifyTransportResult(status="sent", transport="acp")
+        )
+    )
+    service = PeerDeliveryService(
+        config=Config(),
+        registry=registry,  # type: ignore[arg-type]
+        message_router=SimpleNamespace(),  # type: ignore[arg-type]
+        transport_router=transport_router,  # type: ignore[arg-type]
+    )
+
+    result = await service.notify_result(
+        from_peer="sender-codex", to_peer="target-codex", text="heads up",
+    )
+    assert result.delivery_state == "delivered"
+    assert result.reason == "broker_accepted"
+    assert result.transport == "acp"

--- a/tests/test_transport_router.py
+++ b/tests/test_transport_router.py
@@ -90,6 +90,61 @@ async def test_ask_routes_to_acp_before_websocket() -> None:
 
 
 @pytest.mark.asyncio
+async def test_acp_ask_propagates_turn_state_working_then_idle() -> None:
+    # codex ACP must-fix #1: an in-flight ACP prompt must be visible as
+    # turn_state=working, settling back to idle on completion.
+    target = _acp_peer()
+    registry = SimpleNamespace(add_event=Mock(), update_peer_turn_state=AsyncMock())
+    ws_router = SimpleNamespace(send_ask=AsyncMock(), send_notification=AsyncMock())
+    acp_manager = SimpleNamespace(
+        prompt=AsyncMock(return_value=AcpPromptResult(stop_reason="end_turn", text="answer")),
+    )
+    on_complete = AsyncMock()
+
+    router = PeerTransportRouter(
+        config=_config(acp_enabled=True),
+        registry=registry,
+        message_router=ws_router,
+        acp_manager=acp_manager,
+    )
+    await router.send_ask(_ask_envelope(target), on_acp_complete=on_complete)
+    await _wait_for_await(on_complete)
+
+    states = [call.args[1] for call in registry.update_peer_turn_state.await_args_list]
+    assert states == ["working", "idle"]
+    assert all(
+        call.args[0] == "target-id"
+        for call in registry.update_peer_turn_state.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_acp_ask_settles_turn_state_idle_on_error() -> None:
+    # turn_state must return to idle even when the ACP prompt fails, so a peer
+    # is never stuck showing "working" after a crashed/timed-out turn.
+    target = _acp_peer()
+    registry = SimpleNamespace(add_event=Mock(), update_peer_turn_state=AsyncMock())
+    ws_router = SimpleNamespace(send_ask=AsyncMock(), send_notification=AsyncMock())
+    acp_manager = SimpleNamespace(prompt=AsyncMock(side_effect=RuntimeError("boom")))
+    on_complete = AsyncMock()
+
+    router = PeerTransportRouter(
+        config=_config(acp_enabled=True),
+        registry=registry,
+        message_router=ws_router,
+        acp_manager=acp_manager,
+    )
+    await router.send_ask(_ask_envelope(target), on_acp_complete=on_complete)
+    await _wait_for_await(on_complete)
+
+    states = [call.args[1] for call in registry.update_peer_turn_state.await_args_list]
+    assert states == ["working", "idle"]
+    # the asker still gets the failure surfaced
+    on_complete.assert_awaited_once()
+    assert on_complete.await_args_list[0].args[2] is not None
+
+
+@pytest.mark.asyncio
 async def test_notify_routes_to_acp_and_discards_reply() -> None:
     target = _acp_peer()
     registry = SimpleNamespace(add_event=Mock())


### PR DESCRIPTION
## What

Verifies and closes the must-fix gaps for the experimental ACP (Agent Client Protocol) transport. ACP is a daemon-side broker (the daemon owns a `codex-acp` / `claude-agent-acp` subprocess + the prompt future per peer), so the right bar is not WS-hooks parity but: **asks complete or fail visibly, state is observable, and clients are not misled about delivery.** Reviewed with the `codex` mesh peer (firsthand ACP knowledge); the gap analysis and rankings are in `repowire-mesh/acp-feature-parity` (vault).

Three must-fix items:

### 1. turn_state visibility for in-flight ACP prompts

`deliver_ask_via_acp` now fires an `on_state` callback — `working` when the prompt starts, `idle` when it settles (success or failure, in a `finally`). Wired through `AcpPeerTransport` → `PeerRegistry.update_peer_turn_state`, so the mesh/dashboard can see an ACP peer is mid-turn (the broker's analogue of the WS UserPromptSubmit→Stop transition). Best-effort: a turn_state failure never breaks ask delivery. Orthogonal to WS `BUSY` status semantics, as advised.

### 2. Stale open-ask reconciliation on daemon restart

The AskTracker is in-memory, and an ACP ask is closed only when its daemon-owned prompt task resolves. On restart, both vanish — and unlike a WS peer, an ACP peer has no Stop hook to resurface it, so the asker would wait forever.

New `daemon/acp_reconcile.py`: each ACP ask records a durable `acp_ask` operation (`SQLiteOperationStore`) in `running` state **before** the prompt task is scheduled; the completion wrapper settles it (complete/failed). On startup the lifespan runs `reconcile_acp_inflight`: fail every non-terminal `acp_ask` op and enqueue **one** durable closure (`SQLiteQueuedDeliveryStore`) to the original asker — `"ACP ask lost across daemon restart; please retry."` Idempotent (only sweeps queued/running; failing moves the op terminal). OperationStore for lifecycle, QueuedDeliveryStore for the closure, AskTracker stays the live-turn mechanism only.

Live-verified across a real DB-file restart (op survives as `running` → swept to `failed` → exactly one closure enqueued → second sweep is a no-op).

### 3. Honest ACP notify result semantics

A fire-and-forget `/notify` over ACP returned `reason="transport_delivered"`, but for ACP that only means the broker accepted the prompt task — the reply is discarded, so the daemon never learns whether the runtime completed it. Added `broker_accepted` to the `reason` Literal (result + HTTP response); ACP notify now reports `delivery_state="delivered", reason="broker_accepted"`. Documented in `docs/reference/mcp-tools.md`.

## Testing

- New: `tests/test_acp_reconcile.py` (5 cases: record→running, settle→terminal-ignored, sweep fails+enqueues closure, idempotent across restarts, fail-op-without-asker); turn_state working→idle + idle-on-error in `tests/test_transport_router.py`; `broker_accepted` unit + the end-to-end ACP notify route test updated.
- Full suite: 1582 passing (the 2 pre-existing `test_spawn.py::TestMcpRegistration` failures are unrelated — they fail on clean `main`).
- `ruff` + `ty` on `repowire/`: clean.

## Out of scope (filed as follow-ups, per codex)

- `session/close` vs `session/cancel` cleanup hygiene.
- Durable ACP resume / `runtime_session_id` (the ACP session id is broker-protocol state, not a proven backend resume handle).
- Broadcast over ACP (P2 product-semantics call; would route through `PeerDeliveryService` fanout).

🤖 Reviewed by the `codex` mesh peer.
