### PR TITLE
fix(questions): redeliver answered question replies

### DIFF
--- a/docs/concepts/message-types.md
+++ b/docs/concepts/message-types.md
@@ -36,7 +36,7 @@ Some asks carry a typed question envelope. A structured question can be an ackno
 
 Telegram and the dashboard render structured questions as buttons when possible. ACP tool approvals use the same primitive: the ACP broker registers a blocking choice question, waits for the recorded answer, and maps it back to the runtime's permission decision. The older ACP permission-decision route remains as a compatibility shim.
 
-Plain asks still close with `ack`. `/answer` rejects a plain ask so a reply cannot bypass `ack`'s delivery/retry contract.
+Plain asks still close with `ack`. `/answer` rejects a plain ask so a reply cannot bypass `ack`'s delivery/retry contract. Structured answers are recorded before the human-readable reply is delivered back to the asking peer; if that peer is temporarily offline, Repowire stashes the reply and redelivers it when the peer reconnects.
 
 ## `notify_peer`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -97,7 +97,7 @@ answer(correlation_id: str, option_id: str | None = None, text: str | None = Non
 
 Answer a structured question carried on an ask. Pass `option_id` to select a choice, or `text` for a free-text answer. A bare `answer(cid)` records an acknowledged answer. Tool-permission questions also accept a denied outcome through the dashboard and Telegram renderers; ACP permission prompts deny by default on timeout.
 
-This is the typed counterpart to `ack` for questions such as tool approvals and future AskUserQuestion-style prompts. Plain asks still use `ack`; `/answer` rejects a plain ask so the existing `ack` retry semantics are not bypassed.
+This is the typed counterpart to `ack` for questions such as tool approvals and future AskUserQuestion-style prompts. Plain asks still use `ack`; `/answer` rejects a plain ask so the existing `ack` retry semantics are not bypassed. If the asking peer is offline after a structured answer is recorded, the readable reply is stashed and redelivered on reconnect.
 
 ```python
 answer("acpperm-8b9c1f42", option_id="allow")

--- a/repowire/daemon/ask_tracker.py
+++ b/repowire/daemon/ask_tracker.py
@@ -360,13 +360,23 @@ class AskTracker:
         correlation_id: str,
         framed_reply: str,
         identity: AskerIdentity | None = None,
+        *,
+        allow_answered_question: bool = False,
     ) -> bool:
-        """Stash a completed reply on an open ask for later redelivery.
+        """Stash a completed reply for later redelivery.
 
         Used by the ACP-routed `/ask` path when notify fails with
         TransportError: the assembled ACP answer is real and must not be
         dropped just because the asker is currently offline. Returns True
         if the ask exists and was still open, False otherwise.
+
+        ``allow_answered_question`` is the structured-question escape hatch:
+        `/answer` records the typed answer first (the source of truth), closing
+        the ask with ``close_reason="answered"`` before it attempts the
+        human-readable notify back to the asker. If that notify hits an offline
+        transport, this flag lets the already-answered question carry a
+        pending redelivery without reopening it. It deliberately does *not*
+        permit stashing on arbitrary closed asks.
 
         ``identity`` is the asker's full stable identity tuple at stash time,
         captured by the route handler when the asker peer is resolvable and
@@ -375,7 +385,14 @@ class AskTracker:
         """
         async with self._lock:
             ask = self._asks.get(correlation_id)
-            if not ask or ask.closed:
+            if not ask:
+                return False
+            if ask.closed and not (
+                allow_answered_question
+                and ask.question is not None
+                and ask.answer is not None
+                and ask.close_reason == "answered"
+            ):
                 return False
             ask.pending_reply = framed_reply
             ask.asker_identity = identity
@@ -383,6 +400,38 @@ class AskTracker:
             logger.debug(
                 "Stashed pending reply on ask %s (identity=%s)",
                 correlation_id, "yes" if identity else "no",
+            )
+            return True
+
+    async def mark_pending_reply_delivered(
+        self,
+        correlation_id: str,
+        *,
+        new_from_peer_id: str | None = None,
+        reason: str = "ack_with_msg",
+    ) -> bool:
+        """Mark a stashed reply delivered and clear it.
+
+        Open asks are closed with ``reason``. Already answered structured
+        questions stay closed as ``answered``; only their transient stash is
+        cleared. ``new_from_peer_id`` is used by the registry's identity-rebind
+        pass after a clean-takeover gives the original asker a new peer id.
+        """
+        async with self._lock:
+            ask = self._asks.get(correlation_id)
+            if ask is None or ask.pending_reply is None:
+                return False
+            if new_from_peer_id is not None:
+                ask.from_peer_id = new_from_peer_id
+            if not ask.closed:
+                ask.closed = True
+                ask.close_reason = reason
+                self._cancel_waiter(correlation_id, message=reason)
+            ask.pending_reply = None
+            logger.debug(
+                "Marked pending reply delivered for ask %s%s",
+                correlation_id,
+                f" -> {new_from_peer_id}" if new_from_peer_id else "",
             )
             return True
 
@@ -430,18 +479,17 @@ class AskTracker:
             return True
 
     async def take_pending_replies_for_asker(self, peer_id: str) -> list[Ask]:
-        """Snapshot open asks targeting this asker that have a stashed reply.
+        """Snapshot asks targeting this asker that have a stashed reply.
 
         Caller (peer_registry reconnect path) attempts redelivery for each;
-        on success it closes the ask via ``close`` and the reply will not
-        be re-driven. We snapshot rather than drain so a failed redelivery
-        leaves the reply in place for the next reconnect.
+        on success it marks the reply delivered and the reply will not be
+        re-driven. We snapshot rather than drain so a failed redelivery leaves
+        the reply in place for the next reconnect.
         """
         async with self._lock:
             return [
                 ask for ask in self._asks.values()
                 if ask.from_peer_id == peer_id
-                and not ask.closed
                 and ask.pending_reply is not None
             ]
 
@@ -462,7 +510,7 @@ class AskTracker:
           * every identity field matches the supplied tuple exactly
           * ``from_peer_id not in live_peer_ids`` (the original asker peer_id
             is no longer registered — only then is rebind in play)
-          * the ask is open and has a stashed reply
+          * the ask has a stashed reply
 
         The tracker performs no liveness lookups and no uniqueness gating.
         The caller (PeerRegistry) supplies ``live_peer_ids`` from its own
@@ -472,7 +520,7 @@ class AskTracker:
         async with self._lock:
             out: list[Ask] = []
             for ask in self._asks.values():
-                if ask.closed or ask.pending_reply is None:
+                if ask.pending_reply is None:
                     continue
                 ident = ask.asker_identity
                 if ident is None:

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -1105,9 +1105,11 @@ class PeerRegistry:
         # Out of the lock. Schedule pass-2 (identity-tuple) redelivery for
         # both fresh allocations and same-id reconnects. The new peer is
         # already ONLINE, so update_peer_status won't fire — this is the
-        # only redelivery hook on the SessionStart path. Gated on the
-        # acp_broker_client experiment so flag-off has zero new behaviour.
-        if should_redeliver and result_peer_id and self._acp_redelivery_enabled():
+        # only redelivery hook on the SessionStart path. Pending-reply stashes
+        # are now transport-neutral (ACP replies and structured question
+        # answers both use them), so reconnect always gives the tracker a
+        # chance to drain any existing stash.
+        if should_redeliver and result_peer_id and self._ask_tracker is not None:
             asyncio.create_task(
                 self._redeliver_pending_replies(result_peer_id),
                 name=f"redeliver-{result_peer_id[:12]}",
@@ -1546,24 +1548,14 @@ class PeerRegistry:
         if (
             asker_peer_id is not None
             and self._ask_tracker is not None
-            and self._acp_redelivery_enabled()
         ):
             asyncio.create_task(
                 self._redeliver_pending_replies(asker_peer_id),
                 name=f"redeliver-{asker_peer_id[:12]}",
             )
 
-    def _acp_redelivery_enabled(self) -> bool:
-        """Whether the ACP-routed stash/redeliver path is opted in.
-
-        Defensive against future Config refactors: a missing
-        ``experiments`` block or attribute is treated as flag-off, never
-        a crash.
-        """
-        return bool(getattr(self._experiments, "acp_broker_client", False))
-
     async def _redeliver_pending_replies(self, asker_peer_id: str) -> None:
-        """Drain ACP-stashed replies for an asker that just came back online.
+        """Drain stashed replies for an asker that just came back online.
 
         Two passes:
           1. ``take_pending_replies_for_asker`` — same peer_id reconnect
@@ -1575,9 +1567,11 @@ class PeerRegistry:
              tuple refuses rebind rather than misrouting.
 
         Best-effort: a failure here just leaves the reply stashed for the
-        next reconnect / sweep. Successful redelivery closes the ask
+        next reconnect / sweep. Successful redelivery closes open asks
         (ack_with_msg) and clears the stash so the Ask object isn't holding
-        reply text it can never use again.
+        reply text it can never use again. Already answered structured
+        questions stay closed as answered; only the redelivery stash is
+        drained.
         """
         if self._ask_tracker is None:
             return
@@ -1652,13 +1646,14 @@ class PeerRegistry:
     async def _deliver_one_stashed(
         self, ask: Any, asker_peer_id: str, *, rebind: bool,
     ) -> None:
-        """Deliver a single stashed reply and close the ask on success.
+        """Deliver a single stashed reply and mark it delivered on success.
 
         The Ask object is **never mutated** outside ``AskTracker`` locks.
         Notify targets ``asker_peer_id`` directly (the registry already
         knows the live id from its own pass-1/pass-2 caller); only on
         successful delivery do we ask the tracker to atomically rebind
-        + close + clear (rebind path) or close + clear (same-id path).
+        + clear (rebind path) or clear (same-id path), closing open asks in
+        the same operation.
         On notify failure the stash is left exactly as we found it.
         """
         reply = ask.pending_reply
@@ -1679,15 +1674,11 @@ class PeerRegistry:
             return
         if self._ask_tracker is None:
             return
-        if rebind:
-            await self._ask_tracker.rebind_and_close(
-                ask.correlation_id, asker_peer_id, reason="ack_with_msg",
-            )
-        else:
-            await self._ask_tracker.close(
-                ask.correlation_id, reason="ack_with_msg",
-            )
-            await self._ask_tracker.clear_pending_reply(ask.correlation_id)
+        await self._ask_tracker.mark_pending_reply_delivered(
+            ask.correlation_id,
+            new_from_peer_id=asker_peer_id if rebind else None,
+            reason="ack_with_msg",
+        )
         logger.info(
             "redeliver%s: delivered stashed reply for %s to %s",
             " (rebound)" if rebind else "",

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -823,10 +823,27 @@ async def _answer_question_core(request: AnswerRequest) -> OkResponse:
                 attachments=request.attachments,
             )
             delivery_success = True
-        except (ValueError, TransportError) as e:
-            # The answer is recorded (truth); the asker just didn't get the
-            # human-readable notification this time. Redelivery-to-offline-asker
-            # is tracked as a follow-up (repowire-* — stash on answered question).
+        except TransportError as e:
+            # The answer is recorded (truth); keep its human-readable frame for
+            # the asker's next reconnect. Unlike plain /ack, this does not
+            # leave the question open: structured questions have a durable
+            # typed answer, and blocking transports consume that answer
+            # directly.
+            identity = await _capture_asker_identity(peer_registry, existing.from_peer_id)
+            stashed = await ask_tracker.set_pending_reply(
+                request.correlation_id,
+                framed,
+                identity=identity,
+                allow_answered_question=True,
+            )
+            logger.warning(
+                "answer for %s recorded; asker delivery deferred (%s; stashed=%s)",
+                request.correlation_id, e, stashed,
+            )
+        except ValueError as e:
+            # The asker no longer resolves, so there is no current transport
+            # target or identity tuple to stash against. The typed answer
+            # remains the source of truth.
             logger.warning(
                 "answer for %s recorded; asker delivery deferred (%s)",
                 request.correlation_id, e,

--- a/tests/test_acp_broker_client.py
+++ b/tests/test_acp_broker_client.py
@@ -1207,18 +1207,13 @@ async def test_pending_reply_redelivered_on_asker_reconnect(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_reconnect_redelivery_is_skipped_when_flag_off(tmp_path: Path) -> None:
-    """Codex re-review BLOCKER: flag-off ⇒ zero new behaviour on reconnect.
+async def test_reconnect_redelivery_runs_even_when_acp_flag_off(tmp_path: Path) -> None:
+    """Pending-reply redelivery is now transport-neutral.
 
-    With ``experiments.acp_broker_client`` off, an OFFLINE→ONLINE transition
-    must NOT scan the ask tracker and must NOT call notify on the asker's
-    behalf — even if a pending_reply somehow ended up stashed. The phase-3
-    contract is strict: flag off means the WS/MCP path runs unchanged.
-
-    We seed a stashed reply directly into the tracker (bypassing the
-    flag-gated _acp_complete write path) and assert that the reconnect
-    hook leaves it untouched. With the flag on, the same scenario would
-    drain and deliver — proven by the redelivery test above.
+    ACP replies and structured question answers share the same stash/drain
+    mechanism, so the reconnect hook must no longer be gated by the ACP broker
+    experiment. The write sites decide when a stash exists; reconnect simply
+    gives the tracker a chance to drain one.
     """
     cfg = Config()
     cfg.experiments.acp_broker_client = False  # explicitly off
@@ -1267,13 +1262,12 @@ async def test_reconnect_redelivery_is_skipped_when_flag_off(tmp_path: Path) -> 
     await registry.update_peer_status(asker.peer_id, PeerStatus.ONLINE)
     await asyncio.sleep(0.05)
 
-    # With flag off: no redeliver task scheduled → no notify call,
-    # ask still open, pending_reply still on the ask.
-    assert notify_calls == [], "flag-off path called notify on reconnect"
+    # Even with the ACP flag off, a real stash is drained on reconnect.
+    assert len(notify_calls) == 1
     ask = await at.get(cid)
     assert ask is not None
-    assert ask.closed is False
-    assert ask.pending_reply is not None
+    assert ask.closed is True
+    assert ask.pending_reply is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_ask_routes.py
+++ b/tests/test_ask_routes.py
@@ -1,5 +1,7 @@
 """Tests for /ask, /ack, and /asks/* HTTP routes."""
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -733,3 +735,45 @@ class TestAnswerQuestion:
         assert r.status_code == 200, r.text
         ask = await at.get(cid)
         assert ask.answer.outcome == "denied" and ask.closed
+
+    async def test_answer_stashes_and_redelivers_when_asker_transport_offline(
+        self, env, monkeypatch,
+    ):
+        client, registry, at, msg_router = env
+        asker = await _register_peer(client, "asker")
+        rcv = await _register_peer(client, "rcv")
+        asker_peer = await registry.get_peer(asker)
+        assert asker_peer is not None
+        cid = await self._ask_question(client, asker, rcv, kind="text")
+
+        async def _offline_notify(**_):
+            raise TransportError("asker offline")
+
+        delivery = SimpleNamespace(notify=AsyncMock(side_effect=_offline_notify))
+        monkeypatch.setattr(
+            asks, "peer_delivery_from_state", lambda **_: delivery,
+        )
+        await registry.update_peer_status(asker_peer.peer_id, PeerStatus.OFFLINE)
+
+        r = await client.post("/answer", json={
+            "correlation_id": cid,
+            "text": "structured answer",
+        })
+        assert r.status_code == 200, r.text
+        ask = await at.get(cid)
+        assert ask is not None
+        assert ask.closed is True
+        assert ask.close_reason == "answered"
+        assert ask.answer is not None and ask.answer.text == "structured answer"
+        assert ask.pending_reply is not None
+        assert "structured answer" in ask.pending_reply
+
+        await registry.update_peer_status(asker_peer.peer_id, PeerStatus.ONLINE)
+        await asyncio.sleep(0.05)
+
+        ask = await at.get(cid)
+        assert ask is not None
+        assert ask.closed is True
+        assert ask.close_reason == "answered"
+        assert ask.pending_reply is None
+        msg_router.send_notification.assert_awaited()

--- a/tests/test_ask_tracker.py
+++ b/tests/test_ask_tracker.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from repowire.daemon.ask_tracker import AskTracker
+from repowire.protocol.questions import Answer, Question
 
 
 @pytest.fixture
@@ -181,6 +182,70 @@ class TestSetPendingReplyIdentity:
         assert ok is True
         ask = await tracker.get(cid)
         assert ask is not None and ask.asker_identity is None
+
+    async def test_answered_question_can_carry_pending_reply_when_explicit(self, tracker):
+        cid = await tracker.register(
+            "asker-id", "asker", "b-id", "b", "x",
+            question=Question(kind="text"),
+        )
+        await tracker.answer(cid, Answer(text="done"))
+
+        assert await tracker.set_pending_reply(cid, "framed") is False
+        ok = await tracker.set_pending_reply(
+            cid, "framed", allow_answered_question=True,
+        )
+
+        assert ok is True
+        ask = await tracker.get(cid)
+        assert ask is not None
+        assert ask.closed is True
+        assert ask.close_reason == "answered"
+        assert ask.pending_reply == "framed"
+
+    async def test_closed_non_answered_ask_cannot_carry_pending_reply(self, tracker):
+        cid = await tracker.register("asker-id", "asker", "b-id", "b", "x")
+        await tracker.close(cid, reason="ack")
+
+        ok = await tracker.set_pending_reply(
+            cid, "framed", allow_answered_question=True,
+        )
+
+        assert ok is False
+        ask = await tracker.get(cid)
+        assert ask is not None and ask.pending_reply is None
+
+    async def test_take_pending_replies_includes_answered_question_stashes(self, tracker):
+        cid = await tracker.register(
+            "asker-id", "asker", "b-id", "b", "x",
+            question=Question(kind="text"),
+        )
+        await tracker.answer(cid, Answer(text="done"))
+        await tracker.set_pending_reply(
+            cid, "framed", allow_answered_question=True,
+        )
+
+        out = await tracker.take_pending_replies_for_asker("asker-id")
+
+        assert len(out) == 1 and out[0].correlation_id == cid
+
+    async def test_mark_pending_reply_delivered_keeps_answered_question_closed(self, tracker):
+        cid = await tracker.register(
+            "asker-id", "asker", "b-id", "b", "x",
+            question=Question(kind="text"),
+        )
+        await tracker.answer(cid, Answer(text="done"))
+        await tracker.set_pending_reply(
+            cid, "framed", allow_answered_question=True,
+        )
+
+        ok = await tracker.mark_pending_reply_delivered(cid)
+
+        assert ok is True
+        ask = await tracker.get(cid)
+        assert ask is not None
+        assert ask.closed is True
+        assert ask.close_reason == "answered"
+        assert ask.pending_reply is None
 
 
 class TestTakeOrphanPendingRepliesMatching:


### PR DESCRIPTION
## Summary
- allow already answered structured questions to carry a pending readable reply for offline asker redelivery
- make pending-reply reconnect drain transport-neutral and preserve answered question state while clearing the stash
- document the structured-answer redelivery behavior

## Tests
- uv run pytest tests/test_ask_tracker.py tests/test_ask_routes.py tests/test_acp_broker_client.py -q
- uv run ruff check repowire/ tests/
- uv run ty check repowire/
- uv run pytest -q (1657 passed)

## Notes
- Plain asks still use /ack and keep the existing fail-loud 503/retry contract; /answer still rejects plain asks.
- Blocking tool-permission questions remain unaffected because the runtime consumes the recorded Answer directly.