### PR TITLE
refactor: route cli ask through ask lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Key modules (the graph in `graphify-out/` is the live map; these are the hubs):
 
 ### Transport mechanics worth knowing
 
-- **Hooks (default):** SessionStart registers the peer + spawns the ws-hook (flock-deduped) + injects context. Stop posts chat turns, delivers the legacy /query response, then fetches `/asks/pending` and emits `{"decision":"block","reason":<reminder>}` if open asks exist (Stop can't add context otherwise), then marks online. UserPromptSubmit → BUSY; Notification(idle_prompt) → ONLINE. The ws-hook injects `[ask #cid]` text on arrival; the Stop reminder is the *only* thing that resurfaces an un-acked ask.
+- **Hooks (default):** SessionStart registers the peer + spawns the ws-hook (flock-deduped) + injects context. Stop posts chat turns, drains any old legacy `/query` FIFO response, then fetches `/asks/pending` and emits `{"decision":"block","reason":<reminder>}` if open asks exist (Stop can't add context otherwise), then marks online. UserPromptSubmit → BUSY; Notification(idle_prompt) → ONLINE. The ws-hook injects `[ask #cid]` text on arrival; the Stop reminder is the *only* thing that resurfaces an un-acked ask.
 - **Channel (experimental, `repowire setup --experimental-channels`):** Claude Code ↔ `channel/server.ts` (MCP stdio) ↔ daemon. Messages arrive as `<channel>` tags; Claude replies via the `reply`/`ack` tools. Requires claude.ai login, Claude Code 2.1.80+, bun. Only the Stop hook is kept in channel mode (for dashboard chat turns).
 - **Config** lives at `~/.repowire/config.yaml` (`daemon`, `relay`, `telegram`, `slack`, `updates`, `experiments`, …), loaded by `config/models.py`. Channel/MCP config is in `~/.claude.json`, managed by `repowire setup`.
 

--- a/docs/contributing/design-notes/claude-code-plugin-packaging.md
+++ b/docs/contributing/design-notes/claude-code-plugin-packaging.md
@@ -130,8 +130,8 @@ Default Claude Code integration remains:
   injects peer context
 - `UserPromptSubmit` marks the peer busy
 - `Notification` repairs idle status
-- `Stop` and `StopFailure` extract chat turns, deliver legacy query responses,
-  fetch pending asks, and repair status
+- `Stop` and `StopFailure` extract chat turns, drain old legacy query FIFO
+  responses, fetch pending asks, and repair status
 - `SessionEnd` tears down the supervisor and marks the peer offline
 
 Channel mode remains an explicit `repowire setup --experimental-channels`

--- a/docs/operate/architecture.md
+++ b/docs/operate/architecture.md
@@ -54,7 +54,7 @@ OpenCode does not expose the same hook shape, so Repowire installs a TypeScript 
 
 ### Channel / ACP transport
 
-`repowire setup --experimental-channels` installs Claude Code's experimental channel/ACP transport. Messages arrive as `<channel source="repowire">` tags, while legacy query replies route through a channel reply tool. The normal `repowire mcp` server remains installed for stable tools such as `ask`, `ack`, `notify_peer`, schedules, and peer listing. This requires Claude Code support, claude.ai login, and `bun`. Treat this path as experimental; hooks + MCP remain the default.
+`repowire setup --experimental-channels` installs Claude Code's experimental channel/ACP transport. Messages arrive as `<channel source="repowire">` tags. The normal `repowire mcp` server remains installed for stable tools such as `ask`, `ack`, `notify_peer`, schedules, and peer listing. This requires Claude Code support, claude.ai login, and `bun`. Treat this path as experimental; hooks + MCP remain the default.
 
 ### Relay
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,6 +85,7 @@ Exits 0 if all checks pass (or only warn/skip). Exits 1 if any check fails — s
 repowire peer new PATH [--backend BACKEND] [--profile PROFILE] [--circle CIRCLE]
 repowire peer list                          # god-view list (all circles, includes caller)
 repowire peer describe NAME_OR_ID [--circle C]  # full state for one peer
+repowire peer ask NAME QUERY [--timeout SEC] [--circle C]  # blocking compatibility ask
 repowire peer claim-role orchestrator [--peer NAME_OR_ID] [--circle C] [--force]
 repowire peer restart NAME_OR_ID [--circle C] [--dry-run] [-m MESSAGE]
 repowire peer doctor NAME_OR_ID [--circle C] [--json] [--fix]  # deep diagnostic + contradictions
@@ -103,6 +104,8 @@ repowire peer ack CORR_ID [-m MESSAGE] [--from-peer NAME]
 For Antigravity interop checks, `python3 scripts/agy_interop_smoke.py --run-cli-fallback` writes a JSON evidence report covering observed hook evidence, MCP availability state, and CLI fallback ask→ack. It records current behaviour only; hook or MCP support is not treated as verified unless the report observes matching daemon evidence.
 
 `peer list` is god-view: it returns every peer regardless of circle and includes the calling shell. The MCP [`list_peers`](mcp-tools.md#list_peers) tool defaults to a peer-facing view (online only, caller hidden).
+
+`peer ask` is a blocking CLI compatibility helper for quick manual checks. It uses the daemon's ask/answer lifecycle under the hood, waits for the recipient to `ack` with a reply, then prints the reply text. For agent-to-agent work, prefer the MCP [`ask`](mcp-tools.md#ask) tool, which returns a correlation id immediately and lets the conversation continue asynchronously.
 
 `peer new` spawns a tmux-backed peer through the daemon `/spawn` route using the configured `daemon.spawn.commands.<backend>` command. Pass `--profile NAME` to append args from `daemon.spawn.profiles.<backend>.<name>`, such as a faster or more capable model selection. Antigravity uses the same daemon pre-registration path as MCP spawn, so it appears immediately as a CLI-fallback peer while upstream hooks are pending. `--command` remains accepted as a deprecated explicit override and bypasses daemon registration/profile resolution.
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -9,6 +9,7 @@ The daemon exposes HTTP routes for the dashboard, hooks, CLI helpers, and client
 - `GET /panes/orphans` lists local tmux panes not bound to any registered peer (with a display-only backend hint); `POST /panes/{pane_id}/link` adopts one — registers the peer AND establishes its inbound ws-hook, rolling the registration back if no live transport connects (fail-closed against ghosts). Driven by `repowire link`.
 - `/ask`, `/ack`, and `/asks/pending` for ask lifecycle.
 - `/answer` records a typed answer to a structured question; `POST /questions/ask-blocking` registers a blocking structured question (tool permission) and holds the connection open until it is answered or the daemon's wait cap elapses, then returns the typed answer (fail-closed: a tool-permission question denies on timeout). Used by blocking transports such as the ACP broker and the Claude Code `PreToolUse` approval hook.
+- `/query` is a legacy blocking compatibility route. It opens a structured text ask through the ask lifecycle, waits for the recipient's answer/ack, and returns the old `{text, error, status}` response shape for existing clients.
 - `/traces/{trace_id}` returns the recorded delivery stages for an ask (`correlation_id`) or notify (`delivery_id`) from the local delivery trace ledger.
 - `/messages` and WebSocket routes for live delivery.
 - `/schedules` for one-shot and recurring scheduled messages.

--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -75,6 +75,10 @@ print(bc)
 daemon attachment metadata (`id`, `path`, `filename`, `size`, `content_type`).
 Omit it for the text-only shape; existing callers do not need to change.
 
+For old blocking integrations, `query(to_peer, text, ...)` is retained as a
+compatibility helper. It returns the historical `{text, error, status}` model,
+but the daemon now backs it with the same ask/answer lifecycle used by `ask`.
+
 ## Listing and inspection
 
 Pull current mesh state. `list_peers` accepts daemon-supported filters; `get_peer` resolves a single peer by name or id. `pending_asks` returns open asks for one pane or peer; pass `direction="outbound"` or `direction="both"` to inspect asks opened by that peer.

--- a/docs/use/features/connect-claude-code.md
+++ b/docs/use/features/connect-claude-code.md
@@ -15,7 +15,7 @@ Six lifecycle events are wired by default:
 | `SessionStart` | Registers the peer with the daemon, spawns the WebSocket hook supervisor, injects the peer list as context |
 | `UserPromptSubmit` | Marks the peer `busy` |
 | `Notification` | Resets the peer to `online` when Claude Code emits an idle prompt |
-| `Stop` | Extracts response + tool calls from the transcript, delivers any pending legacy `/query`, fetches `/asks/pending` and emits a reminder block if open asks exist, then marks the peer `online` |
+| `Stop` | Extracts response + tool calls from the transcript, drains any old legacy `/query` FIFO response, fetches `/asks/pending` and emits a reminder block if open asks exist, then marks the peer `online` |
 | `StopFailure` | Uses the same stop handler to repair status after API-level stop failures |
 | `SessionEnd` | Tears down the WebSocket hook supervisor, marks the peer `offline` |
 
@@ -46,7 +46,7 @@ repowire setup --experimental-channels
 
 Replaces tmux-injection delivery with direct MCP-channel delivery. When a message arrives, Claude sees a `<channel source="repowire">` tag in its context instead of a `[ask #cid from @peer] ...` line injected into the terminal.
 
-Channel setup adds a separate `repowire-channel` MCP server entry in `~/.claude.json`. The normal `repowire` MCP server remains installed; use its stable tools, including `ack`, for ask lifecycle and parity with the default transport. The channel server itself only handles channel delivery and legacy query replies.
+Channel setup adds a separate `repowire-channel` MCP server entry in `~/.claude.json`. The normal `repowire` MCP server remains installed; use its stable tools, including `ack`, for ask lifecycle and parity with the default transport. The channel server itself only handles channel delivery.
 
 Requirements:
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -3509,34 +3509,38 @@ def peer_rehook(name: str, circle: str | None, apply: bool) -> None:
 @click.option("--circle", "-c", default=None, help="Circle to scope peer lookup")
 def peer_ask(name: str, query: str, timeout: int, circle: str | None) -> None:
     """Ask a peer a question (CLI testing utility)."""
-    import httpx
+    from repowire.client import AsyncRepowireClient
+    from repowire.protocol.errors import (
+        DaemonConnectionError,
+        DaemonHTTPError,
+        DaemonTimeoutError,
+    )
 
     try:
-        with httpx.Client(timeout=float(timeout) + 5.0) as client:
-            body: dict = {
-                "to_peer": name,
-                "text": query,
-                "timeout": timeout,
-            }
-            if circle:
-                body["circle"] = circle
-            resp = client.post(
-                f"{_get_daemon_url()}/query",
-                json=body,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+        async def _run():
+            async with AsyncRepowireClient(
+                base_url=_get_daemon_url(),
+                auth_token=_auth_token(),
+                timeout=float(timeout) + 5.0,
+            ) as client:
+                return await client.query(
+                    name,
+                    query,
+                    timeout=timeout,
+                    circle=circle,
+                )
 
-            if data.get("error"):
-                console.print(f"[red]Error: {data['error']}[/]")
-            else:
-                console.print(f"[cyan]{name}:[/] {data.get('text', '')}")
+        data = asyncio.run(_run())
+        if data.error:
+            console.print(f"[red]Error: {data.error}[/]")
+        else:
+            console.print(f"[cyan]{name}:[/] {data.text or ''}")
 
-    except httpx.ConnectError:
+    except DaemonConnectionError:
         console.print("[red]Error: Cannot connect to daemon. Run 'repowire serve' first.[/]")
-    except httpx.TimeoutException:
+    except DaemonTimeoutError:
         console.print(f"[red]Timeout: No response from {name}[/]")
-    except httpx.HTTPStatusError as e:
+    except DaemonHTTPError as e:
         console.print(f"[red]Error: {e}[/]")
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
@@ -3607,6 +3611,16 @@ def _auth_headers() -> dict[str, str]:
     except Exception:
         return {}
     return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _auth_token() -> str | None:
+    """Return daemon.auth_token if configured, else None."""
+    try:
+        from repowire.config.models import load_config
+
+        return load_config().daemon.auth_token
+    except Exception:
+        return None
 
 
 def _daemon_request_json(

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -414,7 +414,11 @@ class AsyncRepowireClient:
         bypass_circle: bool = False,
         circle: str | None = None,
     ) -> QueryResult:
-        """Send a legacy blocking query and wait for a response."""
+        """Open a blocking compatibility ask and wait for a response.
+
+        The daemon keeps ``/query`` as the old blocking RPC surface, but it is
+        backed by the ask/answer lifecycle.
+        """
         payload: dict[str, Any] = {
             "to_peer": to_peer,
             "text": text,

--- a/repowire/daemon/routes/messages.py
+++ b/repowire/daemon/routes/messages.py
@@ -13,12 +13,14 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from repowire.config.models import DEFAULT_QUERY_TIMEOUT
+from repowire.daemon.ask_service import AskService, AskServiceError, OpenAskCommand
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.peer_delivery import peer_delivery_from_state
 from repowire.daemon.routes._shared import OkResponse
 from repowire.protocol.messages import AttachmentRef
 from repowire.protocol.peers import PeerStatus, TurnState
+from repowire.protocol.questions import Answer, Question
 
 router = APIRouter(tags=["messages"])
 logger = logging.getLogger(__name__)
@@ -154,7 +156,7 @@ async def query_peer(
     request: QueryRequest,
     _: str | None = Depends(require_auth),
 ) -> QueryResponse:
-    """Send a query to a peer and wait for response."""
+    """Compatibility shim: open a blocking text ask and wait for its answer."""
     peer_registry = get_peer_registry()
     state = get_app_state()
     await peer_registry.lazy_repair()
@@ -172,32 +174,100 @@ async def query_peer(
                 error=f"Peer '{request.to_peer}' is offline",
                 status=PeerStatus.OFFLINE.value,
             )
+    else:
+        return QueryResponse(error=f"Unknown peer: {request.to_peer}")
 
     # Use "cli" as default from_peer if not specified
     from_peer = request.from_peer or "cli"
     # Auto-bypass circles for CLI requests (when from_peer was not specified)
     bypass = request.bypass_circle or request.from_peer is None
+    from_peer_id = None
+    try:
+        from_obj = (
+            await peer_registry.get_peer(from_peer, circle=peer.circle)
+            or await peer_registry.get_peer(from_peer)
+        )
+    except ValueError:
+        from_obj = None
+    if from_obj is not None:
+        from_peer_id = from_obj.peer_id
+    query_event_id = peer_registry.add_event(
+        "query",
+        {
+            "from": from_peer,
+            "to": request.to_peer,
+            "text": request.text,
+            "from_peer_id": from_peer_id,
+            "to_peer_id": peer.peer_id,
+            "status": "pending",
+        },
+    )
 
     try:
-        peer_delivery = peer_delivery_from_state(
-            config=state.config,
-            registry=peer_registry,
-            state=state,
+        ask_service = AskService(state=state, peer_registry=peer_registry)
+        result = await ask_service.open_ask(
+            OpenAskCommand(
+                from_peer=from_peer,
+                to_peer=request.to_peer,
+                text=request.text,
+                bypass_circle=bypass,
+                circle=request.circle,
+                question=Question(
+                    kind="text",
+                    prompt=request.text,
+                    blocking=True,
+                    timeout_seconds=request.timeout,
+                    default_answer=Answer(
+                        outcome="timed_out",
+                        message=f"Timeout waiting for {request.to_peer}",
+                    ),
+                    scope="mesh_ask",
+                    metadata={"compat": "query"},
+                ),
+            )
         )
-        response_text = await peer_delivery.query(
-            from_peer=from_peer,
-            to_peer=request.to_peer,
-            text=request.text,
-            timeout=request.timeout,
-            bypass_circle=bypass,
-            circle=request.circle,
+        answer = await state.ask_tracker.wait_for_answer(
+            result.correlation_id,
+            timeout_seconds=request.timeout,
+            default_answer=Answer(
+                outcome="timed_out",
+                message=f"Timeout waiting for {request.to_peer}",
+            ),
+        )
+        if answer.outcome == "timed_out":
+            peer_registry._update_event(query_event_id, {"status": "timeout"})
+            asyncio.ensure_future(peer_registry._check_peer_after_timeout(peer.peer_id))
+            return QueryResponse(error=f"Timeout waiting for {request.to_peer}")
+        if answer.outcome == "cancelled":
+            peer_registry._update_event(
+                query_event_id,
+                {"status": "error", "error": answer.message or "Query cancelled"},
+            )
+            return QueryResponse(error=answer.message or "Query cancelled")
+        response_text = answer.text or answer.message or answer.option_id or ""
+        peer_registry._update_event(query_event_id, {"status": "success"})
+        peer_registry.add_event(
+            "response",
+            {
+                "from": request.to_peer,
+                "to": from_peer,
+                "from_peer_id": peer.peer_id,
+                "to_peer_id": from_peer_id,
+                "text": response_text[:100] + "..." if len(response_text) > 100 else response_text,
+                "correlation_id": query_event_id,
+            },
         )
         return QueryResponse(text=response_text)
     except ValueError as e:
+        peer_registry._update_event(query_event_id, {"status": "error", "error": str(e)})
         return QueryResponse(error=str(e))
-    except TimeoutError:
-        return QueryResponse(error=f"Timeout waiting for {request.to_peer}")
+    except AskServiceError as e:
+        peer_registry._update_event(
+            query_event_id, {"status": "error", "error": str(e.detail)},
+        )
+        return QueryResponse(error=str(e.detail))
     except Exception as e:
+        peer_registry._update_event(query_event_id, {"status": "error", "error": str(e)})
         return QueryResponse(error=f"Query failed: {e}")
 
 

--- a/tests/test_cli_peer_agy.py
+++ b/tests/test_cli_peer_agy.py
@@ -136,6 +136,77 @@ def test_whoami_no_pane_no_name_exits_nonzero(monkeypatch) -> None:
 # --- peer asks -----------------------------------------------------------------
 
 
+def test_peer_ask_uses_client_query_and_prints_reply(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    class FakeAsyncRepowireClient:
+        def __init__(self, *, base_url, auth_token, timeout):
+            calls.append({
+                "base_url": base_url,
+                "auth_token": auth_token,
+                "timeout": timeout,
+            })
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def query(self, to_peer, text, *, timeout=None, circle=None):
+            calls.append({
+                "to_peer": to_peer,
+                "text": text,
+                "query_timeout": timeout,
+                "circle": circle,
+            })
+            return SimpleNamespace(text="pong", error=None)
+
+    _set_auth_token(monkeypatch)
+    monkeypatch.setattr("repowire.cli._get_daemon_url", lambda: "http://daemon")
+    monkeypatch.setattr("repowire.client.AsyncRepowireClient", FakeAsyncRepowireClient)
+
+    result = CliRunner().invoke(
+        main,
+        ["peer", "ask", "worker", "ping", "--timeout", "7", "--circle", "team-a"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {"base_url": "http://daemon", "auth_token": "secret-token", "timeout": 12.0},
+        {
+            "to_peer": "worker",
+            "text": "ping",
+            "query_timeout": 7,
+            "circle": "team-a",
+        },
+    ]
+    assert "worker:" in result.output
+    assert "pong" in result.output
+
+
+def test_peer_ask_prints_query_error(monkeypatch) -> None:
+    class FakeAsyncRepowireClient:
+        def __init__(self, **_):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def query(self, *_args, **_kwargs):
+            return SimpleNamespace(text=None, error="Peer 'worker' is busy")
+
+    monkeypatch.setattr("repowire.client.AsyncRepowireClient", FakeAsyncRepowireClient)
+
+    result = CliRunner().invoke(main, ["peer", "ask", "worker", "ping"])
+
+    assert result.exit_code == 0, result.output
+    assert "Error: Peer 'worker' is busy" in result.output
+
+
 def test_peer_restart_posts_request_and_prints_response(monkeypatch) -> None:
     client = _make_client(monkeypatch)
     client.post.return_value = _response(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -158,6 +158,35 @@ async def test_resume_session_client_posts_payload(client: AsyncRepowireClient):
     assert result.spawned_display_name == "repo-codex"
 
 
+async def test_query_client_posts_compat_payload(client: AsyncRepowireClient):
+    client._request = AsyncMock(  # type: ignore[method-assign]
+        return_value={"text": "pong", "error": None, "status": None}
+    )
+
+    result = await client.query(
+        "worker",
+        "ping",
+        from_peer="cli",
+        timeout=7,
+        bypass_circle=True,
+        circle="team-a",
+    )
+
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "POST",
+        "/query",
+        json={
+            "to_peer": "worker",
+            "text": "ping",
+            "bypass_circle": True,
+            "from_peer": "cli",
+            "timeout": 7,
+            "circle": "team-a",
+        },
+    )
+    assert result.text == "pong"
+
+
 def test_client_peer_defaults_to_daemon_default_circle():
     peer = ClientPeer.model_validate(
         {

--- a/tests/test_query_compat_route.py
+++ b/tests/test_query_compat_route.py
@@ -1,0 +1,107 @@
+"""Compatibility tests for the legacy /query shim."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from repowire.daemon.deps import cleanup_deps
+from repowire.daemon.routes import asks, messages, peers
+
+from .conftest import async_client_for, make_daemon_app
+
+ROUTERS = (peers.router, messages.router, asks.router)
+
+
+@pytest.fixture
+async def env(tmp_path):
+    harness = make_daemon_app(tmp_path, ROUTERS)
+    harness.message_router.send_ask = AsyncMock()
+    harness.message_router.send_notification = AsyncMock()
+    async with async_client_for(harness.app) as client:
+        yield client, harness
+    cleanup_deps()
+
+
+async def _register_peer(client, name: str, pane_id: str | None = None) -> dict:
+    body: dict = {
+        "name": name,
+        "path": f"/tmp/{name}",
+        "circle": "default",
+        "backend": "claude-code",
+    }
+    if pane_id:
+        body["pane_id"] = pane_id
+    response = await client.post("/peers", json=body)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def test_query_shim_blocks_on_structured_ask_answer(env):
+    client, harness = env
+    target = await _register_peer(client, "target", pane_id="%42")
+
+    query_task = asyncio.create_task(
+        client.post(
+            "/query",
+            json={
+                "to_peer": target["display_name"],
+                "text": "status?",
+                "timeout": 2,
+            },
+        )
+    )
+    try:
+        cid = None
+        for _ in range(40):
+            pending = await harness.ask_tracker.pending_for_peer(target["peer_id"])
+            if pending:
+                cid = pending[0].correlation_id
+                break
+            await asyncio.sleep(0.05)
+        assert cid is not None
+        ask = await harness.ask_tracker.get(cid)
+        assert ask is not None
+        assert ask.question is not None
+        assert ask.question.kind == "text"
+        assert ask.question.blocking is True
+        assert ask.question.metadata == {"compat": "query"}
+
+        ack = await client.post(
+            "/ack",
+            json={"correlation_id": cid, "message": "all green"},
+        )
+        assert ack.status_code == 200, ack.text
+
+        response = await query_task
+    finally:
+        if not query_task.done():
+            query_task.cancel()
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"text": "all green", "error": None, "status": None}
+    events = harness.registry.get_events()
+    query_event = next(event for event in events if event["type"] == "query")
+    response_event = next(event for event in events if event["type"] == "response")
+    assert query_event["status"] == "success"
+    assert query_event["to_peer_id"] == target["peer_id"]
+    assert response_event["text"] == "all green"
+    assert response_event["correlation_id"] == query_event["id"]
+
+
+async def test_query_shim_unknown_peer_keeps_legacy_error_shape(env):
+    client, _ = env
+
+    response = await client.post(
+        "/query",
+        json={"to_peer": "ghost", "text": "status?", "timeout": 1},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "text": None,
+        "error": "Unknown peer: ghost",
+        "status": None,
+    }


### PR DESCRIPTION
## Summary
- make `repowire peer ask` use `AsyncRepowireClient.query()` instead of inline `httpx`
- keep `/query` as a documented compatibility shim, but back it with `AskService.open_ask()` + structured text `Question` + `AskTracker.wait_for_answer()`
- preserve the old blocking `{text,error,status}` response shape and query/response event trail
- update CLI, HTTP API, Python client, architecture, and hook docs for the new compatibility semantics

## Scope
Slice 2 of `repowire-44q`: CLI ask/query convergence only. Did not migrate unrelated `cli.py` HTTP call-sites. `/query` is retained as a shim rather than removed for existing clients and relay compatibility.

## Gates
- `uv run --extra dev ruff check repowire/ tests/`
- `uv run --extra dev ty check repowire/`
- `uv run --extra dev pytest` (1764 passed, 2 warnings)
- `uv run --extra docs zensical build --strict`
- `python3 scripts/pre_pr_hygiene.py`