### PR TITLE
fix(spawn): prune dead-pane ownership records + backfill peer_id on rehydrate

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -2103,8 +2103,23 @@ class PeerRegistry:
             await self._evict_stale_peers()
             await self._emit_and_evict_expired_stashes()
             self._prune_delivery_traces()
+            self._prune_spawn_ownership()
             self._save_events()
             self._persist_mappings()
+
+    def _prune_spawn_ownership(self) -> None:
+        """Drop spawn-ownership records pointing at dead tmux panes. Best-effort.
+
+        After a daemon restart these rehydrate and otherwise cause kills to
+        no-op (they point at a dead pane) and weaken kill/restart
+        disambiguation. Piggy-backed on lazy_repair, never on a timer.
+        """
+        try:
+            from repowire.spawn_ownership import prune_dead_ownership
+
+            prune_dead_ownership()
+        except Exception:  # noqa: BLE001 — pruning must not break repair
+            logger.warning("Spawn-ownership prune failed", exc_info=True)
 
     def _prune_delivery_traces(self) -> None:
         """Drop delivery-trace rows older than prune_max_age_hours. Best-effort."""

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -27,6 +27,7 @@ from repowire.spawn import SpawnConfig, SpawnResult, kill_pane, spawn_peer
 from repowire.spawn_ownership import (
     OwnershipValidation,
     _norm_path,
+    backfill_ownership_peer_id,
     find_spawn_ownership_for_peer,
     forget_spawn_ownership,
     probe_tmux_pane,
@@ -390,6 +391,12 @@ def _effective_ownership_validation(peer: Peer) -> OwnershipValidation:
         if direct.ok:
             return direct
     adopted = find_spawn_ownership_for_peer(peer)
+    if adopted.ok:
+        # Rehydrated peer uniquely matched a record by identity + live pane but
+        # the record lost its peer_id across restart. Persist it so the next
+        # lookup has the strong disambiguator (reduces ambiguous_ownership).
+        # Pass the resolved validation to avoid a second correlation probe.
+        backfill_ownership_peer_id(peer, adopted)
     if adopted.ok or direct is None or adopted.error == "ambiguous_ownership":
         return adopted
     return direct

--- a/repowire/spawn_ownership.py
+++ b/repowire/spawn_ownership.py
@@ -9,6 +9,7 @@ is intentionally killed.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import socket
 import subprocess
@@ -19,6 +20,8 @@ from typing import Any, Literal
 
 from repowire.config.models import AgentType, Config
 from repowire.protocol.peers import Peer, PeerRole
+
+logger = logging.getLogger(__name__)
 
 OWNERSHIP_PATH = Config.get_config_dir() / "spawn_ownership.json"
 
@@ -201,6 +204,59 @@ def find_spawn_ownership_for_peer(peer: Peer) -> OwnershipValidation:
             "Manual peers and pre-proof spawns are left untouched."
         ),
     )
+
+
+def prune_dead_ownership() -> int:
+    """Drop ownership records whose pane is no longer live in tmux.
+
+    After a daemon restart, ``spawn_ownership.json`` rehydrates every record
+    from the last run; panes that have since died linger and cause kills to
+    no-op (they point at a dead pane) and weaken disambiguation. This prunes
+    them. Called opportunistically (lazy repair), never on a timer.
+
+    Returns the number of records removed.
+    """
+    records = _load_records()
+    dead = [pane_id for pane_id, rec in records.items() if probe_tmux_pane(rec.pane_id) is None]
+    if not dead:
+        return 0
+    for pane_id in dead:
+        records.pop(pane_id, None)
+    _save_records(records)
+    logger.info("Pruned %d spawn-ownership record(s) with dead panes", len(dead))
+    return len(dead)
+
+
+def backfill_ownership_peer_id(
+    peer: Peer, match: OwnershipValidation | None = None,
+) -> bool:
+    """Write ``peer.peer_id`` back onto its ownership record if it lacks one.
+
+    After restart, records rehydrate with ``peer_id=None`` (the strongest
+    disambiguator is lost). When a peer is uniquely correlated to a live-pane
+    record by identity, persist its peer_id so future lookups are unambiguous.
+    Returns True if a record was updated.
+
+    ``match`` lets a caller that already resolved ownership pass its
+    ``OwnershipValidation`` to avoid a second tmux-probing correlation pass.
+    """
+    if not peer.peer_id:
+        return False
+    if match is None:
+        match = find_spawn_ownership_for_peer(peer)
+    if not match.ok or match.record is None or match.record.peer_id:
+        return False
+    records = _load_records()
+    record = records.get(match.record.pane_id)
+    if record is None or record.peer_id:
+        return False
+    record.peer_id = peer.peer_id
+    _save_records(records)
+    logger.info(
+        "Backfilled peer_id=%s onto spawn-ownership record for pane %s",
+        peer.peer_id, record.pane_id,
+    )
+    return True
 
 
 def validate_spawn_ownership(peer: Peer) -> OwnershipValidation:

--- a/tests/test_spawn_ownership_prune.py
+++ b/tests/test_spawn_ownership_prune.py
@@ -1,0 +1,146 @@
+"""Prune dead-pane spawn-ownership records + backfill peer_id (repowire-wg4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from repowire.config.models import AgentType
+from repowire.protocol.peers import Peer, PeerRole, PeerStatus
+from repowire.spawn_ownership import (
+    OwnershipValidation,
+    TmuxPaneEvidence,
+    _load_records,
+    backfill_ownership_peer_id,
+    prune_dead_ownership,
+    record_spawn_ownership,
+)
+
+
+def _seed(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "repowire.spawn_ownership.OWNERSHIP_PATH", tmp_path / "ownership.json"
+    )
+
+
+def _record(pane_id: str, *, peer_id: str | None = None) -> None:
+    record_spawn_ownership(
+        pane_id=pane_id,
+        path="/tmp/proj",
+        backend=AgentType.CODEX,
+        circle="default",
+        role=PeerRole.AGENT,
+        display_name="proj-codex",
+        tmux_session="sess",
+        peer_id=peer_id,
+        machine="localhost",
+    )
+
+
+def test_prune_drops_dead_pane_records(monkeypatch, tmp_path: Path) -> None:
+    _seed(monkeypatch, tmp_path)
+    _record("%1")  # will be live
+    _record("%2")  # will be dead
+
+    def fake_probe(pane_id: str):
+        if pane_id == "%1":
+            return TmuxPaneEvidence(
+                pane_id="%1", tmux_session="sess", current_path="/tmp/proj", pane_pid="1234",
+            )
+        return None  # %2 is dead
+
+    with patch("repowire.spawn_ownership.probe_tmux_pane", side_effect=fake_probe):
+        removed = prune_dead_ownership()
+
+    assert removed == 1
+    remaining = _load_records()
+    assert "%1" in remaining and "%2" not in remaining
+
+
+def test_prune_is_noop_when_all_live(monkeypatch, tmp_path: Path) -> None:
+    _seed(monkeypatch, tmp_path)
+    _record("%1")
+    evidence = TmuxPaneEvidence(
+        pane_id="%1", tmux_session="sess", current_path="/tmp/proj", pane_pid="1234",
+    )
+    with patch("repowire.spawn_ownership.probe_tmux_pane", return_value=evidence):
+        assert prune_dead_ownership() == 0
+    assert "%1" in _load_records()
+
+
+def test_backfill_writes_peer_id_onto_matching_record(monkeypatch, tmp_path: Path) -> None:
+    _seed(monkeypatch, tmp_path)
+    _record("%1", peer_id=None)  # rehydrated record lost its peer_id
+
+    peer = Peer(
+        peer_id="peer-abc",
+        display_name="proj-codex",
+        path="/tmp/proj",
+        machine="localhost",
+        backend=AgentType.CODEX,
+        circle="default",
+        role=PeerRole.AGENT,
+        status=PeerStatus.ONLINE,
+    )
+    evidence = TmuxPaneEvidence(
+        pane_id="%1", tmux_session="sess", current_path="/tmp/proj", pane_pid="1234",
+    )
+    with patch("repowire.spawn_ownership.probe_tmux_pane", return_value=evidence), \
+         patch("repowire.spawn_ownership.socket.gethostname", return_value="localhost"):
+        updated = backfill_ownership_peer_id(peer)
+
+    assert updated is True
+    assert _load_records()["%1"].peer_id == "peer-abc"
+
+
+def test_backfill_skips_record_that_already_has_peer_id(monkeypatch, tmp_path: Path) -> None:
+    _seed(monkeypatch, tmp_path)
+    _record("%1", peer_id="existing-id")
+
+    peer = Peer(
+        peer_id="peer-abc",
+        display_name="proj-codex",
+        path="/tmp/proj",
+        machine="localhost",
+        backend=AgentType.CODEX,
+        circle="default",
+        role=PeerRole.AGENT,
+        status=PeerStatus.ONLINE,
+    )
+    evidence = TmuxPaneEvidence(
+        pane_id="%1", tmux_session="sess", current_path="/tmp/proj", pane_pid="1234",
+    )
+    with patch("repowire.spawn_ownership.probe_tmux_pane", return_value=evidence), \
+         patch("repowire.spawn_ownership.socket.gethostname", return_value="localhost"):
+        updated = backfill_ownership_peer_id(peer)
+
+    assert updated is False
+    assert _load_records()["%1"].peer_id == "existing-id"  # not overwritten
+
+
+def test_backfill_uses_prevalidated_match_without_reprobing(monkeypatch, tmp_path: Path) -> None:
+    # A caller that already resolved ownership can pass the OwnershipValidation
+    # to avoid a second tmux-probing correlation pass.
+    _seed(monkeypatch, tmp_path)
+    _record("%1", peer_id=None)
+    peer = Peer(
+        peer_id="peer-abc",
+        display_name="proj-codex",
+        path="/tmp/proj",
+        machine="localhost",
+        backend=AgentType.CODEX,
+        circle="default",
+        role=PeerRole.AGENT,
+        status=PeerStatus.ONLINE,
+    )
+    pre = _load_records()["%1"]
+    match = OwnershipValidation(ok=True, record=pre, evidence=None)
+    # No probe patch: a re-probe would fail (real tmux), proving the passed
+    # match short-circuits the correlation.
+    with patch(
+        "repowire.spawn_ownership.find_spawn_ownership_for_peer",
+        side_effect=AssertionError("must not re-correlate when match is supplied"),
+    ):
+        updated = backfill_ownership_peer_id(peer, match)
+    assert updated is True
+    assert _load_records()["%1"].peer_id == "peer-abc"


### PR DESCRIPTION
## What

Fixes spawn-ownership rot (`repowire-wg4`): after a daemon restart, `spawn_ownership.json` rehydrates every record from the previous run, including ones whose tmux pane has since died and ones that lost their `peer_id` (observed 39/39 with `peer_id=null`). Symptoms:
1. `kill_peer` returns 200 but no-ops when ownership points at a dead pane (the process survives).
2. Null `peer_id` removes the strongest disambiguator, raising `ambiguous_ownership` risk across same-path peers.

Two-part fix:

- **`prune_dead_ownership()`** — drops records whose `pane_id` is no longer live in tmux. Wired into `PeerRegistry.lazy_repair` (opportunistic, 30s-throttled, best-effort — no new timer, per the lazy-repair philosophy).
- **`backfill_ownership_peer_id(peer)`** — when a rehydrated peer is uniquely correlated to a live-pane record by identity but the record lost its `peer_id`, persist it. Called from `_effective_ownership_validation` on the restart/rehook adoption path. Never overwrites an existing `peer_id`.

Same identity-churn family as the WS-path fixes (`4a8a535` preserve-mapped-identity, `4566d0b` preserve-certified-identity), but on the spawn-ownership persistence path. Distinct from the durable-resume feature (shipped separately, #323).

## Testing

- New `tests/test_spawn_ownership_prune.py`: prune drops dead-pane records, is a no-op when all live, backfill writes peer_id onto a matching record, backfill skips a record that already has one.
- Full suite: **1599 passing, 0 failures.**
- `ruff` + `ty` on `repowire/`: clean.

Closes repowire-wg4.

🤖 Reviewed by the `codex` mesh peer.
