### PR TITLE
refactor: narrow config import surface

### DIFF
--- a/docs/operate/architecture.md
+++ b/docs/operate/architecture.md
@@ -25,6 +25,7 @@ The daemon is the single routing hub. It does not care whether a peer arrived th
 | Area | Files | Responsibility |
 | --- | --- | --- |
 | Agent backends | `repowire/agent_types.py`, `repowire/agent_backends.py` | Serialized backend identity plus setup, spawn, resume prevalidation, history loading, MCP config, and post-spawn behavior dispatch |
+| Configuration | `repowire/config/models.py`, `repowire/config/paths.py`, `repowire/config/spawn.py`, `repowire/config/relay.py` | Main config value object plus narrow path, spawn, and relay config slices for callers that do not need the whole model |
 | Daemon app | `repowire/daemon/app.py`, `repowire/daemon/deps.py` | FastAPI app factory, dependency wiring, dashboard/static serving |
 | Peer state | `repowire/daemon/peer_registry.py` | Registration, liveness, circles, roles, lazy repair |
 | Message routing | `repowire/daemon/peer_delivery.py`, `repowire/daemon/transport_router.py`, `repowire/daemon/message_router.py`, `repowire/daemon/websocket_transport.py` | Delivery orchestration, ACP-before-WebSocket transport selection, and wire delivery over connected peers |

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -472,7 +472,7 @@ def uninstall(yes: bool) -> None:
     import shutil
     import subprocess
 
-    from repowire.config.models import Config
+    from repowire.config.paths import get_config_dir
     from repowire.service.installer import get_service_status, uninstall_service
 
     console.print("[cyan]Uninstalling repowire...[/]")
@@ -510,7 +510,7 @@ def uninstall(yes: bool) -> None:
     _uninstall_pi()
 
     # Remove config directory
-    config_dir = Config.get_config_dir()
+    config_dir = get_config_dir()
     if config_dir.exists():
         if yes or click.confirm("Remove ~/.repowire/ (config, logs, attachments)?", default=False):
             shutil.rmtree(config_dir)
@@ -1309,7 +1309,8 @@ _ORCHESTRATOR_RUNTIME_COMMANDS = {
 
 def _configured_spawn_command(backend: str, profile: str | None = None) -> str | None:
     """Return the configured spawn command for a backend/runtime profile."""
-    from repowire.config.models import AgentType, apply_spawn_profile, load_config
+    from repowire.agent_types import AgentType
+    from repowire.config.models import apply_spawn_profile, load_config
 
     try:
         backend_type = AgentType(backend)
@@ -1454,7 +1455,7 @@ def orchestrator_start(runtime: str | None, profile: str | None, service: bool) 
     """Spawn the orchestrator peer in its workspace."""
     import httpx
 
-    from repowire.config.models import AgentType
+    from repowire.agent_types import AgentType
     from repowire.orchestrator import (
         init_workspace,
         validate_workspace,
@@ -3116,7 +3117,7 @@ def peer_new(
     """
     import httpx
 
-    from repowire.config.models import AgentType
+    from repowire.agent_types import AgentType
     from repowire.spawn import SpawnConfig, spawn_peer
 
     actual_path = str(Path(path).resolve())
@@ -4303,9 +4304,9 @@ def config_show() -> None:
 @config.command(name="path")
 def config_path() -> None:
     """Show configuration file path."""
-    from repowire.config.models import Config
+    from repowire.config.paths import get_config_path
 
-    console.print(str(Config.get_config_path()))
+    console.print(str(get_config_path()))
 
 
 @config.command(name="get")

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import os
-import shlex
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -15,71 +14,43 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 
-from repowire.agent_backends import DEFAULT_SPAWN_COMMANDS as _DEFAULT_SPAWN_COMMANDS
 from repowire.agent_types import AgentType
+from repowire.config.paths import CACHE_DIR, get_config_dir, get_config_path
+from repowire.config.relay import RelayConfig
+from repowire.config.spawn import (
+    DEFAULT_SPAWN_COMMANDS,
+    SpawnProfile,
+    SpawnSettings,
+    apply_spawn_profile,
+)
 
-DEFAULT_SPAWN_COMMANDS = _DEFAULT_SPAWN_COMMANDS
+__all__ = [
+    "AgentType",
+    "CACHE_DIR",
+    "Config",
+    "DEFAULT_DAEMON_URL",
+    "DEFAULT_HOST",
+    "DEFAULT_PORT",
+    "DEFAULT_QUERY_TIMEOUT",
+    "DEFAULT_SPAWN_COMMANDS",
+    "DaemonConfig",
+    "ExperimentsConfig",
+    "OrchestratorRecallConfig",
+    "PeerConfig",
+    "RelayConfig",
+    "SpawnProfile",
+    "SpawnSettings",
+    "apply_spawn_profile",
+    "load_config",
+]
 
 DEFAULT_QUERY_TIMEOUT: float = 300.0
 """Default timeout in seconds for peer-to-peer queries (5 minutes)."""
-
-CACHE_DIR: Path = Path.home() / ".cache" / "repowire"
-"""Runtime cache directory for logs and transient state."""
 
 DEFAULT_HOST: str = "127.0.0.1"
 DEFAULT_PORT: int = 8377
 DEFAULT_DAEMON_URL: str = f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
 """Default daemon URL used by hooks and MCP server."""
-
-
-class SpawnProfile(BaseModel):
-    """Named spawn command extension for a backend runtime."""
-
-    args: list[str] = Field(
-        default_factory=list,
-        description="Additional command arguments appended to the backend command",
-    )
-    description: str | None = Field(
-        None,
-        description="Human-facing profile description for UIs and docs",
-    )
-
-
-def apply_spawn_profile(base_command: str, profile: SpawnProfile | None) -> str:
-    """Return a backend command with profile args appended."""
-    if profile is None or not profile.args:
-        return base_command
-    return f"{base_command} {shlex.join(profile.args)}"
-
-
-class RelayConfig(BaseModel):
-    """Configuration for relay server connection."""
-
-    enabled: bool = Field(default=False, description="Whether to connect to relay")
-    url: str = Field(default="wss://repowire.io", description="Relay server URL")
-    api_key: str | None = Field(None, description="API key for authentication")
-
-    @property
-    def dashboard_url(self) -> str | None:
-        """Dashboard URL via the relay, or None if not configured."""
-        if not self.api_key:
-            return None
-        return "https://repowire.io/dashboard"
-
-    def ensure_api_key(self) -> str:
-        """Register with relay and set API key if missing. Returns the key."""
-        if self.api_key:
-            return self.api_key
-        import getpass
-
-        import httpx
-
-        relay_http = self.url.replace("wss://", "https://")
-        user_id = getpass.getuser()
-        resp = httpx.post(f"{relay_http}/api/v1/register", json={"user_id": user_id})
-        resp.raise_for_status()
-        self.api_key = resp.json()["api_key"]
-        return self.api_key
 
 
 class PeerConfig(BaseModel):
@@ -145,72 +116,6 @@ class MCPHttpConfig(BaseModel):
         default=False,
         description="Allow lifecycle/admin tools over HTTP MCP",
     )
-
-
-class SpawnSettings(BaseModel):
-    """Settings controlling which runtimes and paths agents are allowed to spawn into.
-
-    New configs should use ``commands`` keyed by AgentType value. ``allowed_commands``
-    is retained as a one-release compatibility path for older clients/configs.
-    ``allowed_paths`` must be non-empty for spawn to be enabled.
-    """
-
-    commands: dict[AgentType, str] = Field(
-        default_factory=dict,
-        description="Spawn command per backend/runtime (empty = spawn disabled)",
-    )
-    allowed_commands: list[str] = Field(
-        default_factory=list,
-        description="Deprecated legacy allowed spawn commands",
-    )
-    allowed_paths: list[str] = Field(
-        default_factory=list,
-        description="Allowed root directories for spawned sessions (empty = spawn disabled)",
-    )
-    profiles: dict[AgentType, dict[str, SpawnProfile]] = Field(
-        default_factory=dict,
-        description="Optional named spawn profiles per backend",
-    )
-    env_path: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Explicit PATH entries for spawned agent processes. When empty, "
-            "Repowire captures the user's login-shell PATH as a fallback."
-        ),
-    )
-    env: dict[str, str] = Field(
-        default_factory=dict,
-        description="Extra environment variables injected into spawned agent commands",
-    )
-
-    @field_validator("env")
-    @classmethod
-    def validate_env_keys(cls, value: dict[str, str]) -> dict[str, str]:
-        for key in value:
-            if not key.isidentifier():
-                raise ValueError("daemon.spawn.env keys must be shell-safe identifiers")
-        return value
-
-    @model_validator(mode="after")
-    def _bootstrap_legacy_allowed_commands(self) -> SpawnSettings:
-        """Migrate legacy allowed_commands into runtime command profiles on load."""
-        if self.commands or not self.allowed_commands:
-            return self
-        from repowire.agent_backends import AGENT_BACKENDS
-
-        inferred: dict[AgentType, str] = {}
-        command_to_backend = {
-            cli_name: backend_type
-            for backend_type, backend in AGENT_BACKENDS.items()
-            for cli_name in backend.cli_names
-        }
-        for command in self.allowed_commands:
-            head = command.split(None, 1)[0] if command else ""
-            backend = command_to_backend.get(head)
-            if backend and backend not in inferred:
-                inferred[backend] = command
-        self.commands = inferred
-        return self
 
 
 class OrchestratorRecallConfig(BaseModel):
@@ -520,12 +425,12 @@ class Config(BaseModel):
     @classmethod
     def get_config_dir(cls) -> Path:
         """Get the Repowire config directory."""
-        return Path.home() / ".repowire"
+        return get_config_dir()
 
     @classmethod
     def get_config_path(cls) -> Path:
         """Get the config file path."""
-        return cls.get_config_dir() / "config.yaml"
+        return get_config_path()
 
     def save(self) -> None:
         """Save configuration to file atomically (write tmp + rename, 0600 perms)."""

--- a/repowire/config/paths.py
+++ b/repowire/config/paths.py
@@ -1,0 +1,18 @@
+"""Filesystem paths used by Repowire configuration and runtime caches."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CACHE_DIR: Path = Path.home() / ".cache" / "repowire"
+"""Runtime cache directory for logs and transient state."""
+
+
+def get_config_dir() -> Path:
+    """Get the Repowire config directory."""
+    return Path.home() / ".repowire"
+
+
+def get_config_path() -> Path:
+    """Get the Repowire config file path."""
+    return get_config_dir() / "config.yaml"

--- a/repowire/config/relay.py
+++ b/repowire/config/relay.py
@@ -1,0 +1,35 @@
+"""Relay-related configuration models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RelayConfig(BaseModel):
+    """Configuration for relay server connection."""
+
+    enabled: bool = Field(default=False, description="Whether to connect to relay")
+    url: str = Field(default="wss://repowire.io", description="Relay server URL")
+    api_key: str | None = Field(None, description="API key for authentication")
+
+    @property
+    def dashboard_url(self) -> str | None:
+        """Dashboard URL via the relay, or None if not configured."""
+        if not self.api_key:
+            return None
+        return "https://repowire.io/dashboard"
+
+    def ensure_api_key(self) -> str:
+        """Register with relay and set API key if missing. Returns the key."""
+        if self.api_key:
+            return self.api_key
+        import getpass
+
+        import httpx
+
+        relay_http = self.url.replace("wss://", "https://")
+        user_id = getpass.getuser()
+        resp = httpx.post(f"{relay_http}/api/v1/register", json={"user_id": user_id})
+        resp.raise_for_status()
+        self.api_key = resp.json()["api_key"]
+        return self.api_key

--- a/repowire/config/spawn.py
+++ b/repowire/config/spawn.py
@@ -1,0 +1,103 @@
+"""Spawn-related configuration models."""
+
+from __future__ import annotations
+
+import shlex
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from repowire.agent_backends import DEFAULT_SPAWN_COMMANDS
+from repowire.agent_types import AgentType
+
+__all__ = [
+    "DEFAULT_SPAWN_COMMANDS",
+    "SpawnProfile",
+    "SpawnSettings",
+    "apply_spawn_profile",
+]
+
+
+class SpawnProfile(BaseModel):
+    """Named spawn command extension for a backend runtime."""
+
+    args: list[str] = Field(
+        default_factory=list,
+        description="Additional command arguments appended to the backend command",
+    )
+    description: str | None = Field(
+        None,
+        description="Human-facing profile description for UIs and docs",
+    )
+
+
+def apply_spawn_profile(base_command: str, profile: SpawnProfile | None) -> str:
+    """Return a backend command with profile args appended."""
+    if profile is None or not profile.args:
+        return base_command
+    return f"{base_command} {shlex.join(profile.args)}"
+
+
+class SpawnSettings(BaseModel):
+    """Settings controlling which runtimes and paths agents are allowed to spawn into.
+
+    New configs should use ``commands`` keyed by AgentType value. ``allowed_commands``
+    is retained as a one-release compatibility path for older clients/configs.
+    ``allowed_paths`` must be non-empty for spawn to be enabled.
+    """
+
+    commands: dict[AgentType, str] = Field(
+        default_factory=dict,
+        description="Spawn command per backend/runtime (empty = spawn disabled)",
+    )
+    allowed_commands: list[str] = Field(
+        default_factory=list,
+        description="Deprecated legacy allowed spawn commands",
+    )
+    allowed_paths: list[str] = Field(
+        default_factory=list,
+        description="Allowed root directories for spawned sessions (empty = spawn disabled)",
+    )
+    profiles: dict[AgentType, dict[str, SpawnProfile]] = Field(
+        default_factory=dict,
+        description="Optional named spawn profiles per backend",
+    )
+    env_path: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit PATH entries for spawned agent processes. When empty, "
+            "Repowire captures the user's login-shell PATH as a fallback."
+        ),
+    )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra environment variables injected into spawned agent commands",
+    )
+
+    @field_validator("env")
+    @classmethod
+    def validate_env_keys(cls, value: dict[str, str]) -> dict[str, str]:
+        for key in value:
+            if not key.isidentifier():
+                raise ValueError("daemon.spawn.env keys must be shell-safe identifiers")
+        return value
+
+    @model_validator(mode="after")
+    def _bootstrap_legacy_allowed_commands(self) -> SpawnSettings:
+        """Migrate legacy allowed_commands into runtime command profiles on load."""
+        if self.commands or not self.allowed_commands:
+            return self
+        from repowire.agent_backends import AGENT_BACKENDS
+
+        inferred: dict[AgentType, str] = {}
+        command_to_backend = {
+            cli_name: backend_type
+            for backend_type, backend in AGENT_BACKENDS.items()
+            for cli_name in backend.cli_names
+        }
+        for command in self.allowed_commands:
+            head = command.split(None, 1)[0] if command else ""
+            backend = command_to_backend.get(head)
+            if backend and backend not in inferred:
+                inferred[backend] = command
+        self.commands = inferred
+        return self

--- a/repowire/daemon/event_log.py
+++ b/repowire/daemon/event_log.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from repowire.config.models import Config
+from repowire.config import paths as config_paths
 from repowire.daemon.state.events import SQLiteEventStore
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class EventLog:
         max_events: int = 500,
         store: SQLiteEventStore | None = None,
     ) -> None:
-        self.path = path or (Config.get_config_dir() / "events.json")
+        self.path = path or (config_paths.get_config_dir() / "events.json")
         self.events: deque[dict[str, Any]] = deque(maxlen=max_events)
         self.dirty = False
         self.subscribers: set[asyncio.Event] = set()

--- a/repowire/daemon/job_runner.py
+++ b/repowire/daemon/job_runner.py
@@ -11,7 +11,8 @@ from typing import Any
 from fastapi import HTTPException
 
 from repowire.agent_backends import AgentResumePlan
-from repowire.config.models import AgentType, Config
+from repowire.agent_types import AgentType
+from repowire.config.models import Config
 from repowire.daemon.peer_delivery import PeerDeliveryService
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.resume_safety import resolve_resume_safety

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -22,9 +22,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
+from repowire.agent_types import AgentType
 from repowire.config.models import (
     DEFAULT_QUERY_TIMEOUT,
-    AgentType,
     Config,
     DaemonConfig,
     ExperimentsConfig,

--- a/repowire/daemon/relay_client.py
+++ b/repowire/daemon/relay_client.py
@@ -17,7 +17,7 @@ import httpx
 import websockets
 from websockets.asyncio.client import ClientConnection
 
-from repowire.config.models import RelayConfig
+from repowire.config.relay import RelayConfig
 
 logger = logging.getLogger(__name__)
 

--- a/repowire/daemon/resume_safety.py
+++ b/repowire/daemon/resume_safety.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from repowire.agent_backends import AgentResumePlan, agent_backend_for
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 
 # Status values (documented set): "resumable", "missing_id", "unsupported",
 # "unvalidated_backend", "stale_missing_file". Kept as str to avoid Literal

--- a/repowire/daemon/routes/peers.py
+++ b/repowire/daemon/routes/peers.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from repowire import peer_mcp
 from repowire.agent_backends import agent_backend_for, resume_capability_for_registration
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_peer_registry
 from repowire.daemon.diagnostics import (

--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -12,7 +12,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, model_validator
 
 from repowire.agent_backends import agent_backend_for
-from repowire.config.models import AgentType, SpawnProfile, apply_spawn_profile
+from repowire.agent_types import AgentType
+from repowire.config.spawn import SpawnProfile, apply_spawn_profile
 from repowire.daemon.ask_tracker import QuiesceFailedError
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state, get_config, get_peer_registry

--- a/repowire/daemon/routes/websocket.py
+++ b/repowire/daemon/routes/websocket.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.deps import get_app_state
 from repowire.daemon.peer_registry import CircleSource
 from repowire.daemon.routes._shared import is_valid_identifier

--- a/repowire/daemon/routes/work.py
+++ b/repowire/daemon/routes/work.py
@@ -8,7 +8,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.auth import require_auth
 from repowire.daemon.deps import get_app_state
 from repowire.daemon.schedule_cron import CronExpressionError

--- a/repowire/daemon/session_control.py
+++ b/repowire/daemon/session_control.py
@@ -11,7 +11,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from repowire.agent_backends import AgentResumePlan
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.peer_registry import PeerRegistry
 from repowire.daemon.resume_safety import resolve_resume_safety
 from repowire.daemon.spawn_service import SpawnAttemptError, SpawnService

--- a/repowire/daemon/session_controls.py
+++ b/repowire/daemon/session_controls.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from repowire.agent_backends import agent_backend_for, can_resume_backend
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.state.session_bindings import SessionBinding, SQLiteSessionBindingStore
 from repowire.protocol.peers import Peer, PeerStatus
 

--- a/repowire/daemon/session_resume.py
+++ b/repowire/daemon/session_resume.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from repowire.agent_backends import AgentResumePlan, resume_capability_for_registration
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.resume_safety import resolve_resume_safety
 from repowire.daemon.session_controls import SessionResolution
 from repowire.daemon.spawn_service import SpawnService

--- a/repowire/daemon/spawn_service.py
+++ b/repowire/daemon/spawn_service.py
@@ -15,7 +15,8 @@ from typing import Any
 from fastapi import HTTPException, status
 
 from repowire.agent_backends import AgentResumePlan, build_resume_command
-from repowire.config.models import AgentType, SpawnSettings, apply_spawn_profile
+from repowire.agent_types import AgentType
+from repowire.config.spawn import SpawnSettings, apply_spawn_profile
 from repowire.daemon.spawn_diagnostics import capture_spawn_registration_diagnostics
 from repowire.installers.post_spawn import post_spawn_warmup
 from repowire.protocol.peers import PeerRole

--- a/repowire/daemon/state/session_bindings.py
+++ b/repowire/daemon/state/session_bindings.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 from uuid import uuid4
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.daemon.state.database import StateDatabase
 
 BindingStatus = Literal["active", "detached", "resumable", "archived", "lost", "superseded"]

--- a/repowire/hooks/session_handler.py
+++ b/repowire/hooks/session_handler.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import quote
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.hooks._tmux import get_tmux_info
 from repowire.hooks.adapters import normalize
 from repowire.hooks.handoff import load_handoff_context, write_handoff_summary

--- a/repowire/hooks/websocket_hook.py
+++ b/repowire/hooks/websocket_hook.py
@@ -20,7 +20,7 @@ except ImportError as e:
     print("Install with: pip install websockets", file=sys.stderr)
     sys.exit(1)
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 from repowire.hooks._tmux import get_tmux_info
 from repowire.hooks.utils import (
     clear_pane_runtime_state,

--- a/repowire/memory.py
+++ b/repowire/memory.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 import yaml
 
-from repowire.config.models import Config
+from repowire.config import paths as config_paths
 from repowire.orchestrator.persona import get_active_persona, validate_persona_name
 from repowire.orchestrator.workspace import workspace_path
 
@@ -64,7 +64,7 @@ def validate_memory_name(name: str, *, label: str = "name") -> str:
 
 def memory_root() -> Path:
     """Return the mesh-memory root directory."""
-    return Config.get_config_dir() / "memory"
+    return config_paths.get_config_dir() / "memory"
 
 
 def normalize_scope(scope: str | None) -> str:

--- a/repowire/orchestrator/persona.py
+++ b/repowire/orchestrator/persona.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from repowire.config.models import Config
+from repowire.config import paths as config_paths
 from repowire.orchestrator.workspace import workspace_path
 
 _PERSONA_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
@@ -73,7 +73,7 @@ def active_soul_shim_path() -> Path:
 
 def global_persona_dir(name: str) -> Path:
     """Return ~/.repowire/personas/<name>/."""
-    return Config.get_config_dir() / "personas" / validate_persona_name(name)
+    return config_paths.get_config_dir() / "personas" / validate_persona_name(name)
 
 
 def workspace_persona_dir(name: str) -> Path:
@@ -203,7 +203,7 @@ def list_personas() -> list[PersonaSummary]:
     active_path = find_soul_path(active)[0] if active else None
     for source, root in (
         ("workspace", workspace_path() / "personas"),
-        ("global", Config.get_config_dir() / "personas"),
+        ("global", config_paths.get_config_dir() / "personas"),
     ):
         if not root.is_dir():
             continue

--- a/repowire/orchestrator/workspace.py
+++ b/repowire/orchestrator/workspace.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
 
-from repowire.config.models import Config
+from repowire.config import paths as config_paths
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ def _claude_skill_symlink_broken(ws: Path, name: str) -> bool:
 
 def workspace_path() -> Path:
     """Return the orchestrator workspace path."""
-    return Config.get_config_dir() / "orchestrator"
+    return config_paths.get_config_dir() / "orchestrator"
 
 
 @contextmanager

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from repowire.config.models import AgentType
+from repowire.agent_types import AgentType
 
 # Per-turn progress, orthogonal to PeerStatus (online/busy/offline liveness).
 # - "idle":               Stop hook fired, no turn in progress

--- a/repowire/spawn_ownership.py
+++ b/repowire/spawn_ownership.py
@@ -18,12 +18,13 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from repowire.config.models import AgentType, Config
+from repowire.agent_types import AgentType
+from repowire.config import paths as config_paths
 from repowire.protocol.peers import Peer, PeerRole
 
 logger = logging.getLogger(__name__)
 
-OWNERSHIP_PATH = Config.get_config_dir() / "spawn_ownership.json"
+OWNERSHIP_PATH = config_paths.get_config_dir() / "spawn_ownership.json"
 
 OwnershipError = Literal[
     "missing_ownership",

--- a/tests/test_cli_orchestrator.py
+++ b/tests/test_cli_orchestrator.py
@@ -16,8 +16,8 @@ def tmp_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fake_config_dir = tmp_path / ".repowire"
     fake_config_dir.mkdir()
     monkeypatch.setattr(
-        "repowire.orchestrator.workspace.Config.get_config_dir",
-        classmethod(lambda cls: fake_config_dir),
+        "repowire.config.paths.get_config_dir",
+        lambda: fake_config_dir,
     )
     return fake_config_dir / "orchestrator"
 

--- a/tests/test_mesh_memory.py
+++ b/tests/test_mesh_memory.py
@@ -16,8 +16,8 @@ def tmp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fake_config_dir = tmp_path / ".repowire"
     fake_config_dir.mkdir()
     monkeypatch.setattr(
-        "repowire.config.models.Config.get_config_dir",
-        classmethod(lambda cls: fake_config_dir),
+        "repowire.config.paths.get_config_dir",
+        lambda: fake_config_dir,
     )
     return fake_config_dir
 

--- a/tests/test_orchestrator_persona.py
+++ b/tests/test_orchestrator_persona.py
@@ -16,8 +16,8 @@ def tmp_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fake_config_dir = tmp_path / ".repowire"
     fake_config_dir.mkdir()
     monkeypatch.setattr(
-        "repowire.config.models.Config.get_config_dir",
-        classmethod(lambda cls: fake_config_dir),
+        "repowire.config.paths.get_config_dir",
+        lambda: fake_config_dir,
     )
     return fake_config_dir
 

--- a/tests/test_orchestrator_workspace.py
+++ b/tests/test_orchestrator_workspace.py
@@ -15,8 +15,8 @@ def tmp_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     fake_config_dir = tmp_path / ".repowire"
     fake_config_dir.mkdir()
     monkeypatch.setattr(
-        "repowire.orchestrator.workspace.Config.get_config_dir",
-        classmethod(lambda cls: fake_config_dir),
+        "repowire.config.paths.get_config_dir",
+        lambda: fake_config_dir,
     )
     return fake_config_dir / "orchestrator"
 

--- a/tests/test_pane_ownership_recovery.py
+++ b/tests/test_pane_ownership_recovery.py
@@ -88,7 +88,7 @@ async def test_same_path_orchestrator_restart_reuses_sticky_identity(
     registry = _make_registry(tmp_path)
     config_dir = tmp_path / "cfg"
     monkeypatch.setattr(
-        "repowire.orchestrator.workspace.Config.get_config_dir",
+        "repowire.config.paths.get_config_dir",
         lambda: config_dir,
     )
     path = str(config_dir / "orchestrator")
@@ -132,7 +132,7 @@ async def test_same_path_non_config_orchestrator_does_not_reuse_sticky_identity(
     registry = _make_registry(tmp_path)
     config_dir = tmp_path / "cfg"
     monkeypatch.setattr(
-        "repowire.orchestrator.workspace.Config.get_config_dir",
+        "repowire.config.paths.get_config_dir",
         lambda: config_dir,
     )
     wrong_path = str(tmp_path / "other" / "orchestrator")


### PR DESCRIPTION
## Summary

Slice 4 for `repowire-44q.5`: reduce the `Config` / `config.models` import blast radius with no config semantics change.

- Moved path helpers/cache path into `repowire.config.paths`; kept `Config.get_config_dir()` / `Config.get_config_path()` as compatibility delegates.
- Moved spawn config types/helpers into `repowire.config.spawn`; kept `SpawnSettings`, `SpawnProfile`, `DEFAULT_SPAWN_COMMANDS`, and `apply_spawn_profile` re-exported from `config.models`.
- Moved `RelayConfig` into `repowire.config.relay`; kept the `config.models` re-export.
- Repointed production `AgentType` imports to `repowire.agent_types`.
- Updated path-helper tests to patch the new narrow path module.
- Documented the config slices in `docs/operate/architecture.md`.

## Verified Counts

AST-counted on current main before this slice (production `repowire/**/*.py`):

| Metric | Before | After |
| --- | ---: | ---: |
| Direct `Config` class importers from `repowire.config.models` | 14 | 8 |
| Production files importing `repowire.config.models` | 39 | 20 |
| Production files importing `AgentType` from `config.models` | 17 | 0 |
| Production files importing `SpawnSettings` from `config.models` | 1 | 0 |
| Production files importing `RelayConfig` from `config.models` | 1 | 0 |

For the wider repo including tests:

| Metric | Before | After |
| --- | ---: | ---: |
| Direct `Config` class importers | 60 | 54 |
| Files importing `repowire.config.models` | 94 | 75 |
| Files importing `AgentType` from `config.models` | 45 | 28 |

The remaining test imports intentionally exercise the compatibility re-export surface.

## Gates

- `uv run --extra dev ruff check repowire/ tests/`
- `uv run --extra dev ty check repowire/`
- `uv run --extra dev pytest` — 1767 passed, 2 warnings
- `uv run --extra docs zensical build --strict`
- `python3 scripts/pre_pr_hygiene.py`

## Notes

Public config behavior is unchanged. `config.models` remains the compatibility import surface for downstream callers; new internal production code uses the narrower modules.
