### PR TITLE
refactor: route resume history through agent backends

### DIFF
--- a/docs/operate/architecture.md
+++ b/docs/operate/architecture.md
@@ -24,7 +24,7 @@ The daemon is the single routing hub. It does not care whether a peer arrived th
 
 | Area | Files | Responsibility |
 | --- | --- | --- |
-| Agent backends | `repowire/agent_types.py`, `repowire/agent_backends.py` | Serialized backend identity plus setup, spawn, resume, MCP config, and post-spawn behavior dispatch |
+| Agent backends | `repowire/agent_types.py`, `repowire/agent_backends.py` | Serialized backend identity plus setup, spawn, resume prevalidation, history loading, MCP config, and post-spawn behavior dispatch |
 | Daemon app | `repowire/daemon/app.py`, `repowire/daemon/deps.py` | FastAPI app factory, dependency wiring, dashboard/static serving |
 | Peer state | `repowire/daemon/peer_registry.py` | Registration, liveness, circles, roles, lazy repair |
 | Message routing | `repowire/daemon/peer_delivery.py`, `repowire/daemon/transport_router.py`, `repowire/daemon/message_router.py`, `repowire/daemon/websocket_transport.py` | Delivery orchestration, ACP-before-WebSocket transport selection, and wire delivery over connected peers |

--- a/repowire/agent_backends.py
+++ b/repowire/agent_backends.py
@@ -122,6 +122,57 @@ class AgentBackend(ABC):
             return f"{command} {self.resume_subcommand} {quoted_session}"
         return f"{command} {self.resume_flag} {quoted_session}"
 
+    def runtime_session_validation_status(
+        self,
+        peer_path: str | None,
+        runtime_session_id: str | None,
+    ) -> str:
+        """Return backend-specific local resume pre-validation status."""
+        if not runtime_session_id:
+            return "missing_id"
+        if not self.supports_resume:
+            return "unsupported"
+        from repowire.session.history import backend_runtime_session_validation_status
+
+        return backend_runtime_session_validation_status(
+            peer_path,
+            self.agent_type.value,
+            runtime_session_id,
+        )
+
+    def load_bound_history(
+        self,
+        *,
+        peer_path: str | None,
+        runtime_session_id: str | None,
+        runtime_source_uri: str | None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """Load history for a durable runtime binding using this backend."""
+        from repowire.session.history import backend_load_bound_history
+
+        return backend_load_bound_history(
+            peer_path=peer_path,
+            backend=self.agent_type.value,
+            runtime_session_id=runtime_session_id,
+            runtime_source_uri=runtime_source_uri,
+            metadata=metadata,
+        )
+
+    def load_peer_history(
+        self,
+        peer_path: str | None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """Load local peer history using this backend's history support."""
+        from repowire.session.history import backend_load_peer_history
+
+        return backend_load_peer_history(
+            peer_path,
+            self.agent_type.value,
+            metadata,
+        )
+
     async def post_spawn_warmup(
         self,
         pane_id: str,

--- a/repowire/daemon/resume_safety.py
+++ b/repowire/daemon/resume_safety.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from repowire.agent_backends import AgentResumePlan, can_resume_backend
+from repowire.agent_backends import AgentResumePlan, agent_backend_for
 from repowire.config.models import AgentType
-from repowire.session.history import runtime_session_validation_status
 
 # Status values (documented set): "resumable", "missing_id", "unsupported",
 # "unvalidated_backend", "stale_missing_file". Kept as str to avoid Literal
@@ -86,11 +85,12 @@ def resolve_resume_safety(
         return ResumeSafetyDecision(None, False, "unsupported",
                                     _warning_for("unsupported", backend_value))
 
-    if not can_resume_backend(backend, runtime_session_id=runtime_session_id):
+    backend_obj = agent_backend_for(backend)
+    if not backend_obj.can_resume(runtime_session_id):
         return ResumeSafetyDecision(None, False, "unsupported",
                                     _warning_for("unsupported", backend_value))
 
-    status = runtime_session_validation_status(path, backend_value, runtime_session_id)
+    status = backend_obj.runtime_session_validation_status(path, runtime_session_id)
     if status != "resumable":
         return ResumeSafetyDecision(None, False, status, _warning_for(status, backend_value))
 

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -37,8 +37,6 @@ from repowire.hooks.ws_hook_supervisor import link_spawn_ws_hook
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 from repowire.session.history import (
     HistoryLoadResult,
-    load_bound_history,
-    load_peer_history,
     page_turns,
 )
 from repowire.session.timeline import (
@@ -1195,9 +1193,9 @@ def _load_history_for_peer(
 ) -> tuple[HistoryLoadResult, SessionBinding | None]:
     binding = _resolve_history_binding(peer, session_id)
     if binding is not None:
-        history = load_bound_history(
+        backend_obj = agent_backend_for(AgentType(binding.backend))
+        history = backend_obj.load_bound_history(
             peer_path=binding.project_path or peer.path,
-            backend=binding.backend,
             runtime_session_id=binding.runtime_session_id or session_id,
             runtime_source_uri=binding.runtime_source_uri,
             metadata={**peer.metadata, **binding.metadata},
@@ -1205,7 +1203,8 @@ def _load_history_for_peer(
         return history, binding
     # Keep peer/path discovery as the downgrade-compatible route behavior when
     # no binding is available or the observed bindings are ambiguous.
-    return load_peer_history(peer.path, peer.backend, peer.metadata), None
+    backend_obj = agent_backend_for(peer.backend)
+    return backend_obj.load_peer_history(peer.path, peer.metadata), None
 
 
 def _history_degradation_message(history: HistoryLoadResult, items: list[TimelineItem]) -> str:

--- a/repowire/session/history.py
+++ b/repowire/session/history.py
@@ -331,12 +331,12 @@ _RESUME_VALIDATORS = {
 PREVALIDATABLE_RESUME_BACKENDS = frozenset(_RESUME_VALIDATORS)
 
 
-def runtime_session_validation_status(
+def backend_runtime_session_validation_status(
     peer_path: str | None,
     backend: str,
     runtime_session_id: str | None,
 ) -> str:
-    """Granular pre-validation status for a runtime_session_id.
+    """Backend-owned granular pre-validation status for a runtime_session_id.
 
     Returns one of:
     - "missing_id": no id captured
@@ -357,6 +357,24 @@ def runtime_session_validation_status(
     if validator is None:
         return "unvalidated_backend"
     return "resumable" if validator(peer_path, runtime_session_id) else "stale_missing_file"
+
+
+def runtime_session_validation_status(
+    peer_path: str | None,
+    backend: str,
+    runtime_session_id: str | None,
+) -> str:
+    """Compatibility wrapper for backend session pre-validation."""
+    from repowire.agent_backends import agent_backend_for
+    from repowire.agent_types import AgentType
+
+    if not runtime_session_id:
+        return "missing_id"
+    try:
+        backend_obj = agent_backend_for(AgentType(getattr(backend, "value", backend)))
+    except ValueError:
+        return backend_runtime_session_validation_status(peer_path, backend, runtime_session_id)
+    return backend_obj.runtime_session_validation_status(peer_path, runtime_session_id)
 
 
 def runtime_session_resumable(
@@ -400,7 +418,7 @@ def _load_paths(
     return turns
 
 
-def load_bound_history(
+def backend_load_bound_history(
     *,
     peer_path: str | None,
     backend: str,
@@ -446,7 +464,37 @@ def load_bound_history(
             message=f"No {history_backend} history found for this session binding.",
         )
 
-    return load_peer_history(peer_path, backend_value, metadata)
+    return backend_load_peer_history(peer_path, backend_value, metadata)
+
+
+def load_bound_history(
+    *,
+    peer_path: str | None,
+    backend: str,
+    runtime_session_id: str | None,
+    runtime_source_uri: str | None,
+    metadata: dict[str, Any] | None = None,
+) -> HistoryLoadResult:
+    """Compatibility wrapper for backend-bound session history loading."""
+    from repowire.agent_backends import agent_backend_for
+    from repowire.agent_types import AgentType
+
+    try:
+        backend_obj = agent_backend_for(AgentType(getattr(backend, "value", backend)))
+    except ValueError:
+        return backend_load_bound_history(
+            peer_path=peer_path,
+            backend=backend,
+            runtime_session_id=runtime_session_id,
+            runtime_source_uri=runtime_source_uri,
+            metadata=metadata,
+        )
+    return backend_obj.load_bound_history(
+        peer_path=peer_path,
+        runtime_session_id=runtime_session_id,
+        runtime_source_uri=runtime_source_uri,
+        metadata=metadata,
+    )
 
 
 def _extract_text(content: Any) -> str:
@@ -708,7 +756,7 @@ def _sort_newest_first(turns: list[Turn]) -> list[Turn]:
     return turns
 
 
-def load_peer_history(
+def backend_load_peer_history(
     peer_path: str | None,
     backend: str,
     metadata: dict[str, Any] | None = None,
@@ -757,6 +805,22 @@ def load_peer_history(
         backend=backend_value,
         message=f"{backend_value} local history is not supported.",
     )
+
+
+def load_peer_history(
+    peer_path: str | None,
+    backend: str,
+    metadata: dict[str, Any] | None = None,
+) -> HistoryLoadResult:
+    """Compatibility wrapper for backend-owned local peer history loading."""
+    from repowire.agent_backends import agent_backend_for
+    from repowire.agent_types import AgentType
+
+    try:
+        backend_obj = agent_backend_for(AgentType(getattr(backend, "value", backend)))
+    except ValueError:
+        return backend_load_peer_history(peer_path, backend, metadata)
+    return backend_obj.load_peer_history(peer_path, metadata)
 
 
 def load_peer_turns(peer_path: str | None, backend: str) -> list[Turn]:

--- a/tests/test_restart_resume.py
+++ b/tests/test_restart_resume.py
@@ -124,6 +124,14 @@ def _write_claude_session(home: Path, cwd: str, session_id: str) -> None:
     (d / f"{session_id}.jsonl").write_text('{"type":"summary"}\n')
 
 
+def _write_codex_session(home: Path, cwd: str, session_id: str) -> None:
+    d = home / ".codex" / "sessions" / "2026" / "06" / "04"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"rollout-2026-06-04T00-00-00-{session_id}.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"cwd": cwd}}) + "\n"
+    )
+
+
 class TestBackendValidators:
     """runtime_session_validation_status across all backends (fixture dirs)."""
 
@@ -132,8 +140,56 @@ class TestBackendValidators:
         from repowire.session.history import runtime_session_validation_status
         return runtime_session_validation_status(cwd, backend, sid)
 
+    def _backend_status(self, monkeypatch, home, cwd, backend, sid):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        from repowire.agent_backends import agent_backend_for
+
+        return agent_backend_for(backend).runtime_session_validation_status(cwd, sid)
+
     def test_missing_id(self, tmp_path, monkeypatch):
         assert self._status(monkeypatch, tmp_path, "/x", "claude-code", None) == "missing_id"
+
+    def test_agent_backend_validates_claude_resume_session(self, tmp_path, monkeypatch):
+        home = tmp_path / "h"
+        cwd = "/Users/test/repo"
+        sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        _write_claude_session(home, cwd, sid)
+
+        assert self._backend_status(
+            monkeypatch, home, cwd, AgentType.CLAUDE_CODE, sid
+        ) == "resumable"
+        assert self._backend_status(
+            monkeypatch, home, cwd, AgentType.CLAUDE_CODE, "stale-id"
+        ) == "stale_missing_file"
+
+    def test_agent_backend_validates_codex_resume_session(self, tmp_path, monkeypatch):
+        home = tmp_path / "h"
+        cwd = "/Users/test/repo"
+        sid = "codex-session-123"
+        _write_codex_session(home, cwd, sid)
+
+        assert self._backend_status(monkeypatch, home, cwd, AgentType.CODEX, sid) == \
+            "resumable"
+        assert self._backend_status(monkeypatch, home, cwd, AgentType.CODEX, "missing") == \
+            "stale_missing_file"
+
+    def test_resume_safety_uses_backend_validation_boundary(self, tmp_path, monkeypatch):
+        home = tmp_path / "h"
+        cwd = "/Users/test/repo"
+        sid = "codex-session-456"
+        _write_codex_session(home, cwd, sid)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        from repowire.daemon.resume_safety import resolve_resume_safety
+
+        decision = resolve_resume_safety(
+            backend=AgentType.CODEX,
+            path=cwd,
+            runtime_session_id=sid,
+        )
+
+        assert decision.resumable
+        assert decision.plan is not None
+        assert decision.plan.backend == AgentType.CODEX
 
     def test_gemini_resumable_with_directory(self, tmp_path, monkeypatch):
         home = tmp_path / "h"


### PR DESCRIPTION
## Summary

Slice 3 for `repowire-44q.4`: move the resume/history public boundary behind `AgentBackend` without changing runtime behavior.

- Added `AgentBackend.runtime_session_validation_status`, `load_bound_history`, and `load_peer_history`.
- Kept the heavy local transcript/session-store parsers in `repowire.session.history`, now exposed as backend helper functions plus compatibility wrappers.
- Updated `resume_safety` and peer timeline/history route loading to use the backend boundary.
- Added targeted Claude + Codex backend validation tests and a Codex resume-safety test.
- Updated the architecture module table to name resume prevalidation/history loading as backend-owned.

## Gates

- `uv run --extra dev ruff check repowire/ tests/`
- `uv run --extra dev ty check repowire/`
- `uv run --extra dev pytest` — 1767 passed, 2 warnings
- `uv run --extra docs zensical build --strict`
- `python3 scripts/pre_pr_hygiene.py`

## Notes

Public behavior is intentionally preserved. I did not update README/concepts/workflows because this is an internal architecture seam rather than a user-facing capability change; `docs/operate/architecture.md` now reflects the boundary.
