### PR TITLE
refactor: route spawn validation through service

### DIFF
--- a/repowire/daemon/routes/spawn.py
+++ b/repowire/daemon/routes/spawn.py
@@ -40,6 +40,8 @@ from repowire.spawn_ownership import (
     validate_spawn_ownership,
 )
 
+__all__ = ["SpawnResult"]
+
 # Strong references to background warmup tasks. asyncio holds only weak refs to
 # tasks, so without this set a long-sleeping warmup can be GC'd mid-flight.
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
@@ -267,63 +269,24 @@ async def _authorize_kill(registry: PeerRegistry, from_peer: str | None) -> None
     """Hook for future role-based authorization (e.g. orchestrator-only kill)."""
 
 
-def _record_daemon_spawn_ownership(
-    result: SpawnResult,
-    *,
-    path: str,
-    backend: AgentType,
-    circle: str,
-    role: PeerRole | str,
-    peer_id: str | None = None,
-) -> None:
-    """Record explicit ownership for panes created by daemon spawn/restart."""
+def _spawn_service(state: Any | None = None) -> SpawnService:
+    """Return the daemon spawn service for route handlers.
 
-    if not result.pane_id:
-        return
-    record_spawn_ownership(
-        pane_id=result.pane_id,
-        path=path,
-        backend=backend,
-        circle=circle,
-        role=role,
-        display_name=result.display_name,
-        tmux_session=result.tmux_session,
-        peer_id=peer_id,
-    )
-
-
-def _validate_spawn_path(path: str) -> None:
-    """Validate path against configured spawn roots.
-
-    Raises HTTPException 403 if spawn is disabled or the path is not allowed.
-    Raises HTTPException 404 if the path does not exist on disk.
+    Routes should not construct or bypass spawn behavior ad hoc. Keeping the
+    fallback construction here makes the SpawnService boundary explicit while
+    preserving test harnesses that initialize only partial app state.
     """
-    cfg = get_config()
-    allowed_paths = cfg.daemon.spawn.allowed_paths
-    commands = cfg.daemon.spawn.commands
-
-    if not commands or not allowed_paths:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Spawn is disabled. Set daemon.spawn.commands and "
-                "daemon.spawn.allowed_paths in ~/.repowire/config.yaml"
-            ),
-        )
-
-    resolved = Path(path).expanduser().resolve()
-    if not resolved.exists():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Path does not exist: {path}",
-        )
-
-    allowed_roots = [Path(p).expanduser().resolve() for p in allowed_paths]
-    if not any(resolved == root or root in resolved.parents for root in allowed_roots):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Path not under any allowed_paths: {path}",
-        )
+    state = state or get_app_state()
+    service = getattr(state, "spawn_service", None)
+    if service is not None:
+        return service
+    return SpawnService(
+        spawn=get_config().daemon.spawn,
+        spawned_pane_ids=_SPAWNED_PANE_IDS,
+        background_tasks=_BACKGROUND_TASKS,
+        spawn_impl=spawn_peer,
+        warmup_impl=post_spawn_warmup,
+    )
 
 
 @router.post("/spawn", response_model=SpawnResponse)
@@ -346,13 +309,7 @@ async def spawn(
         )
     else:
         backend = request.backend
-    service = getattr(get_app_state(), "spawn_service", None) or SpawnService(
-        spawn=get_config().daemon.spawn,
-        spawned_pane_ids=_SPAWNED_PANE_IDS,
-        background_tasks=_BACKGROUND_TASKS,
-        spawn_impl=spawn_peer,
-        warmup_impl=post_spawn_warmup,
-    )
+    service = _spawn_service()
     resolved_path = str(Path(request.path).expanduser().resolve())
     result = service.spawn(
         path=request.path,
@@ -844,18 +801,10 @@ async def restart_peer(
             },
         )
 
-    _validate_spawn_path(peer.path)
-
     spawn_circle = peer.circle or "default"
-    resolved_path = str(Path(peer.path).expanduser().resolve())
     state = get_app_state()
-    service = getattr(state, "spawn_service", None) or SpawnService(
-        spawn=get_config().daemon.spawn,
-        spawned_pane_ids=_SPAWNED_PANE_IDS,
-        background_tasks=_BACKGROUND_TASKS,
-        spawn_impl=spawn_peer,
-        warmup_impl=post_spawn_warmup,
-    )
+    service = _spawn_service(state)
+    resolved_path = service.validate_path(peer.path)
     resume_target_for_peer = _restart_resume_target(
         peer=peer,
         resolved_path=resolved_path,
@@ -1251,13 +1200,7 @@ async def switch_peer_backend(
     # the peer until end_quiesce() runs. Without the barrier a fresh /ask could
     # race between the pending check and the kill and be orphaned by the switch.
     state = get_app_state()
-    service = getattr(state, "spawn_service", None) or SpawnService(
-        spawn=get_config().daemon.spawn,
-        spawned_pane_ids=_SPAWNED_PANE_IDS,
-        background_tasks=_BACKGROUND_TASKS,
-        spawn_impl=spawn_peer,
-        warmup_impl=post_spawn_warmup,
-    )
+    service = _spawn_service(state)
     # Validate the resolved command + peer's existing path against config before
     # any destructive action so a misconfigured switch cannot kill a live peer.
     service.validate_path(peer.path)

--- a/tests/test_restart_peer_route.py
+++ b/tests/test_restart_peer_route.py
@@ -113,6 +113,25 @@ def _spawn_result(pane_id: str = "%202") -> SpawnResult:
     )
 
 
+class _SpySpawnService:
+    def __init__(self, tmp_path: Path):
+        self.tmp_path = tmp_path
+        self.validated_paths: list[str] = []
+
+    def validate_path(self, path: str) -> str:
+        self.validated_paths.append(path)
+        return str(Path(path).expanduser().resolve())
+
+    def resolve_command(self, backend, profile=None):
+        return "claude"
+
+    def resume_command(self, command, *, backend, resume_plan):
+        return f"{command} --resume {resume_plan.runtime_session_id}"
+
+    def spawn(self, **kwargs):
+        raise AssertionError("dry-run restart must not spawn")
+
+
 def _patch_resume():
     def fake_resolve_resume_safety(
         *,
@@ -223,6 +242,23 @@ class TestRestartPeerRoute:
         assert response.json()["restarted"] is False
         mock_kill.assert_not_called()
         mock_spawn.assert_not_called()
+
+    async def test_restart_validates_path_through_spawn_service(self, env, tmp_path):
+        name = await _register(env.client, path=str(tmp_path), pane_id="%101")
+        spawn_routes._SPAWNED_PANE_IDS.add("%101")
+        service = _SpySpawnService(tmp_path)
+
+        with patch.object(spawn_routes, "_spawn_service", return_value=service), \
+            patch.object(spawn_routes, "kill_pane") as mock_kill, \
+            _patch_resume():
+            response = await env.client.post(
+                f"/peers/{name}/restart",
+                json={"dry_run": True},
+            )
+
+        assert response.status_code == 200, response.text
+        assert service.validated_paths == [str(tmp_path)]
+        mock_kill.assert_not_called()
 
     async def test_dry_run_uses_durable_ownership_after_daemon_restart(
         self, env, tmp_path, monkeypatch,


### PR DESCRIPTION
## Summary
- Confirmed spawn-producing route entrypoints already use SpawnService.spawn after #349/#356.
- Removed the remaining route-local spawn path validator from restart and route restart path validation through SpawnService.validate_path.
- Centralized spawn route access to the daemon spawn service in _spawn_service, leaving spawn_peer only as the injected low-level implementation for fallback/test harness construction.
- Added a restart regression test proving dry-run restart validates through the injected spawn service.

## Gates
- uv run --extra dev ruff check repowire/ tests/
- uv run --extra dev ty check repowire/
- uv run --extra dev pytest: 1781 passed, 2 existing FastAPI deprecation warnings

## Docs
No public docs change: this is an internal route/service-boundary cleanup with no user-visible behavior change.