### PR TITLE
feat(acp): broadcast reaches ACP peers via broker fanout

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -134,6 +134,8 @@ Fan out to every online peer in your circle. No correlation, no reply. Use spari
 broadcast("rebasing main, hold pushes for ~5 min")
 ```
 
+ACP-brokered peers (experimental) are included in the fan-out: each receives the broadcast text as a fire-and-forget prompt through the broker (reply discarded), the same broker-accepted semantics as an ACP `notify_peer`. They appear in the response's `sent_to` on broker handoff, not on runtime completion.
+
 ## Inspection
 
 ### `list_peers`

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -33,6 +33,7 @@ from repowire.daemon.transport_router import (
 )
 from repowire.daemon.websocket_transport import DeliveryInjectionError, TransportError
 from repowire.protocol.messages import AttachmentRef
+from repowire.protocol.peers import PeerStatus
 
 logger = logging.getLogger(__name__)
 
@@ -498,20 +499,46 @@ class PeerDeliveryService:
             },
         )
 
+        # ACP-routed recipients have no WS session, so MessageRouter.broadcast
+        # (which iterates live WS sessions) never reaches them. Fan out to the
+        # eligible ACP peers through the same ACP-before-WS router used for
+        # notify (fire-and-forget; reply discarded), and exclude them from the
+        # WS broadcast so a hybrid peer can't receive twice.
+        acp_sent: list[str] = []
+        acp_failed: list[dict[str, str]] = []
+        if self._transport_router is not None:
+            for peer in peers:
+                if peer.peer_id in exclude_session_ids:
+                    continue
+                # Match WS broadcast semantics: only reach live peers, never
+                # resurrect an OFFLINE one (codex review). ONLINE/BUSY are
+                # eligible; the ACP client lock serializes a BUSY peer's prompts.
+                if peer.status == PeerStatus.OFFLINE:
+                    continue
+                if self._router().acp_route(peer) is None:
+                    continue
+                exclude_session_ids.add(peer.peer_id)
+                try:
+                    if await self._router().broadcast_to_acp(peer, text):
+                        acp_sent.append(peer.display_name)
+                except Exception as e:  # noqa: BLE001 — one ACP failure must not abort fanout
+                    acp_failed.append({"peer": peer.display_name, "error": str(e)})
+
         sent_ids, failed = await self._message_router.broadcast(
             from_peer=from_peer,
             text=text,
             exclude=exclude_session_ids,
         )
         return (
-            [id_to_name[sid] for sid in sent_ids if sid in id_to_name],
+            [id_to_name[sid] for sid in sent_ids if sid in id_to_name] + acp_sent,
             [
                 {
                     "peer": id_to_name.get(f["session_id"], f["session_id"]),
                     "error": f["error"],
                 }
                 for f in failed
-            ],
+            ]
+            + acp_failed,
         )
 
     def _router(self) -> PeerTransportRouter:

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -270,6 +270,30 @@ class AcpPeerTransport:
             to_repowire_session_id=envelope.to_repowire_session_id,
         )
 
+    async def send_broadcast(self, text: str, decision: AcpRouteDecision) -> None:
+        """Fire-and-forget broadcast text to one ACP peer (reply discarded).
+
+        Like notify, this returns after the prompt task is scheduled — it does
+        NOT await the runtime, so a slow ACP peer can't make broadcast block.
+        """
+        if decision is None or decision.spec is None:
+            raise RuntimeError("ACP transport selected without an ACP route")
+
+        async def _drop_result(
+            _cid: str, _reply: str | None, _err: str | None,
+        ) -> None:
+            return None
+
+        cid = f"bcast-{uuid.uuid4().hex[:8]}"
+        await deliver_ask_via_acp(
+            manager=self._manager,
+            spec=decision.spec,
+            correlation_id=cid,
+            text=text,
+            on_complete=_drop_result,
+            on_state=self._state_callback(decision.spec.peer_id),
+        )
+
 
 class PeerTransportRouter:
     """Choose ACP before WebSocket for peer delivery."""
@@ -296,6 +320,20 @@ class PeerTransportRouter:
         before dispatch without duplicating the flag/metadata decision.
         """
         return self._acp_decision(target)
+
+    async def broadcast_to_acp(self, target: Peer, text: str) -> bool:
+        """Fire-and-forget broadcast to ``target`` iff it routes over ACP.
+
+        Returns True when the prompt task was scheduled (the ACP analogue of a
+        WS broadcast send), False when the peer is not ACP-routed (the caller
+        leaves it to the WS fanout). Raises on a genuine ACP dispatch error so
+        the caller can record it as a per-recipient failure.
+        """
+        decision = self._acp_decision(target)
+        if decision is None or self._acp is None:
+            return False
+        await self._acp.send_broadcast(text, decision)
+        return True
 
     def _acp_decision(self, target: Peer) -> AcpRouteDecision | None:
         experiments = self._experiments

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -537,6 +537,103 @@ async def test_public_notify_route_does_not_503_for_acp_peer(
 
 
 @pytest.mark.asyncio
+async def test_broadcast_reaches_acp_peer_without_ws_session(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    # repowire-7bc: broadcast must reach ACP-routed peers (no WS session) via the
+    # broker, reporting them in sent_to and prompting the ACP manager.
+    app, _registry, _at, manager = _make_public_app(tmp_path, flag=True)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            sender = await _register_plain_peer(http, name="sender")
+            acp_peer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            r = await http.post("/broadcast", json={
+                "from_peer": sender,
+                "text": "all hands",
+            })
+            assert r.status_code == 200, r.text
+            assert acp_peer in r.json()["sent_to"]
+            # the broker actually received the broadcast text
+            await asyncio.sleep(0)
+            assert any(text == "all hands" for _pid, text in manager.prompts)
+    finally:
+        await asyncio.sleep(0)
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_excludes_named_acp_peer(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    # An explicitly-excluded ACP peer must not be prompted.
+    app, _registry, _at, manager = _make_public_app(tmp_path, flag=True)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            sender = await _register_plain_peer(http, name="sender")
+            acp_peer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+
+            r = await http.post("/broadcast", json={
+                "from_peer": sender,
+                "text": "skip you",
+                "exclude": [acp_peer],
+            })
+            assert r.status_code == 200, r.text
+            assert acp_peer not in r.json()["sent_to"]
+            await asyncio.sleep(0)
+            assert manager.prompts == []
+    finally:
+        await asyncio.sleep(0)
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_skips_offline_acp_peer(
+    tmp_path: Path, acp_peer_config: AcpPeerConfig,
+) -> None:
+    # Broadcast must not resurrect an OFFLINE ACP peer (codex review): match WS
+    # broadcast semantics — only live peers are reached.
+    app, registry, _at, manager = _make_public_app(
+        tmp_path, flag=True, skip_lazy_repair=True,
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            sender = await _register_plain_peer(http, name="sender")
+            acp_peer = await _register_acp_peer(
+                http, name="answerer", acp_config=acp_peer_config,
+            )
+            # Mark the ACP peer OFFLINE (e.g. reaped/disconnected).
+            for p in await registry.get_all_peers():
+                if p.display_name == acp_peer:
+                    p.status = PeerStatus.OFFLINE
+
+            r = await http.post("/broadcast", json={
+                "from_peer": sender,
+                "text": "anyone home",
+            })
+            assert r.status_code == 200, r.text
+            assert acp_peer not in r.json()["sent_to"]
+            await asyncio.sleep(0)
+            assert manager.prompts == []
+    finally:
+        await asyncio.sleep(0)
+        await manager.close()
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
 async def test_lazy_repair_does_not_demote_acp_peers_with_flag_on(
     tmp_path: Path, acp_peer_config: AcpPeerConfig,
 ) -> None:


### PR DESCRIPTION
## What

Broadcast now reaches ACP-brokered peers. Previously `broadcast` went `PeerDeliveryService.broadcast → MessageRouter.broadcast`, which iterates live WS sessions — ACP peers have no WS session, so they were invisible to broadcast (not even attempted).

Per the ACP must-fix review's guidance, the fan-out to ACP peers lives in **`PeerDeliveryService`** (not special-cased in `MessageRouter`) and goes through the same ACP-before-WS router used for notify:

- The eligible recipient set + circle/exclude filtering is computed exactly as before.
- Eligible peers that route over ACP (`router.acp_route(peer)`) are dispatched via a new `PeerTransportRouter.broadcast_to_acp` → `AcpPeerTransport.send_broadcast` — a fire-and-forget prompt (reply discarded), non-blocking (returns after the prompt task is scheduled, so a slow ACP runtime can't make broadcast synchronous).
- Those ACP peers are **excluded from the WS broadcast** so a hybrid peer can't receive twice.
- ACP successes merge into `sent_to`; per-recipient ACP failures append to `failed` without aborting the WS fanout or other ACP peers.

`sent_to` for an ACP recipient means broker handoff (broker-accepted), matching ACP notify semantics — documented in `docs/reference/mcp-tools.md`. The proven WS batch fanout is untouched.

## Testing

- New: broadcast reaches an ACP peer with no WS session (in `sent_to`, broker prompted); an excluded ACP peer is not prompted.
- Existing broadcast tests unchanged + passing.
- Full suite: 1592 passing (the 2 pre-existing `test_spawn.py::TestMcpRegistration` failures are unrelated).
- `ruff` + `ty` on `repowire/`: clean.

Closes repowire-7bc.

🤖 Reviewed by the `codex` mesh peer.
