### PR TITLE
[codex] Hide Telegram from Telegram peer list

### DIFF
--- a/docs/capabilities/telegram.md
+++ b/docs/capabilities/telegram.md
@@ -22,7 +22,7 @@ telegram:
 
 | Command | What it does |
 | --- | --- |
-| `/peers` (or `/start`, `/list`) | Show online peers as inline buttons; tap to pick a target |
+| `/peers` (or `/start`, `/list`) | Show other online peers as inline buttons; tap to pick a target |
 | `/select <peer>` | Sticky-route subsequent messages to that peer until `/clear` |
 | `/switch <peer>` | Alias for `/select` |
 | `/clear` | Clear the sticky target |

--- a/docs/guides/use-telegram.md
+++ b/docs/guides/use-telegram.md
@@ -23,7 +23,7 @@ Create a Telegram bot token and know the chat id Repowire should accept.
 
 ## Verify
 
-Send `/peers` from Telegram and confirm the expected peers appear. If messages do not arrive, check [Telegram](../capabilities/telegram.md) and [Diagnostic commands](../troubleshooting/diagnostics.md).
+Send `/peers` from Telegram and confirm the expected non-Telegram peers appear. If messages do not arrive, check [Telegram](../capabilities/telegram.md) and [Diagnostic commands](../troubleshooting/diagnostics.md).
 
 ## Related
 

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -775,7 +775,7 @@ class TelegramPeer:
             str(peer.get("display_name") or ""),
             str(peer.get("name") or ""),
         }
-        self_identifiers = {self._display_name, self._peer_id, "telegram"}
+        self_identifiers = {self._display_name, self._peer_id}
         if identifiers & {i for i in self_identifiers if i}:
             return True
         return peer.get("role") == "service" and peer.get("path") == "/telegram"

--- a/repowire/telegram/bot.py
+++ b/repowire/telegram/bot.py
@@ -259,6 +259,7 @@ class TelegramPeer:
         self._chat_id = chat_id
         self._daemon_url = daemon_url.rstrip("/")
         self._display_name = display_name
+        self._peer_id: str | None = None
         self._circle = circle
         self._bot_path = f"/bot{bot_token}"
         self._http = httpx.AsyncClient(base_url="https://api.telegram.org", timeout=10.0)
@@ -324,6 +325,9 @@ class TelegramPeer:
                     assigned_name = resp.get("display_name")
                     if isinstance(assigned_name, str) and assigned_name:
                         self._display_name = assigned_name
+                    assigned_peer_id = resp.get("peer_id") or resp.get("session_id")
+                    if isinstance(assigned_peer_id, str) and assigned_peer_id:
+                        self._peer_id = assigned_peer_id
                     logger.info("Connected: %s", resp.get("session_id"))
                     # Best-effort: route user messages to the orchestrator by
                     # default if one is registered. User can still /select.
@@ -757,12 +761,24 @@ class TelegramPeer:
         try:
             r = await self._http.get(f"{self._daemon_url}/peers")
             peers = r.json().get("peers", [])
+            peers = [p for p in peers if not self._is_self_peer(p)]
             self._peers_cache = peers
             self._peers_cache_at = now
             return peers
         except Exception:
             logger.warning("Failed to fetch peers", exc_info=True)
             return []
+
+    def _is_self_peer(self, peer: dict[str, Any]) -> bool:
+        identifiers = {
+            str(peer.get("peer_id") or ""),
+            str(peer.get("display_name") or ""),
+            str(peer.get("name") or ""),
+        }
+        self_identifiers = {self._display_name, self._peer_id, "telegram"}
+        if identifiers & {i for i in self_identifiers if i}:
+            return True
+        return peer.get("role") == "service" and peer.get("path") == "/telegram"
 
     async def _fetch_orchestrator_status(
         self, *, use_cache: bool = True,

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -254,6 +254,37 @@ async def test_send_peer_message_includes_attachments(
 
 
 @pytest.mark.asyncio
+async def test_fetch_online_peers_hides_telegram_self(
+    telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    telegram_bot._display_name = "telegram-claude-code"
+    telegram_bot._peer_id = "svc-telegram"
+    get = AsyncMock(return_value=SimpleNamespace(json=lambda: {
+        "peers": [
+            {
+                "peer_id": "svc-telegram",
+                "display_name": "telegram-claude-code",
+                "status": "online",
+                "role": "service",
+                "path": "/telegram",
+            },
+            {
+                "peer_id": "agent-1",
+                "display_name": "agent",
+                "status": "online",
+                "role": "agent",
+                "path": "/projects/agent",
+            },
+        ],
+    }))
+    monkeypatch.setattr(telegram_bot._http, "get", get)
+
+    peers = await telegram_bot._fetch_online_peers(use_cache=False)
+
+    assert [p["display_name"] for p in peers] == ["agent"]
+
+
+@pytest.mark.asyncio
 async def test_peer_picker_targets_peer_id_for_duplicate_names(
     telegram_bot: TelegramPeer, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Hide the Telegram service peer from peer lists rendered inside Telegram.

The Telegram bot was fetching `/peers` and reusing that raw response for `/peers`, retry target buttons, and the persistent reply keyboard. Because Telegram itself is registered as a service peer, it could appear as a selectable target in its own UI.

This change stores the daemon-assigned Telegram peer id on WebSocket connect and filters self rows out of the Telegram peer cache by peer id, display name/name, and the service `/telegram` fallback. It also updates Telegram docs to describe the list as showing other peers.

## Validation

- `uv run pytest tests/test_telegram_bot.py -q`
- `uv run ruff check repowire/telegram/bot.py tests/test_telegram_bot.py`
- `uv run ty check repowire/telegram/bot.py`
- `python3 scripts/pre_pr_hygiene.py`

## Notes

`bd dolt push` was attempted during publish, but this checkout's Beads database has no Dolt remote configured. Git push succeeded.