### PR TITLE
refactor: extract peer registry seams

### DIFF
--- a/docs/operate/architecture.md
+++ b/docs/operate/architecture.md
@@ -27,7 +27,7 @@ The daemon is the single routing hub. It does not care whether a peer arrived th
 | Agent backends | `repowire/agent_types.py`, `repowire/agent_backends.py` | Serialized backend identity plus setup, spawn, resume prevalidation, history loading, MCP config, and post-spawn behavior dispatch |
 | Configuration | `repowire/config/models.py`, `repowire/config/paths.py`, `repowire/config/spawn.py`, `repowire/config/relay.py` | Main config value object plus narrow path, spawn, and relay config slices for callers that do not need the whole model |
 | Daemon app | `repowire/daemon/app.py`, `repowire/daemon/deps.py` | FastAPI app factory, dependency wiring, dashboard/static serving |
-| Peer state | `repowire/daemon/peer_registry.py` | Registration, liveness, circles, roles, lazy repair |
+| Peer state | `repowire/daemon/peer_registry.py`, `repowire/daemon/registry_identity.py`, `repowire/daemon/registry_events.py`, `repowire/daemon/registry_repair.py` | Registration, identity mapping, liveness, circles, roles, lazy repair, and contradiction events |
 | Message routing | `repowire/daemon/peer_delivery.py`, `repowire/daemon/transport_router.py`, `repowire/daemon/message_router.py`, `repowire/daemon/websocket_transport.py` | Delivery orchestration, ACP-before-WebSocket transport selection, and wire delivery over connected peers |
 | Ask lifecycle | `repowire/daemon/ask_tracker.py`, `repowire/daemon/routes/asks.py` | Open ask state, pending reminders, close/ack handling |
 | Session controls | `repowire/daemon/session_controls.py`, `repowire/daemon/routes/sessions.py` | Session-binding resolution and session-targeted control capability routes |

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import re
-import subprocess
 import time
 from collections import deque
 from dataclasses import asdict, dataclass
@@ -32,6 +31,14 @@ from repowire.config.models import (
 from repowire.daemon import diagnostics as diag
 from repowire.daemon.delivery_trace import DeliveryTraceStore
 from repowire.daemon.event_log import EventLog
+from repowire.daemon.registry_events import PeerContradictionTracker
+from repowire.daemon.registry_identity import (
+    CircleSource,
+    SessionMapping,
+    is_configured_orchestrator_path,
+    normalize_identity_path,
+)
+from repowire.daemon.registry_repair import has_runtime_evidence
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
 
@@ -45,9 +52,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CircleSource = Literal["tmux", "spawn_hint", "fallback"]
-
-
 def _serialize_attachments(attachments: list | None) -> list[dict[str, Any]]:
     if not attachments:
         return []
@@ -55,34 +59,6 @@ def _serialize_attachments(attachments: list | None) -> list[dict[str, Any]]:
         item.model_dump(exclude_none=True) if hasattr(item, "model_dump") else item
         for item in attachments
     ]
-
-
-def normalize_identity_path(raw: str) -> str:
-    """Canonical path form for asker identity matching.
-
-    Used symmetrically at stash time (in routes/asks.py) and at rebind time
-    (in PeerRegistry._redeliver_pending_replies). Returns "" when ``raw`` is
-    empty so the strictness gate can refuse no-path stashes.
-    """
-    if not raw:
-        return ""
-    try:
-        return os.path.normpath(os.path.realpath(raw))
-    except (OSError, ValueError):
-        return os.path.normpath(raw)
-
-
-def _is_configured_orchestrator_path(raw: str | None) -> bool:
-    """Return True when ``raw`` is the configured orchestrator workspace path."""
-    if not raw:
-        return False
-    try:
-        from repowire.orchestrator.workspace import workspace_path
-
-        expected = normalize_identity_path(str(workspace_path()))
-    except Exception:  # noqa: BLE001 - path check must fail closed
-        return False
-    return normalize_identity_path(raw) == expected
 
 
 class PaneHijackRejectedError(Exception):
@@ -103,38 +79,6 @@ class RoleClaimResult:
     peer: Peer
     previous_holders: list[dict[str, str | None]]
     already_held: bool = False
-
-
-# ---------------------------------------------------------------------------
-# SessionMapping dataclass (previously in session_mapper.py)
-# ---------------------------------------------------------------------------
-
-@dataclass
-class SessionMapping:
-    """Persistent mapping of session to peer identity."""
-
-    session_id: str  # "repow-dev-a1b2c3d4"
-    display_name: str
-    circle: str
-    backend: AgentType
-    path: str | None = None
-    role: PeerRole = PeerRole.AGENT
-    updated_at: str | None = None
-    description: str = ""
-    model: str | None = None
-    # Pid of the agent process that last owned this peer. Persisted so the
-    # pane-hijack guard (issue #190) survives daemon restart: when the
-    # original peer rehydrates via its ws-hook, we restore this value into
-    # the in-memory Peer and the guard can compare against it.
-    agent_pid: int | None = None
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.backend, AgentType):
-            self.backend = AgentType(self.backend)
-        if not isinstance(self.role, PeerRole):
-            self.role = PeerRole(self.role)
-        if self.updated_at is None:
-            self.updated_at = datetime.now(timezone.utc).isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -201,10 +145,7 @@ class PeerRegistry:
         self._last_repair: float = 0.0
         self._repair_lock = asyncio.Lock()
 
-        # Transition-only dedup for fail-loud contradiction events: (peer_id, code)
-        # is emitted once on entry into the contradictory state and discarded on
-        # recovery or reap, so the 30s lazy_repair cadence doesn't spam events.
-        self._emitted_contradictions: set[tuple[str, str]] = set()
+        self._contradictions = PeerContradictionTracker()
 
         # When each peer's current description was set. Used for clear-on-read
         # TTL — see config.daemon.description_ttl_seconds. Registry-internal
@@ -463,33 +404,15 @@ class PeerRegistry:
 
         Best-effort: a logging/event-store failure must never abort reconciliation.
         """
-        key = (peer.peer_id, code)
-        if key in self._emitted_contradictions:
-            return
-        self._emitted_contradictions.add(key)
-        try:
-            self.add_event(
-                "peer_contradiction",
-                {
-                    "code": code,
-                    "severity": severity,
-                    "peer_id": peer.peer_id,
-                    "peer_name": peer.display_name,
-                    "detail": detail,
-                },
-            )
-        except Exception:  # noqa: BLE001 - reconciliation must not break on event errors
-            logger.warning("Failed to emit peer_contradiction %s", code, exc_info=True)
+        self._contradictions.emit(peer, code, severity, detail, self.add_event)
 
     def _clear_contradiction(self, peer_id: str, code: str) -> None:
         """Forget a contradiction so a future recurrence re-emits once."""
-        self._emitted_contradictions.discard((peer_id, code))
+        self._contradictions.clear(peer_id, code)
 
     def _clear_all_contradictions(self, peer_id: str) -> None:
         """Drop all contradiction state for a peer (e.g. on reap)."""
-        self._emitted_contradictions = {
-            (pid, code) for (pid, code) in self._emitted_contradictions if pid != peer_id
-        }
+        self._contradictions.clear_all(peer_id)
 
     def subscribe_events(self) -> asyncio.Event:
         """Register a wakeup Event fired on each add_event call.
@@ -1075,8 +998,8 @@ class PeerRegistry:
                         same_sticky_identity = (
                             sticky_holder.backend == backend
                             and sticky_holder.circle == circle
-                            and _is_configured_orchestrator_path(sticky_holder.path)
-                            and _is_configured_orchestrator_path(path)
+                            and is_configured_orchestrator_path(sticky_holder.path)
+                            and is_configured_orchestrator_path(path)
                         )
                         if same_sticky_identity:
                             old_status = sticky_holder.status
@@ -2410,7 +2333,7 @@ class PeerRegistry:
 
         checks = await asyncio.gather(
             *(
-                asyncio.to_thread(self._has_runtime_evidence, peer)
+                asyncio.to_thread(has_runtime_evidence, peer)
                 for peer in pane_candidates
             ),
             return_exceptions=True,
@@ -2460,36 +2383,6 @@ class PeerRegistry:
         if count:
             logger.info("demoted %d ghost peers (no WebSocket/runtime evidence)", count)
         return count
-
-    @staticmethod
-    def _has_runtime_evidence(peer: Peer) -> bool:
-        """Best-effort runtime proof for a disconnected pane-backed peer.
-
-        This is demand-driven lazy repair, not polling. It intentionally
-        checks only local process/tmux evidence and does not attempt any
-        WebSocket recovery.
-        """
-        if peer.agent_pid is not None:
-            try:
-                os.kill(peer.agent_pid, 0)
-                return True
-            except PermissionError:
-                return True
-            except OSError:
-                pass
-
-        if not peer.pane_id:
-            return False
-        try:
-            result = subprocess.run(
-                ["tmux", "display-message", "-t", peer.pane_id, "-p", "#{pane_pid}"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-        except (FileNotFoundError, OSError, subprocess.SubprocessError):
-            return False
-        return result.returncode == 0 and bool(result.stdout.strip())
 
     async def _demote_unsafe_connected_peers(self) -> int:
         """Mark connected tmux peers OFFLINE if their pane is no longer safe."""
@@ -2755,7 +2648,7 @@ class PeerRegistry:
             peer_id = peer.peer_id
             circle = peer.circle
             if not transport.is_connected(peer_id):
-                has_evidence = await asyncio.to_thread(self._has_runtime_evidence, peer)
+                has_evidence = await asyncio.to_thread(has_runtime_evidence, peer)
                 return (peer_id, circle) if has_evidence else None
             if peer.backend == AgentType.OPENCODE:
                 return (peer_id, circle)

--- a/repowire/daemon/registry_events.py
+++ b/repowire/daemon/registry_events.py
@@ -42,6 +42,7 @@ class PeerContradictionTracker:
                 },
             )
         except Exception:  # noqa: BLE001 - reconciliation must not break on event errors
+            self._emitted.discard(key)
             logger.warning("Failed to emit peer_contradiction %s", code, exc_info=True)
 
     def clear(self, peer_id: str, code: str) -> None:

--- a/repowire/daemon/registry_events.py
+++ b/repowire/daemon/registry_events.py
@@ -1,0 +1,55 @@
+"""Event helpers owned by the peer registry."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from repowire.protocol.peers import Peer
+
+logger = logging.getLogger(__name__)
+
+
+class PeerContradictionTracker:
+    """Transition-only dedup for fail-loud peer contradiction events."""
+
+    def __init__(self) -> None:
+        self._emitted: set[tuple[str, str]] = set()
+
+    def emit(
+        self,
+        peer: Peer,
+        code: str,
+        severity: str,
+        detail: str,
+        add_event: Callable[[str, dict[str, Any]], str],
+    ) -> None:
+        """Emit ``peer_contradiction`` once per peer/code transition."""
+        key = (peer.peer_id, code)
+        if key in self._emitted:
+            return
+        self._emitted.add(key)
+        try:
+            add_event(
+                "peer_contradiction",
+                {
+                    "code": code,
+                    "severity": severity,
+                    "peer_id": peer.peer_id,
+                    "peer_name": peer.display_name,
+                    "detail": detail,
+                },
+            )
+        except Exception:  # noqa: BLE001 - reconciliation must not break on event errors
+            logger.warning("Failed to emit peer_contradiction %s", code, exc_info=True)
+
+    def clear(self, peer_id: str, code: str) -> None:
+        """Forget one contradiction so a future recurrence re-emits once."""
+        self._emitted.discard((peer_id, code))
+
+    def clear_all(self, peer_id: str) -> None:
+        """Drop all contradiction state for a peer."""
+        self._emitted = {
+            (pid, code) for (pid, code) in self._emitted if pid != peer_id
+        }

--- a/repowire/daemon/registry_identity.py
+++ b/repowire/daemon/registry_identity.py
@@ -1,0 +1,62 @@
+"""Identity helpers and durable mapping types for the peer registry."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+from repowire.agent_types import AgentType
+from repowire.protocol.peers import PeerRole
+
+CircleSource = Literal["tmux", "spawn_hint", "fallback"]
+
+
+def normalize_identity_path(raw: str) -> str:
+    """Canonical path form for peer identity matching."""
+    if not raw:
+        return ""
+    try:
+        return os.path.normpath(os.path.realpath(raw))
+    except (OSError, ValueError):
+        return os.path.normpath(raw)
+
+
+def is_configured_orchestrator_path(raw: str | None) -> bool:
+    """Return True when ``raw`` is the configured orchestrator workspace path."""
+    if not raw:
+        return False
+    try:
+        from repowire.orchestrator.workspace import workspace_path
+
+        expected = normalize_identity_path(str(workspace_path()))
+    except Exception:  # noqa: BLE001 - path check must fail closed
+        return False
+    return normalize_identity_path(raw) == expected
+
+
+@dataclass
+class SessionMapping:
+    """Persistent mapping of session to peer identity."""
+
+    session_id: str  # "repow-dev-a1b2c3d4"
+    display_name: str
+    circle: str
+    backend: AgentType
+    path: str | None = None
+    role: PeerRole = PeerRole.AGENT
+    updated_at: str | None = None
+    description: str = ""
+    model: str | None = None
+    # Pid of the agent process that last owned this peer. Persisted so the
+    # pane-hijack guard survives daemon restart.
+    agent_pid: int | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend, AgentType):
+            self.backend = AgentType(self.backend)
+        if not isinstance(self.role, PeerRole):
+            self.role = PeerRole(self.role)
+        if self.updated_at is None:
+            self.updated_at = datetime.now(timezone.utc).isoformat()

--- a/repowire/daemon/registry_repair.py
+++ b/repowire/daemon/registry_repair.py
@@ -1,0 +1,37 @@
+"""Pure repair probes used by lazy peer-registry reconciliation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from repowire.protocol.peers import Peer
+
+
+def has_runtime_evidence(peer: Peer) -> bool:
+    """Best-effort runtime proof for a disconnected pane-backed peer.
+
+    This is demand-driven lazy repair, not polling. It intentionally checks only
+    local process/tmux evidence and does not attempt any WebSocket recovery.
+    """
+    if peer.agent_pid is not None:
+        try:
+            os.kill(peer.agent_pid, 0)
+            return True
+        except PermissionError:
+            return True
+        except OSError:
+            pass
+
+    if not peer.pane_id:
+        return False
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-t", peer.pane_id, "-p", "#{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())

--- a/repowire/daemon/registry_repair.py
+++ b/repowire/daemon/registry_repair.py
@@ -14,7 +14,7 @@ def has_runtime_evidence(peer: Peer) -> bool:
     This is demand-driven lazy repair, not polling. It intentionally checks only
     local process/tmux evidence and does not attempt any WebSocket recovery.
     """
-    if peer.agent_pid is not None:
+    if peer.agent_pid is not None and peer.agent_pid > 0:
         try:
             os.kill(peer.agent_pid, 0)
             return True

--- a/tests/test_contradiction_dedup.py
+++ b/tests/test_contradiction_dedup.py
@@ -100,9 +100,15 @@ async def test_recovery_then_recurrence_reemits():
 def test_clear_all_contradictions():
     transport = FakeTransport()
     registry = _registry(transport)
-    registry._emitted_contradictions.add(("p1", diag.ONLINE_BUT_NO_WS))
-    registry._emitted_contradictions.add(("p1", diag.PANE_MISSING))
-    registry._emitted_contradictions.add(("p2", diag.ONLINE_BUT_NO_WS))
+    peer1 = _online_no_pane_peer("p1")
+    peer2 = _online_no_pane_peer("p2")
+    registry._emit_contradiction(peer1, diag.ONLINE_BUT_NO_WS, "error", "one")
+    registry._emit_contradiction(peer1, diag.PANE_MISSING, "error", "two")
+    registry._emit_contradiction(peer2, diag.ONLINE_BUT_NO_WS, "error", "three")
     registry._clear_all_contradictions("p1")
-    assert ("p2", diag.ONLINE_BUT_NO_WS) in registry._emitted_contradictions
-    assert not any(pid == "p1" for pid, _ in registry._emitted_contradictions)
+
+    registry._emit_contradiction(peer1, diag.ONLINE_BUT_NO_WS, "error", "again")
+    registry._emit_contradiction(peer2, diag.ONLINE_BUT_NO_WS, "error", "again")
+    events = _contradiction_events(registry)
+    assert [e["peer_id"] for e in events].count("p1") == 3
+    assert [e["peer_id"] for e in events].count("p2") == 1

--- a/tests/test_lazy_repair.py
+++ b/tests/test_lazy_repair.py
@@ -237,11 +237,11 @@ class TestLazyRepairDebounce:
             live.agent_pid = 999_999_999
 
         monkeypatch.setattr(
-            "repowire.daemon.peer_registry.os.kill",
+            "repowire.daemon.registry_repair.os.kill",
             lambda _pid, _sig: (_ for _ in ()).throw(ProcessLookupError()),
         )
         monkeypatch.setattr(
-            "repowire.daemon.peer_registry.subprocess.run",
+            "repowire.daemon.registry_repair.subprocess.run",
             lambda *_args, **_kwargs: subprocess.CompletedProcess(
                 args=["tmux"], returncode=1, stdout="", stderr="can't find pane",
             ),
@@ -280,11 +280,11 @@ class TestLazyRepairDebounce:
             manager._peers[peer.peer_id].agent_pid = 999_999_999
 
         monkeypatch.setattr(
-            "repowire.daemon.peer_registry.os.kill",
+            "repowire.daemon.registry_repair.os.kill",
             lambda _pid, _sig: (_ for _ in ()).throw(ProcessLookupError()),
         )
         monkeypatch.setattr(
-            "repowire.daemon.peer_registry.subprocess.run",
+            "repowire.daemon.registry_repair.subprocess.run",
             lambda *_args, **_kwargs: subprocess.CompletedProcess(
                 args=["tmux"], returncode=0, stdout="123\n", stderr="",
             ),

--- a/tests/test_registry_events.py
+++ b/tests/test_registry_events.py
@@ -39,6 +39,23 @@ def test_contradiction_tracker_dedups_until_cleared():
     assert len(events) == 2
 
 
+def test_contradiction_tracker_retries_after_event_sink_failure():
+    tracker = PeerContradictionTracker()
+    events: list[tuple[str, dict]] = []
+    peer = _peer()
+
+    def failing_add_event(event_type: str, payload: dict) -> None:
+        raise RuntimeError("event store unavailable")
+
+    def add_event(event_type: str, payload: dict) -> None:
+        events.append((event_type, payload))
+
+    tracker.emit(peer, "online_but_no_ws", "error", "missing ws", failing_add_event)
+    tracker.emit(peer, "online_but_no_ws", "error", "missing ws", add_event)
+
+    assert len(events) == 1
+
+
 def test_contradiction_tracker_clear_all_is_peer_scoped():
     tracker = PeerContradictionTracker()
     events: list[tuple[str, dict]] = []

--- a/tests/test_registry_events.py
+++ b/tests/test_registry_events.py
@@ -1,0 +1,60 @@
+"""Tests for peer-registry event seam helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from repowire.agent_types import AgentType
+from repowire.daemon.registry_events import PeerContradictionTracker
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+def _peer(peer_id: str = "repow-dev-abc12345") -> Peer:
+    return Peer(
+        peer_id=peer_id,
+        display_name="worker",
+        path="/tmp/project",
+        machine="test",
+        backend=AgentType.CLAUDE_CODE,
+        circle="dev",
+        status=PeerStatus.ONLINE,
+        last_seen=datetime.now(timezone.utc),
+    )
+
+
+def test_contradiction_tracker_dedups_until_cleared():
+    tracker = PeerContradictionTracker()
+    events: list[tuple[str, dict]] = []
+    peer = _peer()
+
+    def add_event(event_type: str, payload: dict) -> None:
+        events.append((event_type, payload))
+
+    tracker.emit(peer, "online_but_no_ws", "error", "missing ws", add_event)
+    tracker.emit(peer, "online_but_no_ws", "error", "still missing", add_event)
+    assert len(events) == 1
+
+    tracker.clear(peer.peer_id, "online_but_no_ws")
+    tracker.emit(peer, "online_but_no_ws", "error", "missing again", add_event)
+    assert len(events) == 2
+
+
+def test_contradiction_tracker_clear_all_is_peer_scoped():
+    tracker = PeerContradictionTracker()
+    events: list[tuple[str, dict]] = []
+    peer1 = _peer("p1")
+    peer2 = _peer("p2")
+
+    def add_event(event_type: str, payload: dict) -> None:
+        events.append((event_type, payload))
+
+    tracker.emit(peer1, "a", "error", "one", add_event)
+    tracker.emit(peer1, "b", "error", "two", add_event)
+    tracker.emit(peer2, "a", "error", "three", add_event)
+
+    tracker.clear_all(peer1.peer_id)
+    tracker.emit(peer1, "a", "error", "again", add_event)
+    tracker.emit(peer2, "a", "error", "again", add_event)
+
+    assert [event[1]["peer_id"] for event in events].count("p1") == 3
+    assert [event[1]["peer_id"] for event in events].count("p2") == 1

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -1,0 +1,51 @@
+"""Tests for peer-registry identity helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from repowire.agent_types import AgentType
+from repowire.daemon import peer_registry
+from repowire.daemon.registry_identity import (
+    SessionMapping,
+    is_configured_orchestrator_path,
+    normalize_identity_path,
+)
+from repowire.protocol.peers import PeerRole
+
+
+def test_session_mapping_coerces_backend_role_and_timestamp():
+    mapping = SessionMapping(
+        session_id="repow-dev-abc12345",
+        display_name="worker",
+        circle="dev",
+        backend=AgentType.CODEX.value,
+        role=PeerRole.ORCHESTRATOR.value,
+    )
+
+    assert mapping.backend is AgentType.CODEX
+    assert mapping.role is PeerRole.ORCHESTRATOR
+    assert mapping.updated_at is not None
+    datetime.fromisoformat(mapping.updated_at)
+
+
+def test_normalize_identity_path_is_reexported_from_peer_registry(tmp_path):
+    raw = tmp_path / "folder" / ".." / "folder"
+    expected = normalize_identity_path(str(raw))
+
+    assert peer_registry.normalize_identity_path(str(raw)) == expected
+
+
+def test_configured_orchestrator_path_matches_canonical_path(monkeypatch, tmp_path):
+    orchestrator_dir = tmp_path / "orchestrator"
+    orchestrator_dir.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(orchestrator_dir, target_is_directory=True)
+
+    monkeypatch.setattr(
+        "repowire.orchestrator.workspace.workspace_path",
+        lambda: orchestrator_dir,
+    )
+
+    assert is_configured_orchestrator_path(str(alias))
+    assert not is_configured_orchestrator_path(str(tmp_path / "other"))

--- a/tests/test_registry_repair.py
+++ b/tests/test_registry_repair.py
@@ -37,6 +37,19 @@ def test_has_runtime_evidence_accepts_live_agent_pid(monkeypatch):
     assert calls == [(12345, 0)]
 
 
+def test_has_runtime_evidence_ignores_non_positive_agent_pid(monkeypatch):
+    calls: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, signal: int) -> None:
+        calls.append((pid, signal))
+
+    monkeypatch.setattr("repowire.daemon.registry_repair.os.kill", fake_kill)
+
+    assert not has_runtime_evidence(_peer(agent_pid=0))
+    assert not has_runtime_evidence(_peer(agent_pid=-123))
+    assert calls == []
+
+
 def test_has_runtime_evidence_falls_back_to_live_tmux_pane(monkeypatch):
     def fake_kill(pid: int, signal: int) -> None:
         raise ProcessLookupError

--- a/tests/test_registry_repair.py
+++ b/tests/test_registry_repair.py
@@ -1,0 +1,63 @@
+"""Tests for peer-registry lazy-repair runtime probes."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+
+from repowire.agent_types import AgentType
+from repowire.daemon.registry_repair import has_runtime_evidence
+from repowire.protocol.peers import Peer, PeerStatus
+
+
+def _peer(*, agent_pid: int | None = None, pane_id: str | None = None) -> Peer:
+    return Peer(
+        peer_id="repow-dev-abc12345",
+        display_name="worker",
+        path="/tmp/project",
+        machine="test",
+        backend=AgentType.CLAUDE_CODE,
+        circle="dev",
+        status=PeerStatus.OFFLINE,
+        pane_id=pane_id,
+        agent_pid=agent_pid,
+        last_seen=datetime.now(timezone.utc),
+    )
+
+
+def test_has_runtime_evidence_accepts_live_agent_pid(monkeypatch):
+    calls: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, signal: int) -> None:
+        calls.append((pid, signal))
+
+    monkeypatch.setattr("repowire.daemon.registry_repair.os.kill", fake_kill)
+
+    assert has_runtime_evidence(_peer(agent_pid=12345))
+    assert calls == [(12345, 0)]
+
+
+def test_has_runtime_evidence_falls_back_to_live_tmux_pane(monkeypatch):
+    def fake_kill(pid: int, signal: int) -> None:
+        raise ProcessLookupError
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0, stdout="222\n", stderr="")
+
+    monkeypatch.setattr("repowire.daemon.registry_repair.os.kill", fake_kill)
+    monkeypatch.setattr("repowire.daemon.registry_repair.subprocess.run", fake_run)
+
+    assert has_runtime_evidence(_peer(agent_pid=12345, pane_id="%7"))
+
+
+def test_has_runtime_evidence_rejects_missing_pid_and_pane():
+    assert not has_runtime_evidence(_peer())
+
+
+def test_has_runtime_evidence_rejects_dead_tmux_pane(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="no pane")
+
+    monkeypatch.setattr("repowire.daemon.registry_repair.subprocess.run", fake_run)
+
+    assert not has_runtime_evidence(_peer(pane_id="%7"))


### PR DESCRIPTION
## Summary
- Extract peer identity helpers and SessionMapping into registry_identity while preserving old peer_registry imports for compatibility.
- Extract contradiction event dedup into registry_events and runtime-evidence probing into registry_repair.
- Keep PeerRegistry public behavior/signatures stable; update focused tests and architecture docs for the new internal seam modules.

## Gates
- uv run --extra dev ruff check repowire/ tests/
- uv run --extra dev ty check repowire/
- uv run --extra dev pytest
- uv run --extra docs zensical build --strict

## Notes
- Scope intentionally stays narrow: no lazy_repair algorithm changes, no registration semantics changes, no identity policy changes.
- Existing imports from repowire.daemon.peer_registry for SessionMapping / normalize_identity_path / CircleSource continue to work via module imports.