### PR TITLE
feat(asks): ask-many fanout with lazy aggregation

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -136,6 +136,23 @@ broadcast("rebasing main, hold pushes for ~5 min")
 
 ACP-brokered peers (experimental) are included in the fan-out: each receives the broadcast text as a fire-and-forget prompt through the broker (reply discarded), the same broker-accepted semantics as an ACP `notify_peer`. They appear in the response's `sent_to` on broker handoff, not on runtime completion.
 
+### `ask_many` / `ask_many_result`
+
+```python
+ask_many(peer_names: list[str], query: str, circle: str | None = None, timeout_seconds: int = 300) -> str
+ask_many_result(parent_id: str) -> str
+```
+
+Ask the same question to several peers in parallel under one parent (`askm-...`). Each recipient gets a normal child ask it closes with `ack`/`ack(msg)` — `ask_many` is a fan-out, not a vote: no quorum, no retry, no aggregation logic beyond collecting replies. Best-effort per peer (a recipient that fails to resolve or deliver is recorded as a `failed` child and does not abort the rest; the peer list is deduped and bounded).
+
+`ask_many` returns the `parent_id`; poll `ask_many_result(parent_id)` for the current rollup — per-peer status (`pending` / `acked` / `replied` / `failed`), captured reply bodies, and a `state` of `complete` / `partial` / `pending`. Timeout is lazy: a parent past its `timeout_seconds` deadline with open children reports `partial` / `timed_out` at read time (no background timer). State is in-memory and does not survive a daemon restart.
+
+```python
+parent = ask_many(["reviewer-a", "reviewer-b"], "ready to merge #42?")
+# ... later ...
+ask_many_result(parent)  # shows who replied, who's still pending
+```
+
 ## Inspection
 
 ### `list_peers`

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -24,6 +24,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from repowire import __version__
 from repowire.config.models import Config, load_config
 from repowire.daemon.acp_reconcile import reconcile_acp_inflight
+from repowire.daemon.ask_many import AskManyTracker
 from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.auth import require_localhost
 from repowire.daemon.delivery_trace import DeliveryTraceStore
@@ -273,6 +274,7 @@ def create_app(
         app.state.transport = transport
         app.state.query_tracker = query_tracker
         app.state.ask_tracker = ask_tracker
+        app.state.ask_many_tracker = AskManyTracker(ask_tracker)
         app.state.event_log = event_log
         app.state.message_router = message_router
         app.state.peer_registry = peer_registry
@@ -623,6 +625,7 @@ def create_test_app(
         app.state.transport = transport
         app.state.query_tracker = query_tracker
         app.state.ask_tracker = ask_tracker
+        app.state.ask_many_tracker = AskManyTracker(ask_tracker)
         app.state.event_log = event_log
         app.state.message_router = msg_router
         app.state.peer_registry = registry

--- a/repowire/daemon/ask_many.py
+++ b/repowire/daemon/ask_many.py
@@ -1,0 +1,158 @@
+"""In-memory ask-many fanout tracking (repowire-sip.8).
+
+A parent ``askm-`` anchor fans out to N normal child asks (each a regular
+``ask-`` row carrying ``parent_id``). The parent is never delivered and never
+appears in ``/asks/pending``; children deliver + ack exactly like any ask.
+Aggregation derives the parent view from the children at read time.
+
+v1 is deliberately dumb: no quorum, no retry, no map-reduce, no background
+timeouts. Timeout/partial state is computed lazily at GET time from the parent
+deadline. In-memory only, like AskTracker — parent + children vanish on daemon
+restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+from repowire.daemon.ask_tracker import Ask, AskTracker
+
+DEFAULT_ASK_MANY_TIMEOUT_SECONDS = 300
+MAX_ASK_MANY_PEERS = 50
+
+
+def new_ask_many_id() -> str:
+    return f"askm-{uuid4().hex[:8]}"
+
+
+@dataclass
+class AskManyChild:
+    """A child entry: a resolved peer + its correlation_id, or a pre-registration
+    failure (no correlation_id) when the peer couldn't be resolved/delivered."""
+
+    peer_name: str
+    correlation_id: str | None = None
+    peer_id: str | None = None
+    delivery_error: str | None = None
+
+
+@dataclass
+class AskManyParent:
+    parent_id: str
+    from_peer_id: str | None
+    from_peer_name: str
+    text: str
+    children: list[AskManyChild] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timeout_seconds: int = DEFAULT_ASK_MANY_TIMEOUT_SECONDS
+
+
+def _child_status(ask: Ask | None) -> str:
+    """Derive a child's status from its (optional) Ask row.
+
+    failed: never registered (resolution/delivery failure) or closed send_failed.
+    replied: closed with a captured reply body.
+    acked: closed without a body (bare ack) or via reply_to.
+    pending: still open.
+    """
+    if ask is None:
+        return "failed"
+    if not ask.closed:
+        return "pending"
+    if ask.close_reason == "send_failed":
+        return "failed"
+    if ask.reply_text is not None:
+        return "replied"
+    return "acked"
+
+
+class AskManyTracker:
+    """Holds ask-many parents in memory; children live in the AskTracker."""
+
+    def __init__(self, ask_tracker: AskTracker) -> None:
+        self._ask_tracker = ask_tracker
+        self._parents: dict[str, AskManyParent] = {}
+        self._lock = asyncio.Lock()
+
+    async def create(
+        self,
+        *,
+        from_peer_id: str | None,
+        from_peer_name: str,
+        text: str,
+        timeout_seconds: int = DEFAULT_ASK_MANY_TIMEOUT_SECONDS,
+    ) -> AskManyParent:
+        parent = AskManyParent(
+            parent_id=new_ask_many_id(),
+            from_peer_id=from_peer_id,
+            from_peer_name=from_peer_name,
+            text=text,
+            timeout_seconds=timeout_seconds,
+        )
+        async with self._lock:
+            self._parents[parent.parent_id] = parent
+        return parent
+
+    async def add_child(self, parent_id: str, child: AskManyChild) -> None:
+        async with self._lock:
+            parent = self._parents.get(parent_id)
+            if parent is not None:
+                parent.children.append(child)
+
+    async def get(self, parent_id: str) -> AskManyParent | None:
+        return self._parents.get(parent_id)
+
+    async def status(self, parent_id: str, *, now: datetime | None = None) -> dict[str, Any] | None:
+        """Aggregate the current parent view from its children. Lazy timeout."""
+        parent = self._parents.get(parent_id)
+        if parent is None:
+            return None
+        now = now or datetime.now(timezone.utc)
+
+        child_views: list[dict[str, Any]] = []
+        counts = {"acked": 0, "replied": 0, "pending": 0, "failed": 0}
+        for child in parent.children:
+            ask = (
+                await self._ask_tracker.get(child.correlation_id)
+                if child.correlation_id
+                else None
+            )
+            status = _child_status(ask)
+            counts[status] += 1
+            child_views.append(
+                {
+                    "peer": child.peer_name,
+                    "peer_id": child.peer_id,
+                    "correlation_id": child.correlation_id,
+                    "status": status,
+                    "reply": ask.reply_text if ask else None,
+                    "close_reason": ask.close_reason if ask else None,
+                    "error": child.delivery_error,
+                }
+            )
+
+        deadline = parent.created_at + timedelta(seconds=parent.timeout_seconds)
+        any_open = counts["pending"] > 0
+        timed_out = any_open and now >= deadline
+        if not any_open:
+            state = "complete"
+        elif timed_out:
+            state = "partial"
+        else:
+            state = "pending"
+
+        return {
+            "parent_id": parent.parent_id,
+            "from_peer": parent.from_peer_name,
+            "text": parent.text,
+            "created_at": parent.created_at.isoformat(),
+            "deadline": deadline.isoformat(),
+            "state": state,
+            "timed_out": timed_out,
+            "rollup": {"total": len(parent.children), **counts},
+            "children": child_views,
+        }

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -100,6 +100,13 @@ class Ask:
     pending_reply: str | None = None
     asker_identity: AskerIdentity | None = None
     pending_reply_at: datetime | None = None
+    # ask-many fanout: set on children of an askm- parent. ``reply_text`` is the
+    # captured ack message body (the normal ack path frames+notifies+closes but
+    # does not retain the body); populated only after the framed reply is
+    # delivered, so a 503'd reply leaves the child showing pending.
+    parent_id: str | None = None
+    reply_text: str | None = None
+    replied_at: datetime | None = None
 
 
 class AskTracker:
@@ -164,12 +171,15 @@ class AskTracker:
         correlation_id: str | None = None,
         from_repowire_session_id: str | None = None,
         to_repowire_session_id: str | None = None,
+        parent_id: str | None = None,
     ) -> str:
         """Register a new open ask. Returns the correlation_id.
 
         If correlation_id is supplied and already exists, this is treated as
         a retry: the existing entry is preserved (lifecycle state intact)
         and the same id is returned. Auto-generated cids never collide.
+
+        ``parent_id`` links this ask as a child of an ask-many parent.
 
         Raises QuiescedError if either endpoint is mid-switch.
         """
@@ -192,9 +202,28 @@ class AskTracker:
                 from_repowire_session_id=from_repowire_session_id,
                 to_repowire_session_id=to_repowire_session_id,
                 reply_to=reply_to,
+                parent_id=parent_id,
             )
             logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)
             return cid
+
+    async def capture_child_reply(self, correlation_id: str, reply_text: str) -> None:
+        """Record an ack message body on an ask-many child after reply delivery.
+
+        The normal ack path frames + notifies + closes but does not retain the
+        body; ask-many aggregation needs it. No-op for non-child asks or when
+        already captured. Call only after the framed reply was delivered.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is None or ask.parent_id is None or ask.reply_text is not None:
+                return
+            ask.reply_text = reply_text
+            ask.replied_at = datetime.now(timezone.utc)
+
+    async def list_by_parent(self, parent_id: str) -> list[Ask]:
+        """Return all child asks for an ask-many parent (snapshot)."""
+        return [a for a in self._asks.values() if a.parent_id == parent_id]
 
     async def close(self, correlation_id: str, reason: str) -> Ask | None:
         """Close an ask. Returns the Ask if it existed and wasn't already closed."""

--- a/repowire/daemon/deps.py
+++ b/repowire/daemon/deps.py
@@ -17,6 +17,7 @@ class AppState(Protocol):
     transport: Any
     query_tracker: Any
     ask_tracker: Any
+    ask_many_tracker: Any
     peer_registry: PeerRegistry
     peer_delivery: PeerDeliveryService
     acp_permission_broker: Any

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -28,6 +28,12 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from repowire.daemon.ask_many import (
+    DEFAULT_ASK_MANY_TIMEOUT_SECONDS,
+    MAX_ASK_MANY_PEERS,
+    AskManyChild,
+    AskManyTracker,
+)
 from repowire.daemon.ask_tracker import AskerIdentity, AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
@@ -326,6 +332,11 @@ async def _acp_complete(
             has_attachments=False,
         )
         return
+    # Reply delivered to the asker: capture the body for ask-many aggregation
+    # (no-op for non-child asks). Only here — the TransportError/ValueError/error
+    # paths above must NOT mark a child replied without proven delivery.
+    if not is_error and reply is not None:
+        await ask_tracker.capture_child_reply(correlation_id, reply)
     await ask_tracker.close(
         correlation_id, reason="ack_with_msg" if not is_error else "send_failed",
     )
@@ -337,6 +348,28 @@ async def _acp_complete(
         has_message=not is_error,
         has_attachments=False,
     )
+
+
+def _make_on_acp_complete(ask_tracker: AskTracker, peer_registry: PeerRegistry):
+    """Build the ACP completion callback used for ask + ask-many children.
+
+    Delegates to the shared _acp_complete, which captures the ask-many child
+    reply only after the framed reply is delivered to the asker (so a failed
+    delivery leaves the child pending, not replied).
+    """
+
+    async def _on_acp_complete(
+        correlation_id: str, reply: str | None, error: str | None,
+    ) -> None:
+        await _acp_complete(
+            correlation_id=correlation_id,
+            reply=reply,
+            error=error,
+            ask_tracker=ask_tracker,
+            peer_registry=peer_registry,
+        )
+
+    return _on_acp_complete
 
 
 @router.post("/ask", response_model=AskResponse)
@@ -549,6 +582,144 @@ async def open_ask(
     return AskResponse(correlation_id=cid)
 
 
+class AskManyRequest(BaseModel):
+    """Open a parent ask-many fanning out to a bounded peer list."""
+
+    from_peer: str = Field(..., description="Display name of the sender")
+    to_peers: list[str] = Field(..., description="Recipient display names (deduped)")
+    text: str = Field(..., description="Ask content sent to every recipient")
+    circle: str | None = Field(default=None)
+    bypass_circle: bool = Field(default=False)
+    timeout_seconds: int = Field(
+        default=DEFAULT_ASK_MANY_TIMEOUT_SECONDS,
+        description="Lazy deadline for partial/timeout reporting (no active timer)",
+    )
+
+
+class AskManyChildResponse(BaseModel):
+    peer: str
+    correlation_id: str | None = None
+    delivered: bool = False
+    error: str | None = None
+
+
+class AskManyResponse(BaseModel):
+    parent_id: str
+    children: list[AskManyChildResponse]
+
+
+@router.post("/ask-many", response_model=AskManyResponse)
+async def open_ask_many(
+    request: AskManyRequest,
+    _: str | None = Depends(require_auth),
+) -> AskManyResponse:
+    """Fan out one ask to many peers under a parent id, best-effort per child.
+
+    Each child is a normal ask (acked via the usual /ack); the parent is a
+    tracking anchor only. A child that fails to resolve/deliver is recorded as
+    a failed child and does not abort the rest. v1: no quorum/retry/map-reduce.
+    """
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    ask_tracker: AskTracker = state.ask_tracker
+    ask_many: AskManyTracker = state.ask_many_tracker
+    await peer_registry.lazy_repair()
+
+    if not request.to_peers:
+        raise HTTPException(status_code=422, detail="to_peers must not be empty")
+    if len(request.to_peers) > MAX_ASK_MANY_PEERS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"to_peers exceeds the {MAX_ASK_MANY_PEERS}-peer limit",
+        )
+
+    parent = await ask_many.create(
+        from_peer_id=None,
+        from_peer_name=request.from_peer,
+        text=request.text,
+        timeout_seconds=request.timeout_seconds,
+    )
+
+    peer_delivery = peer_delivery_from_state(
+        config=state.config, registry=peer_registry, state=state,
+    )
+
+    children: list[AskManyChildResponse] = []
+    seen_peer_ids: set[str] = set()
+    for to_peer in dict.fromkeys(request.to_peers):  # de-dup by display name
+        try:
+            peer = await peer_registry.get_peer(to_peer, circle=request.circle)
+        except ValueError as e:
+            peer = None
+            resolve_error = str(e)
+        else:
+            resolve_error = None if peer else f"peer not found: {to_peer}"
+        if peer is None:
+            await ask_many.add_child(
+                parent.parent_id, AskManyChild(peer_name=to_peer, delivery_error=resolve_error),
+            )
+            children.append(AskManyChildResponse(peer=to_peer, error=resolve_error))
+            continue
+        if peer.peer_id in seen_peer_ids:
+            continue  # de-dup peers that resolve to the same identity
+        seen_peer_ids.add(peer.peer_id)
+
+        from_obj = await _resolve_sender_for_target(request.from_peer, peer)
+        from_peer_id = from_obj.peer_id if from_obj else request.from_peer
+        from_peer_name = from_obj.display_name if from_obj else request.from_peer
+        cid = await ask_tracker.register(
+            from_peer_id=from_peer_id,
+            from_peer_name=from_peer_name,
+            to_peer_id=peer.peer_id,
+            to_peer_name=peer.display_name,
+            text=request.text,
+            parent_id=parent.parent_id,
+        )
+        try:
+            await peer_delivery.deliver_ask(
+                from_peer=from_peer_id,
+                to_peer=peer.peer_id,
+                text=request.text,
+                correlation_id=cid,
+                bypass_circle=request.bypass_circle,
+                on_acp_complete=_make_on_acp_complete(ask_tracker, peer_registry),
+            )
+            delivered = True
+            err = None
+        except (TransportError, DeliveryInjectionError, ValueError) as e:
+            await ask_tracker.close(cid, reason="send_failed")
+            delivered = False
+            err = str(e)
+        await ask_many.add_child(
+            parent.parent_id,
+            AskManyChild(
+                peer_name=peer.display_name, correlation_id=cid, peer_id=peer.peer_id,
+                delivery_error=err,
+            ),
+        )
+        children.append(
+            AskManyChildResponse(
+                peer=peer.display_name, correlation_id=cid, delivered=delivered, error=err,
+            )
+        )
+
+    return AskManyResponse(parent_id=parent.parent_id, children=children)
+
+
+@router.get("/ask-many/{parent_id}")
+async def ask_many_result(
+    parent_id: str,
+    _: str | None = Depends(require_auth),
+) -> dict:
+    """Aggregate an ask-many parent's current state from its children."""
+    state = get_app_state()
+    ask_many: AskManyTracker = state.ask_many_tracker
+    result = await ask_many.status(parent_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"ask-many {parent_id} not found")
+    return result
+
+
 @router.post("/ack", response_model=OkResponse)
 async def ack_ask(
     request: AckRequest,
@@ -653,6 +824,11 @@ async def ack_ask(
                 detail=f"Reply delivery error: {e}",
             )
 
+        # Reply delivered: capture the body for ask-many aggregation (no-op for
+        # non-child asks) BEFORE closing, so a 503'd delivery above never marks
+        # the child replied.
+        if request.message and existing.parent_id is not None:
+            await ask_tracker.capture_child_reply(request.correlation_id, request.message)
         await ask_tracker.close(request.correlation_id, reason="ack_with_msg")
     else:
         _emit_ack_event(

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -942,6 +942,80 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         return result.get("correlation_id", "")
 
     @mcp.tool()
+    async def ask_many(
+        peer_names: list[str],
+        query: str,
+        circle: str | None = None,
+        timeout_seconds: int = 300,
+    ) -> str:
+        """[Repowire mesh] Ask the same question to several peers in parallel.
+
+        Opens one parent ask-many and a child ask per peer. Each child is a
+        normal ask the recipient closes with `ack`/`ack(msg)`. Returns a parent
+        id; poll `ask_many_result(parent_id)` to see replies, pending peers, and
+        partial/timeout state. Best-effort per peer (a failed recipient does not
+        abort the rest). No quorum/retry — it's a fanout, not a vote.
+
+        Args:
+            peer_names: Recipient display names (deduped; bounded list).
+            query: The question sent to every recipient.
+            circle: Optional target lookup circle.
+            timeout_seconds: Lazy deadline for partial/timeout reporting.
+
+        Returns:
+            parent_id (askm-...) to pass to ask_many_result.
+        """
+        await _ensure_registered(strict=True)
+        from_peer_name, _my_circle, _ = await _get_my_identity()
+        from_peer = _cached_peer_id or from_peer_name
+        body: dict = {
+            "from_peer": from_peer,
+            "to_peers": peer_names,
+            "text": query,
+            "timeout_seconds": timeout_seconds,
+        }
+        if circle is not None:
+            body["circle"] = circle
+        result = await daemon_request("POST", "/ask-many", body)
+        parent_id = result.get("parent_id", "")
+        children = result.get("children", [])
+        delivered = sum(1 for c in children if c.get("delivered"))
+        return f"{parent_id} ({delivered}/{len(children)} delivered)"
+
+    @mcp.tool()
+    async def ask_many_result(parent_id: str) -> str:
+        """[Repowire mesh] Aggregate the current state of an ask-many fanout.
+
+        Shows per-peer status (pending/acked/replied/failed) + rollup +
+        partial/timeout state. Replies are captured from acked children. State
+        is current-at-read (no background timer).
+
+        Args:
+            parent_id: The askm-... id returned by ask_many.
+
+        Returns:
+            A human-readable rollup of the ask-many fanout.
+        """
+        await _ensure_registered(strict=True)
+        result = await daemon_request("GET", f"/ask-many/{quote(parent_id, safe='')}")
+        rollup = result.get("rollup", {})
+        lines = [
+            f"ask-many {result.get('parent_id')} — state={result.get('state')} "
+            f"({rollup.get('replied', 0)} replied, {rollup.get('acked', 0)} acked, "
+            f"{rollup.get('pending', 0)} pending, {rollup.get('failed', 0)} failed)"
+        ]
+        for child in result.get("children", []):
+            reply = child.get("reply")
+            if reply:
+                suffix = f": {reply}"
+            elif child.get("error"):
+                suffix = f" ({child['error']})"
+            else:
+                suffix = ""
+            lines.append(f"  {child['peer']} — {child['status']}{suffix}")
+        return "\n".join(lines)
+
+    @mcp.tool()
     async def ack(
         correlation_id: str,
         message: str | None = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from repowire.config.models import Config
+from repowire.daemon.ask_many import AskManyTracker
 from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.delivery_trace import DeliveryTraceStore
 from repowire.daemon.deps import init_deps
@@ -73,6 +74,7 @@ def make_daemon_app(
         "transport": transport,
         "query_tracker": query_tracker,
         "ask_tracker": ask_tracker,
+        "ask_many_tracker": AskManyTracker(ask_tracker),
         "message_router": message_router,
         "peer_registry": registry,
         "relay_mode": cfg.relay.enabled,

--- a/tests/test_ask_many.py
+++ b/tests/test_ask_many.py
@@ -1,0 +1,154 @@
+"""ask-many fanout aggregation (repowire-sip.8)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from repowire.daemon.ask_many import AskManyChild, AskManyTracker
+from repowire.daemon.ask_tracker import AskTracker
+
+
+async def _register_child(at: AskTracker, parent_id: str, to_name: str) -> str:
+    return await at.register(
+        from_peer_id="asker",
+        from_peer_name="asker",
+        to_peer_id=f"id-{to_name}",
+        to_peer_name=to_name,
+        text="q",
+        parent_id=parent_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_reply_rolls_up_complete_with_bodies():
+    at = AskTracker()
+    am = AskManyTracker(at)
+    parent = await am.create(from_peer_id="asker", from_peer_name="asker", text="q")
+
+    for name in ("alice", "bob"):
+        cid = await _register_child(at, parent.parent_id, name)
+        await am.add_child(parent.parent_id, AskManyChild(peer_name=name, correlation_id=cid))
+        # simulate ack-with-message: capture reply, then close
+        await at.capture_child_reply(cid, f"{name} says hi")
+        await at.close(cid, reason="ack_with_msg")
+
+    status = await am.status(parent.parent_id)
+    assert status["state"] == "complete"
+    assert status["timed_out"] is False
+    assert status["rollup"] == {"total": 2, "acked": 0, "replied": 2, "pending": 0, "failed": 0}
+    replies = {c["peer"]: c["reply"] for c in status["children"]}
+    assert replies == {"alice": "alice says hi", "bob": "bob says hi"}
+
+
+@pytest.mark.asyncio
+async def test_bare_ack_is_acked_not_replied():
+    at = AskTracker()
+    am = AskManyTracker(at)
+    parent = await am.create(from_peer_id="asker", from_peer_name="asker", text="q")
+    cid = await _register_child(at, parent.parent_id, "alice")
+    await am.add_child(parent.parent_id, AskManyChild(peer_name="alice", correlation_id=cid))
+    await at.close(cid, reason="ack")  # bare ack, no body
+
+    status = await am.status(parent.parent_id)
+    assert status["rollup"]["acked"] == 1
+    assert status["rollup"]["replied"] == 0
+    assert status["children"][0]["status"] == "acked"
+
+
+@pytest.mark.asyncio
+async def test_partial_timeout_when_deadline_passed_with_open_child():
+    at = AskTracker()
+    am = AskManyTracker(at)
+    parent = await am.create(
+        from_peer_id="asker", from_peer_name="asker", text="q", timeout_seconds=60,
+    )
+    done = await _register_child(at, parent.parent_id, "alice")
+    await am.add_child(parent.parent_id, AskManyChild(peer_name="alice", correlation_id=done))
+    await at.close(done, reason="ack")
+
+    pending = await _register_child(at, parent.parent_id, "bob")
+    await am.add_child(parent.parent_id, AskManyChild(peer_name="bob", correlation_id=pending))
+
+    # before deadline -> pending; after -> partial
+    before = await am.status(parent.parent_id, now=parent.created_at + timedelta(seconds=10))
+    assert before["state"] == "pending"
+    assert before["timed_out"] is False
+
+    after = await am.status(parent.parent_id, now=parent.created_at + timedelta(seconds=120))
+    assert after["state"] == "partial"
+    assert after["timed_out"] is True
+    assert after["rollup"] == {"total": 2, "acked": 1, "replied": 0, "pending": 1, "failed": 0}
+
+
+@pytest.mark.asyncio
+async def test_failed_child_counts_as_failed():
+    at = AskTracker()
+    am = AskManyTracker(at)
+    parent = await am.create(from_peer_id="asker", from_peer_name="asker", text="q")
+    # a child that never registered (resolution failure) — no correlation_id
+    await am.add_child(
+        parent.parent_id,
+        AskManyChild(peer_name="ghost", delivery_error="peer not found: ghost"),
+    )
+    # a child closed send_failed (delivery failure after register)
+    cid = await _register_child(at, parent.parent_id, "bob")
+    await am.add_child(parent.parent_id, AskManyChild(peer_name="bob", correlation_id=cid))
+    await at.close(cid, reason="send_failed")
+
+    status = await am.status(parent.parent_id)
+    assert status["rollup"]["failed"] == 2
+    statuses = {c["peer"]: c["status"] for c in status["children"]}
+    assert statuses == {"ghost": "failed", "bob": "failed"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_parent_returns_none():
+    am = AskManyTracker(AskTracker())
+    assert await am.status("askm-nope") is None
+
+
+@pytest.mark.asyncio
+async def test_capture_child_reply_is_noop_for_non_child_ask():
+    at = AskTracker()
+    cid = await at.register(
+        from_peer_id="a", from_peer_name="a", to_peer_id="b", to_peer_name="b", text="q",
+    )
+    await at.capture_child_reply(cid, "ignored")  # no parent_id -> no-op
+    ask = await at.get(cid)
+    assert ask is not None and ask.reply_text is None
+
+
+@pytest.mark.asyncio
+async def test_acp_child_reply_not_captured_when_asker_delivery_fails():
+    # codex catch: an ACP child whose reply delivery to the asker fails must NOT
+    # expose a reply body — capture only after delivery succeeds, matching the
+    # WS /ack 503 path. Here notify raises TransportError -> child stays pending.
+    from unittest.mock import AsyncMock
+
+    from repowire.daemon.routes.asks import _acp_complete
+    from repowire.daemon.websocket_transport import TransportError
+
+    at = AskTracker()
+    am = AskManyTracker(at)
+    parent = await am.create(from_peer_id="asker", from_peer_name="asker", text="q")
+    cid = await _register_child(at, parent.parent_id, "alice")
+    await am.add_child(parent.parent_id, AskManyChild(peer_name="alice", correlation_id=cid))
+
+    registry = AsyncMock()
+    registry.notify = AsyncMock(side_effect=TransportError("asker offline"))
+    registry.add_event = lambda *a, **k: None
+    registry.set_pending_reply = AsyncMock()
+
+    await _acp_complete(
+        correlation_id=cid, reply="the answer", error=None,
+        ask_tracker=at, peer_registry=registry,
+    )
+
+    ask = await at.get(cid)
+    assert ask is not None and ask.reply_text is None  # not captured
+    status = await am.status(parent.parent_id)
+    child = status["children"][0]
+    assert child["status"] == "pending"  # stayed open (stashed for redelivery)
+    assert child["reply"] is None

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -558,3 +558,88 @@ class TestDeprecatedNoOps:
             json={"correlation_id": "legacy-cid"},
         )
         assert r.status_code == 200
+
+
+class TestAskMany:
+    async def test_fanout_aggregates_replies_and_bare_acks(self, env):
+        # End-to-end: POST /ask-many to two peers, ack one with a message and
+        # one bare, then GET the aggregated result (acceptance: all-reply path +
+        # child-ack routing under a parent).
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        alice = await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+
+        r = await client.post("/ask-many", json={
+            "from_peer": asker,
+            "to_peers": [alice, bob],
+            "text": "standup?",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["parent_id"].startswith("askm-")
+        children = {c["peer"]: c for c in body["children"]}
+        assert set(children) == {alice, bob}
+        assert all(c["correlation_id"].startswith("ask-") for c in children.values())
+
+        # alice replies with a message, bob bare-acks
+        await client.post("/ack", json={
+            "correlation_id": children[alice]["correlation_id"],
+            "message": "done",
+        })
+        await client.post("/ack", json={
+            "correlation_id": children[bob]["correlation_id"],
+        })
+
+        res = await client.get(f"/ask-many/{body['parent_id']}")
+        assert res.status_code == 200, res.text
+        agg = res.json()
+        assert agg["state"] == "complete"
+        assert agg["rollup"] == {"total": 2, "acked": 1, "replied": 1, "pending": 0, "failed": 0}
+        by_peer = {c["peer"]: c for c in agg["children"]}
+        assert by_peer[alice]["status"] == "replied"
+        assert by_peer[alice]["reply"] == "done"
+        assert by_peer[bob]["status"] == "acked"
+
+    async def test_partial_when_one_peer_pending(self, env):
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        alice = await _register_peer(client, "alice")
+        bob = await _register_peer(client, "bob")
+        r = await client.post("/ask-many", json={
+            "from_peer": asker, "to_peers": [alice, bob], "text": "?",
+        })
+        children = {c["peer"]: c for c in r.json()["children"]}
+        await client.post("/ack", json={"correlation_id": children[alice]["correlation_id"]})
+
+        agg = (await client.get(f"/ask-many/{r.json()['parent_id']}")).json()
+        # bob still open, deadline not passed -> pending state, 1 pending child
+        assert agg["state"] == "pending"
+        assert agg["rollup"]["pending"] == 1
+        assert agg["rollup"]["acked"] == 1
+
+    async def test_unknown_peer_is_failed_child_not_fatal(self, env):
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        alice = await _register_peer(client, "alice")
+        r = await client.post("/ask-many", json={
+            "from_peer": asker, "to_peers": [alice, "ghost"], "text": "?",
+        })
+        assert r.status_code == 200, r.text
+        agg = (await client.get(f"/ask-many/{r.json()['parent_id']}")).json()
+        by_peer = {c["peer"]: c for c in agg["children"]}
+        assert by_peer["ghost"]["status"] == "failed"
+        assert by_peer[alice]["status"] in {"pending", "acked"}
+
+    async def test_empty_peer_list_422(self, env):
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        r = await client.post("/ask-many", json={
+            "from_peer": asker, "to_peers": [], "text": "?",
+        })
+        assert r.status_code == 422
+
+    async def test_unknown_parent_404(self, env):
+        client, _, _, _ = env
+        r = await client.get("/ask-many/askm-nope")
+        assert r.status_code == 404


### PR DESCRIPTION
## What

Adds `ask-many` (`repowire-sip.8`): ask the same question to several peers in parallel under a parent id, collecting replies. Designed dumb per the bead — no quorum, retry, or map-reduce.

Shape (designed with codex):
- **Parent is separate** (`AskManyTracker` / `AskManyParent`), never delivered, never in `/asks/pending`. **Children are normal asks** carrying a new `parent_id` field — they deliver via the existing `PeerDeliveryService` (ACP-before-WS) and close via the normal `/ack`. Aggregation derives the parent view from the children at read time.
- **`POST /ask-many`** {from_peer, to_peers, text, circle?, timeout_seconds?} → creates the parent, dedups + bounds the peer list (≤50), registers a child per peer with `parent_id`, delivers best-effort. A peer that fails to resolve/deliver becomes a `failed` child without aborting the rest.
- **`GET /ask-many/{parent_id}`** → per-child status (`pending`/`acked`/`replied`/`failed`) + reply bodies + rollup + `state` (`complete`/`partial`/`pending`). **Lazy timeout**: a parent past its deadline with open children reports `partial`/`timed_out` at read time — no background timer (matches the no-poll philosophy).
- **Reply capture** (codex's key catch): the normal `ack(cid, msg)` frames + notifies + closes but does *not* retain the body. Added `AskTracker.capture_child_reply`, called from the `/ack` WS path **and** `_acp_complete` **only after the reply is delivered** — so a 503'd ack leaves the child `pending`, never falsely `replied`.
- **MCP tools** `ask_many` / `ask_many_result`.

In-memory only (consistent with AskTracker); parent + children vanish on daemon restart like any open ask — wording avoids implying durable tracking.

## Testing

- `tests/test_ask_many.py` (6 unit): all-reply→complete with bodies, bare-ack vs replied, partial-timeout (before/after deadline), failed children (unresolved + send_failed), unknown parent, capture-noop for non-child.
- `tests/test_ask_routes.py::TestAskMany` (5 end-to-end): fanout + reply aggregation, partial-when-pending, unknown-peer-is-failed-child (not fatal), empty-list 422, unknown-parent 404.
- Full suite: **1616 passing, 0 failures.** `ruff` + `ty` on `repowire/`: clean.

Closes repowire-sip.8.

🤖 Reviewed by the `codex` mesh peer.
