### PR TITLE
feat(skills): repowire skill pack + config-get seam + plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "repowire",
+  "owner": {
+    "name": "Prassanna Ravishankar",
+    "url": "https://github.com/prassanna-ravishankar/repowire"
+  },
+  "plugins": [
+    {
+      "name": "repowire",
+      "source": ".",
+      "description": "Repowire mesh usage skills: cross-agent review/plan, delegate, patterns, and install/update — backend-agnostic, parameterised on the agent you choose."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "repowire",
+  "description": "Repowire mesh usage skills for AI coding agents: cross-agent review and planning, delegate, usage patterns, and install/update. Backend-agnostic and parameterised on the agent you choose.",
+  "author": {
+    "name": "Prassanna Ravishankar"
+  },
+  "homepage": "https://github.com/prassanna-ravishankar/repowire",
+  "license": "MIT"
+}

--- a/docs/capabilities/skills.md
+++ b/docs/capabilities/skills.md
@@ -1,0 +1,66 @@
+# Skills
+
+## What it does
+
+Repowire ships its mesh usage patterns as **skills** — backend-agnostic
+`SKILL.md` recipes an agent can load to coordinate over the mesh. The skills are
+the single source under `skills/` in the repo and install through three
+compatible channels.
+
+The initial pack:
+
+- **`repowire-patterns`** — reference for ask/ack vs notify, broadcast, peer
+  discovery, and the cross-agent workflows. Teaching only; nothing depends on it.
+- **`cross-agent-review`** — have a *different* agent backend review your work.
+- **`cross-agent-plan`** — get an independent plan from a different backend.
+- **`delegate`** — hand a task to a peer (reuse an existing one, or spawn with
+  the user's go-ahead) and track it via the ask/ack lifecycle.
+- **`repowire-install`** — install/update repowire and the skill pack from inside
+  an agent session, then verify with `whoami` / `list-peers` / `doctor`.
+
+## Backend is parameterised, never hardcoded
+
+The cross-agent and delegate skills resolve which backend to use in this order:
+
+1. an explicit argument the user gives,
+2. the matching default from config (read via `repowire config get skills.<key>`),
+3. a safe fallback — pick an available *different* backend or ask; never default
+   to your own backend for a review/plan, and never hardcode one.
+
+Defaults live in `~/.repowire/config.yaml`:
+
+```yaml
+skills:
+  default_backend: codex              # generic fallback for any skill
+  default_reviewer_backend: codex     # cross-agent-review
+  default_planner_backend: gemini     # cross-agent-plan
+  default_delegate_backend: codex     # delegate
+  default_circle: default
+```
+
+`repowire config get skills.default_reviewer_backend` is a read-only seam skills
+use to fetch a default without parsing the yaml; it prints nothing (exit 0) when
+unset so callers fall back cleanly.
+
+## Install channels
+
+All three read the same `skills/` source:
+
+- **`npx skills add`** — installs the pack (scans `skills/`) for any agent:
+  ```bash
+  npx skills add prassanna-ravishankar/repowire
+  # or one skill:
+  npx skills add https://github.com/prassanna-ravishankar/repowire/tree/main/skills/cross-agent-review
+  ```
+- **Claude Code plugin marketplace** — `.claude-plugin/marketplace.json` + the
+  `repowire` plugin bundle the same skills:
+  ```text
+  /plugin marketplace add prassanna-ravishankar/repowire
+  /plugin install repowire@repowire
+  ```
+- **`repowire-install` skill** — bootstraps/updates the pack from inside an agent
+  session and verifies the mesh.
+
+Skills are markdown recipes that call the existing `mcp__repowire__*` tools (with
+CLI fallbacks). They don't change the daemon, hooks, or command semantics —
+`repowire setup` remains the supported install path.

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4181,8 +4181,24 @@ def config_get(key: str, as_json: bool) -> None:
 
     from repowire.config.models import load_config
 
-    node: object = load_config()
-    for part in key.split("."):
+    cfg = load_config()
+    # Skill backend keys resolve through SkillsConfig.resolve() so an operator who
+    # sets only skills.default_backend still gets it for every per-skill key.
+    skill_backend_keys = {
+        "default_reviewer_backend",
+        "default_planner_backend",
+        "default_delegate_backend",
+    }
+    parts = key.split(".")
+    if len(parts) == 2 and parts[0] == "skills" and parts[1] in skill_backend_keys:
+        resolved = cfg.skills.resolve(parts[1])
+        if resolved is None:
+            return
+        click.echo(json.dumps(resolved, default=str) if as_json else str(resolved))
+        return
+
+    node: object = cfg
+    for part in parts:
         if hasattr(node, part):
             node = getattr(node, part)
         else:

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4167,6 +4167,38 @@ def config_path() -> None:
     console.print(str(Config.get_config_path()))
 
 
+@config.command(name="get")
+@click.argument("key")
+@click.option("--json", "as_json", is_flag=True, help="Emit the value as JSON")
+def config_get(key: str, as_json: bool) -> None:
+    """Print a config value by dotted key, e.g. skills.default_reviewer_backend.
+
+    Read-only seam for skills/scripts to resolve defaults without parsing the
+    yaml themselves. Prints nothing (exit 0) when the value is unset so callers
+    can fall back; exits 2 on an unknown key path.
+    """
+    import sys
+
+    from repowire.config.models import load_config
+
+    node: object = load_config()
+    for part in key.split("."):
+        if hasattr(node, part):
+            node = getattr(node, part)
+        else:
+            console.print(f"unknown config key: {key}", highlight=False)
+            sys.exit(2)
+    if node is None:
+        return  # unset → empty output, exit 0 so callers fall back
+    if as_json:
+        try:
+            click.echo(json.dumps(node, default=str))
+        except TypeError:
+            click.echo(json.dumps(str(node)))
+    else:
+        click.echo(str(node))
+
+
 @main.group(hidden=True)
 def hook() -> None:
     """Internal hook handlers (called by Claude Code or Codex)."""

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -412,6 +412,39 @@ class ExperimentsConfig(BaseModel):
     )
 
 
+class SkillsConfig(BaseModel):
+    """Defaults for the repowire skill pack (cross-agent review/plan/delegate).
+
+    Skills are backend-agnostic markdown; these defaults let an operator pick
+    which agent a skill prefers without editing the skill. A skill resolves a
+    backend as: explicit arg > the matching default here > a safe fallback
+    (ask, or pick a different available backend — never hardcode one). The
+    per-skill defaults default to ``default_backend`` when unset.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    default_backend: str | None = Field(
+        None, description="Fallback backend for skills when no per-skill default is set",
+    )
+    default_reviewer_backend: str | None = Field(
+        None, description="Preferred backend for cross-agent-review",
+    )
+    default_planner_backend: str | None = Field(
+        None, description="Preferred backend for cross-agent-plan",
+    )
+    default_delegate_backend: str | None = Field(
+        None, description="Preferred backend for delegate",
+    )
+    default_circle: str | None = Field(
+        None, description="Default circle for skills that spawn or target peers",
+    )
+
+    def resolve(self, key: str) -> str | None:
+        """Resolve a per-skill backend key, falling back to default_backend."""
+        return getattr(self, key, None) or self.default_backend
+
+
 class Config(BaseModel):
     """Main Repowire configuration."""
 
@@ -425,6 +458,7 @@ class Config(BaseModel):
     slack: SlackConfig = Field(default_factory=SlackConfig)
     updates: UpdatesConfig = Field(default_factory=UpdatesConfig)
     experiments: ExperimentsConfig = Field(default_factory=ExperimentsConfig)
+    skills: SkillsConfig = Field(default_factory=SkillsConfig)
 
     @classmethod
     def get_config_dir(cls) -> Path:

--- a/skills/cross-agent-plan/SKILL.md
+++ b/skills/cross-agent-plan/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cross-agent-plan
+description: Get an independent implementation plan from a DIFFERENT AI agent over the repowire mesh before you build (e.g. have Gemini or Codex draft an approach for Claude to critique). Use when you want a second perspective on how to approach a task.
+---
+
+# Cross-agent plan
+
+Ask a peer running a **different** agent backend to draft (or critique) a plan,
+so the planning perspective is genuinely independent.
+
+## Resolve the planner backend
+
+1. **Explicit argument** — if the user named a backend, use it.
+2. **Configured default** — else:
+   ```bash
+   repowire config get skills.default_planner_backend
+   ```
+   (Empty output means unset.)
+3. **Safe fallback** — else pick an online peer on a backend *different from yours*,
+   or ask the user. Never default to your own backend; never hardcode one.
+
+Discover peers/backends: `list_peers()` (MCP) or `repowire list-peers` (CLI).
+
+## Run the planning round
+
+1. Find (or, with the user's go-ahead, spawn — see `delegate`) a peer on the
+   chosen backend.
+2. Send the task + constraints and ask for a concrete step-by-step plan.
+   - MCP: `ask(peer_name, "Draft an implementation plan for: <task + constraints>")`
+   - CLI: `repowire ask <peer> "..."`
+3. `ask` returns a `correlation_id`; the peer replies via `ack(corr_id, <plan>)`.
+4. Critique/merge the returned plan with your own; chain follow-ups with
+   `ask(reply_to=corr_id, ...)`.
+
+Keep the brief tight — state the goal, the constraints, and what a good plan must
+cover, so the cross-agent plan is comparable to your own.

--- a/skills/cross-agent-plan/SKILL.md
+++ b/skills/cross-agent-plan/SKILL.md
@@ -19,7 +19,7 @@ so the planning perspective is genuinely independent.
 3. **Safe fallback** — else pick an online peer on a backend *different from yours*,
    or ask the user. Never default to your own backend; never hardcode one.
 
-Discover peers/backends: `list_peers()` (MCP) or `repowire list-peers` (CLI).
+Discover peers/backends: `list_peers()` (MCP) or `repowire peer list` (CLI).
 
 ## Run the planning round
 
@@ -27,7 +27,8 @@ Discover peers/backends: `list_peers()` (MCP) or `repowire list-peers` (CLI).
    chosen backend.
 2. Send the task + constraints and ask for a concrete step-by-step plan.
    - MCP: `ask(peer_name, "Draft an implementation plan for: <task + constraints>")`
-   - CLI: `repowire ask <peer> "..."`
+   - Tracked ask is MCP-only (no CLI lifecycle equivalent — `repowire peer ask` is
+     a synchronous test utility, not this).
 3. `ask` returns a `correlation_id`; the peer replies via `ack(corr_id, <plan>)`.
 4. Critique/merge the returned plan with your own; chain follow-ups with
    `ask(reply_to=corr_id, ...)`.

--- a/skills/cross-agent-review/SKILL.md
+++ b/skills/cross-agent-review/SKILL.md
@@ -24,7 +24,7 @@ Pick the reviewer in this order:
 
 You can see who is available and on which backend:
 - MCP: `list_peers()`
-- CLI: `repowire list-peers` (or `repowire peer list`)
+- CLI: `repowire peer list`
 
 ## Run the review
 
@@ -32,7 +32,8 @@ You can see who is available and on which backend:
 2. Send it a review request with the concrete diff/PR/plan to review. Be specific
    about what to check.
    - MCP: `ask(peer_name, "Review this diff for correctness + bugs: <context>")`
-   - CLI: `repowire ask <peer> "..."`
+   - The tracked ask/ack lifecycle is MCP-only — there's no CLI equivalent for a
+     non-blocking ask (`repowire peer ask` is a synchronous test utility, not this).
 3. `ask` is non-blocking and returns a `correlation_id`. The reviewer closes the
    thread with `ack(corr_id, <their review>)` — that reply comes back to you.
 4. Apply the review; iterate with `ask(reply_to=corr_id, ...)` for follow-ups.

--- a/skills/cross-agent-review/SKILL.md
+++ b/skills/cross-agent-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: cross-agent-review
+description: Get a code/PR/plan review from a DIFFERENT AI agent over the repowire mesh (e.g. have Codex review Claude's work). Use when you want an independent second opinion from another backend before merging or committing.
+---
+
+# Cross-agent review
+
+Ask a peer running a **different** agent backend to review your work, so the
+review is genuinely independent (not the same model checking itself).
+
+## Resolve the reviewer backend
+
+Pick the reviewer in this order:
+
+1. **Explicit argument** — if the user named a backend (e.g. "review with codex"), use it.
+2. **Configured default** — else read it:
+   ```bash
+   repowire config get skills.default_reviewer_backend
+   ```
+   (Prints the value, or nothing if unset. `--json` for the raw value.)
+3. **Safe fallback** — if still unset, pick any *online peer whose backend differs
+   from yours*, or ask the user which backend to use. **Never** default to your own
+   backend — that defeats the purpose. Never hardcode a specific backend.
+
+You can see who is available and on which backend:
+- MCP: `list_peers()`
+- CLI: `repowire list-peers` (or `repowire peer list`)
+
+## Run the review
+
+1. Find (or spawn) a peer on the chosen backend.
+2. Send it a review request with the concrete diff/PR/plan to review. Be specific
+   about what to check.
+   - MCP: `ask(peer_name, "Review this diff for correctness + bugs: <context>")`
+   - CLI: `repowire ask <peer> "..."`
+3. `ask` is non-blocking and returns a `correlation_id`. The reviewer closes the
+   thread with `ack(corr_id, <their review>)` — that reply comes back to you.
+4. Apply the review; iterate with `ask(reply_to=corr_id, ...)` for follow-ups.
+
+If no different-backend peer is available and the user wants one, spawn it
+(see the `delegate` skill) — but only with the user's go-ahead.

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: delegate
+description: Hand a task to another AI agent peer over the repowire mesh — reuse an existing peer on the chosen backend, or spawn one if none exists. Use when you want to offload work to a specific agent (e.g. delegate a refactor to a Codex peer) and track it to completion.
+---
+
+# Delegate a task to a peer
+
+Hand a self-contained task to a peer on a chosen backend and track it via the
+ask/ack lifecycle.
+
+## Resolve the delegate backend
+
+1. **Explicit argument** — if the user named a backend, use it.
+2. **Configured default** — else:
+   ```bash
+   repowire config get skills.default_delegate_backend
+   ```
+3. **Safe fallback** — else ask the user which backend to delegate to. Don't
+   hardcode one. (Unlike review/plan, delegation MAY target your own backend —
+   delegating to another claude-code peer is legitimate.)
+
+## Choose / create the executor
+
+1. **Prefer an existing peer** on the chosen backend (idle if possible):
+   - MCP: `list_peers()` → pick an online peer with the right backend.
+   - CLI: `repowire list-peers`.
+2. **Spawn only if none exists AND the user is clearly delegating** (don't spawn
+   silently). Confirm before spawning:
+   - MCP: `spawn_peer(path, backend=<chosen>, circle=<skills.default_circle or current>)`
+   - CLI: `repowire peer spawn ...`
+   Default circle: `repowire config get skills.default_circle` (else your current circle).
+
+## Hand off + track
+
+1. Send a complete, self-contained brief (the peer doesn't share your context):
+   - MCP: `ask(peer_name, "<full task brief + acceptance criteria>")`
+   - CLI: `repowire ask <peer> "..."`
+2. `ask` returns a `correlation_id`; the peer reports back via `ack(corr_id, ...)`.
+3. Track to completion; chain follow-ups with `ask(reply_to=corr_id, ...)`.
+
+Use `notify_peer` (fire-and-forget) only for nudges, not for tracked delegation —
+delegation needs the ack lifecycle.

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -23,18 +23,19 @@ ask/ack lifecycle.
 
 1. **Prefer an existing peer** on the chosen backend (idle if possible):
    - MCP: `list_peers()` → pick an online peer with the right backend.
-   - CLI: `repowire list-peers`.
+   - CLI: `repowire peer list`.
 2. **Spawn only if none exists AND the user is clearly delegating** (don't spawn
    silently). Confirm before spawning:
    - MCP: `spawn_peer(path, backend=<chosen>, circle=<skills.default_circle or current>)`
-   - CLI: `repowire peer spawn ...`
+   - CLI: `repowire peer new ...`
    Default circle: `repowire config get skills.default_circle` (else your current circle).
 
 ## Hand off + track
 
 1. Send a complete, self-contained brief (the peer doesn't share your context):
    - MCP: `ask(peer_name, "<full task brief + acceptance criteria>")`
-   - CLI: `repowire ask <peer> "..."`
+   - Tracked delegation is MCP-only (`repowire peer ask` is a synchronous test
+     utility, not the ask/ack lifecycle). To close from the CLI: `repowire peer ack <cid>`.
 2. `ask` returns a `correlation_id`; the peer reports back via `ack(corr_id, ...)`.
 3. Track to completion; chain follow-ups with `ask(reply_to=corr_id, ...)`.
 

--- a/skills/repowire-install/SKILL.md
+++ b/skills/repowire-install/SKILL.md
@@ -55,9 +55,9 @@ Read one back with `repowire config get skills.default_reviewer_backend`.
 ## 4. Verify
 
 ```bash
-repowire whoami       # you're on the mesh
-repowire list-peers   # see other agents
-repowire doctor       # health + drift checks
+repowire peer whoami   # you're on the mesh
+repowire peer list     # see other agents
+repowire doctor        # health + drift checks
 ```
-If `whoami`/`list-peers` fail, run `repowire setup` and re-check — don't create
-an alternate local mesh.
+If `peer whoami` / `peer list` fail, run `repowire setup` and re-check — don't
+create an alternate local mesh.

--- a/skills/repowire-install/SKILL.md
+++ b/skills/repowire-install/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: repowire-install
+description: Install or update repowire and its skill pack from inside an agent session — ensure the repowire CLI/hooks are set up, install the skills, and verify the mesh works. Use on a fresh machine or to refresh skills to the latest.
+---
+
+# Install / update repowire + skills
+
+Bring an agent session up to full repowire capability. This is an
+install/update helper run from *inside* an agent — it assumes you can run shell
+commands. (It is not a magical pre-install bootstrap; the repowire package
+provides the CLI/hooks.)
+
+## 1. Ensure repowire is installed
+
+```bash
+repowire --version    # already installed?
+```
+If missing, install the CLI and set up hooks/MCP:
+```bash
+uv tool install repowire        # or: pipx install repowire
+repowire setup                  # daemon, hooks, MCP, service (the supported path)
+```
+`repowire setup` is the source of truth for daemon/hook/MCP/service install —
+this skill never replaces it.
+
+## 2. Install / update the skill pack
+
+The skills live in the repowire repo under `skills/`. Install the set into your
+agent's skills directory with the skills CLI (works for any agent, not just
+Claude):
+```bash
+npx skills add prassanna-ravishankar/repowire        # scans skills/, installs the pack
+# or a single skill:
+npx skills add https://github.com/prassanna-ravishankar/repowire/tree/main/skills/cross-agent-review
+```
+Claude Code users can instead add the plugin marketplace:
+```text
+/plugin marketplace add prassanna-ravishankar/repowire
+/plugin install repowire@repowire
+```
+
+## 3. Set skill defaults (optional)
+
+Skills resolve a backend as: explicit arg > config default > safe fallback. Set
+defaults in `~/.repowire/config.yaml`:
+```yaml
+skills:
+  default_reviewer_backend: codex
+  default_planner_backend: gemini
+  default_delegate_backend: codex
+  default_circle: default
+```
+Read one back with `repowire config get skills.default_reviewer_backend`.
+
+## 4. Verify
+
+```bash
+repowire whoami       # you're on the mesh
+repowire list-peers   # see other agents
+repowire doctor       # health + drift checks
+```
+If `whoami`/`list-peers` fail, run `repowire setup` and re-check — don't create
+an alternate local mesh.

--- a/skills/repowire-patterns/SKILL.md
+++ b/skills/repowire-patterns/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: repowire-patterns
+description: Reference for how to use the repowire mesh — ask/ack vs notify, broadcast, peer discovery, spawning, and cross-agent workflows. Use when you need to coordinate with other AI agents over repowire and want the right primitive for the job.
+---
+
+# Repowire usage patterns
+
+Repowire is a mesh where AI coding agents (Claude Code, Codex, Gemini, OpenCode,
+Pi, …) each get an address and talk to each other. This is a teaching reference;
+the action skills (`cross-agent-review`, `cross-agent-plan`, `delegate`) apply
+these patterns. It does not depend on those skills being installed.
+
+## Pick the right primitive
+
+| Want | Use | Lifecycle |
+|------|-----|-----------|
+| Tracked request that needs a reply | `ask(peer, text)` → peer `ack(corr_id, reply)` | Non-blocking; returns `correlation_id`; reopen with `ask(reply_to=...)` |
+| Fire-and-forget nudge / status | `notify_peer(peer, text)` | No reply expected |
+| Message everyone in your circle | `broadcast(text)` | No per-peer lifecycle |
+| Close an inbound ask | `ack(corr_id)` bare, or `ack(corr_id, reply)` | The only close/reply op for an ask |
+| See who's around | `list_peers()` | Returns names, backends, status |
+| Who am I | `whoami()` | Your peer identity/circle |
+
+Each MCP tool has a CLI equivalent (`repowire ask|ack|notify|broadcast|list-peers|whoami`)
+for agents that don't surface `mcp__repowire__*`.
+
+## Rules that bite
+
+- **`ask` is non-blocking** — it returns a `correlation_id`, not a reply. The reply
+  arrives later as an `ack`. Don't wait synchronously.
+- **`ack` is the only way to close an inbound ask.** Bare `ack(corr_id)` = "seen,
+  no action"; `ack(corr_id, msg)` = reply. Unacked asks resurface as reminders.
+- **Identity is `peer_id`; addressing is `display_name`.** Names can collide; pass
+  `circle` to disambiguate.
+- **Cross-agent means a different backend.** For an independent review/plan, target
+  a peer whose backend differs from yours (see `cross-agent-review`/`cross-agent-plan`).
+- **Spawn deliberately.** `spawn_peer` starts a new agent; confirm with the user
+  rather than spawning silently.
+
+## Cross-agent workflows
+
+- Independent review: `cross-agent-review` (have a different backend review your work).
+- Independent planning: `cross-agent-plan`.
+- Offload work: `delegate` (reuse or spawn a peer, hand off, track via ack).
+
+Backends for these are parameterised via `repowire config get skills.*` defaults,
+overridable per call — never hardcode a backend.

--- a/skills/repowire-patterns/SKILL.md
+++ b/skills/repowire-patterns/SKILL.md
@@ -21,8 +21,12 @@ these patterns. It does not depend on those skills being installed.
 | See who's around | `list_peers()` | Returns names, backends, status |
 | Who am I | `whoami()` | Your peer identity/circle |
 
-Each MCP tool has a CLI equivalent (`repowire ask|ack|notify|broadcast|list-peers|whoami`)
-for agents that don't surface `mcp__repowire__*`.
+The tracked **ask/ack/notify/broadcast lifecycle is MCP-only** — use the
+`mcp__repowire__*` tools. There is no honest CLI equivalent for non-blocking ask
+(the `repowire peer ask` command is a synchronous testing utility, not the
+ask/ack lifecycle). For agents without MCP, the CLI offers these real fallbacks:
+`repowire peer list`, `repowire peer whoami`, `repowire peer ack <cid>`,
+`repowire peer asks` (list pending), `repowire peer new` (spawn).
 
 ## Rules that bite
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from repowire.config.models import (
     PeerConfig,
     RelayConfig,
     RemoteToolApprovalConfig,
+    SkillsConfig,
     SpawnProfile,
     SpawnSettings,
     UpdatesConfig,
@@ -391,3 +392,50 @@ class TestRemoteToolApprovalConfig:
 
     def test_positive_timeout_is_kept(self):
         assert RemoteToolApprovalConfig(timeout_seconds=10.0).timeout_seconds == 10.0
+
+
+class TestSkillsConfig:
+    def test_defaults_are_all_none(self):
+        cfg = SkillsConfig()
+        assert cfg.default_backend is None
+        assert cfg.default_reviewer_backend is None
+        assert cfg.resolve("default_reviewer_backend") is None
+
+    def test_resolve_prefers_per_skill_over_generic(self):
+        cfg = SkillsConfig(default_backend="claude-code", default_reviewer_backend="codex")
+        assert cfg.resolve("default_reviewer_backend") == "codex"
+
+    def test_resolve_falls_back_to_default_backend(self):
+        cfg = SkillsConfig(default_backend="gemini")
+        assert cfg.resolve("default_planner_backend") == "gemini"
+
+    def test_config_exposes_skills_section(self):
+        assert isinstance(Config().skills, SkillsConfig)
+
+
+class TestConfigGetCommand:
+    def _invoke(self, monkeypatch, key, cfg, extra=None):
+        from repowire.cli import main
+
+        monkeypatch.setattr("repowire.config.models.load_config", lambda: cfg)
+        return CliRunner().invoke(main, ["config", "get", key, *(extra or [])])
+
+    def test_prints_a_set_value(self, monkeypatch):
+        cfg = Config(skills=SkillsConfig(default_reviewer_backend="codex"))
+        result = self._invoke(monkeypatch, "skills.default_reviewer_backend", cfg)
+        assert result.exit_code == 0
+        assert result.output.strip() == "codex"
+
+    def test_unset_value_prints_nothing_exit_zero(self, monkeypatch):
+        result = self._invoke(monkeypatch, "skills.default_reviewer_backend", Config())
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_unknown_key_exits_2(self, monkeypatch):
+        result = self._invoke(monkeypatch, "skills.nope", Config())
+        assert result.exit_code == 2
+
+    def test_nested_non_skills_key(self, monkeypatch):
+        result = self._invoke(monkeypatch, "daemon.port", Config())
+        assert result.exit_code == 0
+        assert result.output.strip() != ""  # daemon.port has a default

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -439,3 +439,16 @@ class TestConfigGetCommand:
         result = self._invoke(monkeypatch, "daemon.port", Config())
         assert result.exit_code == 0
         assert result.output.strip() != ""  # daemon.port has a default
+
+    def test_skill_key_resolves_generic_default_backend(self, monkeypatch):
+        # Per-skill key unset but default_backend set → the seam resolves it
+        # (regression: raw attr traversal returned empty here).
+        cfg = Config(skills=SkillsConfig(default_backend="codex"))
+        result = self._invoke(monkeypatch, "skills.default_reviewer_backend", cfg)
+        assert result.exit_code == 0
+        assert result.output.strip() == "codex"
+
+    def test_skill_key_per_skill_wins_over_generic(self, monkeypatch):
+        cfg = Config(skills=SkillsConfig(default_backend="codex", default_planner_backend="gemini"))
+        result = self._invoke(monkeypatch, "skills.default_planner_backend", cfg)
+        assert result.output.strip() == "gemini"


### PR DESCRIPTION
`s62` (skills marketplace) — Prass-scoped: ship repowire usage patterns as backend-agnostic skills, one source, three channels. No arch change.

## What

**Skill pack** (`skills/<name>/SKILL.md`, repo root — the single publishable source):
- `repowire-patterns` (teaching reference, no deps), `cross-agent-review`, `cross-agent-plan`, `delegate`, `repowire-install`.
- Backend is **parameterised**, never hardcoded: each skill resolves `arg > repowire config get skills.<key> > safe fallback (different/available backend or ask)`. cross-agent-review/plan require a *different* backend; delegate may reuse-or-spawn (with confirm). Each action skill is self-contained (own backend-resolution paragraph + CLI fallback) — can't assume `patterns` is installed (plugin copy-isolation + npx independent install).

**Config seam** (read-only): `SkillsConfig` (`default_backend` + per-skill `default_reviewer/planner/delegate_backend` + `default_circle`); `repowire config get <dotted.key> [--json]` prints the value, nothing-on-unset (exit 0), exit 2 on unknown key. No `config set`.

**Channels** (all read `skills/`): `npx skills add` (scans `skills/`, subfolder install supported), Claude plugin marketplace (`.claude-plugin/marketplace.json` + `plugin.json`), and the `repowire-install` skill.

## Research grounding

npx skills (vercel-labs/skills): scans `skills/`, SKILL.md name+description frontmatter, subfolder install. Claude marketplace docs: `.claude-plugin/marketplace.json {name, owner, plugins:[{name, source}]}` + per-plugin `plugin.json`; plugins are copy-isolated (no `../` refs). claudecodeui: commands are backend-agnostic markdown, routing is backend-aware — so we ship agnostic skills, reuse repowire's existing per-backend routing.

## Tests

SkillsConfig (defaults/resolve/per-skill-over-generic) + `config get` CLI (set value, unset→empty exit 0, unknown→exit 2, nested non-skills key). 1714 backend pass, ruff+ty clean.
