### PR TITLE
fix: harden durable worker spawns

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,6 +101,13 @@ Spawn is disabled until `allowed_paths` and at least one runtime command are con
 
 `profiles` is optional and keyed first by backend, then by a user-defined profile name. Each profile appends structured `args` to the configured backend command; Repowire does not hardcode provider model names. For example, spawning `codex` with profile `fast` runs the configured `daemon.spawn.commands.codex` command plus the profile args. Profile descriptions are informational and may be shown by UIs.
 
+`env_path` and `env` define the environment injected into spawned agent commands.
+`env_path` becomes the spawned process `PATH`; `env` adds extra variables such as
+tool config paths. If neither `env.PATH` nor `env_path` is set, Repowire captures
+the user's login-shell PATH and injects it so launchd/tmux-spawned workers can
+still see tools installed by Homebrew, nvm, and similar shell setup. This env is
+used by MCP/dashboard spawn, backend switching, restart, and durable job workers.
+
 Explicit command overrides still win over profiles. `repowire peer restart` preserves the peer's backend, path, circle, role, and mesh identity, but this slice does not persist the selected profile in peer state. Restart therefore uses the current configured backend command unless a future lane records spawn profile metadata.
 
 `allowed_commands` is a deprecated compatibility field. When present in an older config, Repowire normalizes it into `commands` while loading config; new configs should not add it.

--- a/docs/use/features/spawning.md
+++ b/docs/use/features/spawning.md
@@ -22,9 +22,21 @@ daemon:
     commands:
       claude-code: claude
       codex: codex
+    env_path:
+      - ~/.local/bin
+      - ~/.nvm/versions/node/v23.9.0/bin
+      - /opt/homebrew/bin
+      - /usr/bin
+      - /bin
 ```
 
 Profiles can append structured args to configured backend commands. Repowire does not hardcode provider model names.
+
+`env_path` is optional. When set, Repowire injects it as the spawned agent's `PATH`
+before launching the backend command. This is useful for durable job workers
+started by the daemon, because they should not depend on whichever PATH the tmux
+server happened to inherit. When `env_path` is omitted, Repowire captures the
+user's login-shell PATH and injects that as a fallback.
 
 ## Common workflows
 

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -171,6 +171,25 @@ class SpawnSettings(BaseModel):
         default_factory=dict,
         description="Optional named spawn profiles per backend",
     )
+    env_path: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit PATH entries for spawned agent processes. When empty, "
+            "Repowire captures the user's login-shell PATH as a fallback."
+        ),
+    )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra environment variables injected into spawned agent commands",
+    )
+
+    @field_validator("env")
+    @classmethod
+    def validate_env_keys(cls, value: dict[str, str]) -> dict[str, str]:
+        for key in value:
+            if not key.isidentifier():
+                raise ValueError("daemon.spawn.env keys must be shell-safe identifiers")
+        return value
 
     @model_validator(mode="after")
     def _bootstrap_legacy_allowed_commands(self) -> SpawnSettings:

--- a/repowire/daemon/job_runner.py
+++ b/repowire/daemon/job_runner.py
@@ -19,7 +19,7 @@ from repowire.daemon.session_control import (
     ExecutorAcquisitionUnavailableError,
     SessionControlService,
 )
-from repowire.daemon.spawn_service import SpawnService
+from repowire.daemon.spawn_service import SpawnAttemptError, SpawnService
 from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 from repowire.daemon.work_store import TrackedWork, now_iso
 from repowire.protocol.peers import Peer, PeerStatus
@@ -375,47 +375,69 @@ class JobRunner:
             "Please register with the mesh; the job request will arrive as an ask."
         )
         resume_plan = self._resume_plan_for(work, path=str(path), backend=backend)
+        def mark_spawned(spawn_result) -> None:
+            self._store.update_attempt(
+                work.work_id,
+                attempt_id=attempt_id,
+                phase="resume_spawned" if resume_plan is not None else "spawned",
+                tmux={"tmux_session": spawn_result.tmux_session, "pane_id": spawn_result.pane_id},
+                resume_plan=self._resume_plan_info(resume_plan),
+            )
+
         try:
-            spawn_result = self._spawn.spawn(
+            registration = await self._spawn.spawn_registered(
                 path=str(path),
                 backend=backend,
                 profile=target.get("profile"),
                 circle=work.circle or "default",
                 message=warmup,
                 resume_plan=resume_plan,
+                on_spawned=mark_spawned,
+                await_peer=lambda spawn_result: self._await_spawned_peer(
+                    spawn_result.display_name,
+                    work.circle or "default",
+                    path=str(path),
+                    backend=backend,
+                    pane_id=spawn_result.pane_id,
+                ),
             )
-        except HTTPException as e:
+        except SpawnAttemptError as e:
+            original = e.original
+            if isinstance(original, HTTPException):
+                error = {
+                    "reason": "spawn_failed",
+                    "status_code": original.status_code,
+                    "detail": original.detail,
+                    "attempt": e.attempt,
+                    "registration_attempts": e.registration_attempts,
+                }
+            else:
+                error = {
+                    "reason": "spawn_failed",
+                    "message": str(original),
+                    "type": type(original).__name__,
+                    "attempt": e.attempt,
+                    "registration_attempts": e.registration_attempts,
+                }
             return self._store.update_attempt(
                 work.work_id,
                 attempt_id=attempt_id,
                 status="failed",
                 phase="spawn",
-                error={"reason": "spawn_failed", "status_code": e.status_code, "detail": e.detail},
+                error=error,
             )
-        except Exception as e:
-            return self._store.update_attempt(
-                work.work_id,
-                attempt_id=attempt_id,
-                status="failed",
-                phase="spawn",
-                error={"reason": "spawn_failed", "message": str(e), "type": type(e).__name__},
-            )
-        self._store.update_attempt(
-            work.work_id,
-            attempt_id=attempt_id,
-            phase="resume_spawned" if resume_plan is not None else "spawned",
-            tmux={"tmux_session": spawn_result.tmux_session, "pane_id": spawn_result.pane_id},
-            resume_plan=self._resume_plan_info(resume_plan),
-        )
-        resolved = await self._await_spawned_peer(
-            spawn_result.display_name,
-            work.circle or "default",
-            path=str(path),
-            backend=backend,
-            pane_id=spawn_result.pane_id,
-        )
+
+        resolved = registration.resolved_peer
         if resolved is None:
-            return self._mark_unavailable(work, attempt_id, "spawned_peer_not_registered")
+            return self._mark_unavailable(
+                work,
+                attempt_id,
+                "spawned_peer_not_registered",
+                error={
+                    "reason": "spawned_peer_not_registered",
+                    "registration_attempts": registration.registration_attempts,
+                },
+            )
         self._store.update_attempt(
             work.work_id,
             attempt_id=attempt_id,
@@ -674,6 +696,7 @@ class JobRunner:
         reason: str,
         *,
         assigned_peer_id: str | None = None,
+        error: dict[str, Any] | None = None,
     ) -> None:
         self._store.update_attempt(
             work.work_id,
@@ -681,7 +704,7 @@ class JobRunner:
             status="unavailable",
             phase="resolve_peer",
             assigned_peer_id=assigned_peer_id,
-            error={"reason": reason},
+            error=error or {"reason": reason},
         )
         return None
 

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -27,7 +27,7 @@ from repowire.hooks.utils import clear_pane_runtime_state, read_pane_runtime_met
 from repowire.hooks.ws_hook_supervisor import maybe_respawn
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus
-from repowire.spawn import SpawnConfig, SpawnResult, kill_pane, spawn_peer
+from repowire.spawn import SpawnResult, kill_pane, spawn_peer
 from repowire.spawn_ownership import (
     OwnershipValidation,
     _norm_path,
@@ -1245,31 +1245,32 @@ async def switch_peer_backend(
             },
         )
 
-    command = _command_for_backend(request.new_backend)
-    if command is None:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "command_unavailable",
-                "hint": (
-                    f"No entry in daemon.spawn.commands maps to "
-                    f"{request.new_backend.value!r}. Add "
-                    f"daemon.spawn.commands.{request.new_backend.value} to "
-                    "~/.repowire/config.yaml."
-                ),
-                "new_backend": request.new_backend.value,
-            },
-        )
-
-    # Validate the resolved command + peer's existing path against config so
-    # operators can't bypass /spawn's guardrails via a backend switch.
-    _validate_spawn_path(peer.path)
-
     # Acquire the ask-tracker quiesce barrier atomically: this both verifies no
     # open asks exist for the peer AND blocks new /ask registrations targeting
     # the peer until end_quiesce() runs. Without the barrier a fresh /ask could
     # race between the pending check and the kill and be orphaned by the switch.
     state = get_app_state()
+    service = getattr(state, "spawn_service", None) or SpawnService(
+        spawn=get_config().daemon.spawn,
+        spawned_pane_ids=_SPAWNED_PANE_IDS,
+        background_tasks=_BACKGROUND_TASKS,
+        spawn_impl=spawn_peer,
+        warmup_impl=post_spawn_warmup,
+    )
+    # Validate the resolved command + peer's existing path against config before
+    # any destructive action so a misconfigured switch cannot kill a live peer.
+    service.validate_path(peer.path)
+    try:
+        command = service.resolve_command(request.new_backend)
+    except HTTPException as e:
+        if isinstance(e.detail, dict) and e.detail.get("error") == "command_unavailable":
+            detail = dict(e.detail)
+            detail["new_backend"] = request.new_backend.value
+            raise HTTPException(status_code=e.status_code, detail=detail) from e
+        raise
+    env = service.spawn_env()
+    service.validate_command_env(command, env)
+
     ask_tracker = state.ask_tracker
     try:
         await ask_tracker.begin_quiesce(peer.peer_id)
@@ -1325,42 +1326,20 @@ async def switch_peer_backend(
             _SPAWNED_PANE_IDS.discard(peer.pane_id)
         await peer_registry.unregister_peer(peer.peer_id)
 
-        # Respawn with the new backend.
-        try:
-            result: SpawnResult = spawn_peer(
-                SpawnConfig(
-                    path=resolved_path,
-                    circle=spawn_circle,
-                    backend=request.new_backend,
-                    command=command,
-                )
-            )
-        except (ValueError, RuntimeError) as e:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=str(e),
-            ) from e
-
-        if result.pane_id:
-            _SPAWNED_PANE_IDS.add(result.pane_id)
-            task = asyncio.create_task(
-                post_spawn_warmup(
-                    request.new_backend,
-                    result.pane_id,
-                    path=resolved_path,
-                    circle=spawn_circle,
-                    message=result.message,
-                )
-            )
-            _BACKGROUND_TASKS.add(task)
-            task.add_done_callback(_BACKGROUND_TASKS.discard)
+        # Respawn with the new backend through SpawnService so switch uses the
+        # same validation, ownership, warmup, and env/PATH launch layer as /spawn.
+        result = service.spawn(
+            path=resolved_path,
+            circle=spawn_circle,
+            backend=request.new_backend,
+        )
 
         return SwitchBackendResponse(
             display_name=result.display_name,
             tmux_session=result.tmux_session,
             old_backend=current_backend,
             new_backend=request.new_backend,
-            command=command,
+            command=result.command or "",
         )
     finally:
         await ask_tracker.end_quiesce(peer.peer_id)

--- a/repowire/daemon/session_control.py
+++ b/repowire/daemon/session_control.py
@@ -14,7 +14,7 @@ from repowire.agent_backends import AgentResumePlan
 from repowire.config.models import AgentType
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.resume_safety import resolve_resume_safety
-from repowire.daemon.spawn_service import SpawnService
+from repowire.daemon.spawn_service import SpawnAttemptError, SpawnService
 from repowire.daemon.state.operations import SQLiteOperationStore
 from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
 from repowire.daemon.work_store import TrackedWork, now_iso
@@ -180,38 +180,39 @@ class SessionControlService:
             "Please register with the mesh; the job request will arrive as an ask."
         )
         try:
-            spawn_result = self._spawn.spawn(
+            registration = await self._spawn.spawn_registered(
                 path=str(path),
                 backend=backend,
                 profile=target.get("profile"),
                 circle=circle,
                 message=warmup,
                 resume_plan=resume_plan,
+                await_peer=lambda spawn_result: self._await_spawned_peer(
+                    spawn_result.display_name,
+                    circle,
+                    path=str(path),
+                    backend=backend,
+                    pane_id=spawn_result.pane_id,
+                ),
             )
-        except HTTPException as e:
-            error = {
-                "reason": "spawn_failed",
-                "status_code": e.status_code,
-                "detail": e.detail,
-            }
-            self._operations.fail(
-                operation.operation_id,
-                strategy=strategy,
-                error=error,
-            )
-            raise ExecutorAcquisitionUnavailableError(
-                "spawn_failed",
-                operation_id=operation.operation_id,
-                status="failed",
-                phase="spawn",
-                error=error,
-            ) from e
-        except Exception as e:
-            error = {
-                "reason": "spawn_failed",
-                "message": str(e),
-                "type": type(e).__name__,
-            }
+        except SpawnAttemptError as e:
+            original = e.original
+            if isinstance(original, HTTPException):
+                error = {
+                    "reason": "spawn_failed",
+                    "status_code": original.status_code,
+                    "detail": original.detail,
+                    "attempt": e.attempt,
+                    "registration_attempts": e.registration_attempts,
+                }
+            else:
+                error = {
+                    "reason": "spawn_failed",
+                    "message": str(original),
+                    "type": type(original).__name__,
+                    "attempt": e.attempt,
+                    "registration_attempts": e.registration_attempts,
+                }
             self._operations.fail(
                 operation.operation_id,
                 strategy=strategy,
@@ -225,15 +226,12 @@ class SessionControlService:
                 error=error,
             ) from e
 
-        resolved = await self._await_spawned_peer(
-            spawn_result.display_name,
-            circle,
-            path=str(path),
-            backend=backend,
-            pane_id=spawn_result.pane_id,
-        )
+        resolved = registration.resolved_peer
         if resolved is None:
-            error = {"reason": "spawned_peer_not_registered"}
+            error = {
+                "reason": "spawned_peer_not_registered",
+                "registration_attempts": registration.registration_attempts,
+            }
             self._operations.fail(
                 operation.operation_id,
                 state="unavailable",

--- a/repowire/daemon/spawn_diagnostics.py
+++ b/repowire/daemon/spawn_diagnostics.py
@@ -1,0 +1,93 @@
+"""Diagnostics for spawned peers that fail to self-register."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import shutil
+import subprocess
+from typing import Any
+
+from repowire.spawn_ownership import probe_tmux_pane
+
+
+async def capture_spawn_registration_diagnostics(
+    *,
+    pane_id: str | None,
+    command: str | None,
+    env: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Capture bounded evidence for a spawned peer registration timeout."""
+    return await asyncio.to_thread(
+        _capture_spawn_registration_diagnostics,
+        pane_id=pane_id,
+        command=command,
+        env=env,
+    )
+
+
+def _capture_spawn_registration_diagnostics(
+    *,
+    pane_id: str | None,
+    command: str | None,
+    env: dict[str, str] | None,
+) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {
+        "pane_id": pane_id,
+        "command": command,
+    }
+    path = (env or {}).get("PATH") or os.environ.get("PATH") or ""
+    diagnostics["path"] = path
+    command_head = _command_head(command)
+    if command_head:
+        diagnostics["command_head"] = command_head
+        diagnostics["command_resolved"] = shutil.which(command_head, path=path)
+
+    if pane_id:
+        evidence = probe_tmux_pane(pane_id)
+        diagnostics["pane_live"] = evidence is not None
+        if evidence is not None:
+            diagnostics["tmux_session"] = evidence.tmux_session
+            diagnostics["pane_current_path"] = evidence.current_path
+            diagnostics["pane_pid"] = evidence.pane_pid
+        diagnostics["pane_tail"] = _capture_pane_tail(pane_id)
+    else:
+        diagnostics["pane_live"] = None
+    return diagnostics
+
+
+def _command_head(command: str | None) -> str | None:
+    if not command:
+        return None
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    if parts[0] != "env":
+        return parts[0]
+    for part in parts[1:]:
+        if "=" not in part:
+            return part
+    return None
+
+
+def _capture_pane_tail(pane_id: str, *, max_chars: int = 4000) -> str | None:
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-pt", pane_id, "-S", "-80"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    tail = result.stdout.strip()
+    if len(tail) > max_chars:
+        return tail[-max_chars:]
+    return tail

--- a/repowire/daemon/spawn_service.py
+++ b/repowire/daemon/spawn_service.py
@@ -3,18 +3,24 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+import os
+import shlex
+import shutil
+import subprocess
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from fastapi import HTTPException, status
 
 from repowire.agent_backends import AgentResumePlan, build_resume_command
 from repowire.config.models import AgentType, SpawnSettings, apply_spawn_profile
+from repowire.daemon.spawn_diagnostics import capture_spawn_registration_diagnostics
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import PeerRole
-from repowire.spawn import SpawnConfig, SpawnResult, spawn_peer
-from repowire.spawn_ownership import record_spawn_ownership
+from repowire.spawn import SpawnConfig, SpawnResult, kill_pane, spawn_peer
+from repowire.spawn_ownership import forget_spawn_ownership, record_spawn_ownership
 
 
 @dataclass(frozen=True)
@@ -23,6 +29,29 @@ class SpawnServiceResult:
     tmux_session: str
     pane_id: str | None
     message: str | None
+    command: str | None = None
+    env: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class SpawnRegistrationResult:
+    spawn_result: SpawnServiceResult | None
+    resolved_peer: Any | None
+    registration_attempts: list[dict[str, Any]]
+
+
+class SpawnAttemptError(Exception):
+    def __init__(
+        self,
+        original: Exception,
+        *,
+        attempt: int,
+        registration_attempts: list[dict[str, Any]],
+    ) -> None:
+        super().__init__(str(original))
+        self.original = original
+        self.attempt = attempt
+        self.registration_attempts = registration_attempts
 
 
 class SpawnService:
@@ -115,6 +144,8 @@ class SpawnService:
         command = self.resolve_command(backend, profile)
         if resume_plan is not None:
             command = self.resume_command(command, backend=backend, resume_plan=resume_plan)
+        env = self.spawn_env()
+        self.validate_command_env(command, env)
         try:
             result = self._spawn_impl(
                 SpawnConfig(
@@ -125,6 +156,7 @@ class SpawnService:
                     message=message,
                     role=role.value,
                     peer_id=peer_id,
+                    env=env,
                 )
             )
         except (ValueError, RuntimeError) as e:
@@ -161,6 +193,108 @@ class SpawnService:
             tmux_session=result.tmux_session,
             pane_id=result.pane_id,
             message=result.message,
+            command=command,
+            env=env,
+        )
+
+    async def spawn_registered(
+        self,
+        *,
+        path: str,
+        backend: AgentType,
+        await_peer: Callable[[SpawnServiceResult], Awaitable[Any | None]],
+        profile: str | None = None,
+        circle: str = "default",
+        message: str | None = None,
+        role: PeerRole = PeerRole.AGENT,
+        peer_id: str | None = None,
+        resume_plan: AgentResumePlan | None = None,
+        attempts: int = 2,
+        on_spawned: Callable[[SpawnServiceResult], None] | None = None,
+    ) -> SpawnRegistrationResult:
+        """Spawn and wait for the peer to self-register, retrying timed-out panes."""
+        registration_attempts: list[dict[str, Any]] = []
+        spawn_result: SpawnServiceResult | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                spawn_result = self.spawn(
+                    path=path,
+                    backend=backend,
+                    profile=profile,
+                    circle=circle,
+                    message=message,
+                    role=role,
+                    peer_id=peer_id,
+                    resume_plan=resume_plan,
+                )
+            except Exception as exc:
+                raise SpawnAttemptError(
+                    exc,
+                    attempt=attempt,
+                    registration_attempts=registration_attempts,
+                ) from exc
+            if on_spawned is not None:
+                on_spawned(spawn_result)
+            resolved = await await_peer(spawn_result)
+            if resolved is not None:
+                return SpawnRegistrationResult(
+                    spawn_result=spawn_result,
+                    resolved_peer=resolved,
+                    registration_attempts=registration_attempts,
+                )
+            diagnostics = await capture_spawn_registration_diagnostics(
+                pane_id=spawn_result.pane_id,
+                command=spawn_result.command,
+                env=spawn_result.env,
+            )
+            diagnostics["attempt"] = attempt
+            registration_attempts.append(diagnostics)
+            if spawn_result.pane_id:
+                kill_pane(spawn_result.pane_id)
+                forget_spawn_ownership(spawn_result.pane_id)
+
+        return SpawnRegistrationResult(
+            spawn_result=spawn_result,
+            resolved_peer=None,
+            registration_attempts=registration_attempts,
+        )
+
+    def spawn_env(self) -> dict[str, str]:
+        """Return explicit environment injected into spawned agent commands."""
+        env = {key: str(value) for key, value in self._spawn.env.items()}
+        if "PATH" not in env:
+            if self._spawn.env_path:
+                env["PATH"] = os.pathsep.join(
+                    str(Path(entry).expanduser()) for entry in self._spawn.env_path
+                )
+            else:
+                captured = capture_login_shell_path()
+                if captured:
+                    env["PATH"] = captured
+        return env
+
+    def validate_command_env(self, command: str, env: dict[str, str]) -> None:
+        """Fail fast when an explicitly configured PATH cannot find the command head."""
+        explicit_path = bool(self._spawn.env_path or "PATH" in self._spawn.env)
+        if not explicit_path:
+            return
+        command_head = command_head_for_probe(command)
+        if command_head is None:
+            return
+        path = env.get("PATH") or os.environ.get("PATH") or ""
+        if shutil.which(command_head, path=path):
+            return
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "command_unavailable",
+                "command": command_head,
+                "path": path,
+                "hint": (
+                    "The configured spawn PATH cannot find the backend command. "
+                    "Update daemon.spawn.env_path or daemon.spawn.commands."
+                ),
+            },
         )
 
     @staticmethod
@@ -191,3 +325,49 @@ class SpawnService:
                     "hint": str(e),
                 },
             ) from e
+
+
+def capture_login_shell_path() -> str | None:
+    """Capture PATH from the user's login shell for launchd/tmux-spawned agents."""
+    shell = os.environ.get("SHELL") or "/bin/zsh"
+    start = "REPOWIRE_PATH_START:"
+    end = ":REPOWIRE_PATH_END"
+    try:
+        result = subprocess.run(
+            [shell, "-lc", f'printf "{start}%s{end}" "$PATH"'],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout
+    start_idx = output.rfind(start)
+    if start_idx < 0:
+        return None
+    path_start = start_idx + len(start)
+    end_idx = output.find(end, path_start)
+    if end_idx < 0:
+        return None
+    path = output[path_start:end_idx].strip()
+    return path or None
+
+
+def command_head_for_probe(command: str) -> str | None:
+    """Return a simple executable head for PATH probing, or None for complex shell."""
+    command = command.rsplit("&&", 1)[-1].strip()
+    if any(token in command for token in ("||", ";", "|", "$(", "`", "<", ">")):
+        return None
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    head = parts[0]
+    if head in {"alias", "cd", "command", "eval", "exec", "export", "source"}:
+        return None
+    return head

--- a/repowire/spawn.py
+++ b/repowire/spawn.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
@@ -29,6 +30,7 @@ class SpawnConfig:
     message: str | None = None  # Optional warmup intent passed to post_spawn_warmup
     role: str | None = None  # Optional peer role (e.g. "orchestrator"); default agent
     peer_id: str | None = None  # Optional same-id reconnect hint for durable restart
+    env: dict[str, str] = field(default_factory=dict)  # Explicit env overlay for launched cmd
 
     @property
     def display_name(self) -> str:
@@ -111,7 +113,7 @@ def spawn_peer(config: SpawnConfig) -> SpawnResult:
         pending_first_turn=bool(config.message),
     )
 
-    pane.send_keys(cmd, enter=True)
+    pane.send_keys(_command_with_env(cmd, config.env), enter=True)
 
     tmux_session = f"{config.circle}:{window_name}"
 
@@ -173,6 +175,17 @@ def _unique_window_name(session: libtmux.Session, base_name: str) -> str:
     while f"{base_name}-{i}" in existing_names:
         i += 1
     return f"{base_name}-{i}"
+
+
+def _command_with_env(command: str, env: dict[str, str]) -> str:
+    """Prefix a tmux shell command with explicit environment assignments."""
+    clean_env = {key: value for key, value in env.items() if key and value is not None}
+    if not clean_env:
+        return command
+    assignments = " ".join(
+        f"{key}={shlex.quote(str(value))}" for key, value in sorted(clean_env.items())
+    )
+    return f"env {assignments} {command}"
 
 
 def attach_session(tmux_session: str) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -283,6 +283,8 @@ class TestSpawnSettings:
         assert spawn.commands == {}
         assert spawn.allowed_commands == []
         assert spawn.allowed_paths == []
+        assert spawn.env_path == []
+        assert spawn.env == {}
 
     def test_with_values(self):
         spawn = SpawnSettings(
@@ -291,6 +293,18 @@ class TestSpawnSettings:
         )
         assert len(spawn.commands) == 2
         assert "~/git" in spawn.allowed_paths
+
+    def test_spawn_env_values(self):
+        spawn = SpawnSettings(
+            env_path=["~/.local/bin", "/opt/homebrew/bin"],
+            env={"GOOGLE_APPLICATION_CREDENTIALS": "~/secret.json"},
+        )
+        assert spawn.env_path == ["~/.local/bin", "/opt/homebrew/bin"]
+        assert spawn.env["GOOGLE_APPLICATION_CREDENTIALS"] == "~/secret.json"
+
+    def test_spawn_env_rejects_unsafe_keys(self):
+        with pytest.raises(ValueError, match="shell-safe identifiers"):
+            SpawnSettings(env={"BAD-KEY": "value"})
 
     def test_legacy_allowed_commands_bootstrap_commands(self):
         spawn = SpawnSettings(allowed_commands=["claude --model opus", "codex"])

--- a/tests/test_durable_job_runner.py
+++ b/tests/test_durable_job_runner.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -26,7 +27,13 @@ from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
 from repowire.daemon.routes import work as work_routes
 from repowire.daemon.session_control import SessionControlService
-from repowire.daemon.spawn_service import SpawnService, SpawnServiceResult
+from repowire.daemon.spawn_service import (
+    SpawnRegistrationResult,
+    SpawnService,
+    SpawnServiceResult,
+    capture_login_shell_path,
+    command_head_for_probe,
+)
 from repowire.daemon.state.calendar import SQLiteCalendarStore
 from repowire.daemon.state.database import StateDatabase
 from repowire.daemon.state.operations import SQLiteOperationStore
@@ -66,6 +73,27 @@ class FakeSpawn:
             tmux_session=self.tmux_session,
             pane_id=self.pane_id,
             message=kwargs.get("message"),
+        )
+
+    async def spawn_registered(self, *, await_peer, attempts=2, on_spawned=None, **kwargs):
+        registration_attempts: list[dict] = []
+        spawn_result = None
+        for attempt in range(1, attempts + 1):
+            spawn_result = self.spawn(**kwargs)
+            if on_spawned is not None:
+                on_spawned(spawn_result)
+            resolved = await await_peer(spawn_result)
+            if resolved is not None:
+                return SpawnRegistrationResult(
+                    spawn_result=spawn_result,
+                    resolved_peer=resolved,
+                    registration_attempts=registration_attempts,
+                )
+            registration_attempts.append({"attempt": attempt})
+        return SpawnRegistrationResult(
+            spawn_result=spawn_result,
+            resolved_peer=None,
+            registration_attempts=registration_attempts,
         )
 
 
@@ -509,6 +537,69 @@ async def test_path_backend_job_defaults_to_per_fire(tmp_path):
     attempt = result.provenance["runner"]["attempts"][0]
     assert attempt["acquisition"]["strategy"] == "spawned_peer"
     assert attempt["acquisition"]["release_handle"]["pane_id"] == spawn.pane_id
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_session_control_retries_spawn_registration_timeout(tmp_path, monkeypatch):
+    _cfg, _registry, db, store, _calendar, _session_bindings, _delivery, spawn, runner = _env(
+        tmp_path
+    )
+    worker_path = str(tmp_path / "daily-email-brief")
+    work = store.create(
+        title="daily brief",
+        circle="default",
+        request={"execution": {"target": {"path": worker_path, "backend": "codex"}}},
+    )
+
+    async def never_registered(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "repowire.daemon.session_control.SessionControlService._await_spawned_peer",
+        never_registered,
+    )
+
+    result = await runner.run_job(work.work_id)
+
+    assert result.state == "unavailable"
+    assert len(spawn.calls) == 2
+    attempt = result.provenance["runner"]["attempts"][0]
+    assert attempt["error"]["reason"] == "spawned_peer_not_registered"
+    assert [item["attempt"] for item in attempt["error"]["registration_attempts"]] == [1, 2]
+    db.close()
+    cleanup_deps()
+
+
+@pytest.mark.anyio
+async def test_legacy_runner_retries_spawn_registration_timeout(tmp_path, monkeypatch):
+    _cfg, _registry, db, store, _calendar, _session_bindings, _delivery, spawn, runner = _env(
+        tmp_path
+    )
+    runner._session_control = None
+    worker_path = str(tmp_path / "daily-email-brief")
+    work = store.create(
+        title="daily brief",
+        circle="default",
+        request={"execution": {"target": {"path": worker_path, "backend": "codex"}}},
+    )
+
+    async def never_registered(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "repowire.daemon.job_runner.JobRunner._await_spawned_peer",
+        never_registered,
+    )
+
+    result = await runner.run_job(work.work_id)
+
+    assert result.state == "unavailable"
+    assert len(spawn.calls) == 2
+    attempt = result.provenance["runner"]["attempts"][0]
+    assert attempt["error"]["reason"] == "spawned_peer_not_registered"
+    assert [item["attempt"] for item in attempt["error"]["registration_attempts"]] == [1, 2]
     db.close()
     cleanup_deps()
 
@@ -1514,6 +1605,216 @@ async def test_spawn_service_passes_codex_resume_command_to_spawn(tmp_path, monk
     assert spawn_config.command == (
         "codex --dangerously-bypass-approvals-and-sandbox resume codex-runtime-1"
     )
+
+
+@pytest.mark.anyio
+async def test_spawn_service_uses_explicit_env_path(tmp_path, monkeypatch):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CODEX] = "codex"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    cfg.daemon.spawn.env_path = ["~/.local/bin", "/opt/homebrew/bin"]
+    cfg.daemon.spawn.env = {"GWS_CONFIG": "~/calendar.yaml"}
+    spawn_impl = Mock(
+        return_value=SimpleNamespace(
+            display_name="daily-email-brief",
+            tmux_session="default:daily-email-brief",
+            pane_id="%661",
+            message="warm",
+        )
+    )
+    monkeypatch.setattr("repowire.daemon.spawn_service.capture_login_shell_path", Mock())
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.shutil.which",
+        Mock(return_value="/opt/homebrew/bin/codex"),
+    )
+    monkeypatch.setattr("repowire.daemon.spawn_service.record_spawn_ownership", Mock())
+
+    async def warmup(*_args, **_kwargs):
+        return None
+
+    service = SpawnService(
+        spawn=cfg.daemon.spawn,
+        spawned_pane_ids=set(),
+        background_tasks=set(),
+        spawn_impl=spawn_impl,
+        warmup_impl=warmup,
+    )
+
+    result = service.spawn(path=str(tmp_path), backend=AgentType.CODEX, message="warm")
+
+    spawn_config = spawn_impl.call_args.args[0]
+    assert spawn_config.env == {
+        "GWS_CONFIG": "~/calendar.yaml",
+        "PATH": f"{Path('~/.local/bin').expanduser()}{os.pathsep}/opt/homebrew/bin",
+    }
+    assert result.env == spawn_config.env
+
+
+@pytest.mark.anyio
+async def test_spawn_service_falls_back_to_login_shell_path(tmp_path, monkeypatch):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CODEX] = "codex"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    spawn_impl = Mock(
+        return_value=SimpleNamespace(
+            display_name="daily-email-brief",
+            tmux_session="default:daily-email-brief",
+            pane_id="%661",
+            message="warm",
+        )
+    )
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.capture_login_shell_path",
+        Mock(return_value="/nvm/bin:/opt/homebrew/bin:/usr/bin"),
+    )
+    monkeypatch.setattr("repowire.daemon.spawn_service.record_spawn_ownership", Mock())
+
+    async def warmup(*_args, **_kwargs):
+        return None
+
+    service = SpawnService(
+        spawn=cfg.daemon.spawn,
+        spawned_pane_ids=set(),
+        background_tasks=set(),
+        spawn_impl=spawn_impl,
+        warmup_impl=warmup,
+    )
+
+    service.spawn(path=str(tmp_path), backend=AgentType.CODEX, message="warm")
+
+    spawn_config = spawn_impl.call_args.args[0]
+    assert spawn_config.env == {"PATH": "/nvm/bin:/opt/homebrew/bin:/usr/bin"}
+
+
+@pytest.mark.anyio
+async def test_spawn_service_explicit_env_path_fails_fast_when_command_missing(
+    tmp_path, monkeypatch,
+):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CODEX] = "codex"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    cfg.daemon.spawn.env_path = ["/nope"]
+    spawn_impl = Mock()
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.shutil.which",
+        Mock(return_value=None),
+    )
+
+    service = SpawnService(
+        spawn=cfg.daemon.spawn,
+        spawned_pane_ids=set(),
+        background_tasks=set(),
+        spawn_impl=spawn_impl,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        service.spawn(path=str(tmp_path), backend=AgentType.CODEX, message="warm")
+
+    assert getattr(exc_info.value, "status_code") == 422
+    assert exc_info.value.detail["error"] == "command_unavailable"
+    spawn_impl.assert_not_called()
+
+
+def test_capture_login_shell_path_ignores_noisy_startup_output(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                "hello from zshrc\n"
+                "REPOWIRE_PATH_START:/nvm/bin:/opt/homebrew/bin:/usr/bin:"
+                "REPOWIRE_PATH_END\n"
+                "goodbye from zshrc\n"
+            ),
+        )
+
+    monkeypatch.setattr("repowire.daemon.spawn_service.subprocess.run", fake_run)
+
+    assert capture_login_shell_path() == "/nvm/bin:/opt/homebrew/bin:/usr/bin"
+
+
+def test_capture_login_shell_path_requires_sentinel(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout="hello\n/usr/bin:/bin\n")
+
+    monkeypatch.setattr("repowire.daemon.spawn_service.subprocess.run", fake_run)
+
+    assert capture_login_shell_path() is None
+
+
+def test_command_head_for_probe_uses_last_and_segment():
+    assert command_head_for_probe("cd /work && codex --model fast") == "codex"
+
+
+@pytest.mark.anyio
+async def test_spawn_service_registration_retry_captures_both_attempts_and_cleans_up(
+    tmp_path, monkeypatch,
+):
+    cfg = Config()
+    cfg.daemon.spawn.commands[AgentType.CODEX] = "codex"
+    cfg.daemon.spawn.allowed_paths = [str(tmp_path)]
+    spawned = [
+        SimpleNamespace(
+            display_name="daily-email-brief",
+            tmux_session="default:daily-email-brief",
+            pane_id="%701",
+            message="warm",
+        ),
+        SimpleNamespace(
+            display_name="daily-email-brief-2",
+            tmux_session="default:daily-email-brief-2",
+            pane_id="%702",
+            message="warm",
+        ),
+    ]
+    spawn_impl = Mock(side_effect=spawned)
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.capture_login_shell_path",
+        Mock(return_value="/usr/bin:/bin"),
+    )
+    monkeypatch.setattr("repowire.daemon.spawn_service.record_spawn_ownership", Mock())
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.capture_spawn_registration_diagnostics",
+        AsyncMock(side_effect=[
+            {"pane_id": "%701", "pane_live": True},
+            {"pane_id": "%702", "pane_live": False},
+        ]),
+    )
+    kill_pane = Mock(return_value=True)
+    forget_spawn_ownership = Mock()
+    monkeypatch.setattr("repowire.daemon.spawn_service.kill_pane", kill_pane)
+    monkeypatch.setattr(
+        "repowire.daemon.spawn_service.forget_spawn_ownership",
+        forget_spawn_ownership,
+    )
+
+    async def never_registered(_spawn_result):
+        return None
+
+    async def warmup(*_args, **_kwargs):
+        return None
+
+    service = SpawnService(
+        spawn=cfg.daemon.spawn,
+        spawned_pane_ids=set(),
+        background_tasks=set(),
+        spawn_impl=spawn_impl,
+        warmup_impl=warmup,
+    )
+
+    result = await service.spawn_registered(
+        path=str(tmp_path),
+        backend=AgentType.CODEX,
+        message="warm",
+        await_peer=never_registered,
+    )
+
+    assert result.resolved_peer is None
+    assert [item["attempt"] for item in result.registration_attempts] == [1, 2]
+    assert [item["pane_id"] for item in result.registration_attempts] == ["%701", "%702"]
+    assert kill_pane.call_args_list[0].args == ("%701",)
+    assert kill_pane.call_args_list[1].args == ("%702",)
+    assert forget_spawn_ownership.call_args_list[0].args == ("%701",)
+    assert forget_spawn_ownership.call_args_list[1].args == ("%702",)
 
 
 @pytest.mark.anyio

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -293,6 +293,30 @@ class TestSpawnPeer:
 
     @patch("repowire.spawn._get_or_create_session")
     @patch("repowire.spawn.libtmux.Server")
+    def test_spawn_peer_prefixes_explicit_env(
+        self,
+        mock_server_class: MagicMock,
+        mock_get_session: MagicMock,
+    ) -> None:
+        """Spawned workers launch with explicit env instead of incidental tmux env."""
+        _mock_session, _mock_window, mock_pane = self._tmux_spawn(mock_get_session)
+        config = SpawnConfig(
+            path="/tmp/test",
+            circle="dev",
+            backend=AgentType.CODEX,
+            command="codex run",
+            env={"PATH": "/Users/me/bin:/opt/homebrew/bin", "FOO": "two words"},
+        )
+
+        spawn_peer(config)
+
+        mock_pane.send_keys.assert_called_once_with(
+            "env FOO='two words' PATH=/Users/me/bin:/opt/homebrew/bin codex run",
+            enter=True,
+        )
+
+    @patch("repowire.spawn._get_or_create_session")
+    @patch("repowire.spawn.libtmux.Server")
     def test_spawn_peer_unknown_backend_raises(
         self,
         mock_server_class: MagicMock,

--- a/tests/test_switch_backend_route.py
+++ b/tests/test_switch_backend_route.py
@@ -14,7 +14,7 @@ from httpx import ASGITransport, AsyncClient
 
 from repowire.config.models import AgentType, Config
 from repowire.daemon.ask_tracker import AskTracker
-from repowire.daemon.deps import cleanup_deps, init_deps
+from repowire.daemon.deps import cleanup_deps, get_config, init_deps
 from repowire.daemon.message_router import MessageRouter
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.query_tracker import QueryTracker
@@ -100,6 +100,12 @@ class TestSwitchBackendRoute:
     async def test_same_host_happy_path(self, env, tmp_path):
         name = await _register(env.client, name="alpha", backend="claude-code",
                                 path=str(tmp_path))
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        codex_bin = bin_dir / "codex"
+        codex_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+        codex_bin.chmod(0o755)
+        get_config().daemon.spawn.env_path = [str(bin_dir)]
         with patch.object(spawn_routes, "spawn_peer", return_value=_fake_spawn(
             "alpha", "default:alpha", "%101",
         )) as mock_spawn, \
@@ -124,6 +130,7 @@ class TestSwitchBackendRoute:
         assert spawn_cfg.backend is AgentType.CODEX
         assert spawn_cfg.circle == "default"
         assert spawn_cfg.path == str(Path(tmp_path).resolve())
+        assert spawn_cfg.env == {"PATH": str(bin_dir)}
 
         # Registry must have unregistered the old peer.
         assert await env.registry.get_peer(name) is None


### PR DESCRIPTION
## Summary
- add explicit daemon.spawn.env_path/env handling for spawned agents, with login-shell PATH fallback and command preflight for explicit PATH configs
- inject the resolved env at the tmux command boundary instead of depending on incidental tmux PATH
- retry spawned durable-job workers once after registration timeout, capture bounded diagnostics, and clean up unregistered panes before retry/failure
- document spawn env config and add coverage for config, spawn injection, session_control, and legacy job_runner paths

## Validation
- uv run pytest
- uv run ruff check repowire/ tests/
- uv run ty check repowire/
- uv run --extra docs zensical build --strict
- python3 scripts/pre_pr_hygiene.py

## Notes
- The observed gws 403 insufficientPermissions is a user OAuth re-consent issue, not a Repowire spawn bug; this PR improves worker env and failure evidence so that kind of error can surface as itself.
- No release tag; merge/deploy is intentionally left to Prass.