### PR TITLE
refactor(config): narrow PeerRegistry to DaemonConfig+ExperimentsConfig

### DIFF
--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -299,7 +299,6 @@ def create_app(
         app.state.acp_manager = acp_manager
         from repowire.daemon.transport_router import transport_router_from_state
         peer_delivery = PeerDeliveryService(
-            config=cfg,
             registry=peer_registry,
             message_router=message_router,
             transport_router=transport_router_from_state(
@@ -649,7 +648,6 @@ def create_test_app(
         app.state.acp_manager = acp_manager
         from repowire.daemon.transport_router import transport_router_from_state
         peer_delivery = PeerDeliveryService(
-            config=cfg,
             registry=registry,
             message_router=msg_router,
             transport_router=transport_router_from_state(

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -87,7 +87,6 @@ class PeerDeliveryService:
     def __init__(
         self,
         *,
-        config: Config,
         registry: PeerRegistry,
         message_router: MessageRouter,
         transport_router: PeerTransportRouter | None = None,
@@ -96,7 +95,6 @@ class PeerDeliveryService:
         queued_delivery_store: SQLiteQueuedDeliveryStore | None = None,
         operation_store: Any | None = None,
     ) -> None:
-        self._config = config
         self._registry = registry
         self._message_router = message_router
         self._transport_router = transport_router
@@ -665,7 +663,6 @@ def peer_delivery_from_state(
         state=state,
     )
     return PeerDeliveryService(
-        config=config,
         registry=registry,
         message_router=getattr(state, "message_router"),
         transport_router=transport_router,

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -22,7 +22,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
-from repowire.config.models import DEFAULT_QUERY_TIMEOUT, AgentType, Config
+from repowire.config.models import (
+    DEFAULT_QUERY_TIMEOUT,
+    AgentType,
+    Config,
+    DaemonConfig,
+    ExperimentsConfig,
+)
 from repowire.daemon import diagnostics as diag
 from repowire.daemon.delivery_trace import DeliveryTraceStore
 from repowire.daemon.event_log import EventLog
@@ -133,8 +139,8 @@ class PeerRegistry:
 
     def __init__(
         self,
-        config: Config,
-        message_router: MessageRouter,
+        config: Config | None = None,
+        message_router: MessageRouter | None = None,
         query_tracker: QueryTracker | None = None,
         transport: WebSocketTransport | None = None,
         persistence_path: Path | None = None,
@@ -142,9 +148,22 @@ class PeerRegistry:
         event_bus: EventBus | None = None,
         event_log: EventLog | None = None,
         state_db: StateDatabase | None = None,
+        *,
+        daemon: DaemonConfig | None = None,
+        experiments: ExperimentsConfig | None = None,
     ) -> None:
-        self._config = config
-        self._router = message_router
+        # The registry only needs two config slices (daemon timings +
+        # experiments), not the whole Config god-object. Accept either a full
+        # Config (existing callers) or the slices directly (newer callers), and
+        # store only the slices so the registry's dependency surface is narrow.
+        if config is not None:
+            daemon = daemon or config.daemon
+            experiments = experiments or config.experiments
+        self._daemon = daemon or DaemonConfig()
+        self._experiments = experiments or ExperimentsConfig()
+        if message_router is None:
+            raise ValueError("PeerRegistry requires a message_router")
+        self._router: MessageRouter = message_router
         self._query_tracker = query_tracker
         self._transport = transport
         self._ask_tracker = ask_tracker
@@ -1237,7 +1256,7 @@ class PeerRegistry:
         two means the wire is dead. Public accessor so callers (routes, MCP)
         don't reach into `_config`.
         """
-        return self._config.daemon.heartbeat_interval * 2
+        return self._daemon.heartbeat_interval * 2
 
     async def get_orchestrator(self, circle: str) -> Peer | None:
         """Return the live orchestrator for a circle, or None.
@@ -1359,11 +1378,10 @@ class PeerRegistry:
         from repowire.daemon.transport_router import PeerTransportRouter
 
         return PeerDeliveryService(
-            config=self._config,
             registry=self,
             message_router=self._router,
             transport_router=PeerTransportRouter(
-                config=self._config,
+                experiments=self._experiments,
                 registry=self,
                 message_router=self._router,
             ),
@@ -1542,8 +1560,7 @@ class PeerRegistry:
         ``experiments`` block or attribute is treated as flag-off, never
         a crash.
         """
-        experiments = getattr(self._config, "experiments", None)
-        return bool(getattr(experiments, "acp_broker_client", False))
+        return bool(getattr(self._experiments, "acp_broker_client", False))
 
     async def _redeliver_pending_replies(self, asker_peer_id: str) -> None:
         """Drain ACP-stashed replies for an asker that just came back online.
@@ -1871,7 +1888,7 @@ class PeerRegistry:
         """
         if not peer.description:
             return
-        ttl = self._config.daemon.description_ttl_seconds
+        ttl = self._daemon.description_ttl_seconds
         if ttl <= 0:
             return
         set_at = self._description_set_at.get(peer.peer_id)
@@ -2093,7 +2110,7 @@ class PeerRegistry:
         """Drop delivery-trace rows older than prune_max_age_hours. Best-effort."""
         if self._state_db is None:
             return
-        max_age_hours = self._config.daemon.prune_max_age_hours
+        max_age_hours = self._daemon.prune_max_age_hours
         if not max_age_hours or max_age_hours <= 0:
             return
         try:
@@ -2123,8 +2140,8 @@ class PeerRegistry:
         if not self._transport:
             return 0
         acp_flag = (
-            bool(self._config.experiments.acp_broker_client)
-            if self._config.experiments
+            bool(self._experiments.acp_broker_client)
+            if self._experiments
             else False
         )
         async with self._lock:
@@ -2266,7 +2283,7 @@ class PeerRegistry:
         backend does not emit Stop/AfterAgent. It intentionally ignores
         awaiting_input and any peer with recent liveness progress.
         """
-        timeout = self._config.daemon.stale_busy_timeout_seconds
+        timeout = self._daemon.stale_busy_timeout_seconds
         if timeout <= 0:
             return 0
 
@@ -2297,7 +2314,7 @@ class PeerRegistry:
         demoted by the WebSocket liveness checks above; this pass removes peers
         that stayed offline past the configured grace window.
         """
-        ttl = self._config.daemon.peer_reap_ttl_seconds
+        ttl = self._daemon.peer_reap_ttl_seconds
         if ttl <= 0:
             return 0
 
@@ -2364,7 +2381,7 @@ class PeerRegistry:
 
         Returns number of evicted peers.
         """
-        max_age = self._config.daemon.prune_max_age_hours * 3600
+        max_age = self._daemon.prune_max_age_hours * 3600
         now = time.time()
         async with self._lock:
             stale = [

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol, cast
 
 from repowire.acp import AcpRouteDecision, deliver_ask_via_acp, maybe_decide_acp_route
-from repowire.config.models import Config
+from repowire.config.models import Config, ExperimentsConfig
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.protocol.messages import AttachmentRef
@@ -277,12 +277,12 @@ class PeerTransportRouter:
     def __init__(
         self,
         *,
-        config: Config,
+        experiments: ExperimentsConfig,
         registry: PeerRegistry,
         message_router: MessageRouter,
         acp_manager: Any | None = None,
     ) -> None:
-        self._config = config
+        self._experiments = experiments
         self._registry = registry
         self._ws = WebSocketPeerTransport(registry, message_router)
         self._acp = (
@@ -298,7 +298,7 @@ class PeerTransportRouter:
         return self._acp_decision(target)
 
     def _acp_decision(self, target: Peer) -> AcpRouteDecision | None:
-        experiments = self._config.experiments
+        experiments = self._experiments
         flag = bool(experiments.acp_broker_client) if experiments else False
         if not flag or self._acp is None:
             return None
@@ -372,7 +372,7 @@ def transport_router_from_state(
     message_router = getattr(state, "message_router")
     acp_manager = getattr(state, "acp_manager", None)
     return PeerTransportRouter(
-        config=config,
+        experiments=getattr(config, "experiments", None) or ExperimentsConfig(),
         registry=registry,
         message_router=message_router,
         acp_manager=acp_manager,

--- a/tests/test_claim_role.py
+++ b/tests/test_claim_role.py
@@ -141,7 +141,7 @@ async def test_claim_orchestrator_allows_stale_holder(tmp_path: Path) -> None:
 @pytest.fixture
 async def client(tmp_path: Path):
     registry = _make_registry(tmp_path)
-    cfg = registry._config
+    cfg = Config()
     state = SimpleNamespace(
         config=cfg,
         transport=registry._transport,

--- a/tests/test_pane_ownership_recovery.py
+++ b/tests/test_pane_ownership_recovery.py
@@ -185,7 +185,7 @@ async def test_register_route_reports_unassigned_sticky_orchestrator_pane(
     from repowire.daemon.routes import peers
 
     registry = _make_registry(tmp_path)
-    cfg = registry._config
+    cfg = Config()
     state = SimpleNamespace(
         config=cfg,
         transport=registry._transport,

--- a/tests/test_queued_deliveries.py
+++ b/tests/test_queued_deliveries.py
@@ -64,7 +64,6 @@ def _make_app(tmp_path: Path, cfg: Config | None = None) -> tuple[FastAPI, Simpl
         state_db=state_db,
     )
     state.peer_delivery = PeerDeliveryService(
-        config=cfg,
         registry=registry,
         message_router=msg_router,
         transport_router=transport_router_from_state(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1237,7 +1237,6 @@ async def test_acp_notify_reason_is_broker_accepted():
         )
     )
     service = PeerDeliveryService(
-        config=Config(),
         registry=registry,  # type: ignore[arg-type]
         message_router=SimpleNamespace(),  # type: ignore[arg-type]
         transport_router=transport_router,  # type: ignore[arg-type]

--- a/tests/test_session_mapper.py
+++ b/tests/test_session_mapper.py
@@ -483,7 +483,7 @@ async def test_same_workspace_temp_peer_does_not_replace_fresh_orchestrator(tmp_
     """A split-pane temp peer in the orchestrator workspace must not become
     the active orchestrator while the real holder is fresh."""
     registry = _make_registry(tmp_path)
-    registry._config.daemon.heartbeat_interval = 30
+    registry._daemon.heartbeat_interval = 30
     orch_path = str(tmp_path / "orchestrator")
     Path(orch_path).mkdir()
     real_id, real_name = await registry.allocate_and_register(

--- a/tests/test_sse_stream.py
+++ b/tests/test_sse_stream.py
@@ -49,7 +49,7 @@ def _make_registry(tmp_path: Path) -> PeerRegistry:
 
 def _make_app(tmp_path: Path) -> tuple[FastAPI, PeerRegistry]:
     registry = _make_registry(tmp_path)
-    cfg = registry._config
+    cfg = Config()
     app_state = SimpleNamespace(
         config=cfg,
         transport=registry._transport,

--- a/tests/test_transport_router.py
+++ b/tests/test_transport_router.py
@@ -75,7 +75,7 @@ async def test_ask_routes_to_acp_before_websocket() -> None:
     on_complete = AsyncMock()
 
     router = PeerTransportRouter(
-        config=_config(acp_enabled=True),
+        experiments=_config(acp_enabled=True).experiments,
         registry=registry,
         message_router=ws_router,
         acp_manager=acp_manager,
@@ -102,7 +102,7 @@ async def test_acp_ask_propagates_turn_state_working_then_idle() -> None:
     on_complete = AsyncMock()
 
     router = PeerTransportRouter(
-        config=_config(acp_enabled=True),
+        experiments=_config(acp_enabled=True).experiments,
         registry=registry,
         message_router=ws_router,
         acp_manager=acp_manager,
@@ -129,7 +129,7 @@ async def test_acp_ask_settles_turn_state_idle_on_error() -> None:
     on_complete = AsyncMock()
 
     router = PeerTransportRouter(
-        config=_config(acp_enabled=True),
+        experiments=_config(acp_enabled=True).experiments,
         registry=registry,
         message_router=ws_router,
         acp_manager=acp_manager,
@@ -156,7 +156,7 @@ async def test_notify_routes_to_acp_and_discards_reply() -> None:
     )
 
     router = PeerTransportRouter(
-        config=_config(acp_enabled=True),
+        experiments=_config(acp_enabled=True).experiments,
         registry=registry,
         message_router=ws_router,
         acp_manager=acp_manager,
@@ -179,7 +179,7 @@ async def test_flag_off_acp_peer_falls_through_to_websocket() -> None:
         prompt=AsyncMock(return_value=AcpPromptResult(stop_reason="end_turn", text="unused")),
     )
     router = PeerTransportRouter(
-        config=_config(acp_enabled=False),
+        experiments=_config(acp_enabled=False).experiments,
         registry=registry,
         message_router=ws_router,
         acp_manager=acp_manager,


### PR DESCRIPTION
## What

Completes the deferred slice-narrowing from the config decouple train (#324). The `PeerRegistry` / `PeerTransportRouter` / `PeerDeliveryService` cluster no longer depends on the whole `Config` god-object internally — each holds only the slice it actually reads.

- **PeerRegistry** reads 5 `daemon.*` fields + `experiments`. Its constructor keeps accepting `config: Config` (so the ~32 instantiation sites, mostly tests, don't churn) but now *also* accepts `daemon=`/`experiments=` slices directly, and stores **only** `self._daemon: DaemonConfig` + `self._experiments: ExperimentsConfig` — no retained `self._config`. New code/tests can pass slices; a future bead can drop the `Config` adapter.
- **PeerTransportRouter** narrowed from `config: Config` to `experiments: ExperimentsConfig` (the only thing it read). The `transport_router_from_state` boundary maps `config.experiments` in.
- **PeerDeliveryService** dropped its `config` param entirely — it was stored but never read.
- `_compat_delivery_service` (the legacy `query`/`notify`/`deliver_ask`/`broadcast` facade, still used by the scheduler + asks route) now builds the sub-services from slices.

Net: `self._config` count across all three modules is now zero. `Config` is gone from this cluster's internal dependency surface — the meaningful god-node in-degree reduction — with bounded churn (registry internals + 3 router sites + 5 delivery sites + 4 test-internal `_config` references), not a 40-file sweep.

## Approach

Hybrid per codex's review: keep the boring wiring (`config=Config()`) at the 32 PeerRegistry call sites via a constructor adapter, but sever the internal/structural coupling. Pure signature narrowing everywhere would've been a 40-file sweep; pure "retain self._config" would've left the hidden coupling exactly where the compat facade needed it.

## Testing

- Full suite: 1587 passing (the 2 pre-existing `test_spawn.py::TestMcpRegistration` failures are unrelated — they fail on clean `main`).
- `ruff` + `ty` on `repowire/`: clean.

Closes repowire-dmv.

🤖 Reviewed by the `codex` mesh peer.
