### PR TITLE
feat(dashboard): show peer turn_state hints in roster

### DIFF
--- a/web/app/dashboard/components/PeerRoster.tsx
+++ b/web/app/dashboard/components/PeerRoster.tsx
@@ -3,7 +3,7 @@ import { Search } from "lucide-react";
 import { cn, shortPath, statusDot } from "../lib/utils";
 import type { Peer } from "../types";
 import { peerLabel } from "../types";
-import { StatusLabel, statusRank } from "./status";
+import { StatusLabel, TurnStateHint, statusRank } from "./status";
 
 export function PeerRoster({
   peers,
@@ -89,6 +89,7 @@ function PeerRow({ peer, active, onClick }: { peer: Peer; active: boolean; onCli
       <div className="mb-1 flex min-w-0 items-center gap-2.5">
         <span className={cn("h-2 w-2 shrink-0 rounded-full", statusDot(peer.status))} />
         <span className="min-w-0 flex-1 truncate font-mono text-[13px] font-semibold">{peerLabel(peer)}</span>
+        <TurnStateHint turnState={peer.turn_state} />
         <StatusLabel status={peer.status} />
       </div>
       <div className="ml-[18px] truncate font-mono text-[11px] leading-5 text-outline">

--- a/web/app/dashboard/components/status.test.tsx
+++ b/web/app/dashboard/components/status.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TurnStateHint } from "./status";
+
+describe("TurnStateHint", () => {
+  it("surfaces pending_first_turn as a needs-prompt hint", () => {
+    render(<TurnStateHint turnState="pending_first_turn" />);
+    expect(screen.getByText("needs prompt")).toBeTruthy();
+  });
+
+  it("surfaces awaiting_input", () => {
+    render(<TurnStateHint turnState="awaiting_input" />);
+    expect(screen.getByText("awaiting input")).toBeTruthy();
+  });
+
+  it("surfaces working", () => {
+    render(<TurnStateHint turnState="working" />);
+    expect(screen.getByText("working")).toBeTruthy();
+  });
+
+  it("renders nothing for idle", () => {
+    const { container } = render(<TurnStateHint turnState="idle" />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when turn_state is absent", () => {
+    const { container } = render(<TurnStateHint turnState={undefined} />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/web/app/dashboard/components/status.tsx
+++ b/web/app/dashboard/components/status.tsx
@@ -6,6 +6,26 @@ export function StatusLabel({ status }: { status: Peer["status"] }) {
   return <span className={cn("font-mono text-[9px] font-semibold uppercase tracking-[0.16em]", text)}>{status}</span>;
 }
 
+// Per-turn progress hint, orthogonal to status. Surfaced especially for
+// pending_first_turn (a seeded peer that never received its first prompt) and
+// awaiting_input (waiting on the user mid-turn) so operators can act. idle and
+// null render nothing to keep the roster quiet.
+const TURN_STATE_HINTS: Record<string, { label: string; className: string }> = {
+  pending_first_turn: { label: "needs prompt", className: "text-tertiary-fixed-dim" },
+  awaiting_input: { label: "awaiting input", className: "text-tertiary-fixed-dim" },
+  working: { label: "working", className: "text-outline" },
+};
+
+export function TurnStateHint({ turnState }: { turnState?: Peer["turn_state"] }) {
+  const hint = turnState ? TURN_STATE_HINTS[turnState] : undefined;
+  if (!hint) return null;
+  return (
+    <span className={cn("font-mono text-[9px] font-medium uppercase tracking-[0.12em]", hint.className)}>
+      {hint.label}
+    </span>
+  );
+}
+
 export function statusRank(status: Peer["status"]) {
   if (status === "online") return 0;
   if (status === "busy") return 1;

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -3,6 +3,7 @@ export interface Peer {
   name: string;
   display_name: string;
   status: "online" | "busy" | "offline";
+  turn_state?: "idle" | "working" | "awaiting_input" | "pending_first_turn" | null;
   machine: string;
   path: string;
   tmux_session?: string;


### PR DESCRIPTION
## What

Renders peer `turn_state` in the dashboard roster (`repowire-5aa`), so operators can see per-turn progress orthogonal to online/busy/offline status — especially `pending_first_turn` (a seeded peer that never received its first prompt) which otherwise looks online but is silently waiting.

- `Peer.turn_state` added to the dashboard type (the daemon's `/peers` already emits it via `PeerInfo.turn_state`).
- New `TurnStateHint` component: `pending_first_turn → "needs prompt"`, `awaiting_input → "awaiting input"` (both highlighted), `working → "working"` (subtle), `idle`/null → nothing (keeps the roster quiet).
- Rendered in each `PeerRow` next to the status label.

This complements the ACP turn_state propagation shipped earlier (#325) — ACP peers now surface working/idle here too.

## Testing

- New `status.test.tsx`: 5 cases (each hinted state + idle/absent render nothing).
- Full web suite: 59 passing; `eslint` clean; `next build` clean.
- **Live-verified in-browser** (agent-browser against the running daemon): roster showed `repowire-claude-code` as `WORKING BUSY` and `repowire-codex` as `ONLINE` (idle → no hint), confirming real `/peers` turn_state data renders correctly — not just a green build.

Closes repowire-5aa.

🤖 Reviewed by the `codex` mesh peer.
