### PR TITLE
fix: harden config split edge cases

### DIFF
--- a/repowire/config/relay.py
+++ b/repowire/config/relay.py
@@ -27,9 +27,13 @@ class RelayConfig(BaseModel):
 
         import httpx
 
-        relay_http = self.url.replace("wss://", "https://")
+        relay_http = self.url.replace("wss://", "https://").replace("ws://", "http://")
         user_id = getpass.getuser()
-        resp = httpx.post(f"{relay_http}/api/v1/register", json={"user_id": user_id})
+        resp = httpx.post(
+            f"{relay_http}/api/v1/register",
+            json={"user_id": user_id},
+            timeout=10.0,
+        )
         resp.raise_for_status()
         self.api_key = resp.json()["api_key"]
         return self.api_key

--- a/repowire/config/spawn.py
+++ b/repowire/config/spawn.py
@@ -95,7 +95,8 @@ class SpawnSettings(BaseModel):
             for cli_name in backend.cli_names
         }
         for command in self.allowed_commands:
-            head = command.split(None, 1)[0] if command else ""
+            parts = command.split(None, 1)
+            head = parts[0] if parts else ""
             backend = command_to_backend.get(head)
             if backend and backend not in inferred:
                 inferred[backend] = command

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -276,6 +276,26 @@ class TestRelayConfig:
         relay = RelayConfig()
         assert relay.url == "wss://repowire.io"
 
+    def test_ensure_api_key_supports_local_ws_urls_with_timeout(self):
+        relay = RelayConfig(url="ws://localhost:9000")
+
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"api_key": "rw_local"}
+
+        with patch("getpass.getuser", return_value="tester"), \
+            patch("httpx.post", return_value=Response()) as mock_post:
+            assert relay.ensure_api_key() == "rw_local"
+
+        mock_post.assert_called_once_with(
+            "http://localhost:9000/api/v1/register",
+            json={"user_id": "tester"},
+            timeout=10.0,
+        )
+
 
 class TestSpawnSettings:
     def test_defaults_empty(self):
@@ -310,6 +330,10 @@ class TestSpawnSettings:
         spawn = SpawnSettings(allowed_commands=["claude --model opus", "codex"])
         assert spawn.commands[AgentType.CLAUDE_CODE] == "claude --model opus"
         assert spawn.commands[AgentType.CODEX] == "codex"
+
+    def test_legacy_allowed_commands_ignore_blank_commands(self):
+        spawn = SpawnSettings(allowed_commands=["   ", "", "codex"])
+        assert spawn.commands == {AgentType.CODEX: "codex"}
 
     def test_profiles_can_extend_backend_commands(self):
         spawn = SpawnSettings(


### PR DESCRIPTION
## Summary

Follow-up to Slice 4 / PR #355 for two valid review findings that landed after the slice merge:

- `RelayConfig.ensure_api_key()` now converts local `ws://` relay URLs to `http://` as well as `wss://` to `https://`.
- Relay registration now uses an explicit `timeout=10.0`.
- Legacy `daemon.spawn.allowed_commands` ignores blank/whitespace-only entries instead of indexing into an empty `split()` result.
- Added regression tests for both cases.

## Gates

- `uv run --extra dev pytest tests/test_config.py tests/test_antigravity_installer.py::test_legacy_allowed_commands_maps_agy_to_antigravity` — 75 passed
- `uv run --extra dev ruff check repowire/config tests/test_config.py`
- `uv run --extra dev ty check repowire/`

