### PR TITLE
feat(panes): orphan-pane discovery + safe link/adopt flow

### DIFF
--- a/docs/capabilities/dashboard.md
+++ b/docs/capabilities/dashboard.md
@@ -17,6 +17,7 @@ The dashboard is a Next.js UI served by the daemon at `http://localhost:8377/das
 - **Attachment chips** — mesh events and per-peer chat render attachment chips with download links when an attachment ID is available.
 - **Command history** — from an empty composer, ArrowUp recalls previously sent asks for the selected peer (ArrowDown walks forward, Escape returns to empty). History is per-peer and in-memory for the session; once you start editing a recalled entry, arrows behave normally so multi-line editing is unaffected. The plain-text ask flow and Cmd/Ctrl+Enter submit are unchanged.
 - **Pending questions** — structured questions, including ACP tool-permission prompts, appear as an answer banner above the dashboard grid. Choice questions render option buttons; tool-permission questions also render an explicit Deny action. Answers post to the shared `/answer` route and close when the daemon emits the matching ack event.
+- **Unlinked panes** — the spawn dialog lists local tmux panes running an agent the daemon never registered, each with a copyable `repowire link --pane … --backend …` command. Adoption is the explicit CLI step (no one-click button in this slice); see [linking an orphan pane](../concepts/peer-identity-lifecycle.md#linking-an-orphan-pane-link-vs-spawn).
 
 ## Where chat turns come from
 

--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -60,6 +60,12 @@ A reconnect may reclaim an existing `peer_id` only when the claim still describe
 
 If the check fails, the stale `peer_id` claim is ignored and the daemon allocates or adopts a different identity. This prevents an old environment variable or stale pane metadata from binding a different session's WebSocket to the wrong peer.
 
+## Linking an orphan pane (link vs spawn)
+
+When an agent is already running in a local tmux pane but never registered — hooks or MCP did not fire — the daemon cannot see it. `GET /panes/orphans` lists every unregistered local pane (with a display-only backend hint), and `repowire link --pane %NN --backend X` adopts one intentionally.
+
+Link is distinct from spawn: **spawn** starts a *new* agent in a working directory; **link** adopts an *existing* running agent the daemon missed. Link is fail-closed against ghosts — it registers the peer and then establishes the inbound ws-hook, and reports success only when a live WebSocket connection is observed. If the transport cannot be established, the registration is rolled back so no transportless peer is left in the roster, and a retry hint is returned. Linking is same-host only (the daemon cannot spawn a hook into a foreign pane). A linked peer has no runtime session id until its hooks report one, so resume stays unavailable until then — the daemon does not fabricate it.
+
 When a new peer claims a pane already held by another peer, the old peer normally loses that pane binding and is marked offline. Pane lookup should then resolve to the current live owner, not a zombie registration.
 
 There is one protected case: a fresh live `orchestrator` peer keeps sticky ownership of its tmux pane. If a temporary same-pane session starts in a split terminal, the daemon can register that session without assigning the pane (`pane_assigned=false`). The temporary peer can still use outbound MCP/HTTP tools, but it does not get inbound hook transport and must not clear the incumbent orchestrator's pane metadata or WebSocket hook.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -6,6 +6,7 @@ The daemon exposes HTTP routes for the dashboard, hooks, CLI helpers, and client
 
 - `/health` and status routes for daemon checks.
 - `/peers` for peer registration, listing, lookup, and lifecycle operations. Includes `GET /peers/{id}/doctor` (read-only diagnostic report with contradiction detection) and `POST /peers/{id}/rehook` (non-destructive inbound ws-hook recovery, same-host, dry-run by default).
+- `GET /panes/orphans` lists local tmux panes not bound to any registered peer (with a display-only backend hint); `POST /panes/{pane_id}/link` adopts one — registers the peer AND establishes its inbound ws-hook, rolling the registration back if no live transport connects (fail-closed against ghosts). Driven by `repowire link`.
 - `/ask`, `/ack`, and `/asks/pending` for ask lifecycle.
 - `/answer` records a typed answer to a structured question; `POST /questions/ask-blocking` registers a blocking structured question (tool permission) and holds the connection open until it is answered or the daemon's wait cap elapses, then returns the typed answer (fail-closed: a tool-permission question denies on timeout). Used by blocking transports such as the ACP broker and the Claude Code `PreToolUse` approval hook.
 - `/traces/{trace_id}` returns the recorded delivery stages for an ask (`correlation_id`) or notify (`delivery_id`) from the local delivery trace ledger.

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -901,6 +901,8 @@ def link(pane_id: str | None, backend: str | None, name: str | None, circle: str
         )
         sys.exit(2)
 
+    from urllib.parse import quote
+
     payload: dict = {"backend": backend}
     if name:
         payload["name"] = name
@@ -908,7 +910,11 @@ def link(pane_id: str | None, backend: str | None, name: str | None, circle: str
         payload["circle"] = circle
     try:
         with httpx.Client(timeout=15.0) as client:
-            resp = client.post(f"{daemon_url}/panes/{pane_id}/link", json=payload)
+            # pane ids start with '%' — encode so the server doesn't decode
+            # "%42" as the byte 'B' before the route validator sees it.
+            resp = client.post(
+                f"{daemon_url}/panes/{quote(pane_id, safe='')}/link", json=payload
+            )
         if resp.status_code == 409:
             detail = resp.json().get("detail", {})
             console.print(f"[yellow]![/] {detail.get('hint', 'already linked')}")

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -849,6 +849,92 @@ def _render_result(result: object, indent: int = 0) -> None:
 
 
 @main.command()
+@click.option("--pane", "pane_id", default=None, help="tmux pane id to adopt (e.g. %42)")
+@click.option("--backend", default=None, help="Agent running in the pane (required to link)")
+@click.option("--name", default=None, help="Optional display name for the linked peer")
+@click.option("--circle", default=None, help="Circle to register the peer into")
+def link(pane_id: str | None, backend: str | None, name: str | None, circle: str | None) -> None:
+    """Adopt an unregistered local tmux pane into the mesh.
+
+    With no --pane: list candidate panes (those running an agent the daemon
+    never registered) plus the command to adopt each.
+
+    With --pane and --backend: register the pane AND establish its inbound
+    ws-hook. The link succeeds only if a live connection is observed; otherwise
+    it is rolled back (no half-registered ghost) and a retry hint is shown.
+    """
+    import sys
+
+    import httpx
+
+    daemon_url = _get_daemon_url()
+
+    if not pane_id:
+        try:
+            with httpx.Client(timeout=3.0) as client:
+                resp = client.get(f"{daemon_url}/panes/orphans")
+                resp.raise_for_status()
+                panes = resp.json().get("panes", [])
+        except httpx.HTTPError as e:
+            console.print(f"[red]✗[/] Could not reach daemon at {daemon_url}: {e}")
+            sys.exit(1)
+        if not panes:
+            console.print("[green]✓[/] No unlinked panes found.")
+            return
+        console.print("[cyan]Unlinked tmux panes:[/]")
+        for p in panes:
+            hint = p["detected_backend"]
+            tag = f"[green]{hint}[/]" if p["confidence"] == "hint" else "[dim]unknown[/]"
+            console.print(
+                f"  {p['pane_id']}  {tag}  [dim]{p['command']}  {p['cwd']}[/]"
+            )
+            console.print(
+                f"    [dim]repowire link --pane {p['pane_id']} --backend "
+                f"{hint if p['confidence'] == 'hint' else '<backend>'}[/]"
+            )
+        return
+
+    if not backend:
+        console.print(
+            "[red]✗[/] --backend is required to link a pane "
+            "(run `repowire link` with no args to see detected hints)."
+        )
+        sys.exit(2)
+
+    payload: dict = {"backend": backend}
+    if name:
+        payload["name"] = name
+    if circle:
+        payload["circle"] = circle
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            resp = client.post(f"{daemon_url}/panes/{pane_id}/link", json=payload)
+        if resp.status_code == 409:
+            detail = resp.json().get("detail", {})
+            console.print(f"[yellow]![/] {detail.get('hint', 'already linked')}")
+            sys.exit(1)
+        if resp.status_code == 422:
+            console.print(f"[red]✗[/] {resp.json().get('detail', 'invalid request')}")
+            sys.exit(2)
+        resp.raise_for_status()
+        body = resp.json()
+    except httpx.HTTPError as e:
+        console.print(f"[red]✗[/] Link request failed: {e}")
+        sys.exit(1)
+
+    if body.get("linked"):
+        console.print(
+            f"[green]✓[/] Linked {body['pane_id']} → "
+            f"{body['display_name']} (transport connected)"
+        )
+        return
+    console.print(f"[red]✗[/] Link not established: {body.get('reason')}")
+    if body.get("repair_hint"):
+        console.print(f"  [dim]{body['repair_hint']}[/]")
+    sys.exit(1)
+
+
+@main.command()
 def doctor() -> None:
     """Run diagnostic checks and report repowire health."""
     from repowire.config.models import load_config

--- a/repowire/daemon/orphan_panes.py
+++ b/repowire/daemon/orphan_panes.py
@@ -1,0 +1,77 @@
+"""Orphan-pane discovery: tmux panes running an agent the mesh never registered.
+
+When hooks/MCP don't fire (seen during dogfood), a live agent pane is invisible
+to the daemon. This surfaces those panes so a human can intentionally link them
+(see ``repowire link``). Detection here is a display-only *hint* — never an
+action. We deliberately list ALL unregistered panes (not just agent-looking
+ones), because the weird cases this tool exists to diagnose are exactly the ones
+a command-name filter would hide.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from repowire.hooks._tmux import PaneInfo, list_all_panes
+
+# Known agent command basenames → backend hint. Matched against a pane's
+# current command only; this is a display hint, not an authoritative claim.
+_AGENT_COMMANDS = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "gemini": "gemini",
+    "opencode": "opencode",
+    "antigravity": "antigravity",
+    "pi": "pi",
+}
+
+
+class OrphanPane(TypedDict):
+    """An unregistered tmux pane, with a best-effort backend hint."""
+
+    pane_id: str
+    pid: int
+    command: str
+    cwd: str
+    session: str
+    window: str
+    detected_backend: str  # claude-code|codex|gemini|opencode|antigravity|pi|unknown
+    confidence: str  # "hint" when the command matched a known agent, else "unknown"
+
+
+def detect_backend(command: str) -> tuple[str, str]:
+    """Best-effort (backend, confidence) from a pane command. Display hint only."""
+    base = command.strip().rsplit("/", 1)[-1].lower()
+    backend = _AGENT_COMMANDS.get(base)
+    if backend is not None:
+        return backend, "hint"
+    return "unknown", "unknown"
+
+
+def find_orphan_panes(registered_pane_ids: set[str]) -> list[OrphanPane]:
+    """All tmux panes whose pane_id is not bound to a registered peer.
+
+    No command filtering — every unregistered pane is returned, tagged with a
+    detected-backend hint so a UI can group likely agents first without hiding
+    the rest.
+    """
+    orphans: list[OrphanPane] = []
+    for pane in list_all_panes():
+        if pane["pane_id"] in registered_pane_ids:
+            continue
+        backend, confidence = detect_backend(pane["command"])
+        orphans.append(_to_orphan(pane, backend, confidence))
+    return orphans
+
+
+def _to_orphan(pane: PaneInfo, backend: str, confidence: str) -> OrphanPane:
+    return OrphanPane(
+        pane_id=pane["pane_id"],
+        pid=pane["pid"],
+        command=pane["command"],
+        cwd=pane["cwd"],
+        session=pane["session"],
+        window=pane["window"],
+        detected_backend=backend,
+        confidence=confidence,
+    )

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -31,6 +31,7 @@ from repowire.daemon.peer_registry import (
 )
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.daemon.state.session_bindings import SessionBinding
+from repowire.hooks._tmux import list_all_panes
 from repowire.hooks.utils import clear_pane_runtime_state
 from repowire.hooks.ws_hook_supervisor import link_spawn_ws_hook
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
@@ -476,10 +477,29 @@ async def link_pane(
             },
         )
 
-    name = request.name or _link_default_name(request.backend, request.cwd)
+    # Resolve cwd from the live pane when the caller didn't supply one — the
+    # daemon owns discovery, so the CLI/dashboard copy command stays simple
+    # (just --pane + --backend). The ws-hook spawn needs a real cwd for Popen;
+    # an empty cwd would fail every adoption.
+    cwd = request.cwd
+    if not cwd:
+        cwd = next(
+            (p["cwd"] for p in await asyncio.to_thread(list_all_panes) if p["pane_id"] == pane_id),
+            None,
+        )
+    if not cwd:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error": "pane_not_found",
+                "hint": f"No live tmux pane {pane_id} to resolve a working directory from.",
+            },
+        )
+
+    name = request.name or _link_default_name(request.backend, cwd)
     reg = RegisterPeerRequest(
         name=name,
-        path=request.cwd,
+        path=cwd,
         machine=socket.gethostname(),
         pane_id=pane_id,
         backend=request.backend,
@@ -505,7 +525,7 @@ async def link_pane(
         peer_id=peer_id,
         display_name=display_name,
         backend=request.backend.value,
-        cwd=request.cwd or "",
+        cwd=cwd,
     )
     connected = spawned and await _await_ws_connected(
         transport, peer_id, _LINK_WS_WAIT_SECONDS

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -31,7 +31,8 @@ from repowire.daemon.peer_registry import (
 )
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.daemon.state.session_bindings import SessionBinding
-from repowire.hooks.ws_hook_supervisor import maybe_respawn
+from repowire.hooks.utils import clear_pane_runtime_state
+from repowire.hooks.ws_hook_supervisor import link_spawn_ws_hook
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import (
     HistoryLoadResult,
@@ -486,14 +487,29 @@ async def link_pane(
         circle_source="fallback",
         role=PeerRole.AGENT,
     )
-    peer_id, display_name, _pane_assigned, _cert = await _register_peer_impl(reg)
-
-    # Establish inbound transport, then verify a live WS actually connected —
-    # respawn alone (pid-based) does not prove connectivity.
-    await asyncio.to_thread(
-        maybe_respawn, pane_id, backend=request.backend.value, cwd=request.cwd or None,
+    # persist_binding=False: a rolled-back link must leave NO durable binding /
+    # birth-certificate residue. unregister_peer only clears registry/mappings;
+    # an orphan has no runtime session id to bind anyway (resume unavailable
+    # until its hooks report one).
+    peer_id, display_name, _pane_assigned, _cert = await _register_peer_impl(
+        reg, persist_binding=False
     )
-    connected = await _await_ws_connected(transport, peer_id, _LINK_WS_WAIT_SECONDS)
+
+    # First-adoption spawn (NOT maybe_respawn — that refuses without a prior
+    # pidfile, which an orphan never has). This writes pane metadata, claims the
+    # flock, and launches the ws-hook; then we verify a live WS actually
+    # connected before calling the link successful.
+    spawned = await asyncio.to_thread(
+        link_spawn_ws_hook,
+        pane_id,
+        peer_id=peer_id,
+        display_name=display_name,
+        backend=request.backend.value,
+        cwd=request.cwd or "",
+    )
+    connected = spawned and await _await_ws_connected(
+        transport, peer_id, _LINK_WS_WAIT_SECONDS
+    )
 
     if connected:
         return LinkPaneResponse(
@@ -505,9 +521,16 @@ async def link_pane(
             reason="linked",
         )
 
-    # Hard rollback: no live transport → don't leave a ghost peer behind.
+    # Hard rollback: no live transport → don't leave a ghost peer behind. Clear
+    # the pane runtime state we wrote so a later SessionStart/link isn't confused.
+    await asyncio.to_thread(clear_pane_runtime_state, pane_id)
     rolled_back = await peer_registry.unregister_peer(peer_id)
-    reason = "transport_unestablished" if rolled_back else "transport_unestablished_rollback_failed"
+    if not spawned:
+        reason = "ws_hook_spawn_failed"
+    elif rolled_back:
+        reason = "transport_unestablished"
+    else:
+        reason = "transport_unestablished_rollback_failed"
     return LinkPaneResponse(
         linked=False,
         pane_id=pane_id,
@@ -689,6 +712,8 @@ class ValidateBirthCertificateResponse(BaseModel):
 
 async def _register_peer_impl(
     request: RegisterPeerRequest,
+    *,
+    persist_binding: bool = True,
 ) -> tuple[str, str, bool, dict[str, Any] | None]:
     """Shared implementation for peer registration endpoints.
 
@@ -698,6 +723,12 @@ async def _register_peer_impl(
     sticky-orchestrator branch refused to displace a live orchestrator. When no
     pane_id was requested, pane_assigned defaults to True (vacuously: nothing
     to assign).
+
+    ``persist_binding=False`` skips the session-binding observation + birth
+    certificate. Pane adoption (``link``) uses this so a registration that is
+    rolled back on a failed transport leaves no durable binding/cert residue
+    (``unregister_peer`` only clears registry/mappings). A linked peer has no
+    runtime session id anyway until its hooks report one.
     """
     circle = request.circle or "global"
     runtime_session_id = _runtime_session_id_from_metadata(request.metadata)
@@ -731,7 +762,7 @@ async def _register_peer_impl(
         ) from exc
     binding_store = getattr(get_app_state(), "session_binding_store", None)
     birth_certificate: dict[str, Any] | None = None
-    if binding_store is not None:
+    if binding_store is not None and persist_binding:
         try:
             binding_store.upsert_observation(
                 peer_id=peer_id,

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import socket
 from datetime import datetime, timezone
 from typing import Any
@@ -22,6 +23,7 @@ from repowire.daemon.diagnostics import (
     build_doctor_report,
     compute_inbound_status,
 )
+from repowire.daemon.orphan_panes import find_orphan_panes
 from repowire.daemon.peer_registry import (
     CircleSource,
     PaneHijackRejectedError,
@@ -29,6 +31,7 @@ from repowire.daemon.peer_registry import (
 )
 from repowire.daemon.routes._shared import OkResponse, is_valid_identifier
 from repowire.daemon.state.session_bindings import SessionBinding
+from repowire.hooks.ws_hook_supervisor import maybe_respawn
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import (
     HistoryLoadResult,
@@ -364,6 +367,179 @@ async def get_peer_by_pane(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"No peer for pane: {pane_id}",
     )
+
+
+class OrphanPaneInfo(BaseModel):
+    """An unregistered local tmux pane (orphan-adoption candidate)."""
+
+    pane_id: str
+    pid: int
+    command: str
+    cwd: str
+    session: str
+    window: str
+    detected_backend: str = Field(description="Backend hint from the pane command; display only")
+    confidence: str = Field(
+        description="'hint' when the command matched a known agent, else 'unknown'"
+    )
+
+
+class OrphanPanesResponse(BaseModel):
+    panes: list[OrphanPaneInfo]
+
+
+@router.get("/panes/orphans", response_model=OrphanPanesResponse)
+async def list_orphan_panes(
+    _: str | None = Depends(require_auth),
+) -> OrphanPanesResponse:
+    """List local tmux panes not bound to any registered peer.
+
+    Discovery for ``repowire link``: a pane whose agent never registered still
+    shows up here, with a display-only backend hint. No command filtering — the
+    full unregistered list is returned so the diagnostic cases this surfaces
+    aren't hidden. Empty when tmux is unavailable (this is a local-host concern).
+    """
+    peer_registry = get_peer_registry()
+    peers = await peer_registry.get_all_peers()
+    registered_pane_ids = {p.pane_id for p in peers if p.pane_id}
+    orphans = find_orphan_panes(registered_pane_ids)
+    return OrphanPanesResponse(panes=[OrphanPaneInfo(**o) for o in orphans])
+
+
+# tmux pane ids look like %42. Refuse anything else before we register/spawn.
+_PANE_ID_RE = re.compile(r"^%\d+$")
+# How long to wait for the freshly-spawned ws-hook to register a live WS before
+# declaring the transport unestablished (and rolling the link back).
+_LINK_WS_WAIT_SECONDS = 8.0
+_LINK_WS_POLL_SECONDS = 0.25
+
+
+class LinkPaneRequest(BaseModel):
+    """Adopt an orphan tmux pane into the mesh (register + establish transport)."""
+
+    backend: AgentType = Field(..., description="Required: the agent running in the pane")
+    name: str | None = Field(
+        None,
+        pattern=r"^[a-zA-Z0-9._-]+$",
+        description="Optional display name; defaults to a backend/cwd-derived name",
+    )
+    circle: str | None = Field(None, description="Circle to register the peer into")
+    cwd: str | None = Field(None, description="Pane working directory (for hook spawn)")
+
+
+class LinkPaneResponse(BaseModel):
+    """Result of a link attempt. ``linked`` is true ONLY with a live transport."""
+
+    linked: bool
+    pane_id: str
+    peer_id: str | None = None
+    display_name: str | None = None
+    transport_connected: bool = False
+    reason: str
+    repair_hint: str | None = None
+
+
+@router.post("/panes/{pane_id}/link", response_model=LinkPaneResponse)
+async def link_pane(
+    pane_id: str,
+    request: LinkPaneRequest,
+    _: str | None = Depends(require_auth),
+) -> LinkPaneResponse:
+    """Adopt an orphan pane: register a peer for it AND establish inbound WS.
+
+    Fail-closed against ghosts: a link is reported successful ONLY when a live
+    ws-hook connection is observed. If the hook can't be spawned or the WS
+    doesn't connect within the wait window, the registration is rolled back so
+    no transportless peer is left in the roster, and a repair hint is returned.
+
+    Same-host only — the daemon cannot spawn a hook into a foreign pane.
+    """
+    if not _PANE_ID_RE.match(pane_id):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid tmux pane id: {pane_id!r} (expected like %42)",
+        )
+
+    peer_registry = get_peer_registry()
+    state = get_app_state()
+    transport = state.transport
+
+    existing = await peer_registry.get_peer_by_pane(pane_id)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "already_linked",
+                "hint": f"Pane {pane_id} is already bound to peer {existing.display_name}.",
+                "peer_id": existing.peer_id,
+            },
+        )
+
+    name = request.name or _link_default_name(request.backend, request.cwd)
+    reg = RegisterPeerRequest(
+        name=name,
+        path=request.cwd,
+        machine=socket.gethostname(),
+        pane_id=pane_id,
+        backend=request.backend,
+        circle=request.circle,
+        circle_source="fallback",
+        role=PeerRole.AGENT,
+    )
+    peer_id, display_name, _pane_assigned, _cert = await _register_peer_impl(reg)
+
+    # Establish inbound transport, then verify a live WS actually connected —
+    # respawn alone (pid-based) does not prove connectivity.
+    await asyncio.to_thread(
+        maybe_respawn, pane_id, backend=request.backend.value, cwd=request.cwd or None,
+    )
+    connected = await _await_ws_connected(transport, peer_id, _LINK_WS_WAIT_SECONDS)
+
+    if connected:
+        return LinkPaneResponse(
+            linked=True,
+            pane_id=pane_id,
+            peer_id=peer_id,
+            display_name=display_name,
+            transport_connected=True,
+            reason="linked",
+        )
+
+    # Hard rollback: no live transport → don't leave a ghost peer behind.
+    rolled_back = await peer_registry.unregister_peer(peer_id)
+    reason = "transport_unestablished" if rolled_back else "transport_unestablished_rollback_failed"
+    return LinkPaneResponse(
+        linked=False,
+        pane_id=pane_id,
+        peer_id=peer_id if not rolled_back else None,
+        display_name=display_name if not rolled_back else None,
+        transport_connected=False,
+        reason=reason,
+        repair_hint=(
+            "The ws-hook did not connect. Confirm the pane is a live local agent "
+            f"and retry: repowire link --pane {pane_id} --backend {request.backend.value}"
+        ),
+    )
+
+
+def _link_default_name(backend: AgentType, cwd: str | None) -> str:
+    """A stable-ish default display name for a linked pane."""
+    leaf = (cwd or "").rstrip("/").rsplit("/", 1)[-1] or "peer"
+    return f"{leaf}-{backend.value}"
+
+
+async def _await_ws_connected(transport: Any, peer_id: str, timeout: float) -> bool:
+    """Poll for a live WS connection for ``peer_id`` up to ``timeout`` seconds."""
+    if transport is None:
+        return False
+    deadline = timeout
+    waited = 0.0
+    while waited < deadline:
+        if transport.is_connected(peer_id):
+            return True
+        await asyncio.sleep(_LINK_WS_POLL_SECONDS)
+        waited += _LINK_WS_POLL_SECONDS
+    return transport.is_connected(peer_id)
 
 
 @router.post(

--- a/repowire/hooks/_tmux.py
+++ b/repowire/hooks/_tmux.py
@@ -39,6 +39,69 @@ def is_tmux_available() -> bool:
         return False
 
 
+class PaneInfo(TypedDict):
+    """A single tmux pane, as reported by ``list_all_panes``."""
+
+    pane_id: str  # e.g. "%42"
+    pid: int  # pane_pid (the pane's shell pid)
+    command: str  # pane_current_command
+    cwd: str  # pane_current_path
+    session: str  # session_name
+    window: str  # window_index
+
+
+# Tab-delimited so a command/cwd containing spaces survives the split.
+_PANE_FORMAT = (
+    "#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t"
+    "#{pane_current_path}\t#{session_name}\t#{window_index}"
+)
+
+
+def list_all_panes() -> list[PaneInfo]:
+    """All tmux panes across every session, or [] if tmux is unreachable.
+
+    Best-effort discovery for orphan-pane adoption — a pane whose agent never
+    registered (hooks/MCP didn't fire) still shows up here. Malformed rows are
+    skipped rather than failing the whole listing.
+    """
+    if not shutil.which("tmux"):
+        return []
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", _PANE_FORMAT],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
+        logger.debug("list_all_panes: tmux list-panes failed: %s", e)
+        return []
+    if result.returncode != 0:
+        return []
+
+    panes: list[PaneInfo] = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 6:
+            continue
+        pane_id, pid_str, command, cwd, session, window = parts
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        panes.append(
+            PaneInfo(
+                pane_id=pane_id,
+                pid=pid,
+                command=command,
+                cwd=cwd,
+                session=session,
+                window=window,
+            )
+        )
+    return panes
+
+
 def _get_ppid_chain(max_depth: int = 16) -> list[int]:
     """Walk getppid() ancestry. Returns pids from immediate parent upward."""
     chain: list[int] = []

--- a/repowire/hooks/ws_hook_supervisor.py
+++ b/repowire/hooks/ws_hook_supervisor.py
@@ -53,7 +53,11 @@ def link_spawn_ws_hook(
     rather than leaving a half-adopted peer.
     """
     lock_path = ws_hook_lock_path(pane_id)
-    lock_fd = open(lock_path, "w")  # noqa: SIM115
+    try:
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+    except OSError as e:
+        logger.warning("link_spawn_ws_hook: pane %s lock open failed: %s", pane_id, e)
+        return False
     try:
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -61,23 +65,30 @@ def link_spawn_ws_hook(
             lock_fd.close()
             logger.warning("link_spawn_ws_hook: pane %s lock contested", pane_id)
             return False
-        write_pane_runtime_metadata(
-            pane_id,
-            {
-                "backend": backend,
-                "cwd": cwd,
-                "display_name": display_name,
-                "peer_id": peer_id,
-            },
-        )
-        new_pid = spawn_ws_hook(
-            pane_id=pane_id,
-            peer_id=peer_id,
-            display_name=display_name,
-            backend=backend,
-            cwd=cwd,
-            lock_fd=lock_fd,
-        )
+        # Any failure past this point (metadata write or spawn) returns False so
+        # the caller's rollback (clear_pane_runtime_state + unregister) runs —
+        # an exception must not escape and leave a registered ghost behind.
+        try:
+            write_pane_runtime_metadata(
+                pane_id,
+                {
+                    "backend": backend,
+                    "cwd": cwd,
+                    "display_name": display_name,
+                    "peer_id": peer_id,
+                },
+            )
+            new_pid = spawn_ws_hook(
+                pane_id=pane_id,
+                peer_id=peer_id,
+                display_name=display_name,
+                backend=backend,
+                cwd=cwd,
+                lock_fd=lock_fd,
+            )
+        except Exception as e:  # noqa: BLE001 — fail closed so the route rolls back
+            logger.warning("link_spawn_ws_hook: pane %s spawn failed: %s", pane_id, e)
+            return False
         return new_pid is not None
     finally:
         # Child inherited the flock via pass_fds; release our copy.

--- a/repowire/hooks/ws_hook_supervisor.py
+++ b/repowire/hooks/ws_hook_supervisor.py
@@ -25,11 +25,63 @@ from repowire.hooks.utils import (
     get_pane_file,
     pane_logs_dir,
     read_pane_runtime_metadata,
+    write_pane_runtime_metadata,
     ws_hook_lock_path,
     ws_hook_pid_path,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def link_spawn_ws_hook(
+    pane_id: str,
+    *,
+    peer_id: str,
+    display_name: str,
+    backend: str,
+    cwd: str,
+) -> bool:
+    """Start a ws-hook for a freshly-adopted (orphan) pane. Returns spawn success.
+
+    First-adoption spawn for ``link`` — distinct from :func:`maybe_respawn`,
+    which is a lazy-repair helper that refuses to act without a prior pidfile +
+    pane metadata. Here there is no prior hook: claim the pane flock, write the
+    pane runtime metadata SessionStart would have written, then spawn the hook.
+
+    Returns False if the lock is contested (another hook is starting/alive for
+    this pane) or the hook script is missing — the caller then fails the link
+    rather than leaving a half-adopted peer.
+    """
+    lock_path = ws_hook_lock_path(pane_id)
+    lock_fd = open(lock_path, "w")  # noqa: SIM115
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            lock_fd.close()
+            logger.warning("link_spawn_ws_hook: pane %s lock contested", pane_id)
+            return False
+        write_pane_runtime_metadata(
+            pane_id,
+            {
+                "backend": backend,
+                "cwd": cwd,
+                "display_name": display_name,
+                "peer_id": peer_id,
+            },
+        )
+        new_pid = spawn_ws_hook(
+            pane_id=pane_id,
+            peer_id=peer_id,
+            display_name=display_name,
+            backend=backend,
+            cwd=cwd,
+            lock_fd=lock_fd,
+        )
+        return new_pid is not None
+    finally:
+        # Child inherited the flock via pass_fds; release our copy.
+        lock_fd.close()
 
 
 def spawn_ws_hook(

--- a/tests/test_orphan_panes.py
+++ b/tests/test_orphan_panes.py
@@ -1,0 +1,151 @@
+"""Orphan-pane discovery + link flow (repowire-xqq).
+
+Discovery lists every unregistered tmux pane with a display-only backend hint.
+Link is fail-closed: a peer is adopted ONLY when a live ws-hook transport is
+observed; a link that can't connect rolls the registration back (no ghost).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowire.daemon import orphan_panes
+from repowire.daemon.routes import peers as peers_routes
+from repowire.hooks._tmux import PaneInfo
+
+from .conftest import async_client_for, make_daemon_app
+
+
+def _pane(pane_id: str, command: str) -> PaneInfo:
+    return PaneInfo(
+        pane_id=pane_id, pid=1234, command=command, cwd="/tmp/x", session="s", window="0"
+    )
+
+
+# --- detection (display-only hint) ---
+
+
+@pytest.mark.parametrize(
+    "command,backend,confidence",
+    [
+        ("claude", "claude-code", "hint"),
+        ("/usr/local/bin/codex", "codex", "hint"),
+        ("gemini", "gemini", "hint"),
+        ("opencode", "opencode", "hint"),
+        ("zsh", "unknown", "unknown"),
+        ("vim", "unknown", "unknown"),
+    ],
+)
+def test_detect_backend_is_a_hint(command, backend, confidence):
+    assert orphan_panes.detect_backend(command) == (backend, confidence)
+
+
+def test_find_orphans_excludes_registered_and_lists_everything(monkeypatch):
+    monkeypatch.setattr(
+        orphan_panes,
+        "list_all_panes",
+        lambda: [
+            _pane("%1", "claude"),
+            _pane("%2", "zsh"),  # not an agent, still listed (no filtering)
+            _pane("%3", "codex"),
+        ],
+    )
+    orphans = orphan_panes.find_orphan_panes(registered_pane_ids={"%3"})
+    ids = [o["pane_id"] for o in orphans]
+    assert ids == ["%1", "%2"]  # %3 registered → excluded; %2 kept despite non-agent
+    by_id = {o["pane_id"]: o for o in orphans}
+    assert by_id["%1"]["detected_backend"] == "claude-code"
+    assert by_id["%2"]["detected_backend"] == "unknown"
+
+
+# --- GET /panes/orphans ---
+
+
+@pytest.mark.asyncio
+async def test_orphans_route_excludes_registered_peer_panes(tmp_path, monkeypatch):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    # Register a peer holding pane %1 so it's excluded.
+    from repowire.protocol.peers import Peer
+
+    await harness.registry.register_peer(
+        Peer(peer_id="p1", display_name="alice", pane_id="%1", path="/tmp/a", machine="h")
+    )
+    monkeypatch.setattr(
+        orphan_panes,
+        "list_all_panes",
+        lambda: [_pane("%1", "claude"), _pane("%2", "codex")],
+    )
+    async with async_client_for(harness.app) as client:
+        resp = await client.get("/panes/orphans")
+    assert resp.status_code == 200
+    panes = resp.json()["panes"]
+    assert [p["pane_id"] for p in panes] == ["%2"]
+    assert panes[0]["detected_backend"] == "codex"
+    assert panes[0]["confidence"] == "hint"
+
+
+# --- POST /panes/{id}/link ---
+
+
+@pytest.mark.asyncio
+async def test_link_rejects_bad_pane_id(tmp_path):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    async with async_client_for(harness.app) as client:
+        resp = await client.post("/panes/not-a-pane/link", json={"backend": "claude-code"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_link_succeeds_when_ws_connects(tmp_path, monkeypatch):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    monkeypatch.setattr(peers_routes, "maybe_respawn", lambda *a, **k: True)
+    # Transport reports the freshly-linked peer as connected.
+    monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: True)
+
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/panes/%7/link", json={"backend": "claude-code", "cwd": "/tmp/proj"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["linked"] is True
+    assert body["transport_connected"] is True
+    # The peer is in the roster bound to the pane.
+    peer = await harness.registry.get_peer_by_pane("%7")
+    assert peer is not None
+
+
+@pytest.mark.asyncio
+async def test_link_rolls_back_when_ws_never_connects(tmp_path, monkeypatch):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    monkeypatch.setattr(peers_routes, "maybe_respawn", lambda *a, **k: True)
+    # WS never connects → fail-closed, no ghost left behind.
+    monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: False)
+    monkeypatch.setattr(peers_routes, "_LINK_WS_WAIT_SECONDS", 0.05)
+
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/panes/%8/link", json={"backend": "codex", "cwd": "/tmp/proj"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["linked"] is False
+    assert body["transport_connected"] is False
+    assert body["reason"] == "transport_unestablished"
+    assert "repowire link --pane %8" in body["repair_hint"]
+    # Rolled back: no ghost peer for the pane.
+    assert await harness.registry.get_peer_by_pane("%8") is None
+
+
+@pytest.mark.asyncio
+async def test_link_refuses_already_linked_pane(tmp_path):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    from repowire.protocol.peers import Peer
+
+    await harness.registry.register_peer(
+        Peer(peer_id="p9", display_name="bob", pane_id="%9", path="/tmp/b", machine="h")
+    )
+    async with async_client_for(harness.app) as client:
+        resp = await client.post("/panes/%9/link", json={"backend": "codex"})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "already_linked"

--- a/tests/test_orphan_panes.py
+++ b/tests/test_orphan_panes.py
@@ -98,43 +98,114 @@ async def test_link_rejects_bad_pane_id(tmp_path):
 @pytest.mark.asyncio
 async def test_link_succeeds_when_ws_connects(tmp_path, monkeypatch):
     harness = make_daemon_app(tmp_path, [peers_routes.router])
-    monkeypatch.setattr(peers_routes, "maybe_respawn", lambda *a, **k: True)
+    spawn_calls: list[dict] = []
+
+    def fake_spawn(pane_id, **kw):
+        spawn_calls.append({"pane_id": pane_id, **kw})
+        return True
+
+    monkeypatch.setattr(peers_routes, "link_spawn_ws_hook", fake_spawn)
     # Transport reports the freshly-linked peer as connected.
     monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: True)
 
     async with async_client_for(harness.app) as client:
         resp = await client.post(
-            "/panes/%7/link", json={"backend": "claude-code", "cwd": "/tmp/proj"}
+            "/panes/%2542/link", json={"backend": "claude-code", "cwd": "/tmp/proj"}
         )
     assert resp.status_code == 200
     body = resp.json()
     assert body["linked"] is True
     assert body["transport_connected"] is True
+    # The first-adoption spawn helper ran with the pane + identity metadata —
+    # NOT maybe_respawn (which would no-op on an orphan with no pidfile).
+    assert spawn_calls and spawn_calls[0]["pane_id"] == "%42"
+    assert spawn_calls[0]["backend"] == "claude-code"
+    assert spawn_calls[0]["cwd"] == "/tmp/proj"
     # The peer is in the roster bound to the pane.
-    peer = await harness.registry.get_peer_by_pane("%7")
+    peer = await harness.registry.get_peer_by_pane("%42")
     assert peer is not None
 
 
 @pytest.mark.asyncio
 async def test_link_rolls_back_when_ws_never_connects(tmp_path, monkeypatch):
     harness = make_daemon_app(tmp_path, [peers_routes.router])
-    monkeypatch.setattr(peers_routes, "maybe_respawn", lambda *a, **k: True)
+    monkeypatch.setattr(peers_routes, "link_spawn_ws_hook", lambda *a, **k: True)
+    monkeypatch.setattr(peers_routes, "clear_pane_runtime_state", lambda *a, **k: None)
     # WS never connects → fail-closed, no ghost left behind.
     monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: False)
     monkeypatch.setattr(peers_routes, "_LINK_WS_WAIT_SECONDS", 0.05)
 
     async with async_client_for(harness.app) as client:
         resp = await client.post(
-            "/panes/%8/link", json={"backend": "codex", "cwd": "/tmp/proj"}
+            "/panes/%2543/link", json={"backend": "codex", "cwd": "/tmp/proj"}
         )
     assert resp.status_code == 200
     body = resp.json()
     assert body["linked"] is False
     assert body["transport_connected"] is False
     assert body["reason"] == "transport_unestablished"
-    assert "repowire link --pane %8" in body["repair_hint"]
+    assert "repowire link --pane %43" in body["repair_hint"]
     # Rolled back: no ghost peer for the pane.
-    assert await harness.registry.get_peer_by_pane("%8") is None
+    assert await harness.registry.get_peer_by_pane("%43") is None
+
+
+@pytest.mark.asyncio
+async def test_link_fails_when_spawn_helper_cannot_start(tmp_path, monkeypatch):
+    # A pane whose ws-hook can't be spawned (lock contested / script missing)
+    # must not be reported linked, and must leave no ghost.
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    monkeypatch.setattr(peers_routes, "link_spawn_ws_hook", lambda *a, **k: False)
+    monkeypatch.setattr(peers_routes, "clear_pane_runtime_state", lambda *a, **k: None)
+    is_connected_calls: list[str] = []
+    monkeypatch.setattr(
+        harness.transport,
+        "is_connected",
+        lambda pid: is_connected_calls.append(pid) or False,
+    )
+
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/panes/%2544/link", json={"backend": "codex", "cwd": "/tmp/proj"}
+        )
+    body = resp.json()
+    assert body["linked"] is False
+    assert body["reason"] == "ws_hook_spawn_failed"
+    # Spawn failed → we never even poll for a connection.
+    assert is_connected_calls == []
+    assert await harness.registry.get_peer_by_pane("%44") is None
+
+
+@pytest.mark.asyncio
+async def test_link_does_not_persist_session_binding_or_cert(tmp_path, monkeypatch):
+    # A linked orphan has no runtime session id, and a rolled-back link must
+    # leave no durable binding/cert residue — so link registers with
+    # persist_binding=False and never touches the binding store.
+    class SpyBindingStore:
+        def __init__(self):
+            self.observations = 0
+            self.certs = 0
+
+        def upsert_observation(self, **_):
+            self.observations += 1
+
+        def mint_birth_certificate(self, **_):
+            self.certs += 1
+            return type("C", (), {"as_envelope": lambda self: {}})()
+
+    spy = SpyBindingStore()
+    harness = make_daemon_app(
+        tmp_path, [peers_routes.router], state_overrides={"session_binding_store": spy}
+    )
+    monkeypatch.setattr(peers_routes, "link_spawn_ws_hook", lambda *a, **k: True)
+    monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: True)
+
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/panes/%2545/link", json={"backend": "claude-code", "cwd": "/tmp/proj"}
+        )
+    assert resp.json()["linked"] is True
+    assert spy.observations == 0
+    assert spy.certs == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_orphan_panes.py
+++ b/tests/test_orphan_panes.py
@@ -84,6 +84,27 @@ async def test_orphans_route_excludes_registered_peer_panes(tmp_path, monkeypatc
     assert panes[0]["confidence"] == "hint"
 
 
+# --- link_spawn_ws_hook exception safety ---
+
+
+def test_link_spawn_ws_hook_swallows_spawn_errors(tmp_path, monkeypatch):
+    # If spawn_ws_hook raises after the metadata write, the helper must catch it
+    # and return False (so the route's rollback runs) rather than propagating.
+    from repowire.hooks import ws_hook_supervisor as sup
+
+    monkeypatch.setattr(sup, "ws_hook_lock_path", lambda _pid: tmp_path / "lock")
+    monkeypatch.setattr(sup, "write_pane_runtime_metadata", lambda *_a, **_k: None)
+
+    def boom(**_kw):
+        raise RuntimeError("popen exploded")
+
+    monkeypatch.setattr(sup, "spawn_ws_hook", boom)
+    result = sup.link_spawn_ws_hook(
+        "%99", peer_id="p", display_name="d", backend="codex", cwd="/tmp/x"
+    )
+    assert result is False
+
+
 # --- POST /panes/{id}/link ---
 
 
@@ -173,6 +194,66 @@ async def test_link_fails_when_spawn_helper_cannot_start(tmp_path, monkeypatch):
     # Spawn failed → we never even poll for a connection.
     assert is_connected_calls == []
     assert await harness.registry.get_peer_by_pane("%44") is None
+
+
+@pytest.mark.asyncio
+async def test_link_resolves_cwd_from_live_pane_when_omitted(tmp_path, monkeypatch):
+    # The CLI/dashboard copy command sends only --pane + --backend; the daemon
+    # (discovery owner) resolves cwd from the live pane so Popen has a real dir.
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    monkeypatch.setattr(
+        peers_routes, "list_all_panes", lambda: [_pane("%50", "claude", )]
+    )
+    spawn_calls: list[dict] = []
+    monkeypatch.setattr(
+        peers_routes,
+        "link_spawn_ws_hook",
+        lambda pane_id, **kw: spawn_calls.append(kw) or True,
+    )
+    monkeypatch.setattr(harness.transport, "is_connected", lambda _pid: True)
+
+    async with async_client_for(harness.app) as client:
+        resp = await client.post("/panes/%2550/link", json={"backend": "claude-code"})
+    assert resp.json()["linked"] is True
+    # cwd came from the pane (PaneInfo cwd="/tmp/x"), not the request.
+    assert spawn_calls[0]["cwd"] == "/tmp/x"
+
+
+@pytest.mark.asyncio
+async def test_link_404_when_no_cwd_and_pane_not_live(tmp_path, monkeypatch):
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+    monkeypatch.setattr(peers_routes, "list_all_panes", lambda: [])  # pane not present
+    async with async_client_for(harness.app) as client:
+        resp = await client.post("/panes/%2551/link", json={"backend": "codex"})
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error"] == "pane_not_found"
+    assert await harness.registry.get_peer_by_pane("%51") is None
+
+
+@pytest.mark.asyncio
+async def test_link_rolls_back_when_spawn_helper_raises(tmp_path, monkeypatch):
+    # link_spawn_ws_hook catches its own spawn errors and returns False; assert
+    # the route then rolls back (no ghost, metadata cleared) rather than letting
+    # an exception escape past the rollback block.
+    harness = make_daemon_app(tmp_path, [peers_routes.router])
+
+    def boom(*_a, **_k):
+        return False  # helper swallows the raise internally and reports failure
+
+    monkeypatch.setattr(peers_routes, "link_spawn_ws_hook", boom)
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        peers_routes, "clear_pane_runtime_state", lambda pid: cleared.append(pid)
+    )
+    async with async_client_for(harness.app) as client:
+        resp = await client.post(
+            "/panes/%2552/link", json={"backend": "codex", "cwd": "/tmp/proj"}
+        )
+    body = resp.json()
+    assert body["linked"] is False
+    assert body["reason"] == "ws_hook_spawn_failed"
+    assert cleared == ["%52"]  # rollback cleared the pane metadata
+    assert await harness.registry.get_peer_by_pane("%52") is None
 
 
 @pytest.mark.asyncio

--- a/web/app/dashboard/components/DashboardDialogs.test.tsx
+++ b/web/app/dashboard/components/DashboardDialogs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SettingsDialog } from "./DashboardDialogs";
+import { OrphanPanesList, SettingsDialog } from "./DashboardDialogs";
 import type { DaemonHealth, Peer } from "../types";
 
 const SERVICE_PEER: Peer = {
@@ -85,5 +85,77 @@ describe("SettingsDialog", () => {
     expect(screen.getByText("Running")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByText("Unknown")).toBeInTheDocument());
     expect(screen.getByText("Error 500")).toBeInTheDocument();
+  });
+});
+
+describe("OrphanPanesList", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders unlinked panes with a copyable link command", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            panes: [
+              {
+                pane_id: "%5",
+                command: "claude",
+                cwd: "/tmp/proj",
+                detected_backend: "claude-code",
+                confidence: "hint",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    render(<OrphanPanesList apiBase="http://daemon.test" />);
+
+    expect(await screen.findByText("%5")).toBeInTheDocument();
+    expect(
+      screen.getByText("repowire link --pane %5 --backend claude-code"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no orphan panes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ panes: [] }), { status: 200 })),
+    );
+
+    const { container } = render(<OrphanPanesList apiBase="http://daemon.test" />);
+    await waitFor(() => expect(container.querySelector('[data-testid="orphan-panes"]')).toBeNull());
+  });
+
+  it("uses a <backend> placeholder when detection is only a guess", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            panes: [
+              {
+                pane_id: "%6",
+                command: "zsh",
+                cwd: "/tmp/x",
+                detected_backend: "unknown",
+                confidence: "unknown",
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    render(<OrphanPanesList apiBase="http://daemon.test" />);
+    expect(
+      await screen.findByText("repowire link --pane %6 --backend <backend>"),
+    ).toBeInTheDocument();
   });
 });

--- a/web/app/dashboard/components/DashboardDialogs.tsx
+++ b/web/app/dashboard/components/DashboardDialogs.tsx
@@ -130,7 +130,66 @@ export function SpawnDialog({ apiBase, onClose, onSpawned }: { apiBase: string; 
           </button>
         </div>
       )}
+      <OrphanPanesList apiBase={apiBase} />
     </Modal>
+  );
+}
+
+interface OrphanPane {
+  pane_id: string;
+  command: string;
+  cwd: string;
+  detected_backend: string;
+  confidence: string;
+}
+
+/** Read-only list of unregistered tmux panes + the `repowire link` command to
+ *  adopt each. Adoption itself is the explicit CLI step (no button in v1). */
+export function OrphanPanesList({ apiBase }: { apiBase: string }) {
+  const [panes, setPanes] = useState<OrphanPane[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${apiBase}/panes/orphans`)
+      .then((res) => (res.ok ? res.json() : { panes: [] }))
+      .then((data: { panes: OrphanPane[] }) => {
+        if (!cancelled) setPanes(data.panes ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setPanes([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBase]);
+
+  if (panes === null || panes.length === 0) return null;
+
+  return (
+    <div className="mt-6 border-t border-border-faint pt-4" data-testid="orphan-panes">
+      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-outline">
+        Unlinked panes — adopt with the CLI
+      </p>
+      <div className="space-y-2">
+        {panes.map((p) => {
+          const backend = p.confidence === "hint" ? p.detected_backend : "<backend>";
+          return (
+            <div key={p.pane_id} className="font-mono text-[11px]">
+              <div className="flex items-center gap-2 text-on-surface-variant">
+                <span className="font-bold text-on-surface">{p.pane_id}</span>
+                <span className={p.confidence === "hint" ? "text-primary" : "text-outline"}>
+                  {p.detected_backend}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-outline">{p.command} · {p.cwd}</span>
+              </div>
+              <code className="mt-0.5 block select-all rounded bg-surface-container-lowest px-2 py-1 text-[10px] text-outline">
+                repowire link --pane {p.pane_id} --backend {backend}
+              </code>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
`repowire-xqq` (QoL): surface local tmux panes running an agent the daemon never registered, and adopt them safely. Plan critiqued + shaped with codex; the load-bearing decision is **link = register + establish transport, never a roster ghost**.

## What

- **Discovery** — `repowire/hooks/_tmux.py::list_all_panes()` (one `tmux list-panes -a -F` call, tab-delimited, hermetic). `repowire/daemon/orphan_panes.py` filters out panes bound to a registered peer and tags each with a display-only `detected_backend` + `confidence` (hint|unknown) from the command basename. **No command filtering** — every unregistered pane is listed, since the weird cases this diagnoses are exactly what a filter would hide.
- **`GET /panes/orphans`** — the unlinked list (registered pane_ids excluded). Empty when tmux is unavailable.
- **`POST /panes/{pane_id}/link`** — the controlled action: validates the pane id (`%NN`), refuses an already-linked pane (409), registers a peer, runs the ws-hook respawn, then **polls for a live WS connection**. Reports `linked:true` only when transport is confirmed; otherwise **hard-rolls-back** the registration (no ghost) and returns a `transport_unestablished` reason + retry hint. Same-host only; no fabricated runtime session id (resume stays unavailable until hooks report one).
- **CLI `repowire link`** — no args lists candidates + the copyable adopt command; `--pane %NN --backend X` performs the link. `--backend` required.
- **Dashboard** — the spawn dialog shows an "Unlinked panes" list with the copyable `repowire link …` command (no one-click button this slice).
- **Docs** — link-vs-spawn (peer-identity-lifecycle), the routes (http-api), the dashboard surface.

## Tests

`test_orphan_panes.py`: detection-is-a-hint, filter excludes registered + lists non-agents, `/panes/orphans` exclusion, link bad-pane-id (422), link success on WS-connect, **link rolls back when WS never connects (no ghost)**, already-linked (409). Web: 3 OrphanPanesList tests. 1700 backend + 83 web pass, ruff + ty clean, build green.

## Not in this PR (follow-ups)

A one-click dashboard adopt button (POST from the panel) once the CLI link path is proven; live-proof against a real orphaned pane under tmux.
