### PR TITLE
feat(questions): PreToolUse blocking-approval hook adapter

### DIFF
--- a/docs/concepts/message-types.md
+++ b/docs/concepts/message-types.md
@@ -36,6 +36,12 @@ Some asks carry a typed question envelope. A structured question can be an ackno
 
 Telegram and the dashboard render structured questions as buttons when possible. ACP tool approvals use the same primitive: the ACP broker registers a blocking choice question, waits for the recorded answer, and maps it back to the runtime's permission decision. The older ACP permission-decision route remains as a compatibility shim.
 
+A *blocking* transport — one that owns a suspendable call, such as an ACP runtime or a Claude Code `PreToolUse` hook — can register a question and park until it is answered. The daemon exposes this as `POST /questions/ask-blocking`: the caller posts a tool-permission question, the daemon holds the connection open up to a hard cap while a human surface or peer answers, and returns the typed answer. It is transport-neutral (the ACP broker and the hook share the same register-emit-wait core) and fail-closed (a tool-permission question denies on timeout). The Claude Code remote tool-approval hook is opt-in; see [PreToolUse approval](#pretooluse-tool-approval-claude-code) below.
+
+### PreToolUse tool approval (Claude Code)
+
+When `experiments.remote_tool_approval.enabled` is set, `repowire setup` registers a `PreToolUse` hook scoped to the configured `gated_tools` (mutating/shell tools — `Bash`, `Edit`, `Write`, `MultiEdit`, `NotebookEdit` — never read-only tools). Before a gated tool runs, the hook posts a blocking question to the daemon and waits; an allow from a human surface or peer returns `permissionDecision=allow`, and a deny, timeout, or daemon-unavailable returns `permissionDecision=deny`. Because the decision rides the hook rather than Claude's native approval, it still gates under `--dangerously-skip-permissions`.
+
 Plain asks still close with `ack`. `/answer` rejects a plain ask so a reply cannot bypass `ack`'s delivery/retry contract. Structured answers are recorded before the human-readable reply is delivered back to the asking peer; if that peer is temporarily offline, Repowire stashes the reply and redelivers it when the peer reconnects.
 
 ## `notify_peer`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -89,3 +89,19 @@ Explicit command overrides still win over profiles. `repowire peer restart` pres
 Opt-in release availability checks for `repowire status` and `repowire doctor`. Default: `false`.
 
 When enabled, those commands may query PyPI and report that a newer Repowire release is available. They never install packages, rewrite hooks, restart services, or mutate daemon routing. `repowire update` remains the explicit upgrade path.
+
+## `experiments`
+
+Off-by-default feature flags for code paths not yet ready to be default-on:
+
+```yaml
+experiments:
+  acp_broker_client: true       # route asks to ACP peers through a broker-side ACP client
+  chat_turn_streaming: true     # stream block-level chat_turn_delta events (Claude Code)
+  remote_tool_approval:
+    enabled: true               # PreToolUse hooks-path remote tool approval (Claude Code)
+    gated_tools: [Bash, Edit, Write, MultiEdit, NotebookEdit]
+    timeout_seconds: 45
+```
+
+`remote_tool_approval` gates `gated_tools` behind a blocking approval question: before a gated tool runs, a `PreToolUse` hook posts the question to the daemon and waits for an allow/deny from a human surface or peer, denying on timeout. The installer only registers the `PreToolUse` hook when `enabled` is set; toggling it off and re-running `repowire setup` removes the hook. Read-only tools are never gated. See [Structured questions](../concepts/message-types.md#pretooluse-tool-approval-claude-code).

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -7,6 +7,7 @@ The daemon exposes HTTP routes for the dashboard, hooks, CLI helpers, and client
 - `/health` and status routes for daemon checks.
 - `/peers` for peer registration, listing, lookup, and lifecycle operations. Includes `GET /peers/{id}/doctor` (read-only diagnostic report with contradiction detection) and `POST /peers/{id}/rehook` (non-destructive inbound ws-hook recovery, same-host, dry-run by default).
 - `/ask`, `/ack`, and `/asks/pending` for ask lifecycle.
+- `/answer` records a typed answer to a structured question; `POST /questions/ask-blocking` registers a blocking structured question (tool permission) and holds the connection open until it is answered or the daemon's wait cap elapses, then returns the typed answer (fail-closed: a tool-permission question denies on timeout). Used by blocking transports such as the ACP broker and the Claude Code `PreToolUse` approval hook.
 - `/traces/{trace_id}` returns the recorded delivery stages for an ask (`correlation_id`) or notify (`delivery_id`) from the local delivery trace ledger.
 - `/messages` and WebSocket routes for live delivery.
 - `/schedules` for one-shot and recurring scheduled messages.

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -168,7 +168,12 @@ class ApprovalBroker:
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
-                return PermissionDecision(outcome="denied", message=f"register failed: {e}")
+                # Balance the pending alias emitted above with a closing decision
+                # so a consumer never sees a request with no matching decision
+                # (event truth; codex review).
+                denied = PermissionDecision(outcome="denied", message=f"register failed: {e}")
+                self._emit_decision_event(pending, denied)
+                return denied
             decision = _answer_to_decision(answer)
             if decision.timed_out:
                 self._last_error = "permission request timed out"

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -24,6 +24,11 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
+from repowire.daemon.question_blocking import (
+    CONTROL_PEER_ID,
+    CONTROL_PEER_NAME,
+    register_blocking_question_and_wait,
+)
 from repowire.protocol.questions import Answer, Question, QuestionOption
 
 if TYPE_CHECKING:
@@ -31,11 +36,9 @@ if TYPE_CHECKING:
 
 PermissionOutcome = Literal["allowed", "denied", "cancelled"]
 
-# Virtual recipient for a tool-permission question. Not a real peer and never
-# delivered through MessageRouter — human surfaces answer it via /answer using
-# the ask cid; a future roles/capabilities recipient model can replace it.
-CONTROL_PEER_ID = "__repowire_control__"
-CONTROL_PEER_NAME = "human"
+# CONTROL_PEER_ID / CONTROL_PEER_NAME are re-exported from the shared blocking
+# core so the virtual control-surface recipient is defined in exactly one place.
+__all__ = ["ApprovalBroker", "PermissionDecision", "CONTROL_PEER_ID", "CONTROL_PEER_NAME"]
 
 
 @dataclass(frozen=True)
@@ -131,34 +134,11 @@ class ApprovalBroker:
             },
         )
         repowire_session_id = self._resolve_session_id(peer_id, session_id)
+        text = question.prompt or "ACP tool permission request"
         try:
-            try:
-                await self._ask_tracker.register(
-                    from_peer_id=peer_id,
-                    from_peer_name=peer_id,
-                    to_peer_id=CONTROL_PEER_ID,
-                    to_peer_name=CONTROL_PEER_NAME,
-                    text=question.prompt or "ACP tool permission request",
-                    correlation_id=request_id,
-                    question=question,
-                )
-            except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
-                return PermissionDecision(outcome="denied", message=f"register failed: {e}")
-
-            # Normal ask event (so the dashboard banner + Telegram render it) + the
-            # back-compat ACP-specific alias, both keyed by the same request_id/cid.
-            ask_event = {
-                "from": peer_id,
-                "to": CONTROL_PEER_NAME,
-                "from_peer_id": peer_id,
-                "to_peer_id": CONTROL_PEER_ID,
-                "text": question.prompt or "ACP tool permission request",
-                "correlation_id": request_id,
-                "question": question.model_dump(exclude_none=True),
-                "repowire_session_id": repowire_session_id,
-                "from_repowire_session_id": repowire_session_id,
-            }
-            self._emit_event("ask", ask_event)
+            # Back-compat / audit alias, keyed by the same request_id/cid. Emitted
+            # alongside the normal "ask" event the shared core fires (so the
+            # dashboard banner + Telegram still render the question).
             self._emit_event(
                 "acp_permission_request",
                 {
@@ -172,12 +152,23 @@ class ApprovalBroker:
                     "timeout_seconds": self._timeout_seconds,
                 },
             )
-
-            answer = await self._ask_tracker.wait_for_answer(
-                request_id,
-                timeout_seconds=self._timeout_seconds,
-                default_answer=question.default_answer,
-            )
+            try:
+                answer = await register_blocking_question_and_wait(
+                    self._ask_tracker,
+                    self._emit_event,
+                    question=question,
+                    text=text,
+                    correlation_id=request_id,
+                    server_wait_seconds=self._timeout_seconds,
+                    from_peer_id=peer_id,
+                    from_peer_name=peer_id,
+                    from_repowire_session_id=repowire_session_id,
+                    extra_ask_fields={"repowire_session_id": repowire_session_id},
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — registration must not hard-fail the ACP turn
+                return PermissionDecision(outcome="denied", message=f"register failed: {e}")
             decision = _answer_to_decision(answer)
             if decision.timed_out:
                 self._last_error = "permission request timed out"

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4124,5 +4124,16 @@ def hook_notification() -> None:
     sys.exit(notification_main())
 
 
+@hook.command(name="pretooluse")
+@click.option("--backend", default="claude-code", help="Agent backend")
+def hook_pretooluse(backend: str) -> None:
+    """Handle PreToolUse hook - remote tool approval when opted in."""
+    import sys
+
+    from repowire.hooks.pretooluse_handler import main as pretooluse_main
+
+    sys.exit(pretooluse_main(backend=backend))
+
+
 if __name__ == "__main__":
     main()

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -318,6 +318,34 @@ class UpdatesConfig(BaseModel):
     )
 
 
+# Default tools gated by the PreToolUse remote-approval hook: mutating/shell
+# actions only. Read-only tools (Read/Glob/Grep/LS) are intentionally excluded
+# so the approval prompt fires on consequential actions, not every file read.
+DEFAULT_REMOTE_APPROVAL_TOOLS = ("Bash", "Edit", "Write", "MultiEdit", "NotebookEdit")
+
+
+class RemoteToolApprovalConfig(BaseModel):
+    """PreToolUse hooks-path remote approval (Claude Code).
+
+    When enabled, a PreToolUse hook posts a blocking choice-question to the
+    daemon for the gated tools and awaits an allow/deny from a human surface
+    (dashboard / Telegram) or a peer, denying on timeout. Off-by-default; the
+    installer only registers the hook when ``enabled`` is true.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(default=False, description="Gate gated_tools behind remote approval")
+    gated_tools: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_REMOTE_APPROVAL_TOOLS),
+        description="Tool names that require approval; never gate read-only tools",
+    )
+    timeout_seconds: float = Field(
+        default=45.0,
+        description="Requested wait; the daemon clamps to its blocking-question max",
+    )
+
+
 class ExperimentsConfig(BaseModel):
     """Feature flags for experimental subsystems.
 
@@ -327,6 +355,8 @@ class ExperimentsConfig(BaseModel):
         experiments:
           acp_broker_client: true
           chat_turn_streaming: true
+          remote_tool_approval:
+            enabled: true
 
     Promote to a stable surface or remove once an experiment concludes —
     don't let entries linger.
@@ -358,6 +388,11 @@ class ExperimentsConfig(BaseModel):
             "Deprecated compatibility knob. The daemon state store is SQLite-backed; "
             "legacy JSON files are import-only sources for migrated domains."
         ),
+    )
+
+    remote_tool_approval: RemoteToolApprovalConfig = Field(
+        default_factory=RemoteToolApprovalConfig,
+        description="PreToolUse hooks-path remote tool approval (Claude Code).",
     )
 
 

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -323,6 +323,10 @@ class UpdatesConfig(BaseModel):
 # so the approval prompt fires on consequential actions, not every file read.
 DEFAULT_REMOTE_APPROVAL_TOOLS = ("Bash", "Edit", "Write", "MultiEdit", "NotebookEdit")
 
+# Never gate these read-only tools — approving every file read is pure friction.
+# Filtered out of gated_tools even if a user configures them.
+READ_ONLY_TOOLS = frozenset({"Read", "Glob", "Grep", "LS"})
+
 
 class RemoteToolApprovalConfig(BaseModel):
     """PreToolUse hooks-path remote approval (Claude Code).
@@ -344,6 +348,18 @@ class RemoteToolApprovalConfig(BaseModel):
         default=45.0,
         description="Requested wait; the daemon clamps to its blocking-question max",
     )
+
+    @field_validator("gated_tools")
+    @classmethod
+    def _drop_read_only_tools(cls, tools: list[str]) -> list[str]:
+        """Read-only tools are never gated, even if configured (codex review)."""
+        return [t for t in tools if t not in READ_ONLY_TOOLS]
+
+    @field_validator("timeout_seconds")
+    @classmethod
+    def _positive_timeout(cls, value: float) -> float:
+        """A non-positive timeout would crash the hook HTTP path, not deny cleanly."""
+        return value if value > 0 else 45.0
 
 
 class ExperimentsConfig(BaseModel):

--- a/repowire/daemon/question_blocking.py
+++ b/repowire/daemon/question_blocking.py
@@ -1,0 +1,98 @@
+"""Neutral core for a blocking structured-question round-trip.
+
+A *blocking* transport (an ACP runtime's RequestPermission, a Claude Code
+PreToolUse hook, a future PreToolUse-equivalent) owns a suspendable call: it can
+register a :class:`~repowire.protocol.questions.Question`, park, and resume once
+the answer is recorded. This module is that shared policy center —
+register the question ask, emit the normal ``ask`` event (so the dashboard
+banner and Telegram buttons render it like any other question), await the
+answer, and hand back the typed :class:`~repowire.protocol.questions.Answer`.
+
+It is deliberately transport-neutral: no ACP ``_pending`` bookkeeping, no
+``acp_permission_*`` aliases, no session/tool_call coupling. The ACP broker and
+the ``POST /questions/ask-blocking`` route both call this so timeout / default /
+fail-closed semantics live in exactly one place and cannot drift.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from repowire.protocol.questions import Answer, Question
+
+if TYPE_CHECKING:
+    from repowire.daemon.ask_tracker import AskTracker
+
+# Virtual recipient for a control-surface question (tool permission, approval).
+# Not a real peer and never delivered through MessageRouter — human surfaces
+# answer it via /answer using the ask cid; a future roles/capabilities recipient
+# model can replace it.
+CONTROL_PEER_ID = "__repowire_control__"
+CONTROL_PEER_NAME = "human"
+
+
+class _EmitEvent(Protocol):
+    def __call__(self, event_type: str, data: dict[str, Any], /) -> str: ...
+
+
+async def register_blocking_question_and_wait(
+    ask_tracker: AskTracker,
+    emit_event: _EmitEvent,
+    *,
+    question: Question,
+    text: str,
+    correlation_id: str,
+    server_wait_seconds: float,
+    from_peer_id: str,
+    from_peer_name: str,
+    to_peer_id: str = CONTROL_PEER_ID,
+    to_peer_name: str = CONTROL_PEER_NAME,
+    from_repowire_session_id: str | None = None,
+    extra_ask_fields: dict[str, Any] | None = None,
+) -> Answer:
+    """Register a blocking question ask, emit its ``ask`` event, await the answer.
+
+    The answer recorded on the ask is the source of truth. On timeout,
+    :meth:`AskTracker.wait_for_answer` records the question's ``default_answer``
+    (fail-closed for a tool-permission question), so callers always receive a
+    terminal :class:`Answer` rather than a hang.
+
+    ``correlation_id`` is supplied by the caller so a retrying transport reuses
+    the same ask (registration is idempotent on the cid). ``extra_ask_fields``
+    merges into the emitted ``ask`` event for transport-specific metadata
+    (e.g. a runtime session id) without widening this function's contract.
+
+    Registration failure propagates to the caller, which decides how to fail
+    closed for its transport.
+    """
+    await ask_tracker.register(
+        from_peer_id=from_peer_id,
+        from_peer_name=from_peer_name,
+        to_peer_id=to_peer_id,
+        to_peer_name=to_peer_name,
+        text=text,
+        correlation_id=correlation_id,
+        question=question,
+        from_repowire_session_id=from_repowire_session_id,
+    )
+
+    ask_event: dict[str, Any] = {
+        "from": from_peer_name,
+        "to": to_peer_name,
+        "from_peer_id": from_peer_id,
+        "to_peer_id": to_peer_id,
+        "text": text,
+        "correlation_id": correlation_id,
+        "question": question.model_dump(exclude_none=True),
+    }
+    if from_repowire_session_id is not None:
+        ask_event["from_repowire_session_id"] = from_repowire_session_id
+    if extra_ask_fields:
+        ask_event.update(extra_ask_fields)
+    emit_event("ask", ask_event)
+
+    return await ask_tracker.wait_for_answer(
+        correlation_id,
+        timeout_seconds=server_wait_seconds,
+        default_answer=question.default_answer,
+    )

--- a/repowire/daemon/routes/asks.py
+++ b/repowire/daemon/routes/asks.py
@@ -24,6 +24,7 @@ the upgrade.
 from __future__ import annotations
 
 import logging
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -39,12 +40,19 @@ from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_delivery import peer_delivery_from_state
 from repowire.daemon.peer_registry import PeerRegistry, normalize_identity_path
+from repowire.daemon.question_blocking import register_blocking_question_and_wait
 from repowire.daemon.routes._shared import OkResponse
 from repowire.daemon.state.session_bindings import resolve_repowire_session_id
 from repowire.daemon.websocket_transport import DeliveryInjectionError, TransportError
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import Peer
-from repowire.protocol.questions import Answer, AnswerOutcome, Question
+from repowire.protocol.questions import (
+    Answer,
+    AnswerOutcome,
+    Question,
+    QuestionOption,
+    QuestionScope,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["asks"])
@@ -94,6 +102,68 @@ class AnswerRequest(BaseModel):
     outcome: AnswerOutcome = Field("answered")
     message: str | None = Field(None, description="Optional human note alongside the answer")
     attachments: list[AttachmentRef] = Field(default_factory=list)
+
+
+# Hard server-side cap on how long /questions/ask-blocking holds a connection
+# open waiting for an answer. A blocking transport's client timeout must sit
+# above this (+ network margin) but below its own host timeout (e.g. Claude's
+# PreToolUse hook timeout). Timeout always records the question's default_answer
+# (fail-closed for tool_permission), so the caller never hangs.
+BLOCKING_QUESTION_MAX_WAIT_SECONDS = 55.0
+BLOCKING_QUESTION_DEFAULT_WAIT_SECONDS = 45.0
+
+
+class BlockingQuestionOption(BaseModel):
+    """An answerable option on a blocking question."""
+
+    id: str = Field(..., description="Stable option id the answer selects")
+    title: str = Field(..., description="Human-readable label")
+
+
+class AskBlockingRequest(BaseModel):
+    """Post a blocking structured question from an external transport.
+
+    Transport-neutral: an ACP runtime, a Claude Code PreToolUse hook, or any
+    client that owns a suspendable call registers a question, the daemon holds
+    the connection open up to ``BLOCKING_QUESTION_MAX_WAIT_SECONDS`` while a
+    human surface (dashboard / Telegram) or a peer answers, and the typed
+    answer is returned. Fail-closed: on timeout the question's default answer is
+    recorded.
+    """
+
+    prompt: str = Field(..., description="Short human prompt for the question")
+    options: list[BlockingQuestionOption] = Field(
+        default_factory=list,
+        description="Allow-capable options; at least one required for tool_permission",
+    )
+    scope: QuestionScope | None = Field(
+        None, description="Question scope, e.g. 'tool_permission'",
+    )
+    metadata: dict | None = Field(
+        None, description="Structured (truncated) context for renderers / audit",
+    )
+    timeout_seconds: float | None = Field(
+        None, description="Requested wait; clamped to the daemon max",
+    )
+    correlation_id: str | None = Field(
+        None,
+        description="Caller-supplied cid for idempotent retries (e.g. 'pretool-<hex>')",
+    )
+    origin: str | None = Field(
+        None, description="Originating transport label (e.g. 'pretooluse', 'acp')",
+    )
+    from_peer: str | None = Field(
+        None, description="Display name / id of the peer the question is about",
+    )
+
+
+class AskBlockingResponse(BaseModel):
+    """Resolved answer for a blocking question."""
+
+    correlation_id: str
+    outcome: AnswerOutcome
+    option_id: str | None = None
+    message: str | None = None
 
 
 class AckRequest(BaseModel):
@@ -857,6 +927,77 @@ async def _answer_question_core(request: AnswerRequest) -> OkResponse:
         has_attachments=bool(request.attachments),
     )
     return OkResponse()
+
+
+@router.post("/questions/ask-blocking", response_model=AskBlockingResponse)
+async def ask_blocking_question(
+    request: AskBlockingRequest,
+    _: str | None = Depends(require_auth),
+) -> AskBlockingResponse:
+    """Register a blocking structured question and wait for its answer.
+
+    The daemon holds this connection open up to a hard cap while a human surface
+    (dashboard / Telegram) or a peer answers. Fail-closed: a tool-permission
+    question denies on timeout / acknowledge / no-option (its default answer is
+    recorded through the answer machinery, so first-answer-wins still holds and
+    a late /answer returns 410).
+
+    Returns 422 when a tool_permission question carries no allow-capable option
+    (every answer would deny and the UI would look broken).
+    """
+    if request.scope == "tool_permission" and not request.options:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="tool_permission question requires at least one allow-capable option",
+        )
+
+    state = get_app_state()
+    ask_tracker = state.ask_tracker
+    emit_event = get_peer_registry().add_event
+
+    server_wait = min(
+        request.timeout_seconds or BLOCKING_QUESTION_DEFAULT_WAIT_SECONDS,
+        BLOCKING_QUESTION_MAX_WAIT_SECONDS,
+    )
+    correlation_id = request.correlation_id or f"ask-{uuid4().hex[:8]}"
+    from_peer = request.from_peer or "external"
+
+    # Fail-closed default: tool_permission denies, other scopes time out.
+    default_outcome: AnswerOutcome = (
+        "denied" if request.scope == "tool_permission" else "timed_out"
+    )
+    question = Question(
+        kind="choice",
+        prompt=request.prompt,
+        options=[QuestionOption(id=o.id, title=o.title) for o in request.options],
+        blocking=True,
+        timeout_seconds=server_wait,
+        default_answer=Answer(
+            outcome=default_outcome, message="blocking question timed out",
+        ),
+        scope=request.scope,
+        metadata=request.metadata or {},
+    )
+    try:
+        answer = await register_blocking_question_and_wait(
+            ask_tracker,
+            emit_event,
+            question=question,
+            text=request.prompt,
+            correlation_id=correlation_id,
+            server_wait_seconds=server_wait,
+            from_peer_id=from_peer,
+            from_peer_name=from_peer,
+            extra_ask_fields={"origin": request.origin} if request.origin else None,
+        )
+    except QuiescedError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    return AskBlockingResponse(
+        correlation_id=correlation_id,
+        outcome=answer.outcome,
+        option_id=answer.option_id,
+        message=answer.message,
+    )
 
 
 @router.post("/answer", response_model=OkResponse)

--- a/repowire/hooks/pretooluse_handler.py
+++ b/repowire/hooks/pretooluse_handler.py
@@ -25,6 +25,9 @@ from uuid import uuid4
 from repowire.hooks._tmux import get_pane_id
 from repowire.hooks.utils import daemon_post_with_status, get_display_name
 
+# The single allow option this hook offers. The response must select exactly
+# this id to grant; anything else fails closed.
+_ALLOW_OPTION_ID = "allow"
 # Client HTTP timeout sits above the daemon's wait + a small network margin, but
 # must stay below Claude's configured PreToolUse hook timeout (60s in settings).
 _CLIENT_TIMEOUT_MARGIN_SECONDS = 5.0
@@ -76,11 +79,18 @@ def main(backend: str = "claude-code") -> int:
     if backend != "claude-code":
         return 0  # PreToolUse remote approval is a Claude Code path only
 
+    # This hook is installed/matched ONLY for gated tools, so once it runs we
+    # are about to gate a consequential tool call. Fail closed (deny) on any
+    # condition where we cannot affirmatively verify the call is ungated —
+    # otherwise empty stdout under --dangerously-skip-permissions is a bypass.
+    # The ONLY safe fall-through is: config loads cleanly AND says the tool is
+    # not gated (or the experiment is off).
     try:
         input_data = json.loads(sys.stdin.read())
     except json.JSONDecodeError as e:
         print(f"repowire pretooluse: invalid JSON input: {e}", file=sys.stderr)
-        return 0  # malformed input: don't interfere with the native flow
+        print(json.dumps(_deny_decision("malformed hook input")))
+        return 0
 
     tool_name = input_data.get("tool_name", "")
 
@@ -88,12 +98,13 @@ def main(backend: str = "claude-code") -> int:
         from repowire.config.models import load_config
 
         cfg = load_config()
-    except Exception as e:  # noqa: BLE001 — config failure must not block the tool
+    except Exception as e:  # noqa: BLE001 — can't verify intent → deny, don't bypass
         print(f"repowire pretooluse: config load failed: {e}", file=sys.stderr)
+        print(json.dumps(_deny_decision("approval config unavailable")))
         return 0
     approval = cfg.experiments.remote_tool_approval
     if not approval.enabled or tool_name not in approval.gated_tools:
-        return 0  # experiment off or tool not gated: native flow proceeds
+        return 0  # config loaded and says off / ungated: native flow proceeds
 
     # From here the tool is gated: any failure denies (fail closed).
     tool_input = input_data.get("tool_input", {})
@@ -104,7 +115,7 @@ def main(backend: str = "claude-code") -> int:
 
     payload = {
         "prompt": prompt,
-        "options": [{"id": "allow", "title": f"Allow {tool_name}"}],
+        "options": [{"id": _ALLOW_OPTION_ID, "title": f"Allow {tool_name}"}],
         "scope": "tool_permission",
         "timeout_seconds": server_wait,
         "correlation_id": correlation_id,
@@ -130,7 +141,10 @@ def main(backend: str = "claude-code") -> int:
 
     outcome = body.get("outcome")
     message = body.get("message") or ""
-    if outcome == "answered" and body.get("option_id"):
+    # Allow ONLY on the exact allow option this hook offered. A stale / local /
+    # malformed response carrying a different option_id (e.g. "deny") must not
+    # grant — fail closed.
+    if outcome == "answered" and body.get("option_id") == _ALLOW_OPTION_ID:
         print(json.dumps(_allow_decision(message)))
         return 0
 

--- a/repowire/hooks/pretooluse_handler.py
+++ b/repowire/hooks/pretooluse_handler.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Handle the PreToolUse hook - remote tool approval over the mesh.
+
+When ``experiments.remote_tool_approval.enabled`` is on, a gated tool call
+(Bash / Edit / Write / ...) is suspended: this hook posts a blocking
+choice-question to the daemon and waits for an allow/deny from a human surface
+(dashboard / Telegram) or a peer, then returns a PreToolUse
+``permissionDecision``. It is the hooks-path analogue of the ACP
+ApprovalBroker, sharing the daemon's blocking-question core.
+
+Fail closed everywhere: a daemon that is unavailable, a malformed response, a
+timeout, or any unexpected error denies the tool. Ungated tools (and the
+experiment being off) fall through with no decision so Claude's native flow is
+untouched. This still gates under ``--dangerously-skip-permissions`` because the
+decision rides the hook, not Claude's native approval.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from uuid import uuid4
+
+from repowire.hooks._tmux import get_pane_id
+from repowire.hooks.utils import daemon_post_with_status, get_display_name
+
+# Client HTTP timeout sits above the daemon's wait + a small network margin, but
+# must stay below Claude's configured PreToolUse hook timeout (60s in settings).
+_CLIENT_TIMEOUT_MARGIN_SECONDS = 5.0
+# Cap a tool_input rendered into the prompt so the question stays readable and
+# the emitted event payload stays bounded; full (truncated) input rides metadata.
+_PROMPT_INPUT_MAX_CHARS = 200
+
+
+def _allow_decision(reason: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        },
+    }
+    if reason:
+        out["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    return out
+
+
+def _deny_decision(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        },
+    }
+
+
+def _summarize_input(tool_input: Any) -> str:
+    """Compact one-line rendering of a tool input for the prompt."""
+    try:
+        text = json.dumps(tool_input, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        text = str(tool_input)
+    text = " ".join(text.split())
+    if len(text) > _PROMPT_INPUT_MAX_CHARS:
+        text = text[:_PROMPT_INPUT_MAX_CHARS] + "…"
+    return text
+
+
+def main(backend: str = "claude-code") -> int:
+    """Entry point for the PreToolUse hook.
+
+    Returns 0 always; the decision (if any) is the printed JSON. A bare exit
+    with no decision lets Claude's native permission flow proceed.
+    """
+    if backend != "claude-code":
+        return 0  # PreToolUse remote approval is a Claude Code path only
+
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as e:
+        print(f"repowire pretooluse: invalid JSON input: {e}", file=sys.stderr)
+        return 0  # malformed input: don't interfere with the native flow
+
+    tool_name = input_data.get("tool_name", "")
+
+    try:
+        from repowire.config.models import load_config
+
+        cfg = load_config()
+    except Exception as e:  # noqa: BLE001 — config failure must not block the tool
+        print(f"repowire pretooluse: config load failed: {e}", file=sys.stderr)
+        return 0
+    approval = cfg.experiments.remote_tool_approval
+    if not approval.enabled or tool_name not in approval.gated_tools:
+        return 0  # experiment off or tool not gated: native flow proceeds
+
+    # From here the tool is gated: any failure denies (fail closed).
+    tool_input = input_data.get("tool_input", {})
+    prompt = f"Allow {tool_name}? {_summarize_input(tool_input)}".rstrip()
+    server_wait = approval.timeout_seconds
+    client_timeout = server_wait + _CLIENT_TIMEOUT_MARGIN_SECONDS
+    correlation_id = f"pretool-{uuid4().hex[:12]}"
+
+    payload = {
+        "prompt": prompt,
+        "options": [{"id": "allow", "title": f"Allow {tool_name}"}],
+        "scope": "tool_permission",
+        "timeout_seconds": server_wait,
+        "correlation_id": correlation_id,
+        "origin": "pretooluse",
+        "from_peer": get_display_name(),
+        "metadata": {
+            "tool_name": tool_name,
+            "tool_input": _summarize_input(tool_input),
+            "session_id": input_data.get("session_id", ""),
+            "cwd": input_data.get("cwd", ""),
+            "pane_id": get_pane_id() or "",
+        },
+    }
+
+    status_code, body = daemon_post_with_status(
+        "/questions/ask-blocking", payload, timeout=client_timeout,
+    )
+    if status_code != 200 or not isinstance(body, dict):
+        # Daemon unavailable / rejected / malformed: deny.
+        detail = f"status={status_code}" if status_code else "no response"
+        print(json.dumps(_deny_decision(f"approval unavailable ({detail})")))
+        return 0
+
+    outcome = body.get("outcome")
+    message = body.get("message") or ""
+    if outcome == "answered" and body.get("option_id"):
+        print(json.dumps(_allow_decision(message)))
+        return 0
+
+    # denied / timed_out / cancelled / acknowledged / no-option → fail closed.
+    reason = {
+        "timed_out": "approval timed out",
+        "denied": "denied by operator",
+        "cancelled": "approval cancelled",
+    }.get(str(outcome), f"approval not granted ({outcome})")
+    if message:
+        reason = f"{reason}: {message}"
+    print(json.dumps(_deny_decision(reason)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/repowire/installers/claude_code.py
+++ b/repowire/installers/claude_code.py
@@ -12,8 +12,12 @@ CLAUDE_JSON = Path.home() / ".claude.json"
 
 HOOK_EVENTS = [
     "Stop", "StopFailure", "SessionStart", "SessionEnd",
-    "UserPromptSubmit", "Notification",
+    "UserPromptSubmit", "Notification", "PreToolUse",
 ]
+
+# Per-hook timeout (seconds) for the blocking PreToolUse approval. Must sit
+# above the daemon wait + client margin so the hook isn't killed mid-wait.
+PRETOOLUSE_HOOK_TIMEOUT_SECONDS = 60
 
 # Channel transport requires Claude Code v2.1.80+ with claude.ai login
 CHANNEL_MIN_VERSION = (2, 1, 80)
@@ -56,6 +60,19 @@ def _make_notification_hook_config(command: str, matcher: str) -> dict:
             {
                 "type": "command",
                 "command": command,
+            }
+        ],
+    }
+
+
+def _make_pretooluse_hook_config(command: str, matcher: str, timeout: int) -> dict:
+    return {
+        "matcher": matcher,
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+                "timeout": timeout,
             }
         ],
     }
@@ -104,8 +121,25 @@ def install_hooks(channel_mode: bool = False) -> bool:
             "Notification",
             _make_notification_hook_config("repowire hook notification", "idle_prompt"),
         )
+        # PreToolUse remote approval: opt-in only. Register the hook (matcher
+        # scoped to the configured gated tools) when enabled, otherwise strip
+        # any prior repowire PreToolUse entry so toggling off cleans up.
+        approval = load_config().experiments.remote_tool_approval
+        if approval.enabled and approval.gated_tools:
+            matcher = "|".join(approval.gated_tools)
+            _replace_repowire_hook(
+                settings,
+                "PreToolUse",
+                _make_pretooluse_hook_config(
+                    "repowire hook pretooluse", matcher, PRETOOLUSE_HOOK_TIMEOUT_SECONDS,
+                ),
+            )
+        else:
+            _replace_repowire_hook(settings, "PreToolUse", None)
     else:
-        for event in ("SessionStart", "SessionEnd", "UserPromptSubmit", "Notification"):
+        for event in (
+            "SessionStart", "SessionEnd", "UserPromptSubmit", "Notification", "PreToolUse",
+        ):
             _replace_repowire_hook(settings, event, None)
 
     if not settings.get("hooks"):
@@ -142,6 +176,11 @@ def uninstall_hooks() -> bool:
     return removed_any
 
 
+# PreToolUse is opt-in (remote tool approval); its presence is not required for
+# hooks to count as installed. uninstall still iterates HOOK_EVENTS to clean it.
+_REQUIRED_HOOK_EVENTS = [e for e in HOOK_EVENTS if e != "PreToolUse"]
+
+
 def check_hooks_installed() -> bool:
     settings = _load_claude_settings()
     if "hooks" not in settings:
@@ -149,7 +188,7 @@ def check_hooks_installed() -> bool:
 
     return all(
         any(_is_repowire_hook_entry(entry) for entry in settings["hooks"].get(event, []))
-        for event in HOOK_EVENTS
+        for event in _REQUIRED_HOOK_EVENTS
     )
 
 

--- a/tests/test_acp_permissions.py
+++ b/tests/test_acp_permissions.py
@@ -309,6 +309,35 @@ async def test_tool_permission_answer_does_not_notify_runtime(
 
 
 @pytest.mark.asyncio
+async def test_register_failure_emits_balancing_decision_event() -> None:
+    # If the shared core's registration fails, the pending request alias must be
+    # balanced by a decision event so a consumer never sees a dangling request.
+    events: list[dict] = []
+
+    class BoomTracker(AskTracker):
+        async def register(self, *args, **kwargs):  # type: ignore[override]
+            raise RuntimeError("register boom")
+
+    broker = ApprovalBroker(
+        emit_event=lambda t, d: events.append({"type": t, **d}) or "evt",
+        ask_tracker=BoomTracker(ttl_hours=24.0),
+        timeout_seconds=5.0,
+    )
+
+    decision = await broker.request_permission(
+        peer_id="peer-1",
+        session_id="session-1",
+        tool_call={"name": "shell"},
+        options=[SimpleNamespace(option_id="opt-allow", title="Allow")],
+    )
+
+    assert decision.outcome == "denied"
+    assert any(e["type"] == "acp_permission_request" for e in events)
+    dec = next(e for e in events if e["type"] == "acp_permission_decision")
+    assert dec["outcome"] == "denied"
+
+
+@pytest.mark.asyncio
 async def test_acp_permission_cancellation_cleans_pending_context() -> None:
     tracker = AskTracker(ttl_hours=24.0)
     broker = ApprovalBroker(

--- a/tests/test_claude_code_installer.py
+++ b/tests/test_claude_code_installer.py
@@ -16,22 +16,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from repowire.config.models import Config as RealConfig
 from repowire.installers import claude_code as cc_mod
 
 
-def _retarget(tmp_path, monkeypatch):
+def _retarget(tmp_path, monkeypatch, *, config=None):
     settings = tmp_path / ".claude" / "settings.json"
     claude_json = tmp_path / ".claude.json"
     monkeypatch.setattr(cc_mod, "CLAUDE_SETTINGS", settings)
     monkeypatch.setattr(cc_mod, "CLAUDE_JSON", claude_json)
 
-    class Daemon:
-        auth_token = None
-
-    class Config:
-        daemon = Daemon()
-
-    monkeypatch.setattr(cc_mod, "load_config", lambda: Config())
+    cfg = config or RealConfig()
+    monkeypatch.setattr(cc_mod, "load_config", lambda: cfg)
     return settings, claude_json
 
 
@@ -87,9 +83,10 @@ def test_install_hooks_is_idempotent(tmp_path, monkeypatch):
     cc_mod.install_hooks()
     second = settings.read_text()
     assert first == second
-    # And each event has exactly one entry.
+    # And each (default-on) event has exactly one entry. PreToolUse is opt-in
+    # and absent here, so iterate the required set.
     data = json.loads(second)
-    for event in cc_mod.HOOK_EVENTS:
+    for event in cc_mod._REQUIRED_HOOK_EVENTS:
         assert len(data["hooks"][event]) == 1
 
 
@@ -105,6 +102,58 @@ def test_install_hooks_replaces_existing_repowire_entry_for_same_event(tmp_path,
     data = _read(settings)
     stop_cmds = [e["hooks"][0]["command"] for e in data["hooks"]["Stop"]]
     assert stop_cmds == ["repowire hook stop"]
+
+
+# -- PreToolUse remote approval (opt-in) ------------------------------------
+
+
+def _approval_config(enabled: bool, *, gated=None):
+    cfg = RealConfig()
+    cfg.experiments.remote_tool_approval.enabled = enabled
+    if gated is not None:
+        cfg.experiments.remote_tool_approval.gated_tools = gated
+    return cfg
+
+
+def test_pretooluse_absent_when_approval_disabled(tmp_path, monkeypatch):
+    settings, _ = _retarget(tmp_path, monkeypatch, config=_approval_config(False))
+    cc_mod.install_hooks()
+    data = _read(settings)
+    assert "PreToolUse" not in data["hooks"]
+
+
+def test_pretooluse_registered_when_approval_enabled(tmp_path, monkeypatch):
+    settings, _ = _retarget(
+        tmp_path, monkeypatch, config=_approval_config(True, gated=["Bash", "Edit"]),
+    )
+    cc_mod.install_hooks()
+    entry = _read(settings)["hooks"]["PreToolUse"][0]
+    assert entry["matcher"] == "Bash|Edit"
+    hook = entry["hooks"][0]
+    assert hook["command"] == "repowire hook pretooluse"
+    assert hook["timeout"] == cc_mod.PRETOOLUSE_HOOK_TIMEOUT_SECONDS
+
+
+def test_pretooluse_stripped_when_toggled_off(tmp_path, monkeypatch):
+    settings, _ = _retarget(
+        tmp_path, monkeypatch, config=_approval_config(True, gated=["Bash"]),
+    )
+    cc_mod.install_hooks()
+    assert "PreToolUse" in _read(settings)["hooks"]
+
+    # Re-install with the experiment off: the prior repowire PreToolUse entry
+    # is cleaned up rather than left dangling.
+    _retarget(tmp_path, monkeypatch, config=_approval_config(False))
+    cc_mod.install_hooks()
+    assert "PreToolUse" not in _read(settings)["hooks"]
+
+
+def test_pretooluse_absent_in_channel_mode(tmp_path, monkeypatch):
+    settings, _ = _retarget(
+        tmp_path, monkeypatch, config=_approval_config(True, gated=["Bash"]),
+    )
+    cc_mod.install_hooks(channel_mode=True)
+    assert "PreToolUse" not in _read(settings).get("hooks", {})
 
 
 # -- uninstall_hooks --------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ from repowire.config.models import (
     LoggingConfig,
     PeerConfig,
     RelayConfig,
+    RemoteToolApprovalConfig,
     SpawnProfile,
     SpawnSettings,
     UpdatesConfig,
@@ -371,3 +372,22 @@ class TestLoggingConfig:
         msg = str(exc.value)
         for valid in ["debug", "info", "warning", "error", "critical"]:
             assert valid in msg
+
+
+class TestRemoteToolApprovalConfig:
+    def test_defaults_gate_mutating_tools_only(self):
+        cfg = RemoteToolApprovalConfig()
+        assert cfg.enabled is False
+        assert "Bash" in cfg.gated_tools
+        assert not (set(cfg.gated_tools) & {"Read", "Glob", "Grep", "LS"})
+
+    def test_read_only_tools_are_filtered_out(self):
+        cfg = RemoteToolApprovalConfig(gated_tools=["Bash", "Read", "Grep", "Edit"])
+        assert cfg.gated_tools == ["Bash", "Edit"]
+
+    @pytest.mark.parametrize("bad", [0, -1, -45.0])
+    def test_non_positive_timeout_falls_back_to_default(self, bad: float):
+        assert RemoteToolApprovalConfig(timeout_seconds=bad).timeout_seconds == 45.0
+
+    def test_positive_timeout_is_kept(self):
+        assert RemoteToolApprovalConfig(timeout_seconds=10.0).timeout_seconds == 10.0

--- a/tests/test_pretooluse_handler.py
+++ b/tests/test_pretooluse_handler.py
@@ -157,6 +157,45 @@ def test_prompt_input_is_truncated(monkeypatch):
     assert _decision(decision) == "allow"
 
 
+def test_deny_on_wrong_option_id_fail_closed(monkeypatch):
+    # A stale / local / malformed response selecting a different option must
+    # not allow, even with outcome=answered.
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "answered", "option_id": "deny"}),
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_malformed_input(monkeypatch):
+    # The hook only runs for gated tools; bad JSON means we can't verify, so deny
+    # rather than fall through (which would bypass under skip-permissions).
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json{"))
+    captured = io.StringIO()
+    monkeypatch.setattr("sys.stdout", captured)
+    rc = pretooluse_handler.main(backend="claude-code")
+    assert rc == 0
+    decision = json.loads(captured.getvalue().strip())
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_deny_on_config_load_failure(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_name": "Bash"})))
+
+    def boom():
+        raise RuntimeError("config exploded")
+
+    monkeypatch.setattr("repowire.config.models.load_config", boom)
+    captured = io.StringIO()
+    monkeypatch.setattr("sys.stdout", captured)
+    rc = pretooluse_handler.main(backend="claude-code")
+    assert rc == 0
+    decision = json.loads(captured.getvalue().strip())
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
 def test_non_claude_backend_falls_through(monkeypatch):
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_name": "Bash"})))
     captured = io.StringIO()

--- a/tests/test_pretooluse_handler.py
+++ b/tests/test_pretooluse_handler.py
@@ -1,0 +1,166 @@
+"""PreToolUse remote-approval hook handler (repowire-qnp).
+
+The hook is fail-closed: it only ever ALLOWS on an explicit answered+option,
+and DENIES on timeout / deny / daemon-unavailable / malformed. Ungated tools
+and the experiment being off fall through with no decision (empty stdout) so
+Claude's native flow is untouched.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from repowire.config.models import Config
+from repowire.hooks import pretooluse_handler
+
+
+def _run(monkeypatch, *, input_data, config, post_result=(200, None)):
+    """Drive main() with mocked stdin / config / daemon, return parsed stdout."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(input_data)))
+    monkeypatch.setattr(pretooluse_handler, "get_display_name", lambda: "agent-x")
+    monkeypatch.setattr(pretooluse_handler, "get_pane_id", lambda: "%1")
+    monkeypatch.setattr(
+        "repowire.config.models.load_config", lambda: config,
+    )
+    posted: dict = {}
+
+    def fake_post(path, payload, *, timeout):
+        posted["path"] = path
+        posted["payload"] = payload
+        posted["timeout"] = timeout
+        return post_result
+
+    monkeypatch.setattr(pretooluse_handler, "daemon_post_with_status", fake_post)
+
+    captured = io.StringIO()
+    monkeypatch.setattr("sys.stdout", captured)
+    rc = pretooluse_handler.main(backend="claude-code")
+    assert rc == 0  # the hook never blocks the tool by exit code; decision is in stdout
+    out = captured.getvalue().strip()
+    decision = json.loads(out) if out else None
+    return decision, posted
+
+
+def _enabled_config() -> Config:
+    cfg = Config()
+    cfg.experiments.remote_tool_approval.enabled = True
+    return cfg
+
+
+def _decision(decision) -> str | None:
+    return decision["hookSpecificOutput"]["permissionDecision"] if decision else None
+
+
+def test_experiment_off_falls_through(monkeypatch):
+    decision, posted = _run(
+        monkeypatch, input_data={"tool_name": "Bash"}, config=Config(),
+    )
+    assert decision is None  # no decision: native flow proceeds
+    assert posted == {}  # daemon not contacted
+
+
+def test_ungated_tool_falls_through(monkeypatch):
+    decision, posted = _run(
+        monkeypatch,
+        input_data={"tool_name": "Read", "tool_input": {"file": "x"}},
+        config=_enabled_config(),
+    )
+    assert decision is None
+    assert posted == {}
+
+
+def test_allow_on_answered_option(monkeypatch):
+    decision, posted = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {"command": "ls"}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "answered", "option_id": "allow", "message": "ok"}),
+    )
+    assert _decision(decision) == "allow"
+    assert posted["path"] == "/questions/ask-blocking"
+    assert posted["payload"]["scope"] == "tool_permission"
+    assert posted["payload"]["correlation_id"].startswith("pretool-")
+    # Client timeout sits above the server wait.
+    assert posted["timeout"] > posted["payload"]["timeout_seconds"]
+
+
+def test_deny_on_denied_outcome(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Write", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "denied", "message": "nope"}),
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_timeout(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Edit", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "timed_out"}),
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_acknowledged_fail_closed(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "acknowledged"}),
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_answered_without_option_fail_closed(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "answered"}),  # no option_id
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_daemon_unavailable(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(None, None),  # transport failure
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_deny_on_non_200(monkeypatch):
+    decision, _ = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": {}},
+        config=_enabled_config(),
+        post_result=(503, {"detail": "busy"}),
+    )
+    assert _decision(decision) == "deny"
+
+
+def test_prompt_input_is_truncated(monkeypatch):
+    big = {"command": "x" * 1000}
+    decision, posted = _run(
+        monkeypatch,
+        input_data={"tool_name": "Bash", "tool_input": big},
+        config=_enabled_config(),
+        post_result=(200, {"outcome": "answered", "option_id": "allow"}),
+    )
+    assert len(posted["payload"]["prompt"]) < 400  # bounded, not the full 1000 chars
+    assert _decision(decision) == "allow"
+
+
+def test_non_claude_backend_falls_through(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_name": "Bash"})))
+    captured = io.StringIO()
+    monkeypatch.setattr("sys.stdout", captured)
+    rc = pretooluse_handler.main(backend="codex")
+    assert rc == 0
+    assert captured.getvalue().strip() == ""

--- a/tests/test_question_blocking.py
+++ b/tests/test_question_blocking.py
@@ -1,0 +1,187 @@
+"""Blocking structured-question core + POST /questions/ask-blocking route.
+
+repowire-qnp: the shared register-emit-wait core both the ACP broker and the
+PreToolUse hook ride, and the transport-neutral HTTP seam that lets an external
+suspendable caller (a hook) park on a question without a polling loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from repowire.daemon.ask_tracker import AskTracker
+from repowire.daemon.question_blocking import (
+    CONTROL_PEER_ID,
+    register_blocking_question_and_wait,
+)
+from repowire.daemon.routes import asks as asks_routes
+from repowire.protocol.questions import Answer, Question, QuestionOption
+
+from .conftest import async_client_for, make_daemon_app
+
+
+def _allow_question(timeout: float = 5.0) -> Question:
+    return Question(
+        kind="choice",
+        prompt="Allow Bash?",
+        options=[QuestionOption(id="allow", title="Allow Bash")],
+        blocking=True,
+        timeout_seconds=timeout,
+        default_answer=Answer(outcome="denied", message="timed out"),
+        scope="tool_permission",
+    )
+
+
+# --- shared core ---
+
+
+@pytest.mark.asyncio
+async def test_core_emits_ask_event_and_returns_recorded_answer():
+    tracker = AskTracker(ttl_hours=24.0)
+    events: list[tuple[str, dict]] = []
+
+    async def answer_soon(cid: str):
+        # Let the waiter register, then answer.
+        for _ in range(50):
+            if await tracker.get(cid) is not None:
+                break
+            await asyncio.sleep(0.005)
+        await tracker.answer(cid, Answer(option_id="allow", outcome="answered"))
+
+    answerer = asyncio.create_task(answer_soon("pretool-1"))
+    answer = await register_blocking_question_and_wait(
+        tracker,
+        lambda t, d: events.append((t, d)) or "evt",
+        question=_allow_question(),
+        text="Allow Bash?",
+        correlation_id="pretool-1",
+        server_wait_seconds=5.0,
+        from_peer_id="agent-x",
+        from_peer_name="agent-x",
+    )
+    await answerer
+
+    assert answer.outcome == "answered"
+    assert answer.option_id == "allow"
+    # The normal ask event fired so dashboard/Telegram render it, keyed to control.
+    assert any(t == "ask" and d["correlation_id"] == "pretool-1" for t, d in events)
+    ask_event = next(d for t, d in events if t == "ask")
+    assert ask_event["to_peer_id"] == CONTROL_PEER_ID
+    assert ask_event["question"]["scope"] == "tool_permission"
+
+
+@pytest.mark.asyncio
+async def test_core_timeout_records_default_answer_fail_closed():
+    tracker = AskTracker(ttl_hours=24.0)
+    answer = await register_blocking_question_and_wait(
+        tracker,
+        lambda _t, _d: "evt",
+        question=_allow_question(timeout=0.05),
+        text="Allow Bash?",
+        correlation_id="pretool-timeout",
+        server_wait_seconds=0.05,
+        from_peer_id="agent-x",
+        from_peer_name="agent-x",
+    )
+    assert answer.outcome == "denied"  # default_answer, fail closed
+
+
+# --- route ---
+
+
+@pytest.mark.asyncio
+async def test_route_happy_path_returns_selected_option(tmp_path):
+    harness = make_daemon_app(tmp_path, [asks_routes.router])
+    tracker = harness.ask_tracker
+
+    async def answer_when_open():
+        for _ in range(100):
+            ask = await tracker.get("pretool-route-1")
+            if ask is not None:
+                break
+            await asyncio.sleep(0.005)
+        await tracker.answer("pretool-route-1", Answer(option_id="allow", outcome="answered"))
+
+    async with async_client_for(harness.app) as client:
+        answerer = asyncio.create_task(answer_when_open())
+        resp = await client.post(
+            "/questions/ask-blocking",
+            json={
+                "prompt": "Allow Bash?",
+                "options": [{"id": "allow", "title": "Allow Bash"}],
+                "scope": "tool_permission",
+                "correlation_id": "pretool-route-1",
+                "timeout_seconds": 5.0,
+                "origin": "pretooluse",
+            },
+        )
+        await answerer
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["outcome"] == "answered"
+    assert body["option_id"] == "allow"
+    assert body["correlation_id"] == "pretool-route-1"
+
+
+@pytest.mark.asyncio
+async def test_route_timeout_denies_for_tool_permission(tmp_path):
+    harness = make_daemon_app(tmp_path, [asks_routes.router])
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/questions/ask-blocking",
+            json={
+                "prompt": "Allow Bash?",
+                "options": [{"id": "allow", "title": "Allow Bash"}],
+                "scope": "tool_permission",
+                "correlation_id": "pretool-route-timeout",
+                "timeout_seconds": 0.05,
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["outcome"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_route_tool_permission_requires_an_option(tmp_path):
+    harness = make_daemon_app(tmp_path, [asks_routes.router])
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/questions/ask-blocking",
+            json={"prompt": "Allow Bash?", "options": [], "scope": "tool_permission"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_route_clamps_timeout_to_daemon_max(tmp_path):
+    # A huge requested timeout is clamped so a client can't pin a connection open.
+    harness = make_daemon_app(tmp_path, [asks_routes.router])
+    tracker = harness.ask_tracker
+
+    async def answer_when_open():
+        for _ in range(100):
+            if await tracker.get("pretool-clamp") is not None:
+                break
+            await asyncio.sleep(0.005)
+        ask = await tracker.get("pretool-clamp")
+        assert ask is not None and ask.question is not None
+        assert ask.question.timeout_seconds == asks_routes.BLOCKING_QUESTION_MAX_WAIT_SECONDS
+        await tracker.answer("pretool-clamp", Answer(option_id="allow", outcome="answered"))
+
+    async with async_client_for(harness.app) as client:
+        answerer = asyncio.create_task(answer_when_open())
+        resp = await client.post(
+            "/questions/ask-blocking",
+            json={
+                "prompt": "Allow Bash?",
+                "options": [{"id": "allow", "title": "Allow Bash"}],
+                "scope": "tool_permission",
+                "correlation_id": "pretool-clamp",
+                "timeout_seconds": 99999.0,
+            },
+        )
+        await answerer
+    assert resp.status_code == 200


### PR DESCRIPTION
Closes the last child of the Mesh Questions epic (`repowire-iz6`): a Claude Code `PreToolUse` hook that gates a tool call behind a remote approval, riding the same Question/Answer primitive as ACP.

## What

- **Shared blocking-question core** (`daemon/question_blocking.py`): `register_blocking_question_and_wait(...)` — register a question ask, emit the normal `ask` event (so dashboard/Telegram render it), await `wait_for_answer`, return the typed `Answer`. Transport-neutral: no ACP coupling.
- **ACP broker refactored** onto the shared core — keeps its `_pending` bookkeeping, `acp_permission_*` aliases, and CancelledError handling on the edges, shares the register-emit-wait center. No semantic drift (existing 24 broker/question tests stay green).
- **`POST /questions/ask-blocking`** — transport-neutral HTTP seam: register a blocking question, hold the connection open up to a hard cap (55s), return the answer. Fail-closed (tool_permission denies on timeout); 422 when a tool_permission question carries no allow-capable option.
- **`PreToolUse` hook handler** + `repowire hook pretooluse` — opt-in, matcher-gated (mutating/shell tools only, never read-only), posts to the blocking route, maps the answer to `permissionDecision`. Fail-closed everywhere (deny on timeout / daemon-unavailable / malformed). Gates even under `--dangerously-skip-permissions` because the decision rides the hook.
- **Config** `experiments.remote_tool_approval {enabled, gated_tools, timeout_seconds}`; installer registers the `PreToolUse` hook only when enabled (and strips it when toggled off).
- **Docs**: message-types concept, http-api route, configuration experiment.

## Workflow

Plan critiqued by codex before implementation; iterated on its P0-P2 points (server-blocking endpoint over client-poll, neutral core extraction over broker reuse, asymmetric timeouts, opt-in/fail-closed surface). Patches only — no minor bump.

## Tests

1678 backend pass (+26: blocking core/route, handler allow/deny/timeout/fail-closed/matcher gating, installer opt-in registration). ruff + ty clean.

## Not in this PR

Live-proof under `--dangerously-skip-permissions` (Prass requires before public promise) — to run before promoting the experiment.
