### PR TITLE
fix(acp): session/close on teardown + expose ACP session ids in health

### DIFF
--- a/repowire/acp/client.py
+++ b/repowire/acp/client.py
@@ -321,13 +321,23 @@ class AcpClient:
 
         Idempotent. Does NOT acquire ``self._lock`` so it's safe to call while
         the prompt path already holds it.
+
+        Best-effort ``session/close`` first (lifecycle hygiene: lets the agent
+        flush/release the session) before tearing down stdio. This is distinct
+        from ``cancel()`` (which interrupts active work) — both are kept.
         """
         if self._closed:
             return
         self._closed = True
+        connection, session_id = self._connection, self._session_id
         stack, self._exit_stack = self._exit_stack, None
         self._connection = None
         self._session_id = None
+        if connection is not None and session_id is not None:
+            try:
+                await connection.close_session(session_id)
+            except Exception as e:  # noqa: BLE001 — close is best-effort, never block teardown
+                logger.debug("ACP session/close best-effort failed: %s", e)
         if stack is not None:
             try:
                 await stack.__aexit__(None, None, None)

--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -122,6 +122,13 @@ class AcpClientManager:
             "last_error_peer_id": self._last_error_peer_id,
             "last_error_at": self._last_error_at,
             "last_success_at": self._last_success_at,
+            # Broker-protocol session ids, exposed for diagnostics/timeline only.
+            # NOT a backend resume handle — do not feed into runtime_session_id.
+            "sessions": {
+                peer_id: client.session_id
+                for peer_id, client in self._clients.items()
+                if client.session_id is not None
+            },
         }
 
     async def _drop_if_crashed(self, peer_id: str, client: AcpClient) -> None:

--- a/repowire/daemon/routes/health.py
+++ b/repowire/daemon/routes/health.py
@@ -48,6 +48,9 @@ class AcpBrokerHealth(BaseModel):
     last_error_peer_id: str | None = None
     last_error_at: str | None = None
     last_success_at: str | None = None
+    # peer_id -> broker-protocol ACP session id. Diagnostics/timeline only; this
+    # is NOT a backend resume handle and must not be used as runtime_session_id.
+    sessions: dict[str, str] = Field(default_factory=dict)
     permissions: AcpPermissionHealth = Field(default_factory=AcpPermissionHealth)
 
 
@@ -164,6 +167,7 @@ async def _acp_broker_health(request: Request, config: Any) -> AcpBrokerHealth:
         last_error_peer_id=snapshot.get("last_error_peer_id"),
         last_error_at=snapshot.get("last_error_at"),
         last_success_at=snapshot.get("last_success_at"),
+        sessions=snapshot.get("sessions") or {},
         permissions=permissions,
     )
 

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -137,6 +137,71 @@ async def test_acp_manager_reuses_session_for_peer(acp_peer_config: AcpPeerConfi
         await mgr.close()
 
 
+@pytest.mark.asyncio
+async def test_close_sends_session_close_before_teardown(
+    acp_peer_config: AcpPeerConfig,
+) -> None:
+    # repowire-cju: close() should best-effort session/close before tearing down
+    # stdio (lifecycle hygiene), distinct from cancel().
+    from repowire.acp import AcpClient
+
+    client = AcpClient(acp_peer_config)
+    # Inject a fake live connection + session so close() exercises session/close
+    # without needing the stub to implement it.
+    closed: list[str] = []
+
+    class _FakeConn:
+        async def close_session(self, session_id: str, **_):
+            closed.append(session_id)
+
+    client._connection = _FakeConn()  # type: ignore[assignment]
+    client._session_id = "sess-xyz"
+    await client.close()
+    assert closed == ["sess-xyz"], "close() must call session/close once"
+    # Idempotent: a second close does not re-send.
+    await client.close()
+    assert closed == ["sess-xyz"]
+
+
+@pytest.mark.asyncio
+async def test_close_session_failure_does_not_break_teardown(
+    acp_peer_config: AcpPeerConfig,
+) -> None:
+    # A session/close error (e.g. agent doesn't support it) must not block stdio
+    # teardown — close stays best-effort.
+    from repowire.acp import AcpClient
+
+    client = AcpClient(acp_peer_config)
+
+    class _BadConn:
+        async def close_session(self, session_id: str, **_):
+            raise RuntimeError("not supported")
+
+    client._connection = _BadConn()  # type: ignore[assignment]
+    client._session_id = "sess-abc"
+    await client.close()  # must not raise
+    assert client._closed is True
+
+
+@pytest.mark.asyncio
+async def test_manager_health_snapshot_exposes_acp_session_ids(
+    acp_peer_config: AcpPeerConfig,
+) -> None:
+    # repowire-xig: ACP session ids are surfaced for diagnostics (NOT as a
+    # runtime_session_id resume handle).
+    from repowire.acp import AcpPeerSpec
+
+    mgr = AcpClientManager()
+    spec = AcpPeerSpec(peer_id="peer-diag", config=acp_peer_config)
+    try:
+        await mgr.prompt(spec, "ping")
+        snap = mgr.health_snapshot()
+        assert "peer-diag" in snap["sessions"]
+        assert isinstance(snap["sessions"]["peer-diag"], str)
+    finally:
+        await mgr.close()
+
+
 # ----- end-to-end: /ask via ACP delivers reply via notify -----
 
 


### PR DESCRIPTION
## What

Two small ACP follow-ups from the ACP must-fix review (#325).

### session/close on teardown (repowire-cju)

`AcpClient._close_locked` previously tore down stdio without telling the agent to close the session. Now it best-effort calls `connection.close_session(session_id)` first (the SDK exposes it) — lifecycle hygiene that lets the agent flush/release the session. Distinct from `cancel()` (which interrupts active work); both are kept. Best-effort: a `close_session` failure (e.g. an agent that doesn't implement it) is logged at debug and never blocks teardown. Idempotent.

### Expose ACP session ids for diagnostics (repowire-xig)

`AcpClientManager.health_snapshot()` now includes a `sessions` map (`peer_id -> ACP session id`), surfaced through `/health`'s `acp_broker.sessions`. This is **diagnostics/timeline only** — explicitly NOT a backend resume handle, and not to be fed into `runtime_session_id` (the ACP session id is broker-protocol state, not a proven CLI resume id). Both the manager field and the route schema carry that caveat in comments.

## Testing

- New tests: `session/close` is sent once before teardown (idempotent); a `close_session` failure doesn't break teardown; the manager health snapshot exposes ACP session ids.
- Full suite: 1590 passing (the 2 pre-existing `test_spawn.py::TestMcpRegistration` failures are unrelated).
- `ruff` + `ty` on `repowire/`: clean.

Closes repowire-cju, repowire-xig.

🤖 Reviewed by the `codex` mesh peer.
