### PR TITLE
feat(questions): unified Mesh Questions primitive (approval + choice + ask/ack)

### DIFF
--- a/docs/capabilities/dashboard.md
+++ b/docs/capabilities/dashboard.md
@@ -5,7 +5,7 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 ## What it shows
 
 - **Peer overview** — every peer's status (`online` / `busy` / `offline`), description, project path, circle, backend.
-- **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, and broadcasts.
+- **Live mesh log** — `mesh.log`, a chronological event stream of asks, acks, notifications, broadcasts, and structured questions.
 - **Jobs view** — inspect durable work and recurring job templates from the daemon's `/jobs` surface, then run, retry, or cancel eligible jobs without leaving the dashboard.
 - **Per-peer chat** — selecting a peer replaces the live log with that peer's selected-session timeline. For Claude Code, Codex, and Codex ACP peers, the chat view merges supported persisted local history with realtime `chat_turn` and `chat_turn_delta` events; backends without a supported local history source contribute realtime events and report that degraded state in the timeline response. User and `@dashboard` messages align right; peer messages align left. Tool calls collapse behind a disclosure.
 - **Conversation search** — the peer chat view can search the normalized timeline and jump to a matching turn. Results carry the session/turn cursor used by the timeline, so jumping can switch to the matched session before scrolling. If only the daemon's realtime event ring is searchable because persisted local history is unavailable or unsupported, the dashboard shows that degraded state beside the results.
@@ -15,16 +15,17 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 - **MCP config tab** — supported peers can list, add, and remove MCP servers. The tab labels whether edits affect peer/project config or backend user-global config before showing edit controls.
 - **Attachments** — the compose bar has a file upload button. Files post to `POST /attachments` (10 MB limit, 24 h TTL). The outgoing ask carries structured attachment metadata plus a text fallback with the local path so existing agents can still read it.
 - **Attachment chips** — mesh events and per-peer chat render attachment chips with download links when an attachment ID is available.
+- **Pending questions** — structured questions, including ACP tool-permission prompts, appear as an answer banner above the dashboard grid. Choice questions render option buttons; tool-permission questions also render an explicit Deny action. Answers post to the shared `/answer` route and close when the daemon emits the matching ack event.
 
 ## Where chat turns come from
 
 The dashboard does not poll. The stop hook of every Claude Code, Codex, and Gemini session extracts the response and tool calls from the transcript or runtime output, then posts them to `POST /events/chat` on the daemon. Claude Code can also stream block-level `chat_turn_delta` events while a turn is in progress. The dashboard streams events over Server-Sent Events and merges them with supported backend-local history for the selected peer/session. OpenCode and Pi bridge the same realtime shape via plugins/extensions, but do not expose a supported local history source in this v0.14 slice.
 
-ACP-routed permission prompts emit `acp_permission_request` and `acp_permission_decision` events into the same daemon event stream. Human control surfaces can resolve a pending prompt with `POST /acp/permissions/{request_id}/decision`; if no decision arrives before the broker timeout, the daemon records a timed-out decision and denies by default. This v0.14 slice exposes the event/route contract only; the dashboard approval UI remains planned work.
+ACP-routed permission prompts are represented as structured mesh questions. The daemon emits the normal ask/ack question events for dashboard and Telegram rendering, and also keeps `acp_permission_request` / `acp_permission_decision` events as compatibility/audit aliases. Human control surfaces answer through `POST /answer`; the legacy `POST /acp/permissions/{request_id}/decision` route remains as a compatibility shim. If no decision arrives before the broker timeout, the daemon records a timed-out answer and denies by default.
 
 ## Session command direction
 
-The v0.14 dashboard direction is a timeline-centered view. The current slice merges supported persisted history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, approval handling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.
+The v0.14 dashboard direction is a timeline-centered view. The current slice merges supported persisted history and realtime stream events for the selected peer/session. Peers remain the runtime executors, and broader controls such as model/backend switching, resume, scheduling, and plan-mode decisions remain roadmap items that should attach to shared session commands as those features land.
 
 The daemon route details for timeline, transcript, search, and session-control probes live in [HTTP API](../reference/http-api.md) and [Operations: architecture](../operations/architecture.md). This capability page stays focused on what the dashboard exposes to users.
 

--- a/docs/concepts/message-types.md
+++ b/docs/concepts/message-types.md
@@ -26,6 +26,18 @@ Replies always reach the original asker regardless of circle — the thread was 
 
 Bare ack events and reply notifications carry the same nullable session metadata when a binding is known. Detached or offline peers keep those fields `null`.
 
+## Structured questions and `answer`
+
+Some asks carry a typed question envelope. A structured question can be an acknowledgement, a choice, free text, or a tool-permission prompt. The daemon still tracks it as an ask thread, but the close operation records a typed answer through `/answer` or the `answer` MCP tool:
+
+- Choice answers select an `option_id`.
+- Text answers carry free-form `text`.
+- Tool-permission questions can be denied explicitly, and deny by default on timeout.
+
+Telegram and the dashboard render structured questions as buttons when possible. ACP tool approvals use the same primitive: the ACP broker registers a blocking choice question, waits for the recorded answer, and maps it back to the runtime's permission decision. The older ACP permission-decision route remains as a compatibility shim.
+
+Plain asks still close with `ack`. `/answer` rejects a plain ask so a reply cannot bypass `ack`'s delivery/retry contract.
+
 ## `notify_peer`
 
 Fire-and-forget. No lifecycle, no response expected. Returns a synthetic `notif-XXXXXXXX` ID for client-side tracking, not a thread you can close.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -82,9 +82,26 @@ ack(correlation_id: str, message: str | None = None, attachments: list[dict] | N
 
 Close an open ask. Bare `ack(cid)` signals "seen, no action needed." A reply `ack(cid, message)` closes the thread and delivers the message back to the original asker. Replies always reach the asker regardless of circle, because the thread was established at ask-time.
 
+When the ask carries a structured question, `ack` delegates to the typed answer path: bare `ack(cid)` records an acknowledged answer, while `ack(cid, message)` records a text answer. Use `answer` directly when selecting an option.
+
 ```python
 ack("ask-c1a1c7dd")
 ack("ask-c1a1c7dd", "we expose /health, /peers, /ask, /ack")
+```
+
+### `answer`
+
+```python
+answer(correlation_id: str, option_id: str | None = None, text: str | None = None) -> str
+```
+
+Answer a structured question carried on an ask. Pass `option_id` to select a choice, or `text` for a free-text answer. A bare `answer(cid)` records an acknowledged answer. Tool-permission questions also accept a denied outcome through the dashboard and Telegram renderers; ACP permission prompts deny by default on timeout.
+
+This is the typed counterpart to `ack` for questions such as tool approvals and future AskUserQuestion-style prompts. Plain asks still use `ack`; `/answer` rejects a plain ask so the existing `ack` retry semantics are not bypassed.
+
+```python
+answer("acpperm-8b9c1f42", option_id="allow")
+answer("ask-c1a1c7dd", text="Use the staging database")
 ```
 
 ### `notify_peer`

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -1,15 +1,41 @@
-"""Human approval broker for ACP permission requests."""
+"""ACP tool-permission adapter over the shared mesh-questions primitive.
+
+This is no longer a parallel decision system: a ``RequestPermission`` from an
+ACP runtime is translated into a blocking *choice question* ask registered in
+the ``AskTracker`` (recipient = the virtual ``__repowire_control__`` surface, so
+human answer-paths — dashboard banner, Telegram buttons — render it like any
+other question, and a peer can answer it programmatically). The broker awaits
+``AskTracker.wait_for_answer`` and maps the typed ``Answer`` back to an ACP
+``PermissionDecision``. ``ask.answer`` is the source of truth; the broker keeps
+only a small per-request context map for the compat ``decide``/``get_pending``
+surface and the ACP-specific event aliases.
+
+Fail closed: only an explicit ``allowed`` outcome with a valid option becomes
+``PermissionDecision(outcome="allowed")``; timeout / acknowledge / no-option
+deny.
+"""
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
+from repowire.protocol.questions import Answer, Question, QuestionOption
+
+if TYPE_CHECKING:
+    from repowire.daemon.ask_tracker import AskTracker
+
 PermissionOutcome = Literal["allowed", "denied", "cancelled"]
+
+# Virtual recipient for a tool-permission question. Not a real peer and never
+# delivered through MessageRouter — human surfaces answer it via /answer using
+# the ask cid; a future roles/capabilities recipient model can replace it.
+CONTROL_PEER_ID = "__repowire_control__"
+CONTROL_PEER_NAME = "human"
 
 
 @dataclass(frozen=True)
@@ -24,30 +50,33 @@ class PermissionDecision:
 
 @dataclass
 class _PendingPermission:
-    request_id: str
+    request_id: str  # == the ask correlation_id
     peer_id: str
     session_id: str
     tool_call: dict[str, Any]
     options: list[dict[str, Any]]
-    future: asyncio.Future[PermissionDecision] = field(repr=False)
 
 
 class ApprovalBroker:
-    """Small in-process broker for ACP tool permission decisions.
+    """ACP-protocol adapter: RequestPermission ↔ a blocking choice-question ask.
 
-    The broker emits dashboard event-log records for visibility, waits for a
-    human decision submitted through the daemon, and defaults to deny when the
-    decision does not arrive before the timeout.
+    Registers the question in the ``AskTracker`` and blocks on its answer waiter;
+    the answer (from a human surface or a peer) resolves it. Defaults to deny on
+    timeout. Emits the normal ask event (so the dashboard/Telegram renderers
+    surface it) plus ``acp_permission_request``/``acp_permission_decision``
+    aliases for back-compat/audit, keyed by the same request_id (= ask cid).
     """
 
     def __init__(
         self,
         *,
         emit_event: Callable[[str, dict[str, Any]], str],
+        ask_tracker: AskTracker | None = None,
         resolve_repowire_session_id: Callable[[str, str], str | None] | None = None,
         timeout_seconds: float = 60.0,
     ) -> None:
         self._emit_event = emit_event
+        self._ask_tracker = ask_tracker
         self._resolve_repowire_session_id = resolve_repowire_session_id
         self._timeout_seconds = timeout_seconds
         self._pending: dict[str, _PendingPermission] = {}
@@ -63,29 +92,78 @@ class ApprovalBroker:
         tool_call: Any,
         options: list[Any],
     ) -> PermissionDecision:
-        """Emit a permission request and wait for a decision.
+        """Translate an ACP RequestPermission into a blocking question + await it.
 
-        Timeout intentionally defaults to deny. This is safer than preserving
-        the prior auto-allow fallback, and keeps the ACP subprocess unblocked.
+        Registers a choice question ask (recipient = the virtual control surface)
+        and blocks on its AskTracker answer waiter; a human/dashboard/peer answer
+        resolves it. Timeout intentionally defaults to deny (fail closed), which
+        keeps the ACP subprocess unblocked.
         """
-        loop = asyncio.get_running_loop()
+        if self._ask_tracker is None:
+            # No tracker wired (e.g. a bare test harness): fail closed.
+            return PermissionDecision(outcome="denied", message="approval broker not wired")
+
         normalized_options = [_normalize_option(option) for option in options]
+        request_id = f"acpperm-{uuid4().hex[:12]}"
         pending = _PendingPermission(
-            request_id=f"acpperm-{uuid4().hex[:12]}",
+            request_id=request_id,
             peer_id=peer_id,
             session_id=session_id,
             tool_call=_normalize_payload(tool_call),
             options=normalized_options,
-            future=loop.create_future(),
         )
         async with self._lock:
-            self._pending[pending.request_id] = pending
+            self._pending[request_id] = pending
 
+        question = Question(
+            kind="choice",
+            prompt=_tool_prompt(pending.tool_call),
+            options=[_to_question_option(o) for o in normalized_options],
+            blocking=True,
+            timeout_seconds=self._timeout_seconds,
+            default_answer=Answer(outcome="timed_out", message="permission request timed out"),
+            scope="tool_permission",
+            metadata={
+                "acp_peer_id": peer_id,
+                "acp_session_id": session_id,
+                "tool_call": pending.tool_call,
+                "request_id": request_id,
+            },
+        )
         repowire_session_id = self._resolve_session_id(peer_id, session_id)
+        try:
+            await self._ask_tracker.register(
+                from_peer_id=peer_id,
+                from_peer_name=peer_id,
+                to_peer_id=CONTROL_PEER_ID,
+                to_peer_name=CONTROL_PEER_NAME,
+                text=question.prompt or "ACP tool permission request",
+                correlation_id=request_id,
+                question=question,
+            )
+        except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
+            async with self._lock:
+                self._pending.pop(request_id, None)
+            return PermissionDecision(outcome="denied", message=f"register failed: {e}")
+
+        # Normal ask event (so the dashboard banner + Telegram render it) + the
+        # back-compat ACP-specific alias, both keyed by the same request_id/cid.
+        ask_event = {
+            "from": peer_id,
+            "to": CONTROL_PEER_NAME,
+            "from_peer_id": peer_id,
+            "to_peer_id": CONTROL_PEER_ID,
+            "text": question.prompt or "ACP tool permission request",
+            "correlation_id": request_id,
+            "question": question.model_dump(exclude_none=True),
+            "repowire_session_id": repowire_session_id,
+            "from_repowire_session_id": repowire_session_id,
+        }
+        self._emit_event("ask", ask_event)
         self._emit_event(
             "acp_permission_request",
             {
-                "request_id": pending.request_id,
+                "request_id": request_id,
                 "peer_id": peer_id,
                 "session_id": session_id,
                 "repowire_session_id": repowire_session_id,
@@ -96,20 +174,17 @@ class ApprovalBroker:
             },
         )
 
-        try:
-            decision = await asyncio.wait_for(pending.future, timeout=self._timeout_seconds)
-        except asyncio.TimeoutError:
-            decision = PermissionDecision(
-                outcome="denied",
-                message="permission request timed out",
-                timed_out=True,
-            )
+        answer = await self._ask_tracker.wait_for_answer(
+            request_id,
+            timeout_seconds=self._timeout_seconds,
+            default_answer=question.default_answer,
+        )
+        decision = _answer_to_decision(answer)
+        if decision.timed_out:
             self._last_error = "permission request timed out"
             self._last_error_at = _utc_now()
-        finally:
-            async with self._lock:
-                self._pending.pop(pending.request_id, None)
-
+        async with self._lock:
+            self._pending.pop(request_id, None)
         self._emit_decision_event(pending, decision)
         return decision
 
@@ -121,25 +196,33 @@ class ApprovalBroker:
         option_id: str | None = None,
         message: str | None = None,
     ) -> PermissionDecision | None:
-        """Resolve a pending request.
+        """Back-compat resolver for POST /acp/permissions/{id}/decision.
 
-        Returns ``None`` when the request is unknown or already resolved.
+        Maps the legacy outcome onto an Answer and resolves the underlying
+        question ask. Returns ``None`` when the request is unknown/already
+        resolved. ``ask.answer`` remains the source of truth.
         """
         async with self._lock:
             pending = self._pending.get(request_id)
-            if pending is None or pending.future.done():
-                return None
-            if outcome == "allowed":
-                option_id = option_id or _first_option_id(pending.options)
-            decision = PermissionDecision(
-                outcome=outcome,
-                option_id=option_id,
-                message=message,
-            )
-            pending.future.set_result(decision)
-            self._last_error = None
-            self._last_error_at = None
-            return decision
+        if pending is None or self._ask_tracker is None:
+            return None
+        if outcome == "allowed":
+            option_id = option_id or _first_option_id(pending.options)
+            answer = Answer(option_id=option_id, outcome="answered", message=message)
+        elif outcome == "cancelled":
+            answer = Answer(outcome="cancelled", message=message)
+        else:
+            answer = Answer(outcome="denied", message=message)  # first-class deny
+        try:
+            await self._ask_tracker.answer(request_id, answer)
+        except self._ask_tracker.AlreadyAnsweredError:
+            return None
+        except (KeyError, ValueError):
+            return None
+        decision = PermissionDecision(outcome=outcome, option_id=option_id, message=message)
+        self._last_error = None
+        self._last_error_at = None
+        return decision
 
     async def get_pending(self, request_id: str) -> dict[str, Any] | None:
         """Return a pending request snapshot for validation/UI callers."""
@@ -192,6 +275,38 @@ class ApprovalBroker:
             "last_error": self._last_error,
             "last_error_at": self._last_error_at,
         }
+
+
+def _tool_prompt(tool_call: dict[str, Any]) -> str:
+    """A short human prompt for the tool-permission question."""
+    name = tool_call.get("title") or tool_call.get("name") or tool_call.get("kind") or "a tool"
+    return f"Allow {name}?"
+
+
+def _to_question_option(option: dict[str, Any]) -> QuestionOption:
+    oid = str(option.get("option_id") or option.get("id") or option.get("name") or "option")
+    title = str(option.get("name") or option.get("title") or oid)
+    return QuestionOption(id=oid, title=title)
+
+
+def _answer_to_decision(answer: Answer) -> PermissionDecision:
+    """Map a typed Answer back to an ACP PermissionDecision. Fail closed.
+
+    Only an explicit selected option becomes ``allowed``; timeout / acknowledge /
+    cancel / no-option deny so a tool can never run on an ambiguous answer.
+    """
+    if answer.outcome == "timed_out":
+        return PermissionDecision(outcome="denied", message=answer.message, timed_out=True)
+    if answer.outcome == "cancelled":
+        return PermissionDecision(outcome="cancelled", message=answer.message)
+    if answer.outcome == "denied":
+        return PermissionDecision(outcome="denied", message=answer.message)
+    if answer.outcome == "answered" and answer.option_id:
+        return PermissionDecision(
+            outcome="allowed", option_id=answer.option_id, message=answer.message,
+        )
+    # acknowledged, or answered with no option → fail closed.
+    return PermissionDecision(outcome="denied", option_id=answer.option_id, message=answer.message)
 
 
 def _first_option_id(options: list[dict[str, Any]]) -> str | None:

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -132,59 +132,64 @@ class ApprovalBroker:
         )
         repowire_session_id = self._resolve_session_id(peer_id, session_id)
         try:
-            await self._ask_tracker.register(
-                from_peer_id=peer_id,
-                from_peer_name=peer_id,
-                to_peer_id=CONTROL_PEER_ID,
-                to_peer_name=CONTROL_PEER_NAME,
-                text=question.prompt or "ACP tool permission request",
-                correlation_id=request_id,
-                question=question,
+            try:
+                await self._ask_tracker.register(
+                    from_peer_id=peer_id,
+                    from_peer_name=peer_id,
+                    to_peer_id=CONTROL_PEER_ID,
+                    to_peer_name=CONTROL_PEER_NAME,
+                    text=question.prompt or "ACP tool permission request",
+                    correlation_id=request_id,
+                    question=question,
+                )
+            except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
+                return PermissionDecision(outcome="denied", message=f"register failed: {e}")
+
+            # Normal ask event (so the dashboard banner + Telegram render it) + the
+            # back-compat ACP-specific alias, both keyed by the same request_id/cid.
+            ask_event = {
+                "from": peer_id,
+                "to": CONTROL_PEER_NAME,
+                "from_peer_id": peer_id,
+                "to_peer_id": CONTROL_PEER_ID,
+                "text": question.prompt or "ACP tool permission request",
+                "correlation_id": request_id,
+                "question": question.model_dump(exclude_none=True),
+                "repowire_session_id": repowire_session_id,
+                "from_repowire_session_id": repowire_session_id,
+            }
+            self._emit_event("ask", ask_event)
+            self._emit_event(
+                "acp_permission_request",
+                {
+                    "request_id": request_id,
+                    "peer_id": peer_id,
+                    "session_id": session_id,
+                    "repowire_session_id": repowire_session_id,
+                    "tool_call": pending.tool_call,
+                    "options": normalized_options,
+                    "status": "pending",
+                    "timeout_seconds": self._timeout_seconds,
+                },
             )
-        except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
+
+            answer = await self._ask_tracker.wait_for_answer(
+                request_id,
+                timeout_seconds=self._timeout_seconds,
+                default_answer=question.default_answer,
+            )
+            decision = _answer_to_decision(answer)
+            if decision.timed_out:
+                self._last_error = "permission request timed out"
+                self._last_error_at = _utc_now()
+        except asyncio.CancelledError:
+            # The ACP turn was cancelled while awaiting the decision: close the
+            # question ask and propagate, so no orphan open question lingers.
+            await self._ask_tracker.close(request_id, reason="cancelled")
+            raise
+        finally:
             async with self._lock:
                 self._pending.pop(request_id, None)
-            return PermissionDecision(outcome="denied", message=f"register failed: {e}")
-
-        # Normal ask event (so the dashboard banner + Telegram render it) + the
-        # back-compat ACP-specific alias, both keyed by the same request_id/cid.
-        ask_event = {
-            "from": peer_id,
-            "to": CONTROL_PEER_NAME,
-            "from_peer_id": peer_id,
-            "to_peer_id": CONTROL_PEER_ID,
-            "text": question.prompt or "ACP tool permission request",
-            "correlation_id": request_id,
-            "question": question.model_dump(exclude_none=True),
-            "repowire_session_id": repowire_session_id,
-            "from_repowire_session_id": repowire_session_id,
-        }
-        self._emit_event("ask", ask_event)
-        self._emit_event(
-            "acp_permission_request",
-            {
-                "request_id": request_id,
-                "peer_id": peer_id,
-                "session_id": session_id,
-                "repowire_session_id": repowire_session_id,
-                "tool_call": pending.tool_call,
-                "options": normalized_options,
-                "status": "pending",
-                "timeout_seconds": self._timeout_seconds,
-            },
-        )
-
-        answer = await self._ask_tracker.wait_for_answer(
-            request_id,
-            timeout_seconds=self._timeout_seconds,
-            default_answer=question.default_answer,
-        )
-        decision = _answer_to_decision(answer)
-        if decision.timed_out:
-            self._last_error = "permission request timed out"
-            self._last_error_at = _utc_now()
-        async with self._lock:
-            self._pending.pop(request_id, None)
         self._emit_decision_event(pending, decision)
         return decision
 

--- a/repowire/agent_backends.py
+++ b/repowire/agent_backends.py
@@ -497,7 +497,7 @@ def detect_mcp_backend(
     markers are intentionally weaker than Claude/Gemini process signals because
     shells can carry Codex paths into other runtimes.
     """
-    env = env or os.environ
+    env = os.environ if env is None else env
 
     explicit = _explicit_backend(env)
     if explicit is not None:

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -294,6 +294,7 @@ def create_app(
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(
             emit_event=peer_registry.add_event,
+            ask_tracker=ask_tracker,
             resolve_repowire_session_id=_make_acp_session_resolver(session_binding_store),
         )
         app.state.acp_permission_broker = acp_permission_broker
@@ -644,6 +645,7 @@ def create_test_app(
         from repowire.acp import AcpClientManager, ApprovalBroker
         acp_permission_broker = ApprovalBroker(
             emit_event=registry.add_event,
+            ask_tracker=ask_tracker,
             resolve_repowire_session_id=_make_acp_session_resolver(session_binding_store),
         )
         app.state.acp_permission_broker = acp_permission_broker

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -310,6 +310,8 @@ class AskTracker:
                 raise KeyError(correlation_id)
             if ask.answer is not None:
                 return ask.answer
+            if ask.closed:
+                return Answer(outcome="cancelled", message=ask.close_reason)
             # Fail loud NOW if the default is invalid for this question, rather
             # than silently returning an unrecorded answer at timeout (codex
             # review): the timeout path must always go through answer().

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+from repowire.protocol.questions import Answer, Question
+
 logger = logging.getLogger(__name__)
 
 _EVICTION_INTERVAL_SECONDS = 300.0
@@ -107,6 +109,11 @@ class Ask:
     parent_id: str | None = None
     reply_text: str | None = None
     replied_at: datetime | None = None
+    # Structured question/answer (mesh questions primitive). ``question`` is set
+    # when the ask is a structured question (approval / choice / text); ``answer``
+    # is the typed resolution. A plain ask leaves both None and behaves as today.
+    question: Question | None = None
+    answer: Answer | None = None
 
 
 class AskTracker:
@@ -121,6 +128,11 @@ class AskTracker:
         self._asks: dict[str, Ask] = {}
         self._ttl = timedelta(hours=ttl_hours)
         self._last_eviction: float = 0.0
+        # Live answer waiters for blocking-transport questions. The future is a
+        # convenience for transports that own a suspendable call (ACP, PreToolUse
+        # hook); ``ask.answer`` is the source of truth. Futures vanish on restart
+        # like any open ask.
+        self._answer_waiters: dict[str, asyncio.Future[Answer]] = {}
         # peer_ids currently mid-switch — new asks to/from them are refused so
         # the switch route can kill+respawn without orphaning correlation IDs.
         self._quiescing: set[str] = set()
@@ -172,6 +184,7 @@ class AskTracker:
         from_repowire_session_id: str | None = None,
         to_repowire_session_id: str | None = None,
         parent_id: str | None = None,
+        question: Question | None = None,
     ) -> str:
         """Register a new open ask. Returns the correlation_id.
 
@@ -180,6 +193,8 @@ class AskTracker:
         and the same id is returned. Auto-generated cids never collide.
 
         ``parent_id`` links this ask as a child of an ask-many parent.
+        ``question`` makes this ask a structured question (approval / choice /
+        text); a blocking transport then awaits :meth:`wait_for_answer`.
 
         Raises QuiescedError if either endpoint is mid-switch.
         """
@@ -203,6 +218,7 @@ class AskTracker:
                 to_repowire_session_id=to_repowire_session_id,
                 reply_to=reply_to,
                 parent_id=parent_id,
+                question=question,
             )
             logger.debug("Registered ask %s: %s -> %s", cid, from_peer_name, to_peer_name)
             return cid
@@ -225,6 +241,95 @@ class AskTracker:
         """Return all child asks for an ask-many parent (snapshot)."""
         return [a for a in self._asks.values() if a.parent_id == parent_id]
 
+    class AlreadyAnsweredError(Exception):
+        """Raised by :meth:`answer` when the question was already answered."""
+
+    def _cancel_waiter(self, correlation_id: str, *, message: str | None = None) -> None:
+        """Resolve a dangling answer waiter with a cancelled Answer. Hold lock.
+
+        Called when an ask reaches a terminal state (evict/forget/close/rebind)
+        while a blocking transport is still awaiting it, so the waiter doesn't
+        hang until its own timeout (or forever, if it had none). The waiter's
+        caller sees outcome="cancelled" (with the close reason as the message).
+        """
+        waiter = self._answer_waiters.pop(correlation_id, None)
+        if waiter is not None and not waiter.done():
+            waiter.set_result(Answer(outcome="cancelled", message=message))
+
+    async def answer(self, correlation_id: str, answer: Answer) -> Ask:
+        """Record the typed answer to a question ask. First valid answer wins.
+
+        Stores ``ask.answer`` (the source of truth), closes the ask, and resolves
+        any live waiter future. Validates the answer against the question's
+        options. Raises ``KeyError`` for an unknown id, ``ValueError`` for an
+        invalid answer, and ``AlreadyAnsweredError`` if already resolved.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is None:
+                raise KeyError(correlation_id)
+            if ask.answer is not None:
+                raise self.AlreadyAnsweredError(correlation_id)
+            if ask.question is not None:
+                error = ask.question.validate_answer(answer)
+                if error is not None:
+                    raise ValueError(error)
+            ask.answer = answer
+            if answer.text is not None and ask.reply_text is None:
+                ask.reply_text = answer.text
+                ask.replied_at = datetime.now(timezone.utc)
+            ask.closed = True
+            ask.close_reason = "answered"
+            waiter = self._answer_waiters.pop(correlation_id, None)
+        if waiter is not None and not waiter.done():
+            waiter.set_result(answer)
+        return ask
+
+    async def wait_for_answer(
+        self,
+        correlation_id: str,
+        *,
+        timeout_seconds: float | None,
+        default_answer: Answer | None,
+    ) -> Answer:
+        """Block until ``correlation_id`` is answered, or apply the default on timeout.
+
+        Only meaningful for a transport that owns a suspendable call (ACP, a
+        PreToolUse hook). The returned answer is also recorded on the ask via the
+        timeout path so the ledger stays truthful. If the ask was already
+        answered (race), returns that answer immediately.
+        """
+        resolved_default = default_answer or Answer(outcome="timed_out")
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is None:
+                raise KeyError(correlation_id)
+            if ask.answer is not None:
+                return ask.answer
+            # Fail loud NOW if the default is invalid for this question, rather
+            # than silently returning an unrecorded answer at timeout (codex
+            # review): the timeout path must always go through answer().
+            if ask.question is not None:
+                error = ask.question.validate_answer(resolved_default)
+                if error is not None:
+                    raise ValueError(f"invalid default_answer: {error}")
+            waiter = self._answer_waiters.get(correlation_id)
+            if waiter is None:
+                waiter = asyncio.get_running_loop().create_future()
+                self._answer_waiters[correlation_id] = waiter
+        try:
+            return await asyncio.wait_for(asyncio.shield(waiter), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            try:
+                await self.answer(correlation_id, resolved_default)
+            except (self.AlreadyAnsweredError, KeyError):
+                # A real answer landed in the race window, or the ask was
+                # evicted (which already cancelled this waiter).
+                existing = await self.get(correlation_id)
+                if existing is not None and existing.answer is not None:
+                    return existing.answer
+            return resolved_default
+
     async def close(self, correlation_id: str, reason: str) -> Ask | None:
         """Close an ask. Returns the Ask if it existed and wasn't already closed."""
         async with self._lock:
@@ -233,6 +338,10 @@ class AskTracker:
                 return None
             ask.closed = True
             ask.close_reason = reason
+            # A structured question closed through a non-answer terminal path
+            # (ack/send_failed/reply_to) must not leave a blocking transport
+            # waiting forever (codex review). Resolve any waiter as cancelled.
+            self._cancel_waiter(correlation_id, message=reason)
             logger.debug("Closed ask %s: %s", correlation_id, reason)
             return ask
 
@@ -307,6 +416,7 @@ class AskTracker:
             ask.closed = True
             ask.close_reason = reason
             ask.pending_reply = None
+            self._cancel_waiter(correlation_id, message=reason)
             logger.debug(
                 "Rebound + closed ask %s -> %s (%s)",
                 correlation_id, new_from_peer_id, reason,
@@ -473,6 +583,7 @@ class AskTracker:
                 if not ask.closed:
                     ask.closed = True
                     ask.close_reason = "evicted"
+                self._cancel_waiter(cid)
                 del self._asks[cid]
             return len(doomed)
 
@@ -502,6 +613,7 @@ class AskTracker:
                 if not ask.closed:
                     ask.closed = True
                     ask.close_reason = "evicted"
+                self._cancel_waiter(cid)
                 del self._asks[cid]
             if expired:
                 logger.info("Evicted %d expired asks", len(expired))

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -268,7 +268,11 @@ class AskTracker:
             ask = self._asks.get(correlation_id)
             if ask is None:
                 raise KeyError(correlation_id)
-            if ask.answer is not None:
+            # Guard on closed, not just answer-present: an ask can be closed by
+            # another terminal path (send_failed / ack / reply_to) with no answer
+            # recorded. Answering it would overwrite that close state (gemini
+            # review). First terminal state wins.
+            if ask.closed or ask.answer is not None:
                 raise self.AlreadyAnsweredError(correlation_id)
             if ask.question is not None:
                 error = ask.question.validate_answer(answer)

--- a/repowire/daemon/message_router.py
+++ b/repowire/daemon/message_router.py
@@ -173,22 +173,30 @@ class MessageRouter:
         reply_to: str | None = None,
         intended_recipient_name: str | None = None,
         attachments: list[AttachmentRef] | list[dict[str, Any]] | None = None,
+        question: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Send a first-class ask wire message.
 
-        Wire shape: {type: ask, correlation_id, from_peer, text, reply_to?}.
-        The receiving transport dispatches type=ask explicitly and surfaces
-        the message to the agent (e.g. tmux paste). The daemon doesn't track
-        pickup state — open asks reappear in every Stop hook reminder until
-        acked.
+        Wire shape: {type: ask, correlation_id, from_peer, text, reply_to?,
+        question?}. The receiving transport dispatches type=ask explicitly and
+        surfaces the message to the agent (e.g. tmux paste). The daemon doesn't
+        track pickup state — open asks reappear in every Stop hook reminder
+        until acked. ``question`` carries the structured-question envelope so a
+        renderer (Telegram buttons, dashboard) can present options; the close
+        hint adapts to ``answer(...)`` for a question vs ``ack(...)`` for a plain
+        ask.
 
         Raises:
             TransportError: If send fails
         """
-        hinted_text = (
-            f'{text.rstrip()}\n'
-            f'↳ ack("{correlation_id}") or ack("{correlation_id}", "reply")'
-        )
+        if question is not None:
+            hint = (
+                f'↳ answer("{correlation_id}", option_id=...) '
+                f'or answer("{correlation_id}", text="...")'
+            )
+        else:
+            hint = f'↳ ack("{correlation_id}") or ack("{correlation_id}", "reply")'
+        hinted_text = f"{text.rstrip()}\n{hint}"
         message: dict[str, Any] = {
             "type": "ask",
             "delivery_id": f"ask-delivery-{uuid4().hex[:8]}",
@@ -201,6 +209,8 @@ class MessageRouter:
             message["attachments"] = _dump_attachments(attachments)
         if reply_to is not None:
             message["reply_to"] = reply_to
+        if question is not None:
+            message["question"] = question
         logger.info(
             "Ask delivery trace: sender_identity=%s intended_recipient_name=%s "
             "resolved_peer_id=%s frame.to_peer=%s actual_delivered_pane_id=%s",

--- a/repowire/daemon/peer_delivery.py
+++ b/repowire/daemon/peer_delivery.py
@@ -34,6 +34,7 @@ from repowire.daemon.transport_router import (
 from repowire.daemon.websocket_transport import DeliveryInjectionError, TransportError
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerStatus
+from repowire.protocol.questions import Question
 
 logger = logging.getLogger(__name__)
 
@@ -365,6 +366,7 @@ class PeerDeliveryService:
         circle: str | None = None,
         attachments: list[AttachmentRef] | tuple[AttachmentRef, ...] | None = None,
         on_acp_complete: AskCompletion | None = None,
+        question: Question | None = None,
     ) -> AskTransportResult:
         """Deliver an already-registered ask using ACP-before-WS routing.
 
@@ -410,6 +412,7 @@ class PeerDeliveryService:
                     attachments=tuple(attachments or ()),
                     from_repowire_session_id=from_session_id,
                     to_repowire_session_id=to_session_id,
+                    question=question,
                 ),
                 on_acp_complete=completion,
             )

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -800,8 +800,14 @@ async def _answer_question_core(request: AnswerRequest) -> OkResponse:
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
 
-    # Best-effort: deliver a readable form of the answer back to the asker.
-    body = _answer_reply_text(existing, answer)
+    # Best-effort: deliver a readable form of the answer back to the asker —
+    # EXCEPT for tool-permission questions, where the ACP runtime already
+    # receives the decision via wait_for_answer; a notify back into the runtime
+    # would be a redundant/intrusive prompt (codex review).
+    is_tool_permission = (
+        existing.question is not None and existing.question.scope == "tool_permission"
+    )
+    body = None if is_tool_permission else _answer_reply_text(existing, answer)
     delivery_success = False
     if body:
         framed = f"[ack #{request.correlation_id} from @{existing.to_peer_name}] {body}"

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -34,7 +34,7 @@ from repowire.daemon.ask_many import (
     AskManyChild,
     AskManyTracker,
 )
-from repowire.daemon.ask_tracker import AskerIdentity, AskTracker, QuiescedError
+from repowire.daemon.ask_tracker import Ask, AskerIdentity, AskTracker, QuiescedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_delivery import peer_delivery_from_state
@@ -44,6 +44,7 @@ from repowire.daemon.state.session_bindings import resolve_repowire_session_id
 from repowire.daemon.websocket_transport import DeliveryInjectionError, TransportError
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer
+from repowire.protocol.questions import Answer, AnswerOutcome, Question
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["asks"])
@@ -65,6 +66,13 @@ class AskRequest(BaseModel):
     )
     bypass_circle: bool = Field(default=False)
     circle: str | None = Field(None)
+    question: Question | None = Field(
+        None,
+        description=(
+            "Optional structured question (approval / choice / text). When set, "
+            "the recipient answers via /answer (or ack); the answer is typed."
+        ),
+    )
 
 
 class AskResponse(BaseModel):
@@ -72,6 +80,20 @@ class AskResponse(BaseModel):
 
     correlation_id: str
     error: str | None = None
+
+
+class AnswerRequest(BaseModel):
+    """Answer a question ask (or a plain ask) with a typed Answer.
+
+    Canonical endpoint for the mesh-questions primitive. ``/ack`` delegates here.
+    """
+
+    correlation_id: str
+    option_id: str | None = Field(None, description="Selected option for a choice question")
+    text: str | None = Field(None, description="Free-text answer / reply body")
+    outcome: AnswerOutcome = Field("answered")
+    message: str | None = Field(None, description="Optional human note alongside the answer")
+    attachments: list[AttachmentRef] = Field(default_factory=list)
 
 
 class AckRequest(BaseModel):
@@ -428,6 +450,7 @@ async def open_ask(
             reply_to=request.reply_to,
             from_repowire_session_id=from_repowire_session_id,
             to_repowire_session_id=to_repowire_session_id,
+            question=request.question,
         )
     except QuiescedError as e:
         raise HTTPException(
@@ -720,6 +743,113 @@ async def ask_many_result(
     return result
 
 
+def _answer_reply_text(ask: Ask, answer: Answer) -> str | None:
+    """Human-readable body to deliver back to the asker for an answer.
+
+    A choice answer renders the chosen option's title; a text answer is its
+    text; a bare acknowledge has no body (the asker just learns it was acked).
+    """
+    if answer.text:
+        return answer.text
+    if answer.option_id and ask.question is not None:
+        for opt in ask.question.options:
+            if opt.id == answer.option_id:
+                return opt.title
+        return answer.option_id
+    return answer.message
+
+
+async def _answer_question_core(request: AnswerRequest) -> OkResponse:
+    """Shared answer logic for /answer and the /ack-on-question delegation.
+
+    Records the typed answer (source of truth; resolves any blocking transport's
+    waiter), then best-effort delivers a human-readable form back to the asker.
+    A transient asker-offline does NOT un-resolve the question — the blocking
+    transport cares the answer is recorded; redelivery is separate.
+    """
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+
+    existing = await ask_tracker.get(request.correlation_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=404, detail=f"No open ask with correlation_id: {request.correlation_id}",
+        )
+    # /answer is only for structured questions. A plain ask must go through /ack
+    # so its fail-loud 503/retry contract isn't bypassed (codex review).
+    if existing.question is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ask {request.correlation_id} is not a structured question; use /ack.",
+        )
+    answer = Answer(
+        option_id=request.option_id,
+        text=request.text,
+        outcome=request.outcome,
+        message=request.message,
+    )
+    try:
+        await ask_tracker.answer(request.correlation_id, answer)
+    except ask_tracker.AlreadyAnsweredError:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Ask {request.correlation_id} is already answered/closed.",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    # Best-effort: deliver a readable form of the answer back to the asker.
+    body = _answer_reply_text(existing, answer)
+    delivery_success = False
+    if body:
+        framed = f"[ack #{request.correlation_id} from @{existing.to_peer_name}] {body}"
+        try:
+            peer_delivery = peer_delivery_from_state(
+                config=state.config, registry=peer_registry, state=state,
+            )
+            await peer_delivery.notify(
+                from_peer=existing.to_peer_id,
+                to_peer=existing.from_peer_id,
+                text=framed,
+                bypass_circle=True,
+                attachments=request.attachments,
+            )
+            delivery_success = True
+        except (ValueError, TransportError) as e:
+            # The answer is recorded (truth); the asker just didn't get the
+            # human-readable notification this time. Redelivery-to-offline-asker
+            # is tracked as a follow-up (repowire-* — stash on answered question).
+            logger.warning(
+                "answer for %s recorded; asker delivery deferred (%s)",
+                request.correlation_id, e,
+            )
+    _emit_ack_event(
+        peer_registry=peer_registry,
+        ask=existing,
+        reason="answered",
+        delivered=delivery_success,  # truthful: only true when notify succeeded
+        has_message=bool(body),
+        has_attachments=bool(request.attachments),
+    )
+    return OkResponse()
+
+
+@router.post("/answer", response_model=OkResponse)
+async def answer_question(
+    request: AnswerRequest,
+    _: str | None = Depends(require_auth),
+) -> OkResponse:
+    """Answer a structured question with a typed Answer — the canonical verb.
+
+    Records the answer (resolving any blocking transport's waiter), then
+    best-effort delivers a human-readable form back to the asker. Returns 404
+    (unknown), 410 (already answered/closed), 422 (plain ask — use /ack, or
+    invalid option for the question).
+    """
+    return await _answer_question_core(request)
+
+
 @router.post("/ack", response_model=OkResponse)
 async def ack_ask(
     request: AckRequest,
@@ -754,6 +884,17 @@ async def ack_ask(
             status_code=404,
             detail=f"No open ask with correlation_id: {request.correlation_id}",
         )
+    # Acking a structured QUESTION delegates to the typed answer path so the
+    # blocking transport's waiter resolves and the answer is recorded. A bare
+    # ack on a question = acknowledge; ack-with-message = a text answer.
+    if existing.question is not None and not existing.closed:
+        delegated = AnswerRequest(
+            correlation_id=request.correlation_id,
+            text=request.message,
+            outcome="acknowledged" if not request.message else "answered",
+            attachments=request.attachments,
+        )
+        return await _answer_question_core(delegated)
     if existing.closed and (request.message or request.attachments):
         raise HTTPException(
             status_code=status.HTTP_410_GONE,

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -503,6 +503,7 @@ async def open_ask(
             bypass_circle=True,
             attachments=request.attachments,
             on_acp_complete=_on_acp_complete,
+            question=request.question,
         )
     except ValueError as e:
         if trace is not None:

--- a/repowire/daemon/transport_router.py
+++ b/repowire/daemon/transport_router.py
@@ -18,6 +18,7 @@ from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer, PeerStatus, TurnState
+from repowire.protocol.questions import Question
 
 
 def _text_with_attachment_fallback(text: str, attachments: tuple[AttachmentRef, ...]) -> str:
@@ -45,6 +46,7 @@ class AskEnvelope:
     attachments: tuple[AttachmentRef, ...] = ()
     from_repowire_session_id: str | None = None
     to_repowire_session_id: str | None = None
+    question: Question | None = None
 
 
 @dataclass(frozen=True)
@@ -120,6 +122,11 @@ class WebSocketPeerTransport:
                 "repowire_session_id": envelope.to_repowire_session_id,
                 "from_repowire_session_id": envelope.from_repowire_session_id,
                 "to_repowire_session_id": envelope.to_repowire_session_id,
+                "question": (
+                    envelope.question.model_dump(exclude_none=True)
+                    if envelope.question is not None
+                    else None
+                ),
             },
         )
         hook_delivery = await self._router.send_ask(
@@ -133,6 +140,11 @@ class WebSocketPeerTransport:
                 envelope.intended_recipient_name or envelope.target.display_name
             ),
             attachments=list(envelope.attachments),
+            question=(
+                envelope.question.model_dump(exclude_none=True)
+                if envelope.question is not None
+                else None
+            ),
         )
         return AskTransportResult(
             transport="ws",

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -1058,6 +1058,42 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         )
 
     @mcp.tool()
+    async def answer(
+        correlation_id: str,
+        option_id: str | None = None,
+        text: str | None = None,
+    ) -> str:
+        """[Repowire mesh] Answer a structured question (choice or free-text).
+
+        The typed counterpart to `ack` for questions raised via `ask` with a
+        structured question (an approval, an AskUserQuestion-style choice, or a
+        free-text prompt). Pass `option_id` to pick a choice, or `text` for a
+        free-text answer. The answer is recorded and delivered back to the
+        asker; if the asking transport is blocked waiting (e.g. a tool-approval),
+        this is what unblocks it. Use `ack` for plain asks; use `answer` when the
+        ask carried options you're selecting from.
+
+        Args:
+            correlation_id: The question ask's correlation_id.
+            option_id: The chosen option id (for a choice question).
+            text: A free-text answer (for a text question or freeform reply).
+
+        Returns:
+            Confirmation message.
+        """
+        await _ensure_registered(strict=True)
+        body: dict = {"correlation_id": correlation_id}
+        if option_id is not None:
+            body["option_id"] = option_id
+        if text is not None:
+            body["text"] = text
+        if option_id is None and text is None:
+            body["outcome"] = "acknowledged"
+        await daemon_request("POST", "/answer", body)
+        picked = f"option={option_id}" if option_id else ("text" if text else "acknowledged")
+        return f"answered #{correlation_id} ({picked})"
+
+    @mcp.tool()
     async def notify_peer(
         peer_name: str,
         message: str,

--- a/repowire/protocol/questions.py
+++ b/repowire/protocol/questions.py
@@ -1,0 +1,106 @@
+"""Structured mesh questions — the shared semantic primitive.
+
+A ``Question`` rides on an ask; an ``Answer`` rides on the ack. This turns three
+things into one primitive at points on a spectrum:
+
+  * plain ask        — no question (legacy) or ``Question(kind="acknowledge")``
+  * tool approval     — ``Question(kind="choice", options=[allow, deny],
+                        blocking=True, default_answer=deny)``
+  * AskUserQuestion   — ``Question(kind="choice", options=[...N...])``
+
+The load-bearing boundary (see ``docs``/design notes): ``Question``/``Answer`` is
+the shared *semantic* primitive, but **blocking is a transport capability, not a
+property of every ask**. ``Question.blocking`` is what the origin *requests*;
+whether a wait actually happens depends on the transport binding (ACP and a
+PreToolUse hook own a suspendable call; an MCP ask from an already-running agent
+does not — its answer arrives on a later turn). Bindings must never silently
+pretend a non-blocking origin blocked.
+
+The option shape (``id``/``title``/``description``) matches both ACP's
+``RequestPermission`` options and the harness ``AskUserQuestion`` tool's
+``{label, description}`` — that alignment is why the unification is natural.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+QuestionKind = Literal["acknowledge", "choice", "text"]
+"""How the question is answered: a bare ack, one of N options, or free text."""
+
+QuestionScope = Literal["mesh_ask", "tool_permission", "user_question"]
+"""Where the question originated — diagnostic/routing hint, not behavior."""
+
+AnswerOutcome = Literal["answered", "acknowledged", "timed_out", "cancelled"]
+
+
+class QuestionOption(BaseModel):
+    """One choice for a ``kind="choice"`` question."""
+
+    id: str = Field(..., description="Stable option id echoed back in the Answer")
+    title: str = Field(..., description="Human-facing label")
+    description: str | None = Field(None, description="Optional longer explanation")
+
+
+class Answer(BaseModel):
+    """The typed resolution of a question (rides on the ack)."""
+
+    option_id: str | None = Field(None, description="Selected option id for a choice question")
+    text: str | None = Field(None, description="Free-text answer / reply body")
+    outcome: AnswerOutcome = Field(
+        "answered",
+        description="answered (option/text given), acknowledged (bare), timed_out, cancelled",
+    )
+    message: str | None = Field(None, description="Optional human note alongside the answer")
+
+
+class Question(BaseModel):
+    """A structured question carried on an ask.
+
+    ``Ask.text`` stays the canonical human body; ``prompt`` only overrides when
+    the rendered question differs from the ask text.
+    """
+
+    kind: QuestionKind = Field(..., description="acknowledge | choice | text")
+    prompt: str | None = Field(None, description="Optional rendered prompt; defaults to ask.text")
+    options: list[QuestionOption] = Field(
+        default_factory=list, description="Choices for kind='choice'"
+    )
+    blocking: bool = Field(
+        False,
+        description=(
+            "REQUESTED semantics: does the origin want to suspend until answered? "
+            "Honored only by transports that own a suspendable call (ACP, "
+            "PreToolUse hook). Non-blocking origins must reject or downgrade with "
+            "explicit metadata, never silently fake a block."
+        ),
+    )
+    timeout_seconds: float | None = Field(
+        None, description="How long a blocking transport waits before applying default_answer"
+    )
+    default_answer: Answer | None = Field(
+        None, description="Applied on timeout (e.g. deny for an approval)"
+    )
+    scope: QuestionScope | None = Field(None, description="Origin hint (diagnostic/routing)")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def option_ids(self) -> set[str]:
+        return {opt.id for opt in self.options}
+
+    def validate_answer(self, answer: Answer) -> str | None:
+        """Return an error string if ``answer`` is invalid for this question, else None.
+
+        Enforced in the daemon (not just the UI): a choice must pick a known
+        option (unless it's a timeout/cancel applying the default); text/ack are
+        permissive. First-answer-wins + lifecycle is the tracker's job.
+        """
+        if answer.outcome in ("timed_out", "cancelled"):
+            return None
+        if self.kind == "choice":
+            if answer.option_id is None:
+                return "choice question requires an option_id"
+            if answer.option_id not in self.option_ids():
+                return f"unknown option_id: {answer.option_id}"
+        return None

--- a/repowire/protocol/questions.py
+++ b/repowire/protocol/questions.py
@@ -93,10 +93,12 @@ class Question(BaseModel):
         """Return an error string if ``answer`` is invalid for this question, else None.
 
         Enforced in the daemon (not just the UI): a choice must pick a known
-        option (unless it's a timeout/cancel applying the default); text/ack are
-        permissive. First-answer-wins + lifecycle is the tracker's job.
+        option, UNLESS the answer is a non-selecting outcome (timed_out /
+        cancelled apply a default; acknowledged = "seen, no choice made").
+        text/ack kinds are permissive. First-answer-wins + lifecycle is the
+        tracker's job.
         """
-        if answer.outcome in ("timed_out", "cancelled"):
+        if answer.outcome in ("timed_out", "cancelled", "acknowledged"):
             return None
         if self.kind == "choice":
             if answer.option_id is None:

--- a/repowire/protocol/questions.py
+++ b/repowire/protocol/questions.py
@@ -33,7 +33,7 @@ QuestionKind = Literal["acknowledge", "choice", "text"]
 QuestionScope = Literal["mesh_ask", "tool_permission", "user_question"]
 """Where the question originated — diagnostic/routing hint, not behavior."""
 
-AnswerOutcome = Literal["answered", "acknowledged", "timed_out", "cancelled"]
+AnswerOutcome = Literal["answered", "acknowledged", "denied", "timed_out", "cancelled"]
 
 
 class QuestionOption(BaseModel):
@@ -98,7 +98,7 @@ class Question(BaseModel):
         text/ack kinds are permissive. First-answer-wins + lifecycle is the
         tracker's job.
         """
-        if answer.outcome in ("timed_out", "cancelled", "acknowledged"):
+        if answer.outcome in ("timed_out", "cancelled", "acknowledged", "denied"):
             return None
         if self.kind == "choice":
             if answer.option_id is None:

--- a/repowire/protocol/questions.py
+++ b/repowire/protocol/questions.py
@@ -4,8 +4,8 @@ A ``Question`` rides on an ask; an ``Answer`` rides on the ack. This turns three
 things into one primitive at points on a spectrum:
 
   * plain ask        — no question (legacy) or ``Question(kind="acknowledge")``
-  * tool approval     — ``Question(kind="choice", options=[allow, deny],
-                        blocking=True, default_answer=deny)``
+  * tool approval     — ``Question(kind="choice", options=[allow], blocking=True,
+                        default_answer=deny)`` plus an explicit denied Answer
   * AskUserQuestion   — ``Question(kind="choice", options=[...N...])``
 
 The load-bearing boundary (see ``docs``/design notes): ``Question``/``Answer`` is
@@ -51,7 +51,9 @@ class Answer(BaseModel):
     text: str | None = Field(None, description="Free-text answer / reply body")
     outcome: AnswerOutcome = Field(
         "answered",
-        description="answered (option/text given), acknowledged (bare), timed_out, cancelled",
+        description=(
+            "answered (option/text given), acknowledged (bare), denied, timed_out, cancelled"
+        ),
     )
     message: str | None = Field(None, description="Optional human note alongside the answer")
 
@@ -94,9 +96,9 @@ class Question(BaseModel):
 
         Enforced in the daemon (not just the UI): a choice must pick a known
         option, UNLESS the answer is a non-selecting outcome (timed_out /
-        cancelled apply a default; acknowledged = "seen, no choice made").
-        text/ack kinds are permissive. First-answer-wins + lifecycle is the
-        tracker's job.
+        cancelled apply a default; acknowledged = "seen, no choice made";
+        denied = explicit refusal). text/ack kinds are permissive.
+        First-answer-wins + lifecycle is the tracker's job.
         """
         if answer.outcome in ("timed_out", "cancelled", "acknowledged", "denied"):
             return None

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 _MD_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+=|{}.!\-])")
 
 # Reply-keyboard button markers. Each label is `<marker> <peer_name>`.
+_MAX_REMEMBERED_QUESTIONS = 200  # cap the cid->option-ids map (FIFO eviction)
+
 CURRENT_MARK = "✦"        # currently selected target
 CURRENT_OFF_MARK = "✧"    # currently selected target but peer is offline
 RECENT_MARK = "💬"        # recent notifier
@@ -467,7 +469,11 @@ class TelegramPeer:
             options = question.get("options") or []
             if options:
                 # Remember the option ids for this cid so the index-based
-                # callback can map back to the real option_id.
+                # callback can map back to the real option_id. Bounded + FIFO so
+                # the map can't grow unbounded over a long-lived bot process
+                # (lazy cleanup, no timer — codex review).
+                if len(self._question_options) >= _MAX_REMEMBERED_QUESTIONS:
+                    self._question_options.pop(next(iter(self._question_options)), None)
                 self._question_options[cid] = [
                     str(o.get("id")) for o in options if isinstance(o, dict)
                 ]
@@ -485,6 +491,7 @@ class TelegramPeer:
         try:
             option_id = ids[int(option_index_raw)]
         except (ValueError, IndexError):
+            self._question_options.pop(cid, None)  # stale entry — don't retain
             await self._tg_send(f"Stale or unknown option for `#{_esc(cid[:12])}`")
             return
         try:

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -454,6 +454,8 @@ class TelegramPeer:
         elif data.startswith("answer:"):
             _, cid, option_index = data.split(":", 2)
             await self._answer_choice(cid, option_index)
+        elif data.startswith("deny:"):
+            await self._deny_question(data.split(":", 1)[1])
         elif data.startswith("ack:"):
             cid = data.split(":", 1)[1]
             await self._ack_ask(cid)
@@ -482,8 +484,31 @@ class TelegramPeer:
                     for i, o in enumerate(options)
                     if isinstance(o, dict)
                 ]
+                # ACP tool-permission options are allow-only — add an explicit
+                # Deny that posts outcome:"denied" (no option).
+                if question.get("scope") == "tool_permission":
+                    rows.append([("✕ Deny", f"deny:{cid}")])
                 return _kb(rows)
         return _kb([[("✓ Ack", f"ack:{cid}")]])
+
+    async def _deny_question(self, cid: str) -> None:
+        """Deny a tool-permission question → POST /answer {outcome: denied}."""
+        try:
+            r = await self._http.post(
+                f"{self._daemon_url}/answer",
+                json={"correlation_id": cid, "outcome": "denied"},
+                timeout=5.0,
+            )
+            short = cid[:12]
+            if r.status_code == 200:
+                self._question_options.pop(cid, None)
+                await self._tg_send(f"✕ Denied `#{_esc(short)}`")
+            elif r.status_code == 410:
+                await self._tg_send(f"`#{_esc(short)}` already answered")
+            else:
+                await self._tg_send(f"Deny failed for `#{_esc(short)}`: {r.status_code}")
+        except Exception as e:
+            await self._tg_send(f"Deny error: {_esc(str(e))}")
 
     async def _answer_choice(self, cid: str, option_index_raw: str) -> None:
         """Answer a choice question by option index → POST /answer."""

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -268,6 +268,9 @@ class TelegramPeer:
         self._recents: deque[str] = deque(maxlen=10)
         self._pending_retry: PendingRetry | None = None
         self._keyboard_enabled: bool = True
+        # cid -> ordered option ids, so an index-based answer callback (kept
+        # short for Telegram's 64-byte callback_data limit) maps to a real id.
+        self._question_options: dict[str, list[str]] = {}
         self._peers_cache: list[dict] | None = None
         self._peers_cache_at: float = 0.0
 
@@ -365,7 +368,7 @@ class TelegramPeer:
             self._touch_recent(who)
             cid = msg.get("correlation_id", "")
             short_cid = cid[:12] if cid else "?"
-            markup = _kb([[("✓ Ack", f"ack:{cid}")]]) if cid else None
+            markup = self._ask_markup(cid, msg.get("question")) if cid else None
             await self._tg_send(
                 f"❓ *@{_esc(who)}* `[ask #{_esc(short_cid)}]`\n{_esc(text)}",
                 markup=markup,
@@ -446,9 +449,60 @@ class TelegramPeer:
             await self._tg_send("Cancelled\\.")
         elif data == "peers":
             await self._cmd_peers()
+        elif data.startswith("answer:"):
+            _, cid, option_index = data.split(":", 2)
+            await self._answer_choice(cid, option_index)
         elif data.startswith("ack:"):
             cid = data.split(":", 1)[1]
             await self._ack_ask(cid)
+
+    def _ask_markup(self, cid: str, question: dict | None) -> dict | None:
+        """Inline keyboard for an ask.
+
+        A choice question renders one button per option (callback answer:cid:idx,
+        index-based to stay within Telegram's 64-byte callback_data limit);
+        anything else (plain ask, text, acknowledge) gets the bare Ack button.
+        """
+        if isinstance(question, dict) and question.get("kind") == "choice":
+            options = question.get("options") or []
+            if options:
+                # Remember the option ids for this cid so the index-based
+                # callback can map back to the real option_id.
+                self._question_options[cid] = [
+                    str(o.get("id")) for o in options if isinstance(o, dict)
+                ]
+                rows = [
+                    [(str(o.get("title") or o.get("id")), f"answer:{cid}:{i}")]
+                    for i, o in enumerate(options)
+                    if isinstance(o, dict)
+                ]
+                return _kb(rows)
+        return _kb([[("✓ Ack", f"ack:{cid}")]])
+
+    async def _answer_choice(self, cid: str, option_index_raw: str) -> None:
+        """Answer a choice question by option index → POST /answer."""
+        ids = self._question_options.get(cid, [])
+        try:
+            option_id = ids[int(option_index_raw)]
+        except (ValueError, IndexError):
+            await self._tg_send(f"Stale or unknown option for `#{_esc(cid[:12])}`")
+            return
+        try:
+            r = await self._http.post(
+                f"{self._daemon_url}/answer",
+                json={"correlation_id": cid, "option_id": option_id},
+                timeout=5.0,
+            )
+            short = cid[:12]
+            if r.status_code == 200:
+                self._question_options.pop(cid, None)
+                await self._tg_send(f"✓ Answered `#{_esc(short)}`: {_esc(option_id)}")
+            elif r.status_code == 410:
+                await self._tg_send(f"`#{_esc(short)}` already answered")
+            else:
+                await self._tg_send(f"Answer failed for `#{_esc(short)}`: {r.status_code}")
+        except Exception as e:
+            await self._tg_send(f"Answer error: {_esc(str(e))}")
 
     async def _ack_ask(self, correlation_id: str) -> None:
         """Bare-ack an open ask. Uses the bot's configured display name."""

--- a/tests/test_acp_permissions.py
+++ b/tests/test_acp_permissions.py
@@ -306,3 +306,31 @@ async def test_tool_permission_answer_does_not_notify_runtime(
         notify_spy.assert_not_awaited()  # no runtime notify for a tool-permission answer
     finally:
         cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_cancellation_cleans_pending_context() -> None:
+    tracker = AskTracker(ttl_hours=24.0)
+    broker = ApprovalBroker(
+        emit_event=lambda _event_type, _data: "evt",
+        ask_tracker=tracker,
+        timeout_seconds=60.0,
+    )
+    task = asyncio.create_task(
+        broker.request_permission(
+            peer_id="peer-1",
+            session_id="session-1",
+            tool_call={"name": "shell"},
+            options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+        )
+    )
+    deadline = time.monotonic() + 1.0
+    while broker.health_snapshot()["pending"] == 0 and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert broker.health_snapshot()["pending"] == 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert broker.health_snapshot()["pending"] == 0

--- a/tests/test_acp_permissions.py
+++ b/tests/test_acp_permissions.py
@@ -16,7 +16,7 @@ from repowire.daemon.deps import cleanup_deps, init_deps
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
-from repowire.daemon.routes import acp_permissions
+from repowire.daemon.routes import acp_permissions, asks
 from repowire.daemon.websocket_transport import WebSocketTransport
 
 
@@ -28,7 +28,9 @@ async def test_approval_broker_timeout_emits_default_deny_events() -> None:
         events.append({"type": event_type, **data})
         return f"evt-{len(events)}"
 
-    broker = ApprovalBroker(emit_event=_emit, timeout_seconds=0.01)
+    broker = ApprovalBroker(
+        emit_event=_emit, ask_tracker=AskTracker(ttl_hours=24.0), timeout_seconds=0.01,
+    )
 
     decision = await broker.request_permission(
         peer_id="peer-1",
@@ -39,16 +41,21 @@ async def test_approval_broker_timeout_emits_default_deny_events() -> None:
 
     assert decision.outcome == "denied"
     assert decision.timed_out is True
-    assert events[0]["type"] == "acp_permission_request"
-    assert events[0]["peer_id"] == "peer-1"
-    assert events[0]["session_id"] == "session-1"
-    assert events[0]["tool_call"]["name"] == "shell"
-    assert events[0]["options"] == [{"option_id": "opt-allow", "title": "Allow"}]
-    assert events[0]["status"] == "pending"
-    assert events[1]["type"] == "acp_permission_decision"
-    assert events[1]["request_id"] == events[0]["request_id"]
-    assert events[1]["outcome"] == "denied"
-    assert events[1]["status"] == "timed_out"
+    # A normal ask event (for the dashboard/Telegram renderers) AND the
+    # back-compat ACP-specific aliases are emitted, keyed by the same request_id.
+    ask_evt = next(e for e in events if e["type"] == "ask")
+    assert ask_evt["to_peer_id"] == "__repowire_control__"
+    assert ask_evt["question"]["scope"] == "tool_permission"
+    req = next(e for e in events if e["type"] == "acp_permission_request")
+    assert req["peer_id"] == "peer-1"
+    assert req["session_id"] == "session-1"
+    assert req["tool_call"]["name"] == "shell"
+    assert req["options"] == [{"option_id": "opt-allow", "title": "Allow"}]
+    assert req["status"] == "pending"
+    dec = next(e for e in events if e["type"] == "acp_permission_decision")
+    assert dec["request_id"] == req["request_id"]
+    assert dec["outcome"] == "denied"
+    assert dec["status"] == "timed_out"
 
 
 @pytest.mark.asyncio
@@ -148,7 +155,7 @@ def _make_permission_app(tmp_path: Path) -> tuple[FastAPI, ApprovalBroker, PeerR
     registry._events.clear()
     registry._last_repair = time.monotonic() + 3600
 
-    broker = ApprovalBroker(emit_event=registry.add_event, timeout_seconds=5.0)
+    broker = ApprovalBroker(emit_event=registry.add_event, ask_tracker=at, timeout_seconds=5.0)
     state = SimpleNamespace(
         config=cfg,
         transport=transport,
@@ -163,6 +170,7 @@ def _make_permission_app(tmp_path: Path) -> tuple[FastAPI, ApprovalBroker, PeerR
 
     app = FastAPI()
     app.include_router(acp_permissions.router)
+    app.include_router(asks.router)  # for the generic /answer verb
     return app, broker, registry
 
 
@@ -174,3 +182,127 @@ async def _wait_for_event(registry: PeerRegistry, event_type: str) -> dict:
             return matches[-1]
         await asyncio.sleep(0.01)
     raise AssertionError(f"timed out waiting for {event_type}")
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_resolves_via_generic_answer(tmp_path: Path) -> None:
+    # The keystone: an ACP permission request IS a question ask, so answering it
+    # through the generic /answer route (as a human/peer would) resolves the ACP
+    # PermissionDecision — no ACP-specific decide call needed.
+    app, broker, registry = _make_permission_app(tmp_path)
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1", session_id="session-1",
+                tool_call={"name": "shell"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+            )
+        )
+        req = await _wait_for_event(registry, "acp_permission_request")
+        cid = req["request_id"]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            # answer via the generic verb, picking the allow option
+            r = await http.post("/answer", json={"correlation_id": cid, "option_id": "opt-allow"})
+            assert r.status_code == 200, r.text
+
+        decision = await asyncio.wait_for(task, timeout=1.0)
+        assert decision.outcome == "allowed"
+        assert decision.option_id == "opt-allow"
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_answer_fails_closed_on_bare_ack(tmp_path: Path) -> None:
+    # Acknowledging a tool-permission question (no option selected) must DENY,
+    # never allow — fail closed.
+    app, broker, registry = _make_permission_app(tmp_path)
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1", session_id="session-1",
+                tool_call={"name": "shell"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+            )
+        )
+        req = await _wait_for_event(registry, "acp_permission_request")
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            r = await http.post(
+                "/answer", json={"correlation_id": req["request_id"], "outcome": "acknowledged"},
+            )
+            assert r.status_code == 200, r.text
+        decision = await asyncio.wait_for(task, timeout=1.0)
+        assert decision.outcome == "denied"
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_acp_permission_denied_via_first_class_outcome(tmp_path: Path) -> None:
+    # POST /answer {outcome: "denied"} on a tool-permission → PermissionDecision(denied),
+    # without needing a deny OPTION (ACP options are allow-options).
+    app, broker, registry = _make_permission_app(tmp_path)
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1", session_id="session-1", tool_call={"name": "shell"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+            )
+        )
+        req = await _wait_for_event(registry, "acp_permission_request")
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            r = await http.post(
+                "/answer", json={"correlation_id": req["request_id"], "outcome": "denied"},
+            )
+            assert r.status_code == 200, r.text
+        decision = await asyncio.wait_for(task, timeout=1.0)
+        assert decision.outcome == "denied"
+    finally:
+        cleanup_deps()
+
+
+@pytest.mark.asyncio
+async def test_tool_permission_answer_does_not_notify_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Answering a tool-permission must NOT notify the ACP "asker" — the runtime
+    # already gets the decision via wait_for_answer; a notify would be a
+    # redundant/intrusive prompt (codex review).
+    from unittest.mock import AsyncMock
+
+    import repowire.daemon.routes.asks as asks_mod
+
+    app, broker, registry = _make_permission_app(tmp_path)
+    notify_spy = AsyncMock()
+    try:
+        task = asyncio.create_task(
+            broker.request_permission(
+                peer_id="peer-1", session_id="session-1", tool_call={"name": "shell"},
+                options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+            )
+        )
+        req = await _wait_for_event(registry, "acp_permission_request")
+        # patch peer_delivery so any notify attempt is observable
+        monkeypatch.setattr(
+            asks_mod, "peer_delivery_from_state",
+            lambda **_: SimpleNamespace(notify=notify_spy),
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as http:
+            r = await http.post(
+                "/answer", json={"correlation_id": req["request_id"], "option_id": "opt-allow"},
+            )
+            assert r.status_code == 200, r.text
+        decision = await asyncio.wait_for(task, timeout=1.0)
+        assert decision.outcome == "allowed"
+        notify_spy.assert_not_awaited()  # no runtime notify for a tool-permission answer
+    finally:
+        cleanup_deps()

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -643,3 +643,80 @@ class TestAskMany:
         client, _, _, _ = env
         r = await client.get("/ask-many/askm-nope")
         assert r.status_code == 404
+
+
+class TestAnswerQuestion:
+    async def _ask_question(self, client, asker, recipient, *, kind="choice"):
+        question = {"kind": kind, "blocking": False}
+        if kind == "choice":
+            question["options"] = [
+                {"id": "allow", "title": "Allow"},
+                {"id": "deny", "title": "Deny"},
+            ]
+        r = await client.post("/ask", json={
+            "from_peer": asker, "to_peer": recipient, "text": "run rm -rf?",
+            "question": question,
+        })
+        assert r.status_code == 200, r.text
+        return r.json()["correlation_id"]
+
+    async def test_answer_choice_records_and_delivers(self, env):
+        client, _, at, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        cid = await self._ask_question(client, asker, rcv)
+
+        r = await client.post("/answer", json={"correlation_id": cid, "option_id": "allow"})
+        assert r.status_code == 200, r.text
+        ask = await at.get(cid)
+        assert ask.answer is not None and ask.answer.option_id == "allow"
+        assert ask.closed
+
+    async def test_answer_rejects_unknown_option_422(self, env):
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        cid = await self._ask_question(client, asker, rcv)
+        r = await client.post("/answer", json={"correlation_id": cid, "option_id": "bogus"})
+        assert r.status_code == 422
+
+    async def test_re_answer_is_410(self, env):
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        cid = await self._ask_question(client, asker, rcv)
+        first = await client.post("/answer", json={"correlation_id": cid, "option_id": "deny"})
+        assert first.status_code == 200
+        r2 = await client.post("/answer", json={"correlation_id": cid, "option_id": "allow"})
+        assert r2.status_code == 410
+
+    async def test_answer_unknown_ask_404(self, env):
+        client, _, _, _ = env
+        r = await client.post("/answer", json={"correlation_id": "ask-nope", "option_id": "allow"})
+        assert r.status_code == 404
+
+    async def test_ack_on_question_delegates_to_answer(self, env):
+        # bare ack on a choice question = acknowledged; ack-with-message = text answer
+        client, _, at, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        cid = await self._ask_question(client, asker, rcv, kind="text")
+        r = await client.post("/ack", json={"correlation_id": cid, "message": "the answer is 42"})
+        assert r.status_code == 200, r.text
+        ask = await at.get(cid)
+        assert ask.answer is not None and ask.answer.text == "the answer is 42"
+        assert ask.closed
+
+    async def test_answer_rejects_plain_ask_422(self, env):
+        # codex #1: /answer must not accept a plain ask (would bypass /ack's
+        # fail-loud retry contract). Plain asks go through /ack.
+        client, _, _, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        r = await client.post("/ask", json={
+            "from_peer": asker, "to_peer": rcv, "text": "plain ask, no question",
+        })
+        cid = r.json()["correlation_id"]
+        resp = await client.post("/answer", json={"correlation_id": cid, "text": "hi"})
+        assert resp.status_code == 422
+        assert "not a structured question" in resp.json()["detail"]

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -720,3 +720,16 @@ class TestAnswerQuestion:
         resp = await client.post("/answer", json={"correlation_id": cid, "text": "hi"})
         assert resp.status_code == 422
         assert "not a structured question" in resp.json()["detail"]
+
+    async def test_answer_denied_on_generic_choice_closes_without_option(self, env):
+        # codex check: outcome="denied" is a GENERIC answer (not ACP-only) — it
+        # records + closes a non-permission choice question without needing an
+        # option_id (validation bypass like ack/timeout/cancel).
+        client, _, at, _ = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        cid = await self._ask_question(client, asker, rcv)  # plain choice, no scope
+        r = await client.post("/answer", json={"correlation_id": cid, "outcome": "denied"})
+        assert r.status_code == 200, r.text
+        ask = await at.get(cid)
+        assert ask.answer.outcome == "denied" and ask.closed

--- a/tests/test_questions_primitive.py
+++ b/tests/test_questions_primitive.py
@@ -197,3 +197,18 @@ async def test_plain_ask_without_question_is_unaffected():
     )
     ask = await at.get(cid)
     assert ask is not None and ask.question is None and ask.answer is None
+
+
+@pytest.mark.asyncio
+async def test_answer_on_closed_unanswered_ask_is_rejected():
+    # gemini review: an ask closed by another terminal path (send_failed/ack)
+    # has closed=True but answer=None; answering it must NOT overwrite the close
+    # state — first terminal state wins.
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    await at.close(cid, reason="send_failed")  # closed, no answer
+    with pytest.raises(AskTracker.AlreadyAnsweredError):
+        await at.answer(cid, Answer(option_id="allow"))
+    ask = await at.get(cid)
+    assert ask.close_reason == "send_failed"  # unchanged, not overwritten to "answered"
+    assert ask.answer is None

--- a/tests/test_questions_primitive.py
+++ b/tests/test_questions_primitive.py
@@ -1,0 +1,199 @@
+"""Mesh questions primitive — protocol models + AskTracker answer machinery.
+
+Layer A of the Mesh Questions epic (repowire-iz6): the shared Question/Answer
+shape and the AskTracker register(question=)/wait_for_answer/answer seam that
+blocking transports (ACP, PreToolUse) await and any answer-path resolves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.protocol.questions import Answer, Question, QuestionOption
+
+
+def _allow_deny() -> Question:
+    return Question(
+        kind="choice",
+        options=[
+            QuestionOption(id="allow", title="Allow"),
+            QuestionOption(id="deny", title="Deny"),
+        ],
+        blocking=True,
+        timeout_seconds=0.05,
+        default_answer=Answer(option_id="deny", outcome="timed_out"),
+        scope="tool_permission",
+    )
+
+
+async def _register_question(at: AskTracker, q: Question) -> str:
+    return await at.register(
+        from_peer_id="agent", from_peer_name="agent",
+        to_peer_id="human", to_peer_name="human",
+        text="run rm -rf?", question=q,
+    )
+
+
+# --- protocol model validation ---
+
+def test_choice_requires_known_option():
+    q = _allow_deny()
+    assert q.validate_answer(Answer(option_id="allow")) is None
+    assert q.validate_answer(Answer(option_id="nope")) == "unknown option_id: nope"
+    assert "requires an option_id" in (q.validate_answer(Answer(text="hmm")) or "")
+
+
+def test_timeout_and_cancel_bypass_option_validation():
+    q = _allow_deny()
+    assert q.validate_answer(Answer(outcome="timed_out")) is None
+    assert q.validate_answer(Answer(outcome="cancelled")) is None
+
+
+def test_text_and_acknowledge_are_permissive():
+    assert Question(kind="text").validate_answer(Answer(text="anything")) is None
+    assert Question(kind="acknowledge").validate_answer(Answer(outcome="acknowledged")) is None
+
+
+# --- AskTracker answer machinery ---
+
+@pytest.mark.asyncio
+async def test_answer_records_truth_and_closes():
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    ask = await at.answer(cid, Answer(option_id="allow"))
+    assert ask.answer is not None and ask.answer.option_id == "allow"
+    assert ask.closed and ask.close_reason == "answered"
+
+
+@pytest.mark.asyncio
+async def test_answer_validates_option_id_in_daemon():
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    with pytest.raises(ValueError, match="unknown option_id"):
+        await at.answer(cid, Answer(option_id="bogus"))
+    # ask stays open (no answer recorded)
+    ask = await at.get(cid)
+    assert ask is not None and ask.answer is None and not ask.closed
+
+
+@pytest.mark.asyncio
+async def test_first_answer_wins():
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    await at.answer(cid, Answer(option_id="allow"))
+    with pytest.raises(AskTracker.AlreadyAnsweredError):
+        await at.answer(cid, Answer(option_id="deny"))
+    ask = await at.get(cid)
+    assert ask is not None and ask.answer.option_id == "allow"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_wait_for_answer_resolves_when_answered():
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+
+    async def answer_soon():
+        await asyncio.sleep(0.01)
+        await at.answer(cid, Answer(option_id="allow"))
+
+    asyncio.create_task(answer_soon())
+    result = await at.wait_for_answer(cid, timeout_seconds=1.0, default_answer=None)
+    assert result.option_id == "allow"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_answer_applies_default_on_timeout():
+    at = AskTracker()
+    q = _allow_deny()  # 50ms timeout, default deny
+    cid = await _register_question(at, q)
+    result = await at.wait_for_answer(
+        cid, timeout_seconds=q.timeout_seconds, default_answer=q.default_answer,
+    )
+    assert result.option_id == "deny"
+    assert result.outcome == "timed_out"
+    # the timeout answer is recorded on the ask (ledger stays truthful)
+    ask = await at.get(cid)
+    assert ask is not None and ask.answer is not None and ask.answer.option_id == "deny"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_answer_returns_immediately_if_already_answered():
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    await at.answer(cid, Answer(option_id="allow"))
+    result = await at.wait_for_answer(cid, timeout_seconds=1.0, default_answer=None)
+    assert result.option_id == "allow"
+
+
+@pytest.mark.asyncio
+async def test_text_answer_also_lands_as_reply_text():
+    at = AskTracker()
+    cid = await at.register(
+        from_peer_id="a", from_peer_name="a", to_peer_id="b", to_peer_name="b",
+        text="what's the branch?", question=Question(kind="text"),
+    )
+    ask = await at.answer(cid, Answer(text="main"))
+    assert ask.answer.text == "main"
+    assert ask.reply_text == "main"  # text answers populate reply_text too
+
+
+@pytest.mark.asyncio
+async def test_evicting_ask_cancels_a_dangling_waiter():
+    # A blocking transport awaiting an ask that gets forgotten/evicted must not
+    # hang — the waiter resolves with a cancelled Answer.
+    at = AskTracker()
+    cid = await at.register(
+        from_peer_id="agent", from_peer_name="agent",
+        to_peer_id="human", to_peer_name="human",
+        text="?", question=Question(kind="text"),
+    )
+
+    async def forget_soon():
+        await asyncio.sleep(0.01)
+        await at.forget_peer("human")
+
+    asyncio.create_task(forget_soon())
+    # no timeout — would hang forever without waiter cancellation
+    result = await at.wait_for_answer(cid, timeout_seconds=None, default_answer=None)
+    assert result.outcome == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_answer_rejects_invalid_default_loudly():
+    # codex review: an invalid default_answer must fail loud at the call, not
+    # silently return unrecorded at timeout (which would break the ledger).
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    bad = Answer(option_id="not-an-option", outcome="answered")
+    with pytest.raises(ValueError, match="invalid default_answer"):
+        await at.wait_for_answer(cid, timeout_seconds=0.01, default_answer=bad)
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_a_dangling_waiter():
+    # close() via a non-answer terminal path (ack/send_failed/reply_to) must not
+    # leave a blocking transport waiting forever (codex review).
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+
+    async def close_soon():
+        await asyncio.sleep(0.01)
+        await at.close(cid, reason="send_failed")
+
+    asyncio.create_task(close_soon())
+    result = await at.wait_for_answer(cid, timeout_seconds=None, default_answer=None)
+    assert result.outcome == "cancelled"
+    assert result.message == "send_failed"
+
+
+@pytest.mark.asyncio
+async def test_plain_ask_without_question_is_unaffected():
+    at = AskTracker()
+    cid = await at.register(
+        from_peer_id="a", from_peer_name="a", to_peer_id="b", to_peer_name="b", text="hi",
+    )
+    ask = await at.get(cid)
+    assert ask is not None and ask.question is None and ask.answer is None

--- a/tests/test_questions_primitive.py
+++ b/tests/test_questions_primitive.py
@@ -190,6 +190,19 @@ async def test_close_cancels_a_dangling_waiter():
 
 
 @pytest.mark.asyncio
+async def test_wait_for_answer_on_already_closed_ask_returns_cancelled():
+    # If the terminal close wins before a blocking transport starts waiting,
+    # wait_for_answer must still return immediately instead of creating a
+    # dangling waiter.
+    at = AskTracker()
+    cid = await _register_question(at, _allow_deny())
+    await at.close(cid, reason="send_failed")
+    result = await at.wait_for_answer(cid, timeout_seconds=None, default_answer=None)
+    assert result.outcome == "cancelled"
+    assert result.message == "send_failed"
+
+
+@pytest.mark.asyncio
 async def test_plain_ask_without_question_is_unaffected():
     at = AskTracker()
     cid = await at.register(

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -482,3 +482,30 @@ async def test_answer_callback_posts_chosen_option(
     }
     # cleared after a successful answer
     assert "ask-abc123" not in telegram_bot._question_options
+
+
+@pytest.mark.asyncio
+async def test_question_options_map_is_bounded(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The cid->option-ids map must not grow unbounded over a long bot process.
+    from repowire.telegram.bot import _MAX_REMEMBERED_QUESTIONS
+    monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
+    monkeypatch.setattr(telegram_bot, "_tg_send_attachments", AsyncMock())
+    q = {"kind": "choice", "options": [{"id": "a", "title": "A"}]}
+    for i in range(_MAX_REMEMBERED_QUESTIONS + 50):
+        await telegram_bot._on_ws({
+            "type": "ask", "from_peer": "agent",
+            "correlation_id": f"ask-{i}", "text": "?", "question": q,
+        })
+    assert len(telegram_bot._question_options) <= _MAX_REMEMBERED_QUESTIONS
+
+
+@pytest.mark.asyncio
+async def test_stale_option_index_clears_entry(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    telegram_bot._question_options["ask-1"] = ["allow", "deny"]
+    monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
+    await telegram_bot._on_callback({"id": "cb", "data": "answer:ask-1:9"})  # out of range
+    assert "ask-1" not in telegram_bot._question_options

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -506,6 +506,9 @@ async def test_stale_option_index_clears_entry(
     telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     telegram_bot._question_options["ask-1"] = ["allow", "deny"]
+    monkeypatch.setattr(telegram_bot._http, "post", AsyncMock(
+        return_value=SimpleNamespace(status_code=200),
+    ))
     monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
     await telegram_bot._on_callback({"id": "cb", "data": "answer:ask-1:9"})  # out of range
     assert "ask-1" not in telegram_bot._question_options

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -411,3 +411,74 @@ def test_pending_retry_ttl(offset, expected):
     now = time.monotonic()
     r = PendingRetry(text="hi", expires_at=now + 10)
     assert r.is_active(now + offset) is expected
+
+
+@pytest.mark.asyncio
+async def test_choice_question_renders_option_buttons(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_tg_send", send)
+    monkeypatch.setattr(telegram_bot, "_tg_send_attachments", AsyncMock())
+
+    await telegram_bot._on_ws({
+        "type": "ask",
+        "from_peer": "agent",
+        "correlation_id": "ask-abc123",
+        "text": "run rm -rf?",
+        "question": {
+            "kind": "choice",
+            "options": [
+                {"id": "allow", "title": "Allow"},
+                {"id": "deny", "title": "Deny"},
+            ],
+        },
+    })
+
+    markup = send.await_args.kwargs["markup"]
+    buttons = [b for row in markup["inline_keyboard"] for b in row]
+    assert [b["text"] for b in buttons] == ["Allow", "Deny"]
+    assert [b["callback_data"] for b in buttons] == [
+        "answer:ask-abc123:0", "answer:ask-abc123:1",
+    ]
+    # the option ids are remembered for the index-based callback
+    assert telegram_bot._question_options["ask-abc123"] == ["allow", "deny"]
+
+
+@pytest.mark.asyncio
+async def test_plain_ask_renders_ack_button(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_tg_send", send)
+    monkeypatch.setattr(telegram_bot, "_tg_send_attachments", AsyncMock())
+
+    await telegram_bot._on_ws({
+        "type": "ask", "from_peer": "agent",
+        "correlation_id": "ask-xyz", "text": "fyi",
+    })
+    markup = send.await_args.kwargs["markup"]
+    buttons = [b for row in markup["inline_keyboard"] for b in row]
+    assert [b["callback_data"] for b in buttons] == ["ack:ask-xyz"]
+
+
+@pytest.mark.asyncio
+async def test_answer_callback_posts_chosen_option(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    telegram_bot._question_options["ask-abc123"] = ["allow", "deny"]
+    post = AsyncMock(return_value=SimpleNamespace(status_code=200))
+    monkeypatch.setattr(telegram_bot._http, "post", post)
+    monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
+
+    await telegram_bot._on_callback({"id": "cb-1", "data": "answer:ask-abc123:1"})
+
+    # the /answer POST carried the real option_id resolved from index 1
+    answer_call = next(
+        c for c in post.await_args_list if str(c.args[0]).endswith("/answer")
+    )
+    assert answer_call.kwargs["json"] == {
+        "correlation_id": "ask-abc123", "option_id": "deny",
+    }
+    # cleared after a successful answer
+    assert "ask-abc123" not in telegram_bot._question_options

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -509,3 +509,33 @@ async def test_stale_option_index_clears_entry(
     monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
     await telegram_bot._on_callback({"id": "cb", "data": "answer:ask-1:9"})  # out of range
     assert "ask-1" not in telegram_bot._question_options
+
+
+@pytest.mark.asyncio
+async def test_tool_permission_question_renders_deny_button(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ACP tool-permission options are allow-only → an explicit Deny must appear.
+    send = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "_tg_send", send)
+    monkeypatch.setattr(telegram_bot, "_tg_send_attachments", AsyncMock())
+    await telegram_bot._on_ws({
+        "type": "ask", "from_peer": "worker", "correlation_id": "acpperm-1", "text": "Allow shell?",
+        "question": {"kind": "choice", "scope": "tool_permission",
+                     "options": [{"id": "allow", "title": "Allow"}]},
+    })
+    markup = send.await_args.kwargs["markup"]
+    buttons = [b for row in markup["inline_keyboard"] for b in row]
+    assert [b["callback_data"] for b in buttons] == ["answer:acpperm-1:0", "deny:acpperm-1"]
+
+
+@pytest.mark.asyncio
+async def test_deny_callback_posts_denied_outcome(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post = AsyncMock(return_value=SimpleNamespace(status_code=200))
+    monkeypatch.setattr(telegram_bot._http, "post", post)
+    monkeypatch.setattr(telegram_bot, "_tg_send", AsyncMock())
+    await telegram_bot._on_callback({"id": "cb", "data": "deny:acpperm-1"})
+    call = next(c for c in post.await_args_list if str(c.args[0]).endswith("/answer"))
+    assert call.kwargs["json"] == {"correlation_id": "acpperm-1", "outcome": "denied"}

--- a/web/app/dashboard/components/PendingQuestions.test.tsx
+++ b/web/app/dashboard/components/PendingQuestions.test.tsx
@@ -61,3 +61,34 @@ describe("PendingQuestions", () => {
     });
   });
 });
+
+describe("PendingQuestions tool-permission Deny", () => {
+  it("renders a Deny button for a tool_permission question and POSTs denied", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+    const ev: Event = {
+      id: "p1", type: "ask", timestamp: "2026-05-31T00:00:00Z",
+      correlation_id: "acpperm-1", from: "worker", text: "Allow shell?",
+      question: { kind: "choice", scope: "tool_permission",
+        options: [{ id: "allow", title: "Allow" }] },
+    } as Event;
+    render(<PendingQuestions events={[ev]} apiBase="http://x" />);
+    expect(screen.getByText("Allow")).toBeTruthy();
+    fireEvent.click(screen.getByText(/Deny/));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      correlation_id: "acpperm-1", outcome: "denied",
+    });
+  });
+
+  it("does NOT render Deny for a non-permission choice question", () => {
+    const ev: Event = {
+      id: "p2", type: "ask", timestamp: "2026-05-31T00:00:00Z",
+      correlation_id: "ask-2", from: "agent", text: "pick one",
+      question: { kind: "choice", options: [{ id: "a", title: "A" }] },
+    } as Event;
+    render(<PendingQuestions events={[ev]} apiBase="http://x" />);
+    expect(screen.queryByText(/Deny/)).toBeNull();
+  });
+});

--- a/web/app/dashboard/components/PendingQuestions.test.tsx
+++ b/web/app/dashboard/components/PendingQuestions.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PendingQuestions } from "./PendingQuestions";
+import type { Event } from "../types";
+
+function askEvent(cid: string, opts?: Partial<Event>): Event {
+  return {
+    id: cid,
+    type: "ask",
+    timestamp: "2026-05-31T00:00:00Z",
+    correlation_id: cid,
+    from: "agent",
+    text: "run rm -rf?",
+    question: {
+      kind: "choice",
+      options: [
+        { id: "allow", title: "Allow" },
+        { id: "deny", title: "Deny" },
+      ],
+    },
+    ...opts,
+  } as Event;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("PendingQuestions", () => {
+  it("renders nothing when there are no open questions", () => {
+    const { container } = render(<PendingQuestions events={[]} apiBase="http://x" />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders option buttons for an open choice question", () => {
+    render(<PendingQuestions events={[askEvent("ask-1")]} apiBase="http://x" />);
+    expect(screen.getByText("Allow")).toBeTruthy();
+    expect(screen.getByText("Deny")).toBeTruthy();
+    expect(screen.getByText(/1 question awaiting/)).toBeTruthy();
+  });
+
+  it("drops a question once an ack event for it arrives", () => {
+    const ack: Event = {
+      id: "e2", type: "ack", timestamp: "2026-05-31T00:01:00Z", correlation_id: "ask-1",
+    } as Event;
+    const { container } = render(
+      <PendingQuestions events={[askEvent("ask-1"), ack]} apiBase="http://x" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("POSTs the chosen option to /answer", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<PendingQuestions events={[askEvent("ask-1")]} apiBase="http://x" />);
+    fireEvent.click(screen.getByText("Deny"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://x/answer");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      correlation_id: "ask-1",
+      option_id: "deny",
+    });
+  });
+});

--- a/web/app/dashboard/components/PendingQuestions.tsx
+++ b/web/app/dashboard/components/PendingQuestions.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "../lib/utils";
+import type { AskQuestion, Event } from "../types";
+
+interface PendingQuestion {
+  correlation_id: string;
+  from: string;
+  text: string;
+  question: AskQuestion;
+}
+
+/** Derive still-open questions from the event stream.
+ *
+ * An `ask` event carrying a `question` opens one; a later `ack` event for the
+ * same correlation_id (answered/acked/closed) removes it. This mirrors how the
+ * mesh feed derives state from events — no extra polling. */
+function derivePending(events: Event[]): PendingQuestion[] {
+  const open = new Map<string, PendingQuestion>();
+  for (const event of events) {
+    const cid = event.correlation_id;
+    if (!cid) continue;
+    if (event.type === "ask" && event.question && event.question.kind !== "acknowledge") {
+      open.set(cid, {
+        correlation_id: cid,
+        from: event.from ?? "?",
+        text: event.text ?? "",
+        question: event.question,
+      });
+    } else if (event.type === "ack") {
+      open.delete(cid); // answered / acked / closed
+    }
+  }
+  return Array.from(open.values());
+}
+
+export function PendingQuestions({
+  events,
+  apiBase,
+}: {
+  events: Event[];
+  apiBase: string;
+}) {
+  const pending = useMemo(() => derivePending(events), [events]);
+  const [answering, setAnswering] = useState<Record<string, boolean>>({});
+
+  if (pending.length === 0) return null;
+
+  async function answer(cid: string, body: Record<string, unknown>) {
+    setAnswering((prev) => ({ ...prev, [cid]: true }));
+    try {
+      await fetch(`${apiBase}/answer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ correlation_id: cid, ...body }),
+      });
+    } catch (error) {
+      console.error("Failed to answer question:", error);
+    } finally {
+      setAnswering((prev) => ({ ...prev, [cid]: false }));
+    }
+  }
+
+  return (
+    <div className="col-span-full border-b border-tertiary/30 bg-tertiary-container px-3 py-2 text-on-tertiary-container md:px-5">
+      <div className="font-mono text-[9px] font-bold uppercase tracking-[0.2em]">
+        {pending.length} question{pending.length > 1 ? "s" : ""} awaiting answer
+      </div>
+      {pending.map((q) => (
+        <div key={q.correlation_id} className="mt-1.5 flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] text-on-tertiary-container/85">
+            <span className="font-semibold">@{q.from}</span> {q.text}
+          </span>
+          {q.question.kind === "choice" ? (
+            (q.question.options ?? []).map((opt) => (
+              <button
+                key={opt.id}
+                disabled={answering[q.correlation_id]}
+                onClick={() => answer(q.correlation_id, { option_id: opt.id })}
+                title={opt.description ?? undefined}
+                className={cn(
+                  "rounded border border-tertiary/40 bg-tertiary/15 px-2 py-0.5",
+                  "font-mono text-[11px] font-semibold hover:bg-tertiary/25",
+                  "disabled:opacity-50",
+                )}
+              >
+                {opt.title}
+              </button>
+            ))
+          ) : (
+            <button
+              disabled={answering[q.correlation_id]}
+              onClick={() => answer(q.correlation_id, { outcome: "acknowledged" })}
+              className={cn(
+                "rounded border border-tertiary/40 bg-tertiary/15 px-2 py-0.5",
+                "font-mono text-[11px] font-semibold hover:bg-tertiary/25 disabled:opacity-50",
+              )}
+            >
+              ✓ Acknowledge
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/app/dashboard/components/PendingQuestions.tsx
+++ b/web/app/dashboard/components/PendingQuestions.tsx
@@ -73,21 +73,38 @@ export function PendingQuestions({
             <span className="font-semibold">@{q.from}</span> {q.text}
           </span>
           {q.question.kind === "choice" ? (
-            (q.question.options ?? []).map((opt) => (
-              <button
-                key={opt.id}
-                disabled={answering[q.correlation_id]}
-                onClick={() => answer(q.correlation_id, { option_id: opt.id })}
-                title={opt.description ?? undefined}
-                className={cn(
-                  "rounded border border-tertiary/40 bg-tertiary/15 px-2 py-0.5",
-                  "font-mono text-[11px] font-semibold hover:bg-tertiary/25",
-                  "disabled:opacity-50",
-                )}
-              >
-                {opt.title}
-              </button>
-            ))
+            <>
+              {(q.question.options ?? []).map((opt) => (
+                <button
+                  key={opt.id}
+                  disabled={answering[q.correlation_id]}
+                  onClick={() => answer(q.correlation_id, { option_id: opt.id })}
+                  title={opt.description ?? undefined}
+                  className={cn(
+                    "rounded border border-tertiary/40 bg-tertiary/15 px-2 py-0.5",
+                    "font-mono text-[11px] font-semibold hover:bg-tertiary/25",
+                    "disabled:opacity-50",
+                  )}
+                >
+                  {opt.title}
+                </button>
+              ))}
+              {q.question.scope === "tool_permission" && (
+                // ACP tool-permission options are allow-only; offer an explicit
+                // Deny that posts outcome:"denied" (no option needed).
+                <button
+                  disabled={answering[q.correlation_id]}
+                  onClick={() => answer(q.correlation_id, { outcome: "denied" })}
+                  className={cn(
+                    "rounded border border-error/40 bg-error/15 px-2 py-0.5",
+                    "font-mono text-[11px] font-semibold text-on-error-container",
+                    "hover:bg-error/25 disabled:opacity-50",
+                  )}
+                >
+                  ✕ Deny
+                </button>
+              )}
+            </>
           ) : (
             <button
               disabled={answering[q.correlation_id]}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { MeshFeed } from "./components/MeshFeed";
 import { MobileTabs, type MobileTab } from "./components/MobileTabs";
 import { PeerRoster } from "./components/PeerRoster";
 import { PeerView } from "./components/PeerView";
+import { PendingQuestions } from "./components/PendingQuestions";
 import { TopBar } from "./components/TopBar";
 import { WireTrace } from "./components/WireTrace";
 import type { Event, OrchestratorStatus, Peer } from "./types";
@@ -247,6 +248,8 @@ function DashboardInner() {
           onSpawn={() => setShowSpawn(true)}
           onSettings={() => setShowSettings(true)}
         />
+
+        <PendingQuestions events={events} apiBase={API_BASE} />
 
         {missingOrchestrators.length > 0 && (
           <div className="col-span-full border-b border-error/30 bg-error-container px-3 py-2 text-on-error-container md:px-5">

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -184,4 +184,20 @@ export interface Event {
   kind?: "text" | "tool_use";
   tool_call?: { name: string; input: string };
   is_final?: boolean;
+  // structured question carried on an ask event (mesh questions primitive)
+  question?: AskQuestion | null;
+}
+
+export interface AskQuestionOption {
+  id: string;
+  title: string;
+  description?: string | null;
+}
+
+export interface AskQuestion {
+  kind: "acknowledge" | "choice" | "text";
+  prompt?: string | null;
+  options?: AskQuestionOption[];
+  blocking?: boolean;
+  scope?: string | null;
 }


### PR DESCRIPTION
## What

Unifies agent-initiated **questions** — tool approval, AskUserQuestion-style multiple-choice, and free-text — into one first-class mesh primitive. A `Question` rides on an ask; an `Answer` rides on the ack. The same envelope is answered uniformly by a human (Telegram tap or dashboard banner) **or** another peer (programmatic `/answer`), and ACP tool-approval rides the exact same path.

Inspired by claudecodeui's approval/permission UX, but built natively on repowire's mesh rather than as a separate harness. Designed + reviewed layer-by-layer with the `codex` mesh peer.

### The load-bearing boundary

`Question`/`Answer` is the shared **semantic** primitive; **blocking is a transport capability, not a property of every ask**. The daemon never pretends an MCP ask from an already-running agent can suspend its loop. Transports that own a suspendable call (ACP, a future PreToolUse hook) await; others read the answer on a later turn. The answer-*path* is uniform even though not every origin can synchronously wait.

### Layers

- **Protocol** (`protocol/questions.py`): `Question{kind: acknowledge|choice|text, options[], blocking, timeout_seconds, default_answer, scope, metadata}`, `Answer{option_id?, text?, outcome}`, `QuestionOption`. `validate_answer` is the shared contract.
- **AskTracker**: `Ask` carries `question`/`answer` directly. `register(question=)`, `wait_for_answer(cid, timeout, default)` (the blocker for ACP/PreToolUse), `answer(cid, Answer)` (records the truth, resolves the waiter, first-answer-wins → 410, daemon-side option validation). Waiters are cancelled on every terminal path (evict/forget/close/rebind) so a blocking transport can't hang.
- **Routes / MCP**: canonical `POST /answer`; `/ack` delegates for questions (plain asks keep their fail-loud 503/retry contract — `/answer` rejects a plain ask with 422). MCP `answer(cid, option_id?, text?)` tool; `/ask` carries a question.
- **Renderers**: `question` threads onto the SSE ask event + the WS wire frame. Telegram renders choice options as inline buttons (`/answer`); the dashboard `PendingQuestions` banner renders them in-browser. Both add an explicit **Deny** for `scope=tool_permission` questions (ACP options are allow-only) that posts `outcome:"denied"`.
- **ACP ApprovalBroker → adapter** (the keystone): a `RequestPermission` becomes a blocking choice-question ask (recipient = the virtual `__repowire_control__`/`human` control surface, not a fake peer), awaits `wait_for_answer`, maps the `Answer` back to a `PermissionDecision`. **Fail closed**: only an explicit selected option allows; timeout / acknowledge / deny denies. The legacy `POST /acp/permissions/{id}/decision` stays as a thin compat shim; `acp_permission_request/decision` events preserved as aliases.

### Emerging capabilities

- The agent is answer-source-agnostic: human-via-Telegram, human-via-dashboard, or a peer's programmatic answer all resolve the same question.
- An orchestrator can policy-auto-answer a worker's question.
- Every approval + question is one ask in one ledger (audit/trace/replay).

## Testing

- New: `tests/test_questions_primitive.py` (14 — protocol validation + AskTracker answer/waiter machinery incl. timeout-default, first-answer-wins, waiter-cancel on eviction/close), `tests/test_ask_routes.py::TestAnswerQuestion` (+denied), ACP keystone tests in `test_acp_permissions.py` (permission resolves via generic `/answer`, fail-closed on bare ack, first-class denied, no runtime notify for tool-permission), Telegram + dashboard renderer tests (option buttons, Deny for tool-permission, bounded option-map).
- **1649 backend + 65 web tests pass; ruff + ty + eslint + next build clean.**
- **Live-proven against an isolated branch daemon** (HTTP round-trip, not a stub, no live-mesh impact): a choice-question ask registers, carries the question on its event, `/answer` records it (200), re-answer is 410, unknown option is 422, a plain ask is rejected from `/answer` (422).

## Follow-ups (filed, not blocking)

- `repowire-soh`: redeliver an answered question's reply to an offline asker (only matters for a non-blocking producer; ACP is blocking and consumes `ask.answer` directly).
- `repowire-qnp`: Claude Code `PreToolUse` blocking-approval hook = another adapter on the same path (needs live-proof under `--dangerously-skip-permissions`).
- ACP streaming (`session/update` → `chat_turn_delta`) is the next, separate track.

🤖 Designed + reviewed layer-by-layer with the `codex` mesh peer.
