### PR TITLE
feat: session sharing — relay share tokens, scoped proxy, viewer page

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -159,6 +159,30 @@ repowire trace TRACE_ID [--json]
 
 Shows the recorded delivery stages for one message — an ask (use its `correlation_id`) or a notify (use its `delivery_id`, returned in the `/notify` response). Stages are ordered (`created → resolved_peer → routed → websocket_sent → hook_received → pane_injected → … → acked → closed`, plus failure stages `resolve_failed`, `no_connection`, `injection_failed`). Terminal stages are recorded **truthfully** from the transport outcome: `pane_injected` only when the ws-hook returned an `injected` delivery receipt; `injection_failed` on a `failed`/`rejected` receipt; and `websocket_sent` (unverified) for ACP delivery or legacy hooks that don't acknowledge, rather than assuming injection. This reads the local delivery trace ledger (`GET /traces/{trace_id}`); no external tracing infrastructure is required, and rows older than `daemon.prune_max_age_hours` are pruned during lazy repair. Currently covers ask and notify; query/broadcast pane stages are not yet traced. Exits non-zero if any stage failed.
 
+## `repowire share`
+
+```bash
+repowire share PEER_NAME [--rw] [--ttl SECS]
+repowire share --list
+repowire share --revoke SHARE_ID
+```
+
+Generate a shareable browser link for a running peer. Requires relay (`repowire
+setup --relay`). The link is served by the relay and requires no Repowire
+installation to open.
+
+| Flag | Description |
+|---|---|
+| `PEER_NAME` | Display name of the peer to share. Required — use `repowire peer list` to see registered peers. |
+| `--rw` | Read-write link; viewer can inject asks. Default is read-only. |
+| `--ttl SECS` | Link lifetime in seconds (> 0). Default: no expiry. |
+| `--list` | Show all active share links for this daemon. |
+| `--revoke SHARE_ID` | Revoke a share link immediately. |
+
+The command prints the share URL and the `share_id` needed for revocation.
+
+Links are scoped to one peer. The relay invalidates all links when it restarts.
+
 ## `repowire schedule`
 
 ```bash

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -374,8 +374,47 @@ schedule_delete(schedule_id: str) -> str
 
 Cancel a pending scheduled check-in by the ID `schedule_create` returned.
 
+## Session sharing
+
+### `share_session`
+
+```python
+share_session(
+    peer_name: str | None = None,
+    permissions: str = "ro",
+    ttl_secs: int | None = None,
+) -> str
+```
+
+Generate a shareable relay link for a peer. **Only call when the user explicitly
+asks** — do not share proactively. Requires relay to be configured.
+
+| Arg | Description |
+|---|---|
+| `peer_name` | Display name of the peer to share. Defaults to the calling peer (yourself). |
+| `permissions` | `"ro"` (read-only, default) or `"rw"` (read-write — viewer can inject asks). |
+| `ttl_secs` | Link lifetime in seconds (must be > 0). `None` means no expiry. |
+
+Returns the share URL and `share_id`, e.g.:
+
+```
+share link for my-agent [ro]: https://repowire.io/s/sh_xxx
+share_id: sh_xxx
+expires: never
+```
+
+### `revoke_share`
+
+```python
+revoke_share(share_id: str) -> str
+```
+
+Revoke a share link. Active SSE connections on that link receive a
+`share_expired` event and close within the next keepalive cycle.
+
 ## See also
 
 - The [typed Python client](python-client.md) exposes the same routing calls over the daemon's HTTP API for non-MCP callers.
 - [Message types](../concepts/message-types.md) covers the semantics of `ask`, `ack`, `notify_peer`, and `broadcast` at a higher level.
 - The [orchestrator pattern](../concepts/orchestrator.md) shows where `orchestrator_status`, `review_queue`, and the scheduling tools fit together.
+- [Session sharing](../use/features/session-sharing.md) — full usage guide with examples.

--- a/docs/use/features/session-sharing.md
+++ b/docs/use/features/session-sharing.md
@@ -1,0 +1,131 @@
+# Session sharing
+
+## What it is
+
+Session sharing generates a shareable URL for a running agent peer. Anyone with
+the link can watch the agent's live event stream in a browser — without needing
+a relay key, a running daemon, or any Repowire installation. Optionally, the
+link can allow the viewer to inject asks (read-write).
+
+Links are scoped to a single peer. The rest of the mesh is not visible.
+
+## When to use it
+
+- Hand a link to a colleague so they can observe an agent mid-task without SSH
+  access.
+- Give a stakeholder a live view of a long-running job.
+- Share a debugging session across machines.
+- Let a reviewer inject instructions into an active agent (read-write).
+
+Skip session sharing when the viewer needs full dashboard access. Use
+[relay access](relay-access.md) for that.
+
+## Requirements
+
+The relay must be configured before sharing works:
+
+```bash
+repowire setup --relay
+```
+
+The daemon connects to the hosted relay at `repowire.io`. The share link is
+served from the same relay.
+
+## Quickstart
+
+```bash
+repowire share my-agent
+```
+
+Output:
+
+```
+Share link created — [ro]
+
+  https://repowire.io/s/sh_xxxxxxxxxxxxxxxx
+
+  share_id: sh_xxxxxxxxxxxxxxxx
+  expires:  never
+
+  Revoke:   repowire share --revoke sh_xxxxxxxxxxxxxxxx
+```
+
+Open the URL in any browser. No login required.
+
+## Read-write links
+
+```bash
+repowire share my-agent --rw
+```
+
+The viewer page gains a compose box. Messages sent there arrive as asks from a
+`guest` peer. The agent sees them the same as any other ask.
+
+Use read-write links with people you trust — they can steer the agent.
+
+## Expiry
+
+Links do not expire by default. Set a TTL in seconds:
+
+```bash
+repowire share my-agent --ttl 3600   # expires in 1 hour
+```
+
+Once the link expires, the viewer page shows an expiry notice. Active SSE
+connections also receive a `share_expired` event and close.
+
+Links are invalidated when the relay process restarts. This is intentional:
+restart = clean slate.
+
+## List and revoke
+
+```bash
+repowire share --list
+
+repowire share --revoke sh_xxxxxxxxxxxxxxxx
+```
+
+## From an agent (MCP)
+
+Agents can generate share links for themselves. Call only when the user
+explicitly asks — do not share proactively:
+
+```python
+share_session()                            # share yourself, read-only
+share_session(permissions="rw")            # read-write
+share_session(peer_name="other-agent")     # share a different peer
+share_session(ttl_secs=1800)               # expires in 30 minutes
+```
+
+Revoke a link:
+
+```python
+revoke_share(share_id="sh_xxx")
+```
+
+## What the viewer sees
+
+The viewer page is a minimal dark-themed page that:
+
+- Shows the peer name and permissions badge.
+- Streams live events (asks, chat turns, status changes) as they arrive.
+- Filters events to the shared peer only — other mesh activity is not visible.
+- (Read-write only) Has a compose area to send asks.
+
+## Security model
+
+- **Anyone with the link can view** (ro) or interact (rw). Treat share links as
+  secrets — do not post them publicly.
+- Read-only links cannot inject asks even if the viewer manipulates the request.
+  The relay enforces permissions server-side.
+- Links are not tied to the viewer's identity. There is no login step.
+- All event strings (`type`, `from_peer`, `text`) are HTML-escaped before
+  rendering — no script injection through event content.
+- Revoking a link closes active SSE connections within the next keepalive cycle
+  (≤ 15 seconds).
+
+## See also
+
+- [Relay access](relay-access.md) — full dashboard access for the mesh owner.
+- [`repowire share`](../../reference/cli.md#repowire-share) — CLI reference.
+- [`share_session`](../../reference/mcp-tools.md#share_session) — MCP tool reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
           - Spawning: use/features/spawning.md
           - Orchestration: use/features/orchestration.md
           - Relay access: use/features/relay-access.md
+          - Session sharing: use/features/session-sharing.md
           - Memory: use/features/memory.md
           - Skills: use/features/skills.md
       - Workflows:

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4166,6 +4166,111 @@ def relay_generate_key(user_id: str) -> None:
 
 
 # =============================================================================
+# share command
+# =============================================================================
+
+
+@main.command(name="share")
+@click.argument("peer_name", required=False)
+@click.option("--rw", is_flag=True, default=False, help="Allow viewer to send messages (read-write)")
+@click.option("--ttl", default=None, type=int, metavar="SECS", help="Link lifetime in seconds (default: no expiry)")
+@click.option("--revoke", default=None, metavar="SHARE_ID", help="Revoke a share link by its ID")
+@click.option("--list", "list_shares", is_flag=True, default=False, help="List active share links")
+def share_session(
+    peer_name: str | None,
+    rw: bool,
+    ttl: int | None,
+    revoke: str | None,
+    list_shares: bool,
+) -> None:
+    """Share a peer's session via a relay link.
+
+    Generates a shareable URL for PEER_NAME (defaults to the local daemon's
+    first connected peer). Requires relay to be configured.
+
+    Examples:
+
+      repowire share                      # share first peer, read-only
+      repowire share my-agent --rw        # read-write link
+      repowire share my-agent --ttl 3600  # expires in 1 hour
+      repowire share --list               # show active links
+      repowire share --revoke sh_xxx      # revoke a link
+    """
+    import httpx
+
+    daemon_url = _get_daemon_url()
+
+    if list_shares:
+        try:
+            resp = httpx.get(f"{daemon_url}/shares", timeout=10.0)
+            resp.raise_for_status()
+        except httpx.ConnectError:
+            console.print("[yellow]Daemon is not running.[/]")
+            return
+        tokens = resp.json()
+        if not tokens:
+            console.print("[dim]No active share links.[/]")
+            return
+        for t in tokens:
+            expires = t.get("expires_at") or "never"
+            perms = t.get("permissions", "ro")
+            console.print(f"[cyan]{t['share_id']}[/]  [{perms}]  {t.get('url', '')}  (expires: {expires})")
+        return
+
+    if revoke:
+        try:
+            resp = httpx.delete(f"{daemon_url}/shares/{revoke}", timeout=10.0)
+            resp.raise_for_status()
+        except httpx.ConnectError:
+            console.print("[yellow]Daemon is not running.[/]")
+            return
+        console.print(f"[green]Revoked share link {revoke}[/]")
+        return
+
+    payload: dict = {"permissions": "rw" if rw else "ro"}
+    if peer_name:
+        payload["peer_name"] = peer_name
+    else:
+        # Default to the first registered peer name from the daemon
+        try:
+            pr = httpx.get(f"{daemon_url}/peers", timeout=5.0)
+            pr.raise_for_status()
+            peers_data = pr.json()
+            if not peers_data:
+                console.print("[yellow]No peers registered. Start an agent session first.[/]")
+                return
+            payload["peer_name"] = peers_data[0].get("display_name") or peers_data[0].get("peer_name", "")
+        except Exception:
+            console.print("[yellow]Could not resolve peer name from daemon.[/]")
+            return
+
+    if ttl is not None:
+        payload["ttl_secs"] = ttl
+
+    try:
+        resp = httpx.post(f"{daemon_url}/shares", json=payload, timeout=10.0)
+        resp.raise_for_status()
+    except httpx.ConnectError:
+        console.print("[yellow]Daemon is not running.[/]")
+        return
+    except httpx.HTTPStatusError as e:
+        console.print(f"[red]Error: {e.response.status_code} — {e.response.text}[/]")
+        return
+
+    data = resp.json()
+    url = data.get("url", "")
+    share_id = data.get("share_id", "")
+    perms = data.get("permissions", "ro")
+    expires = data.get("expires_at") or "never"
+
+    console.print(f"\n[green]Share link created[/] — [{perms}]")
+    console.print(f"\n  [bold cyan]{url}[/]\n")
+    console.print(f"  share_id: [dim]{share_id}[/]")
+    console.print(f"  expires:  [dim]{expires}[/]")
+    console.print(f"\n  Revoke:   [dim]repowire share --revoke {share_id}[/]\n")
+
+
+# =============================================================================
 # telegram command group
 # =============================================================================
 

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4172,8 +4172,8 @@ def relay_generate_key(user_id: str) -> None:
 
 @main.command(name="share")
 @click.argument("peer_name", required=False)
-@click.option("--rw", is_flag=True, default=False, help="Allow viewer to send messages (read-write)")
-@click.option("--ttl", default=None, type=int, metavar="SECS", help="Link lifetime in seconds (default: no expiry)")
+@click.option("--rw", is_flag=True, default=False, help="Allow viewer to send messages (rw)")
+@click.option("--ttl", default=None, type=int, metavar="SECS", help="Link lifetime in seconds")
 @click.option("--revoke", default=None, metavar="SHARE_ID", help="Revoke a share link by its ID")
 @click.option("--list", "list_shares", is_flag=True, default=False, help="List active share links")
 def share_session(
@@ -4202,7 +4202,7 @@ def share_session(
 
     if list_shares:
         try:
-            resp = httpx.get(f"{daemon_url}/shares", timeout=10.0)
+            resp = httpx.get(f"{daemon_url}/shares", headers=_auth_headers(), timeout=10.0)
             resp.raise_for_status()
         except httpx.ConnectError:
             console.print("[yellow]Daemon is not running.[/]")
@@ -4214,12 +4214,16 @@ def share_session(
         for t in tokens:
             expires = t.get("expires_at") or "never"
             perms = t.get("permissions", "ro")
-            console.print(f"[cyan]{t['share_id']}[/]  [{perms}]  {t.get('url', '')}  (expires: {expires})")
+            console.print(
+                f"[cyan]{t['share_id']}[/]  [{perms}]  {t.get('url', '')}  (expires: {expires})"
+            )
         return
 
     if revoke:
         try:
-            resp = httpx.delete(f"{daemon_url}/shares/{revoke}", timeout=10.0)
+            resp = httpx.delete(
+                f"{daemon_url}/shares/{revoke}", headers=_auth_headers(), timeout=10.0
+            )
             resp.raise_for_status()
         except httpx.ConnectError:
             console.print("[yellow]Daemon is not running.[/]")
@@ -4227,28 +4231,35 @@ def share_session(
         console.print(f"[green]Revoked share link {revoke}[/]")
         return
 
-    payload: dict = {"permissions": "rw" if rw else "ro"}
-    if peer_name:
-        payload["peer_name"] = peer_name
-    else:
-        # Default to the first registered peer name from the daemon
+    if not peer_name:
+        # Show registered peers so the user can pick one explicitly
         try:
-            pr = httpx.get(f"{daemon_url}/peers", timeout=5.0)
+            pr = httpx.get(f"{daemon_url}/peers", headers=_auth_headers(), timeout=5.0)
             pr.raise_for_status()
-            peers_data = pr.json()
-            if not peers_data:
-                console.print("[yellow]No peers registered. Start an agent session first.[/]")
-                return
-            payload["peer_name"] = peers_data[0].get("display_name") or peers_data[0].get("peer_name", "")
-        except Exception:
-            console.print("[yellow]Could not resolve peer name from daemon.[/]")
+            peers_data = pr.json().get("peers", [])
+        except httpx.ConnectError:
+            console.print("[yellow]Daemon is not running.[/]")
             return
+        except Exception:
+            peers_data = []
+        if peers_data:
+            names = "  ".join(
+                p.get("display_name") or p.get("peer_name", "?") for p in peers_data[:8]
+            )
+            console.print(f"[yellow]Peer name required.[/]  Available: {names}")
+        else:
+            console.print("[yellow]Peer name required. No peers are currently registered.[/]")
+        console.print("[dim]Usage: repowire share <peer_name> [--rw][/]")
+        raise SystemExit(1)
 
+    payload: dict = {"peer_name": peer_name, "permissions": "rw" if rw else "ro"}
     if ttl is not None:
         payload["ttl_secs"] = ttl
 
     try:
-        resp = httpx.post(f"{daemon_url}/shares", json=payload, timeout=10.0)
+        resp = httpx.post(
+            f"{daemon_url}/shares", json=payload, headers=_auth_headers(), timeout=10.0
+        )
         resp.raise_for_status()
     except httpx.ConnectError:
         console.print("[yellow]Daemon is not running.[/]")

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -50,6 +50,7 @@ from repowire.daemon.routes import (
     reviews,
     schedules,
     sessions,
+    shares,
     traces,
     websocket,
     work,
@@ -523,6 +524,7 @@ def create_app(
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
     app.include_router(sessions.router)
+    app.include_router(shares.router)
     app.include_router(traces.router)
     app.include_router(work.router)
 
@@ -780,6 +782,7 @@ def create_test_app(
     app.include_router(lifecycle.router)
     app.include_router(schedules.router)
     app.include_router(sessions.router)
+    app.include_router(shares.router)
     app.include_router(traces.router)
     app.include_router(work.router)
 

--- a/repowire/daemon/routes/shares.py
+++ b/repowire/daemon/routes/shares.py
@@ -23,7 +23,9 @@ router = APIRouter(tags=["shares"])
 class ShareRequest(BaseModel):
     peer_name: str = Field(..., description="Display name of the peer to share")
     permissions: str = Field("ro", description="'ro' (read-only) or 'rw' (read-write)")
-    ttl_secs: int | None = Field(None, description="Token lifetime in seconds; None = no expiry")
+    ttl_secs: int | None = Field(
+        None, gt=0, description="Token lifetime in seconds; None = no expiry"
+    )
 
 
 def _relay_http_and_key() -> tuple[str, str] | None:
@@ -80,7 +82,7 @@ async def list_shares(
             headers={"x-api-key": api_key},
         )
     if resp.status_code != 200:
-        return []
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
     tokens = resp.json()
     for t in tokens:
         t["url"] = f"{base}/s/{t['share_id']}"

--- a/repowire/daemon/routes/shares.py
+++ b/repowire/daemon/routes/shares.py
@@ -33,7 +33,7 @@ def _relay_http_and_key() -> tuple[str, str] | None:
     relay = cfg.relay
     if not relay.enabled or not relay.api_key:
         return None
-    base = relay.url.replace("wss://", "https://").replace("ws://", "http://")
+    base = relay.url.replace("wss://", "https://").replace("ws://", "http://").rstrip("/")
     return base, relay.api_key
 
 

--- a/repowire/daemon/routes/shares.py
+++ b/repowire/daemon/routes/shares.py
@@ -1,0 +1,106 @@
+"""Share session endpoints — wraps relay share-token creation.
+
+POST /shares          create a share token via the relay, return {share_id, url, ...}
+GET  /shares          list active share tokens for this daemon's relay user
+DELETE /shares/{id}   revoke a share token via the relay
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from repowire.daemon.auth import require_auth
+from repowire.daemon.deps import get_app_state
+
+log = logging.getLogger(__name__)
+router = APIRouter(tags=["shares"])
+
+
+class ShareRequest(BaseModel):
+    peer_name: str = Field(..., description="Display name of the peer to share")
+    permissions: str = Field("ro", description="'ro' (read-only) or 'rw' (read-write)")
+    ttl_secs: int | None = Field(None, description="Token lifetime in seconds; None = no expiry")
+
+
+def _relay_http_and_key() -> tuple[str, str] | None:
+    """Return (relay_http_base, api_key) if relay is configured, else None."""
+    state = get_app_state()
+    cfg = state.config  # type: ignore[attr-defined]
+    relay = cfg.relay
+    if not relay.enabled or not relay.api_key:
+        return None
+    base = relay.url.replace("wss://", "https://").replace("ws://", "http://")
+    return base, relay.api_key
+
+
+@router.post("/shares")
+async def create_share(
+    req: ShareRequest,
+    _: str | None = Depends(require_auth),
+) -> dict:
+    cfg = _relay_http_and_key()
+    if cfg is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Relay not configured. Run `repowire setup --relay` first.",
+        )
+    base, api_key = cfg
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base}/api/v1/share",
+            json={
+                "peer_name": req.peer_name,
+                "permissions": req.permissions,
+                "ttl_secs": req.ttl_secs,
+            },
+            headers={"x-api-key": api_key},
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    data = resp.json()
+    data["url"] = f"{base}/s/{data['share_id']}"
+    return data
+
+
+@router.get("/shares")
+async def list_shares(
+    _: str | None = Depends(require_auth),
+) -> list[dict]:
+    cfg = _relay_http_and_key()
+    if cfg is None:
+        return []
+    base, api_key = cfg
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(
+            f"{base}/api/v1/share",
+            headers={"x-api-key": api_key},
+        )
+    if resp.status_code != 200:
+        return []
+    tokens = resp.json()
+    for t in tokens:
+        t["url"] = f"{base}/s/{t['share_id']}"
+    return tokens
+
+
+@router.delete("/shares/{share_id}")
+async def revoke_share(
+    share_id: str,
+    _: str | None = Depends(require_auth),
+) -> dict:
+    cfg = _relay_http_and_key()
+    if cfg is None:
+        raise HTTPException(status_code=503, detail="Relay not configured")
+    base, api_key = cfg
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.delete(
+            f"{base}/api/v1/share/{share_id}",
+            headers={"x-api-key": api_key},
+        )
+    if resp.status_code not in (200, 404):
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return resp.json()

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -1781,15 +1781,20 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
     ) -> str:
         """[Repowire mesh] Share a peer's session via a relay link.
 
+        ONLY call this tool when the user has explicitly asked to share a session
+        or generate a share link. Do not call proactively or as part of routine
+        setup — sharing exposes live agent activity to anyone with the link.
+
         Generates a shareable URL for a peer. Anyone with the URL can observe
         the session (read-only) or interact with the peer (read-write).
 
         Requires relay to be configured (`repowire setup --relay`).
 
         Args:
-            peer_name: Peer to share. Defaults to this peer (yourself).
+            peer_name: Display name of the peer to share. Defaults to yourself.
             permissions: "ro" (read-only, default) or "rw" (read-write).
-            ttl_secs: Link lifetime in seconds. None means no expiry.
+                         Read-write allows the viewer to inject asks.
+            ttl_secs: Link lifetime in seconds (must be > 0). None = no expiry.
 
         Returns:
             The share URL and share_id, e.g. "https://repowire.io/s/sh_xxx"

--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -1773,6 +1773,54 @@ def create_mcp_server(*, streamable_http_path: str = "/mcp") -> FastMCP:
         await daemon_request("DELETE", f"/schedules/{quote(schedule_id, safe='')}")
         return f"deleted schedule {schedule_id}"
 
+    @mcp.tool()
+    async def share_session(
+        peer_name: str | None = None,
+        permissions: str = "ro",
+        ttl_secs: int | None = None,
+    ) -> str:
+        """[Repowire mesh] Share a peer's session via a relay link.
+
+        Generates a shareable URL for a peer. Anyone with the URL can observe
+        the session (read-only) or interact with the peer (read-write).
+
+        Requires relay to be configured (`repowire setup --relay`).
+
+        Args:
+            peer_name: Peer to share. Defaults to this peer (yourself).
+            permissions: "ro" (read-only, default) or "rw" (read-write).
+            ttl_secs: Link lifetime in seconds. None means no expiry.
+
+        Returns:
+            The share URL and share_id, e.g. "https://repowire.io/s/sh_xxx"
+        """
+        await _ensure_registered(strict=True)
+        target = peer_name or (await _get_my_peer_name())
+        result = await daemon_request(
+            "POST",
+            "/shares",
+            {"peer_name": target, "permissions": permissions, "ttl_secs": ttl_secs},
+        )
+        url = result.get("url", "")
+        share_id = result.get("share_id", "")
+        perms = result.get("permissions", permissions)
+        expires = result.get("expires_at") or "never"
+        return f"share link for {target} [{perms}]: {url}\nshare_id: {share_id}\nexpires: {expires}"
+
+    @mcp.tool()
+    async def revoke_share(share_id: str) -> str:
+        """[Repowire mesh] Revoke a previously issued share link.
+
+        Args:
+            share_id: The share_id returned by share_session.
+
+        Returns:
+            Confirmation message.
+        """
+        await _ensure_registered(strict=True)
+        await daemon_request("DELETE", f"/shares/{quote(share_id, safe='')}")
+        return f"revoked share {share_id}"
+
     return mcp
 
 

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -525,6 +525,25 @@ async def _poll_share_events(user_id: str) -> None:
             if not events:
                 continue
 
+            # First poll: record cursor without delivering (avoids history flood)
+            if user_id not in _share_last_event_id:
+                _share_last_event_id[user_id] = events[-1].get("id")
+                continue
+
+            # Relay-side dedup: only deliver events after last known id
+            last_id = _share_last_event_id.get(user_id)
+            if last_id is not None:
+                new_events: list[dict] = []
+                found = False
+                for ev in events:
+                    if found:
+                        new_events.append(ev)
+                    elif ev.get("id") == last_id:
+                        found = True
+                events = new_events if found else events
+
+            if not events:
+                continue
             _share_last_event_id[user_id] = events[-1].get("id")
 
             # Fan out to each share's viewers, filtered by that share's peer_name
@@ -946,6 +965,8 @@ def create_app() -> FastAPI:
         """Issue a share token for a specific peer."""
         if req.permissions not in ("ro", "rw"):
             raise HTTPException(status_code=400, detail="permissions must be 'ro' or 'rw'")
+        if req.ttl_secs is not None and req.ttl_secs <= 0:
+            raise HTTPException(status_code=400, detail="ttl_secs must be a positive integer")
         conn = _get_any_daemon(api_key.user_id)
         if not conn:
             raise HTTPException(status_code=502, detail="No daemon connected")
@@ -1014,6 +1035,9 @@ def create_app() -> FastAPI:
                 while True:
                     if await request.is_disconnected():
                         break
+                    if validate_share_token(share_id) is None:
+                        yield "data: {\"type\":\"share_expired\"}\n\n"
+                        break
                     try:
                         data = await asyncio.wait_for(queue.get(), timeout=15)
                         yield data
@@ -1040,6 +1064,8 @@ def create_app() -> FastAPI:
         if not conn:
             raise HTTPException(status_code=503, detail="Session owner not connected")
         body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
         text = str(body.get("text", "")).strip()
         if not text:
             raise HTTPException(status_code=400, detail="text is required")

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -487,7 +487,9 @@ async def _poll_share_events(user_id: str) -> None:
                 if qs and (t := validate_share_token(sid)) is not None and t.user_id == user_id
             ]
             if not active_shares:
-                continue
+                # No active viewers — self-terminate so we don't hold a task forever
+                _share_pollers.pop(user_id, None)
+                return
 
             conn = _get_any_daemon(user_id)
             if not conn:
@@ -690,8 +692,8 @@ function addEvent(evt) {{
   const from = evt.from_peer || evt.peer_name || "";
   const text = evt.text || evt.content || evt.message || "";
   div.innerHTML =
-    `<div class="event-type">${{type}}</div>` +
-    (from ? `<div class="from">${{from}}</div>` : "") +
+    `<div class="event-type">${{escHtml(type)}}</div>` +
+    (from ? `<div class="from">${{escHtml(from)}}</div>` : "") +
     (text ? `<div class="event-text">${{escHtml(text)}}</div>` : "");
   eventsEl.appendChild(div);
   eventsEl.scrollTop = eventsEl.scrollHeight;
@@ -1021,6 +1023,8 @@ def create_app() -> FastAPI:
                 clients = _share_sse_clients.get(share_id)
                 if clients:
                     clients.discard(queue)
+                    if not clients:
+                        _share_sse_clients.pop(share_id, None)
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
@@ -1044,7 +1048,7 @@ def create_app() -> FastAPI:
             {"from_peer": "guest", "to_peer": token.peer_name, "text": text}
         ).encode()
         request_id = str(uuid4())
-        future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         _http_futures[request_id] = future
         try:
             await conn.websocket.send_json({

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -40,12 +40,25 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from repowire.relay.auth import APIKey, register_token, validate_api_key
+from repowire.relay.share_tokens import (
+    ShareToken,
+    create_share_token,
+    list_share_tokens,
+    revoke_share_token,
+    validate_share_token,
+)
 
 log = logging.getLogger(__name__)
 
 
 class RegisterRequest(BaseModel):
     user_id: str
+
+
+class ShareCreateRequest(BaseModel):
+    peer_name: str
+    permissions: str = "ro"  # "ro" | "rw"
+    ttl_secs: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +106,11 @@ _http_futures: dict[str, asyncio.Future[dict[str, Any]]] = {}  # request_id -> F
 _sse_clients: set[asyncio.Queue[str]] = set()
 _sse_pollers: dict[str, asyncio.Task[None]] = {}  # user_id -> poller task
 _sse_last_event_id: str | None = None
+
+# Share-scoped SSE: per share_id queues + per user_id polling task (reused across shares)
+_share_sse_clients: dict[str, set[asyncio.Queue[str]]] = {}  # share_id -> queues
+_share_pollers: dict[str, asyncio.Task[None]] = {}  # user_id -> share-poller task
+_share_last_event_id: dict[str, str | None] = {}  # user_id -> last seen event id
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -448,6 +466,318 @@ async def _poll_events(user_id: str) -> None:
             log.warning("SSE poller error", exc_info=True)
 
 
+def _event_mentions_peer(event: dict, peer_name: str) -> bool:
+    """Return True if the event is relevant to the given peer."""
+    for key in ("peer_name", "from_peer", "to_peer", "display_name"):
+        if event.get(key) == peer_name:
+            return True
+    return False
+
+
+async def _poll_share_events(user_id: str) -> None:
+    """Shared share-SSE poller: one task per user, fans out filtered events to viewers."""
+    import json as _json
+
+    while True:
+        await asyncio.sleep(2)
+        try:
+            # Only run while there are active share viewers for this user
+            active_shares = [
+                sid for sid, qs in _share_sse_clients.items()
+                if qs and (t := validate_share_token(sid)) is not None and t.user_id == user_id
+            ]
+            if not active_shares:
+                continue
+
+            conn = _get_any_daemon(user_id)
+            if not conn:
+                continue
+
+            req_id = str(uuid4())
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[dict[str, Any]] = loop.create_future()
+            _http_futures[req_id] = future
+
+            last_id = _share_last_event_id.get(user_id)
+            qs_param = f"since={last_id}" if last_id else ""
+            try:
+                await conn.websocket.send_json({
+                    "type": "http_request",
+                    "request_id": req_id,
+                    "method": "GET",
+                    "path": "/events",
+                    "headers": {},
+                    "query_string": qs_param,
+                })
+                resp_msg = await asyncio.wait_for(future, timeout=10)
+            except Exception:
+                continue
+            finally:
+                _http_futures.pop(req_id, None)
+
+            if resp_msg.get("status") != 200:
+                continue
+
+            body = base64.b64decode(resp_msg.get("body", ""))
+            events = _json.loads(body)
+            if not events:
+                continue
+
+            _share_last_event_id[user_id] = events[-1].get("id")
+
+            # Fan out to each share's viewers, filtered by that share's peer_name
+            for share_id in active_shares:
+                token = validate_share_token(share_id)
+                if token is None:
+                    continue
+                queues = _share_sse_clients.get(share_id, set())
+                if not queues:
+                    continue
+                matching = [e for e in events if _event_mentions_peer(e, token.peer_name)]
+                for event in matching:
+                    data = f"data: {_json.dumps(event)}\n\n"
+                    dead: list[asyncio.Queue[str]] = []
+                    for q in queues:
+                        try:
+                            q.put_nowait(data)
+                        except asyncio.QueueFull:
+                            dead.append(q)
+                    for q in dead:
+                        queues.discard(q)
+
+        except Exception:
+            log.warning("share SSE poller error", exc_info=True)
+
+
+_SHARE_VIEWER_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>repowire — {peer_name}</title>
+<style>
+  *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+    background: #0a0a0f;
+    color: #c8c8d0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }}
+  header {{
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid #1a1a2a;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: #0d0d16;
+  }}
+  .logo {{ color: #6a6aaa; font-weight: 600; font-size: 0.85rem; }}
+  .peer-name {{ color: #e0e0e8; font-size: 0.95rem; font-weight: 500; }}
+  .badge {{
+    font-size: 0.65rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 20px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }}
+  .badge-ro {{ background: #1a1a2a; color: #6a6a8a; border: 1px solid #2a2a3a; }}
+  .badge-rw {{ background: #0d2010; color: #4aaa6a; border: 1px solid #1a4a2a; }}
+  .dot {{
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: #3a6a3a;
+    animation: pulse 2s ease-in-out infinite;
+  }}
+  @keyframes pulse {{ 0%, 100% {{ opacity: 1; }} 50% {{ opacity: 0.4; }} }}
+  .events {{
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }}
+  .event {{
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    border: 1px solid #1a1a2a;
+    background: #0d0d18;
+    max-width: 100%;
+    word-break: break-word;
+  }}
+  .event-type {{
+    font-size: 0.7rem;
+    color: #4a4a6a;
+    margin-bottom: 0.2rem;
+    font-family: monospace;
+  }}
+  .event-chat {{ border-color: #1a2a3a; background: #0a1020; }}
+  .event-ask  {{ border-color: #2a2a1a; background: #12100a; }}
+  .event-ack  {{ border-color: #0a2a1a; background: #081410; }}
+  .event-text {{ color: #c8c8d8; white-space: pre-wrap; }}
+  .from {{ color: #6a8aaa; font-size: 0.75rem; margin-bottom: 0.15rem; }}
+  .empty {{ color: #3a3a4a; font-size: 0.85rem; padding: 2rem; text-align: center; }}
+  .compose {{
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid #1a1a2a;
+    display: flex;
+    gap: 0.5rem;
+    background: #0d0d16;
+  }}
+  .compose textarea {{
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    background: #14141f;
+    border: 1px solid #2a2a3a;
+    border-radius: 6px;
+    color: #e0e0e8;
+    font-family: inherit;
+    font-size: 0.85rem;
+    resize: none;
+    height: 60px;
+    outline: none;
+  }}
+  .compose textarea:focus {{ border-color: #3a3a6a; }}
+  .compose button {{
+    padding: 0.5rem 1rem;
+    background: #1a1a3a;
+    border: 1px solid #2a2a4a;
+    border-radius: 6px;
+    color: #c0c0e0;
+    cursor: pointer;
+    font-size: 0.85rem;
+    align-self: flex-end;
+  }}
+  .compose button:hover {{ background: #22223a; }}
+  .compose button:disabled {{ opacity: 0.4; cursor: default; }}
+  .send-status {{ font-size: 0.75rem; color: #4a6a4a; padding: 0.25rem 0; }}
+</style>
+</head>
+<body>
+<header>
+  <span class="logo">repowire</span>
+  <span class="peer-name">{peer_name}</span>
+  <span class="badge {badge_class}">{perms_label}</span>
+  <span class="dot" id="dot" title="live"></span>
+</header>
+<div class="events" id="events">
+  <div class="empty" id="empty">Waiting for events…</div>
+</div>
+{compose_html}
+<script>
+const shareId = "{share_id}";
+const peerName = "{peer_name}";
+const isRw = {is_rw};
+
+const eventsEl = document.getElementById("events");
+const emptyEl = document.getElementById("empty");
+const dot = document.getElementById("dot");
+
+function addEvent(evt) {{
+  if (emptyEl) emptyEl.remove();
+  const div = document.createElement("div");
+  const type = evt.type || "event";
+  div.className = "event" +
+    (type.includes("chat") ? " event-chat" : "") +
+    (type.includes("ask") ? " event-ask" : "") +
+    (type.includes("ack") ? " event-ack" : "");
+  const from = evt.from_peer || evt.peer_name || "";
+  const text = evt.text || evt.content || evt.message || "";
+  div.innerHTML =
+    `<div class="event-type">${{type}}</div>` +
+    (from ? `<div class="from">${{from}}</div>` : "") +
+    (text ? `<div class="event-text">${{escHtml(text)}}</div>` : "");
+  eventsEl.appendChild(div);
+  eventsEl.scrollTop = eventsEl.scrollHeight;
+}}
+
+function escHtml(s) {{
+  return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+}}
+
+const es = new EventSource("/s/" + shareId + "/stream");
+es.onmessage = (e) => {{
+  try {{ addEvent(JSON.parse(e.data)); }} catch (_) {{}}
+}};
+es.onerror = () => {{ dot.style.background = "#6a2a2a"; }};
+es.onopen  = () => {{ dot.style.background = "#3a6a3a"; }};
+
+{send_script}
+</script>
+</body>
+</html>
+"""
+
+_SHARE_SEND_SCRIPT = """\
+const sendBtn = document.getElementById("send-btn");
+const msgInput = document.getElementById("msg-input");
+const sendStatus = document.getElementById("send-status");
+
+async function sendMessage() {
+  const text = msgInput.value.trim();
+  if (!text) return;
+  sendBtn.disabled = true;
+  sendStatus.textContent = "Sending…";
+  try {
+    const r = await fetch("/s/" + shareId + "/ask", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({text}),
+    });
+    if (r.ok) {
+      msgInput.value = "";
+      sendStatus.textContent = "Sent";
+      setTimeout(() => { sendStatus.textContent = ""; }, 2000);
+    } else {
+      sendStatus.textContent = "Error: " + r.status;
+    }
+  } catch (e) {
+    sendStatus.textContent = "Network error";
+  } finally {
+    sendBtn.disabled = false;
+  }
+}
+
+sendBtn.addEventListener("click", sendMessage);
+msgInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+});
+"""
+
+_COMPOSE_HTML = """\
+<div class="compose">
+  <textarea id="msg-input" placeholder="Ask {peer_name} something… (Enter to send)"></textarea>
+  <div style="display:flex;flex-direction:column;gap:0.25rem">
+    <button id="send-btn">Send</button>
+    <span class="send-status" id="send-status"></span>
+  </div>
+</div>
+"""
+
+
+def _build_viewer_html(token: ShareToken) -> str:
+    is_rw = token.permissions == "rw"
+    escaped = html.escape(token.peer_name)
+    compose_html = _COMPOSE_HTML.replace("{peer_name}", escaped) if is_rw else ""
+    send_script = _SHARE_SEND_SCRIPT if is_rw else ""
+    return (
+        _SHARE_VIEWER_HTML
+        .replace("{peer_name}", html.escape(token.peer_name))
+        .replace("{share_id}", html.escape(token.share_id))
+        .replace("{badge_class}", "badge-rw" if is_rw else "badge-ro")
+        .replace("{perms_label}", "read-write" if is_rw else "read-only")
+        .replace("{is_rw}", "true" if is_rw else "false")
+        .replace("{compose_html}", compose_html)
+        .replace("{send_script}", send_script)
+    )
+
+
 def _find_web_output_dir() -> str | None:
     """Find the web/out directory for dashboard static files."""
     import sys
@@ -604,6 +934,143 @@ def create_app() -> FastAPI:
             }
             for d in daemons
         ]
+
+    # -- Share session: create / list / revoke --
+
+    @app.post("/api/v1/share")
+    async def share_create(
+        req: ShareCreateRequest, api_key: APIKey = Depends(get_api_key)
+    ) -> dict[str, Any]:
+        """Issue a share token for a specific peer."""
+        if req.permissions not in ("ro", "rw"):
+            raise HTTPException(status_code=400, detail="permissions must be 'ro' or 'rw'")
+        conn = _get_any_daemon(api_key.user_id)
+        if not conn:
+            raise HTTPException(status_code=502, detail="No daemon connected")
+        token = create_share_token(
+            user_id=api_key.user_id,
+            peer_name=req.peer_name,
+            permissions=req.permissions,
+            ttl_secs=req.ttl_secs,
+        )
+        return token.to_dict()
+
+    @app.get("/api/v1/share")
+    async def share_list(api_key: APIKey = Depends(get_api_key)) -> list[dict[str, Any]]:
+        """List active share tokens for the authenticated user."""
+        return [t.to_dict() for t in list_share_tokens(api_key.user_id)]
+
+    @app.delete("/api/v1/share/{share_id}")
+    async def share_revoke(share_id: str, api_key: APIKey = Depends(get_api_key)) -> dict[str, Any]:
+        """Revoke a share token."""
+        token = validate_share_token(share_id)
+        if token is None:
+            raise HTTPException(status_code=404, detail="Share token not found")
+        if token.user_id != api_key.user_id:
+            raise HTTPException(status_code=403, detail="Not your share token")
+        revoke_share_token(share_id)
+        return {"ok": True, "share_id": share_id}
+
+    # -- Share viewer: /s/{share_id} --
+
+    @app.get("/s/{share_id}", response_class=HTMLResponse)
+    async def share_viewer(share_id: str) -> Response:
+        """Serve the share viewer page for a valid share token."""
+        token = validate_share_token(share_id)
+        if token is None:
+            return HTMLResponse(
+                "<html><body>Share link not found or expired.</body></html>", status_code=404
+            )
+        conn = _get_any_daemon(token.user_id)
+        if not conn:
+            return HTMLResponse(
+                "<html><body>Session owner is not connected.</body></html>", status_code=503
+            )
+        return HTMLResponse(_build_viewer_html(token))
+
+    @app.get("/s/{share_id}/stream")
+    async def share_stream(share_id: str, request: Request) -> StreamingResponse:
+        """SSE stream of events for the shared peer."""
+        token = validate_share_token(share_id)
+        if token is None:
+            raise HTTPException(status_code=404, detail="Share not found or expired")
+        conn = _get_any_daemon(token.user_id)
+        if not conn:
+            raise HTTPException(status_code=503, detail="Session owner not connected")
+
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=64)
+        _share_sse_clients.setdefault(share_id, set()).add(queue)
+
+        # Ensure the share poller is running for this user
+        if token.user_id not in _share_pollers or _share_pollers[token.user_id].done():
+            _share_pollers[token.user_id] = asyncio.create_task(
+                _poll_share_events(token.user_id)
+            )
+
+        async def event_generator():
+            try:
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        data = await asyncio.wait_for(queue.get(), timeout=15)
+                        yield data
+                    except asyncio.TimeoutError:
+                        yield ": keepalive\n\n"
+            finally:
+                clients = _share_sse_clients.get(share_id)
+                if clients:
+                    clients.discard(queue)
+
+        return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+    @app.post("/s/{share_id}/ask")
+    async def share_ask(share_id: str, request: Request) -> Response:
+        """Inject an ask to the shared peer (rw only)."""
+        token = validate_share_token(share_id)
+        if token is None:
+            raise HTTPException(status_code=404, detail="Share not found or expired")
+        if token.permissions != "rw":
+            raise HTTPException(status_code=403, detail="This share link is read-only")
+        conn = _get_any_daemon(token.user_id)
+        if not conn:
+            raise HTTPException(status_code=503, detail="Session owner not connected")
+        body = await request.json()
+        text = str(body.get("text", "")).strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="text is required")
+        import json as _json
+        ask_payload = _json.dumps(
+            {"from_peer": "guest", "to_peer": token.peer_name, "text": text}
+        ).encode()
+        request_id = str(uuid4())
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_event_loop().create_future()
+        _http_futures[request_id] = future
+        try:
+            await conn.websocket.send_json({
+                "type": "http_request",
+                "request_id": request_id,
+                "method": "POST",
+                "path": "/ask",
+                "headers": {"content-type": "application/json"},
+                "query_string": "",
+                "body": base64.b64encode(ask_payload).decode(),
+            })
+        except Exception:
+            _http_futures.pop(request_id, None)
+            raise HTTPException(status_code=502, detail="Failed to reach daemon")
+        try:
+            resp_msg = await asyncio.wait_for(future, timeout=HTTP_TUNNEL_TIMEOUT)
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=504, detail="Daemon did not respond")
+        finally:
+            _http_futures.pop(request_id, None)
+        resp_body = base64.b64decode(resp_msg.get("body", "")) if resp_msg.get("body") else b""
+        return Response(
+            content=resp_body,
+            status_code=resp_msg.get("status", 200),
+            headers=resp_msg.get("headers", {}),
+        )
 
     # -- WebSocket relay endpoint --
 

--- a/repowire/relay/share_tokens.py
+++ b/repowire/relay/share_tokens.py
@@ -1,0 +1,89 @@
+"""In-memory share token registry for session sharing.
+
+Share tokens let a relay user hand someone a scoped URL that proxies
+to a specific peer on their daemon — read-only (observe events) or
+read-write (also inject asks).  Tokens live only for the relay process
+lifetime; they are intentionally not persisted (restarting the relay
+invalidates all share links).
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+log = logging.getLogger(__name__)
+
+_PREFIX = "sh_"
+_TOKEN_BYTES = 12  # 16 chars base64url
+
+
+@dataclass
+class ShareToken:
+    share_id: str
+    user_id: str
+    peer_name: str
+    permissions: str  # "ro" | "rw"
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: datetime | None = None
+
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return datetime.now(timezone.utc) >= self.expires_at
+
+    def to_dict(self) -> dict:
+        return {
+            "share_id": self.share_id,
+            "peer_name": self.peer_name,
+            "permissions": self.permissions,
+            "created_at": self.created_at.isoformat(),
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }
+
+
+_registry: dict[str, ShareToken] = {}
+
+
+def create_share_token(
+    user_id: str,
+    peer_name: str,
+    permissions: str = "ro",
+    ttl_secs: int | None = None,
+) -> ShareToken:
+    share_id = f"{_PREFIX}{secrets.token_urlsafe(_TOKEN_BYTES)}"
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_secs) if ttl_secs else None
+    token = ShareToken(
+        share_id=share_id,
+        user_id=user_id,
+        peer_name=peer_name,
+        permissions=permissions,
+        expires_at=expires_at,
+    )
+    _registry[share_id] = token
+    log.info("share token created: %s peer=%s perms=%s", share_id, peer_name, permissions)
+    return token
+
+
+def validate_share_token(share_id: str) -> ShareToken | None:
+    token = _registry.get(share_id)
+    if token is None:
+        return None
+    if token.is_expired():
+        _registry.pop(share_id, None)
+        log.info("share token expired: %s", share_id)
+        return None
+    return token
+
+
+def revoke_share_token(share_id: str) -> bool:
+    removed = _registry.pop(share_id, None) is not None
+    if removed:
+        log.info("share token revoked: %s", share_id)
+    return removed
+
+
+def list_share_tokens(user_id: str) -> list[ShareToken]:
+    return [t for t in _registry.values() if t.user_id == user_id and not t.is_expired()]

--- a/tests/test_share_relay_routes.py
+++ b/tests/test_share_relay_routes.py
@@ -1,0 +1,208 @@
+"""Tests for relay share session routes."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.anyio
+
+from repowire.relay.auth import _token_registry, register_token
+from repowire.relay.server import _connections, _user_daemons, create_app
+from repowire.relay.share_tokens import _registry as _share_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    _token_registry.clear()
+    _connections.clear()
+    _user_daemons.clear()
+    _share_registry.clear()
+    yield
+    _token_registry.clear()
+    _connections.clear()
+    _user_daemons.clear()
+    _share_registry.clear()
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def api_key():
+    return register_token("testuser").key
+
+
+class TestShareCreate:
+    async def test_requires_auth(self, client):
+        resp = await client.post("/api/v1/share", json={"peer_name": "agent1"})
+        assert resp.status_code == 422  # missing x-api-key header
+
+    async def test_no_daemon_returns_502(self, client, api_key):
+        resp = await client.post(
+            "/api/v1/share",
+            json={"peer_name": "agent1"},
+            headers={"x-api-key": api_key},
+        )
+        assert resp.status_code == 502
+
+    async def test_invalid_permissions_returns_400(self, client, api_key, monkeypatch):
+        # Patch to fake a connected daemon
+        from repowire.relay import server as srv
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        resp = await client.post(
+            "/api/v1/share",
+            json={"peer_name": "agent1", "permissions": "admin"},
+            headers={"x-api-key": api_key},
+        )
+        assert resp.status_code == 400
+
+    async def test_creates_token_when_daemon_connected(self, client, api_key, monkeypatch):
+        from repowire.relay import server as srv
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        resp = await client.post(
+            "/api/v1/share",
+            json={"peer_name": "agent1", "permissions": "ro"},
+            headers={"x-api-key": api_key},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["share_id"].startswith("sh_")
+        assert data["peer_name"] == "agent1"
+        assert data["permissions"] == "ro"
+
+
+class TestShareList:
+    async def test_empty_list(self, client, api_key, monkeypatch):
+        resp = await client.get("/api/v1/share", headers={"x-api-key": api_key})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_lists_own_tokens(self, client, api_key, monkeypatch):
+        from repowire.relay import server as srv
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        await client.post(
+            "/api/v1/share",
+            json={"peer_name": "p1", "permissions": "ro"},
+            headers={"x-api-key": api_key},
+        )
+        resp = await client.get("/api/v1/share", headers={"x-api-key": api_key})
+        assert resp.status_code == 200
+        tokens = resp.json()
+        assert len(tokens) == 1
+        assert tokens[0]["peer_name"] == "p1"
+
+
+class TestShareRevoke:
+    async def test_revoke_nonexistent_returns_404(self, client, api_key):
+        resp = await client.delete("/api/v1/share/sh_ghost", headers={"x-api-key": api_key})
+        assert resp.status_code == 404
+
+    async def test_revoke_own_token(self, client, api_key, monkeypatch):
+        from repowire.relay import server as srv
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        create_resp = await client.post(
+            "/api/v1/share",
+            json={"peer_name": "p1"},
+            headers={"x-api-key": api_key},
+        )
+        share_id = create_resp.json()["share_id"]
+        revoke_resp = await client.delete(f"/api/v1/share/{share_id}", headers={"x-api-key": api_key})
+        assert revoke_resp.status_code == 200
+        assert revoke_resp.json()["ok"] is True
+
+    async def test_cannot_revoke_others_token(self, client, monkeypatch):
+        from repowire.relay import server as srv
+        from repowire.relay.auth import register_token as rt
+        from repowire.relay.share_tokens import create_share_token
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "alice"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        token = create_share_token("alice", "p1", "ro")
+        bob_key = rt("bob").key
+        resp = await client.delete(f"/api/v1/share/{token.share_id}", headers={"x-api-key": bob_key})
+        assert resp.status_code == 403
+
+
+class TestShareViewer:
+    async def test_unknown_share_returns_404(self, client):
+        resp = await client.get("/s/sh_unknown")
+        assert resp.status_code == 404
+
+    async def test_no_daemon_returns_503(self, client):
+        from repowire.relay.share_tokens import create_share_token
+        token = create_share_token("testuser", "p1", "ro")
+        resp = await client.get(f"/s/{token.share_id}")
+        assert resp.status_code == 503
+
+    async def test_ro_viewer_contains_peer_name(self, client, monkeypatch):
+        from repowire.relay import server as srv
+        from repowire.relay.share_tokens import create_share_token
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        token = create_share_token("testuser", "my-agent", "ro")
+        resp = await client.get(f"/s/{token.share_id}")
+        assert resp.status_code == 200
+        assert "my-agent" in resp.text
+        assert "read-only" in resp.text
+        assert "send-btn" not in resp.text
+
+    async def test_rw_viewer_contains_compose(self, client, monkeypatch):
+        from repowire.relay import server as srv
+        from repowire.relay.share_tokens import create_share_token
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        token = create_share_token("testuser", "my-agent", "rw")
+        resp = await client.get(f"/s/{token.share_id}")
+        assert resp.status_code == 200
+        assert "read-write" in resp.text
+        assert "send-btn" in resp.text
+
+
+class TestShareAsk:
+    async def test_ro_ask_rejected(self, client, monkeypatch):
+        from repowire.relay import server as srv
+        from repowire.relay.share_tokens import create_share_token
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        token = create_share_token("testuser", "p1", "ro")
+        resp = await client.post(f"/s/{token.share_id}/ask", json={"text": "hello"})
+        assert resp.status_code == 403
+
+    async def test_empty_text_rejected(self, client, monkeypatch):
+        from repowire.relay import server as srv
+        from repowire.relay.share_tokens import create_share_token
+        from unittest.mock import MagicMock
+        fake_conn = MagicMock()
+        fake_conn.user_id = "testuser"
+        monkeypatch.setattr(srv, "_get_any_daemon", lambda uid: fake_conn)
+        token = create_share_token("testuser", "p1", "rw")
+        resp = await client.post(f"/s/{token.share_id}/ask", json={"text": "  "})
+        assert resp.status_code == 400

--- a/tests/test_share_tokens.py
+++ b/tests/test_share_tokens.py
@@ -1,0 +1,104 @@
+"""Tests for the relay share token registry."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from repowire.relay.share_tokens import (
+    ShareToken,
+    _registry,
+    create_share_token,
+    list_share_tokens,
+    revoke_share_token,
+    validate_share_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    _registry.clear()
+    yield
+    _registry.clear()
+
+
+class TestCreateShareToken:
+    def test_creates_token_with_correct_fields(self):
+        t = create_share_token("user1", "my-agent", "ro")
+        assert t.share_id.startswith("sh_")
+        assert t.user_id == "user1"
+        assert t.peer_name == "my-agent"
+        assert t.permissions == "ro"
+        assert t.expires_at is None
+
+    def test_rw_permissions(self):
+        t = create_share_token("user1", "my-agent", "rw")
+        assert t.permissions == "rw"
+
+    def test_ttl_sets_expires_at(self):
+        before = datetime.now(timezone.utc)
+        t = create_share_token("user1", "my-agent", "ro", ttl_secs=3600)
+        after = datetime.now(timezone.utc)
+        assert t.expires_at is not None
+        assert before + timedelta(seconds=3590) < t.expires_at < after + timedelta(seconds=3610)
+
+    def test_unique_share_ids(self):
+        ids = {create_share_token("u", "p", "ro").share_id for _ in range(20)}
+        assert len(ids) == 20
+
+
+class TestValidateShareToken:
+    def test_valid_token_returned(self):
+        t = create_share_token("user1", "my-agent", "ro")
+        assert validate_share_token(t.share_id) is t
+
+    def test_unknown_token_returns_none(self):
+        assert validate_share_token("sh_notexist") is None
+
+    def test_expired_token_returns_none_and_is_removed(self):
+        t = create_share_token("user1", "my-agent", "ro", ttl_secs=1)
+        # Manually backdate
+        t.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        result = validate_share_token(t.share_id)
+        assert result is None
+        assert t.share_id not in _registry
+
+    def test_non_expired_token_still_valid(self):
+        t = create_share_token("user1", "my-agent", "ro", ttl_secs=9999)
+        assert validate_share_token(t.share_id) is t
+
+
+class TestRevokeShareToken:
+    def test_revoke_removes_token(self):
+        t = create_share_token("user1", "my-agent", "ro")
+        assert revoke_share_token(t.share_id) is True
+        assert validate_share_token(t.share_id) is None
+
+    def test_revoke_nonexistent_returns_false(self):
+        assert revoke_share_token("sh_ghost") is False
+
+
+class TestListShareTokens:
+    def test_returns_only_user_tokens(self):
+        a = create_share_token("alice", "p1", "ro")
+        create_share_token("bob", "p2", "ro")
+        tokens = list_share_tokens("alice")
+        assert len(tokens) == 1
+        assert tokens[0] is a
+
+    def test_excludes_expired(self):
+        t = create_share_token("alice", "p1", "ro", ttl_secs=1)
+        t.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        assert list_share_tokens("alice") == []
+
+
+class TestShareTokenToDict:
+    def test_to_dict_fields(self):
+        t = create_share_token("user1", "my-agent", "rw")
+        d = t.to_dict()
+        assert d["share_id"] == t.share_id
+        assert d["peer_name"] == "my-agent"
+        assert d["permissions"] == "rw"
+        assert d["expires_at"] is None
+        assert "created_at" in d

--- a/web/app/marketing.css
+++ b/web/app/marketing.css
@@ -348,6 +348,42 @@
 
 .rw-marketing .feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .rw-marketing .feature-grid-six .feature { min-height: 190px; }
+.rw-marketing .feature-wide {
+  margin-top: 16px;
+  background: var(--surface); border: 1px solid var(--rds-border);
+  border-radius: var(--rds-radius-lg); padding: 28px 32px;
+  transition: box-shadow var(--t-base) var(--rds-ease), border-color var(--t-base);
+}
+.rw-marketing .feature-wide:hover { box-shadow: var(--shadow-md); border-color: var(--rds-border-strong); }
+.rw-marketing .feature-wide-content { display: flex; gap: 48px; align-items: center; }
+.rw-marketing .feature-wide-copy { flex: 1; }
+.rw-marketing .feature-wide-copy h3 { margin: 8px 0 10px; font-size: 18px; font-weight: 600; letter-spacing: -0.01em; }
+.rw-marketing .feature-wide-copy p { margin: 0 0 16px; font-size: 14.5px; color: var(--fg-muted); line-height: 1.55; }
+.rw-marketing .feature-new-badge {
+  display: inline-block; font-size: 10px; font-weight: 700; letter-spacing: 0.07em;
+  text-transform: uppercase; padding: 2px 7px; border-radius: 20px;
+  background: var(--accent-soft); color: var(--accent-soft-fg); margin-bottom: 6px;
+}
+.rw-marketing .feature-cmd {
+  display: inline-block; font-family: var(--font-mono, monospace); font-size: 13px;
+  background: var(--surface-sunken); border: 1px solid var(--rds-border);
+  border-radius: 6px; padding: 6px 12px; color: var(--fg-muted);
+}
+.rw-marketing .feature-wide-demo {
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  flex-shrink: 0; padding: 20px 28px;
+  background: var(--surface-sunken); border: 1px solid var(--rds-border);
+  border-radius: var(--rds-radius); font-family: var(--font-mono, monospace);
+}
+.rw-marketing .share-demo-url {
+  font-size: 13px; color: var(--fg-muted); letter-spacing: -0.01em;
+}
+.rw-marketing .share-demo-pill {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+  padding: 3px 10px; border-radius: 20px;
+}
+.rw-marketing .share-demo-ro { background: #1a1a2a; color: #6a6a8a; border: 1px solid #2a2a3a; }
+.rw-marketing .share-demo-rw { background: #0d2010; color: #4aaa6a; border: 1px solid #1a4a2a; }
 .rw-marketing .feature {
   background: var(--surface); border: 1px solid var(--rds-border);
   border-radius: var(--rds-radius-lg); padding: 28px;
@@ -463,6 +499,8 @@
   .rw-marketing .mesh-demo { grid-template-columns: 1fr; }
   .rw-marketing .feature-hero { grid-template-columns: 1fr; gap: 24px; }
   .rw-marketing .feature-grid { grid-template-columns: repeat(2, 1fr); }
+  .rw-marketing .feature-wide-content { flex-direction: column; gap: 24px; }
+  .rw-marketing .feature-wide-demo { width: 100%; }
   .rw-marketing .how-grid { grid-template-columns: 1fr; }
   .rw-marketing .footer-inner { grid-template-columns: 1fr; }
   .rw-marketing .topnav { display: none; }

--- a/web/components/marketing/Features.tsx
+++ b/web/components/marketing/Features.tsx
@@ -1,4 +1,4 @@
-type IconName = "ask" | "review" | "handoff" | "context" | "checkpoint" | "compare" | "escalate";
+type IconName = "ask" | "review" | "handoff" | "context" | "checkpoint" | "compare" | "escalate" | "share";
 
 const secondary: { icon: IconName; title: string; body: string }[] = [
   {
@@ -72,6 +72,29 @@ export default function Features() {
             <p>{it.body}</p>
           </div>
         ))}
+      </div>
+
+      <div className="feature feature-wide">
+        <div className="feature-wide-content">
+          <div className="feature-wide-copy">
+            <div className="feature-icon">
+              <FeatureIcon name="share" />
+            </div>
+            <span className="feature-new-badge">New</span>
+            <h3>Share a session</h3>
+            <p>
+              Generate a shareable link for any running agent peer.
+              Read-only observers watch the live event stream in a browser — no login, no Repowire
+              install. Flip to read-write and let a colleague inject asks directly.
+            </p>
+            <code className="feature-cmd">repowire share my-agent [--rw] [--ttl 3600]</code>
+          </div>
+          <div className="feature-wide-demo">
+            <div className="share-demo-pill share-demo-ro">read-only</div>
+            <div className="share-demo-url">repowire.io/s/sh_xxxxxxxx</div>
+            <div className="share-demo-pill share-demo-rw">read-write</div>
+          </div>
+        </div>
       </div>
     </section>
   );
@@ -174,6 +197,16 @@ function FeatureIcon({ name }: { name: IconName }) {
         <svg {...props}>
           <circle cx="12" cy="8" r="4" />
           <path d="M4 21a8 8 0 0 1 16 0" />
+        </svg>
+      );
+    case "share":
+      return (
+        <svg {...props}>
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <path d="M8.59 13.51 15.42 17.49" />
+          <path d="M15.41 6.51 8.59 10.49" />
         </svg>
       );
   }


### PR DESCRIPTION
## Summary

- **New**: `repowire share my-agent [--rw]` generates a shareable link `https://repowire.io/s/sh_xxx`
- **Read-only** viewers get a live SSE event feed filtered to the shared peer; **read-write** viewers can also inject asks via a compose box
- Token registry lives in the relay process (intentional: relay restart = link invalidation = safe default)

## What was built

| Component | File |
|---|---|
| Share token registry | `repowire/relay/share_tokens.py` |
| Relay routes (`/api/v1/share`, `/s/{id}`, `/s/{id}/stream`, `/s/{id}/ask`) | `repowire/relay/server.py` |
| Daemon wrapper (calls relay, returns URL) | `repowire/daemon/routes/shares.py` |
| MCP tools: `share_session`, `revoke_share` | `repowire/mcp/server.py` |
| CLI command: `repowire share` | `repowire/cli.py` |
| Tests (28 passing) | `tests/test_share_tokens.py`, `tests/test_share_relay_routes.py` |

## Security / review notes

Reviewed by Codex agent. Fixes applied in second commit:
- XSS: `type` and `from_peer` fields now escaped via `escHtml()` in viewer HTML
- `asyncio.get_event_loop()` → `get_running_loop()` in share ask tunnel
- SSE queue set pruned after all viewers disconnect (memory leak fix)
- Share poller self-terminates when no active viewers remain (idle task leak fix)
- Trailing slash stripped from `relay.url` before building share URLs

## Test plan

- [ ] `repowire share <peer>` with relay configured returns a URL
- [ ] Opening the URL in a browser shows the peer's events live
- [ ] `--rw` adds a compose box; ro link does not
- [ ] `repowire share --revoke <id>` returns 410 / 404 on the URL
- [ ] MCP `share_session` tool returns the URL correctly
- [ ] `repowire share --list` shows active tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)