### PR TITLE
test(spawn): make MCP backend-detection tests hermetic

### DIFF
--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -663,7 +663,21 @@ class TestMcpRegistration:
             {"ok": True},  # POST /peers/repowire-codex/touch
         ]
 
-        with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
+        # patch.dict merges with the ambient env. When the suite runs INSIDE a
+        # Claude Code session, CLAUDECODE/CLAUDE_CODE_*/AI_AGENT leak in and
+        # claude-code's mcp_runtime_matches wins over the intended codex PATH
+        # signal. Null those markers so detection sees only the codex PATH.
+        with patch.dict(
+            "repowire.mcp.server.os.environ",
+            {
+                "PATH": "/tmp/.codex/bin",
+                "CLAUDECODE": "",
+                "CLAUDE_CODE_SESSION_ID": "",
+                "CLAUDE_CODE_ENTRYPOINT": "",
+                "AI_AGENT": "",
+                "GEMINI_CLI": "",
+            },
+        ):
             await mcp_server._ensure_registered()
 
         assert mock_request.await_count == 4
@@ -706,7 +720,21 @@ class TestMcpRegistration:
             {"ok": True},  # POST /peers/torale-seo/touch
         ]
 
-        with patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"}):
+        # patch.dict merges with the ambient env. When the suite runs INSIDE a
+        # Claude Code session, CLAUDECODE/CLAUDE_CODE_*/AI_AGENT leak in and
+        # claude-code's mcp_runtime_matches wins over the intended codex PATH
+        # signal. Null those markers so detection sees only the codex PATH.
+        with patch.dict(
+            "repowire.mcp.server.os.environ",
+            {
+                "PATH": "/tmp/.codex/bin",
+                "CLAUDECODE": "",
+                "CLAUDE_CODE_SESSION_ID": "",
+                "CLAUDE_CODE_ENTRYPOINT": "",
+                "AI_AGENT": "",
+                "GEMINI_CLI": "",
+            },
+        ):
             await mcp_server._ensure_registered()
 
         assert mcp_server._cached_peer_name == "torale-seo"


### PR DESCRIPTION
## What

Fixes the two long-standing `test_spawn.py::TestMcpRegistration` failures (`repowire-xfw`) that have failed on every local run this session but passed in CI.

### Root cause (evidence-based)

Both tests do `patch.dict("repowire.mcp.server.os.environ", {"PATH": "/tmp/.codex/bin"})` to simulate a Codex runtime, then assert backend detection returns `codex`. But `patch.dict` **merges** with the ambient environment. When the suite runs *inside a Claude Code session*, the real `CLAUDECODE` / `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_ENTRYPOINT` / `AI_AGENT=claude-code` vars leak in, and claude-code's `mcp_runtime_matches` (checked before codex in the detection order) wins over the intended `.codex/`-in-PATH signal — so detection returns `claude-code` and the assertion fails.

On a clean CI shell those vars are absent, so the codex PATH signal is authoritative and the tests pass. That's exactly the "pre-existing, environment-dependent" behavior noted across this session.

### Fix

Test-only: make the patched env hermetic by also nulling the claude-code/gemini detection markers, so detection sees only the codex PATH regardless of where the suite runs. No production code change — the detection logic is correct; the tests just weren't isolated from the host runtime.

## Testing

- `TestMcpRegistration`: 4/4 pass (the 2 previously-failing + 2 that already passed).
- **Full suite: 1595 passing, 0 failures** — genuinely green for the first time (these 2 were the only persistent reds).
- `ruff` clean.

Closes repowire-xfw.

🤖 Reviewed by the `codex` mesh peer.
