### PR TITLE
fix(registry): reclaim display_name on same-session reconnect (stop suffix churn)

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -573,16 +573,45 @@ class PeerRegistry:
         sanitized = sanitized.strip("-")
         return sanitized or "peer"
 
+    @staticmethod
+    def _runtime_session_id(metadata: dict[str, Any] | None) -> str | None:
+        """Extract the runtime (hook) session id from a peer's metadata.
+
+        Mirrors the route-layer extractor. Two peers cannot share a runtime
+        session id (except transiently during a fork), so it is a stable
+        reconnect identity for name reclaim.
+        """
+        if not metadata:
+            return None
+        for key in ("hook_session_id", "runtime_session_id", "session_id"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
     def _build_display_name(
-        self, path: str, circle: str, backend: AgentType,
+        self,
+        path: str,
+        circle: str,
+        backend: AgentType,
+        metadata: dict[str, Any] | None = None,
     ) -> str:
         """Build a unique display_name for a peer. Must hold lock.
 
         Format: {folder}-{backend}[-{suffix}]
-        Prunes offline peers that hold a conflicting name (clean takeover).
+
+        Reclaims (prunes) a conflicting peer when it is the *same logical peer*
+        reconnecting, so a reconnect/daemon-restart keeps its name instead of
+        churning a fresh -2/-3 suffix. "Same logical peer" is decided by, in
+        order: (a) the runtime session id matches (two peers can't share one,
+        except transiently during a fork — so an equal id IS this peer coming
+        back, regardless of the blocker's status); (b) the blocker is OFFLINE
+        (the original clean-takeover rule). Only a genuinely distinct, live peer
+        on the same path+backend+circle gets a suffix.
         """
         folder = self._sanitize_folder_name(Path(path).name) if path else "peer"
         base = f"{folder}-{backend.value}"
+        incoming_session = self._runtime_session_id(metadata)
 
         candidate = base
         suffix = 2
@@ -597,15 +626,25 @@ class PeerRegistry:
                 return candidate
 
             sid, peer = blocker
-            if peer.status == PeerStatus.OFFLINE:
-                # Prune the offline peer entirely (clean takeover)
+            same_session = (
+                incoming_session is not None
+                and self._runtime_session_id(peer.metadata) == incoming_session
+            )
+            if same_session or peer.status == PeerStatus.OFFLINE:
+                # Same logical peer reconnecting (matching runtime session) or a
+                # dead peer holding the name -- reclaim it cleanly.
                 del self._peers[sid]
                 self._mappings.pop(sid, None)
                 self._mappings_dirty = True
-                logger.info(f"Pruned offline peer {candidate} ({sid}) for name reclaim")
+                logger.info(
+                    "Reclaimed name %s from %s (%s) for %s peer (status=%s)",
+                    candidate, peer.display_name, sid,
+                    "reconnecting same-session" if same_session else "offline",
+                    peer.status.value,
+                )
                 return candidate
 
-            # Name held by an active peer -- try next suffix
+            # Name held by a distinct live peer -- try next suffix
             candidate = f"{folder}-{suffix}-{backend.value}"
             suffix += 1
 
@@ -953,7 +992,7 @@ class PeerRegistry:
                 assigned_name = (
                     display_name_override
                     or (preferred_mapping.display_name if preferred_mapping else None)
-                    or self._build_display_name(path or "", circle, backend)
+                    or self._build_display_name(path or "", circle, backend, metadata)
                 )
                 mapping_circle = preferred_mapping.circle if preferred_mapping else circle
                 if display_name_override:

--- a/tests/test_display_name_reclaim.py
+++ b/tests/test_display_name_reclaim.py
@@ -1,0 +1,98 @@
+"""display_name reclaim across reconnect/restart (repowire-pql).
+
+Two peers cannot share a runtime session id, so a registration carrying the
+same session id as a name-blocking peer IS that peer reconnecting and must
+reclaim its name instead of churning a -2/-3 suffix — even if the daemon has
+not yet demoted the prior instance to OFFLINE (the case after a daemon restart
+re-registers the whole mesh).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from repowire.config.models import AgentType, Config
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.protocol.peers import PeerStatus
+
+
+@pytest.fixture
+def registry() -> PeerRegistry:
+    return PeerRegistry(config=Config(), message_router=AsyncMock())
+
+
+async def _register(reg: PeerRegistry, *, session_id: str, status=PeerStatus.ONLINE):
+    return await reg.allocate_and_register(
+        circle="default",
+        backend=AgentType.CLAUDE_CODE,
+        path="/tmp/proj",
+        metadata={"runtime_session_id": session_id},
+        initial_status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_session_reconnect_reclaims_name_without_suffix(registry):
+    # First registration claims "proj-claude-code".
+    _id1, name1 = await _register(registry, session_id="sess-A")
+    assert name1 == "proj-claude-code"
+
+    # The prior instance is still ONLINE (daemon hasn't demoted it yet), but the
+    # reconnect carries the SAME runtime session id -> it is the same logical
+    # peer and must reclaim the name, not get suffixed.
+    assert registry._peers[_id1].status == PeerStatus.ONLINE
+    _id2, name2 = await _register(registry, session_id="sess-A")
+    assert name2 == "proj-claude-code", "same-session reconnect should reclaim its name"
+    # The stale prior instance is gone (reclaimed).
+    assert _id1 not in registry._peers
+
+
+@pytest.mark.asyncio
+async def test_same_session_reconnect_reclaims_from_busy_blocker(registry):
+    # BUSY is a common mid-turn state; a same-session reconnect must reclaim the
+    # name from a BUSY ghost too, not just ONLINE (codex review).
+    _id1, name1 = await _register(registry, session_id="sess-A")
+    registry._peers[_id1].status = PeerStatus.BUSY
+    _id2, name2 = await _register(registry, session_id="sess-A")
+    assert name1 == "proj-claude-code"
+    assert name2 == "proj-claude-code"
+    assert _id1 not in registry._peers
+
+
+@pytest.mark.asyncio
+async def test_distinct_session_same_path_gets_suffixed(registry):
+    # Two genuinely distinct live peers on the same path+backend+circle must NOT
+    # collide -- the second keeps a -2 suffix.
+    _id1, name1 = await _register(registry, session_id="sess-A")
+    _id2, name2 = await _register(registry, session_id="sess-B")
+    assert name1 == "proj-claude-code"
+    assert name2 == "proj-2-claude-code"
+    # Both remain live and addressable.
+    assert _id1 in registry._peers and _id2 in registry._peers
+
+
+@pytest.mark.asyncio
+async def test_offline_prior_instance_is_still_reclaimed(registry):
+    # The original clean-takeover rule still holds: an OFFLINE blocker is pruned
+    # for name reclaim even when the new registration has a different session.
+    _id1, _name1 = await _register(registry, session_id="sess-A")
+    registry._peers[_id1].status = PeerStatus.OFFLINE
+    _id2, name2 = await _register(registry, session_id="sess-B")
+    assert name2 == "proj-claude-code"
+    assert _id1 not in registry._peers
+
+
+@pytest.mark.asyncio
+async def test_no_session_id_falls_back_to_suffix(registry):
+    # Without a runtime session id we cannot prove "same peer", so a live blocker
+    # still gets a suffix (no false reclaim).
+    _id1, name1 = await registry.allocate_and_register(
+        circle="default", backend=AgentType.CLAUDE_CODE, path="/tmp/proj",
+    )
+    _id2, name2 = await registry.allocate_and_register(
+        circle="default", backend=AgentType.CLAUDE_CODE, path="/tmp/proj",
+    )
+    assert name1 == "proj-claude-code"
+    assert name2 == "proj-2-claude-code"


### PR DESCRIPTION
## What

Stops peer `display_name` churn (`-2`/`-3` suffixes) across reconnect and daemon restart. Prass observed names changing 4-5× in one session.

`_build_display_name` previously only reclaimed a conflicting name when the blocking peer was `OFFLINE`. But a daemon restart re-registers the whole mesh before liveness reconciliation demotes the prior instances, so a reconnecting peer found its own name held by a still-`ONLINE` ghost of itself and got suffixed.

Fix anchors name-reclaim on the **runtime session id** invariant (Prass's framing): two peers cannot share a runtime session id (except transiently during a fork). So when a registration carries the same runtime session id as the name-blocking peer, it *is* that peer reconnecting — reclaim the name regardless of the blocker's status. Only a genuinely distinct, live session on the same path+backend+circle gets a suffix. The original OFFLINE-prune rule is preserved as a fallback; with no session id we never falsely reclaim.

The runtime session id is read from `Peer.metadata` (`hook_session_id` / `runtime_session_id` / `session_id`), so the comparison is local — no binding-store coupling.

## Testing

- New `tests/test_display_name_reclaim.py`: same-session reconnect reclaims (prior still ONLINE), distinct session suffixes, OFFLINE-prior still reclaimed, no-session-id falls back to suffix.
- Live-verified against a real registry: same-session reconnect keeps `repowire-claude-code` even with the prior instance ONLINE; a distinct session gets `repowire-2-claude-code`.
- Full suite: 1586 passing (the 2 pre-existing `test_spawn.py::TestMcpRegistration` failures are unrelated — they fail on clean `main`).
- `ruff` + `ty` on `repowire/`: clean.

Closes repowire-pql.
