### PR TITLE
Guard offline peer reaping with runtime evidence

### DIFF
--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -2859,19 +2859,47 @@ class PeerRegistry:
                 and p.last_seen is not None
                 and p.last_seen < cutoff
             ]
+
+        evidence = await self._runtime_evidence_ids(stale)
+
+        spared: list[Peer] = []
+        doomed: list[Peer] = []
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=ttl)
+        async with self._lock:
             for peer in stale:
-                self._peers.pop(peer.peer_id, None)
-                self._mappings.pop(peer.peer_id, None)
-                self._description_set_at.pop(peer.peer_id, None)
-                self._clear_all_contradictions(peer.peer_id)
+                current = self._peers.get(peer.peer_id)
+                if (
+                    current is None
+                    or current.status != PeerStatus.OFFLINE
+                    or current.last_seen is None
+                    or current.last_seen >= cutoff
+                    or self._runtime_marker(peer) != self._runtime_marker(current)
+                ):
+                    continue
+                if current.peer_id in evidence:
+                    spared.append(current)
+                    continue
+                doomed.append(current)
+                self._peers.pop(current.peer_id, None)
+                self._mappings.pop(current.peer_id, None)
+                self._description_set_at.pop(current.peer_id, None)
+                self._clear_all_contradictions(current.peer_id)
                 self._mappings_dirty = True
+
+        for peer in spared:
+            self._emit_offline_peer_still_has_runtime_evidence(
+                peer,
+                reason="offline_ttl_with_runtime_evidence",
+                cutoff=cutoff,
+                ttl_seconds=ttl,
+            )
 
         # Snapshot doomed-with-stash asks BEFORE any destructive cleanup
         # so observers see the pending_reply_lost event before the ask
         # disappears. Order: snapshot → emit → forget/evict.
         doomed_stashes: list[tuple[Any, str]] = []
         if self._ask_tracker is not None:
-            for peer in stale:
+            for peer in doomed:
                 snap = await self._ask_tracker.snapshot_pending_replies_for_peer(
                     peer.peer_id,
                 )
@@ -2881,7 +2909,7 @@ class PeerRegistry:
         for ask, reason in doomed_stashes:
             self._emit_pending_reply_lost(ask, reason)
 
-        for peer in stale:
+        for peer in doomed:
             if self._transport is not None:
                 try:
                     await self._transport.disconnect(peer.peer_id)
@@ -2905,9 +2933,14 @@ class PeerRegistry:
                 },
             )
 
-        if stale:
-            logger.info("reaped %d dangling offline peers", len(stale))
-        return len(stale)
+        if doomed:
+            logger.info("reaped %d dangling offline peers", len(doomed))
+        if spared:
+            logger.warning(
+                "spared %d stale offline peers with runtime evidence",
+                len(spared),
+            )
+        return len(doomed)
 
     async def _evict_stale_peers(self) -> int:
         """Evict long-offline peers from both _peers and _mappings.
@@ -2918,29 +2951,119 @@ class PeerRegistry:
         now = time.time()
         async with self._lock:
             stale = [
-                pid for pid, p in self._peers.items()
+                p for p in self._peers.values()
                 if p.status == PeerStatus.OFFLINE
                 and p.last_seen
                 and (now - p.last_seen.timestamp()) > max_age
             ]
-            for pid in stale:
-                del self._peers[pid]
-                self._mappings.pop(pid, None)
-            if stale:
+
+        evidence = await self._runtime_evidence_ids(stale)
+
+        spared: list[Peer] = []
+        evicted: list[Peer] = []
+        now = time.time()
+        async with self._lock:
+            for peer in stale:
+                current = self._peers.get(peer.peer_id)
+                if (
+                    current is None
+                    or current.status != PeerStatus.OFFLINE
+                    or current.last_seen is None
+                    or (now - current.last_seen.timestamp()) <= max_age
+                    or self._runtime_marker(peer) != self._runtime_marker(current)
+                ):
+                    continue
+                if current.peer_id in evidence:
+                    spared.append(current)
+                    continue
+                evicted.append(current)
+                del self._peers[current.peer_id]
+                self._mappings.pop(current.peer_id, None)
+            if evicted:
                 self._mappings_dirty = True
-                logger.info("evicted %d stale offline peers", len(stale))
-        if stale and self._ask_tracker is not None:
+
+        cutoff = datetime.fromtimestamp(now - max_age, timezone.utc)
+        for peer in spared:
+            self._emit_offline_peer_still_has_runtime_evidence(
+                peer,
+                reason="stale_evict_with_runtime_evidence",
+                cutoff=cutoff,
+                ttl_seconds=max_age,
+            )
+
+        if evicted:
+            logger.info("evicted %d stale offline peers", len(evicted))
+        if spared:
+            logger.warning(
+                "spared %d long-offline peers with runtime evidence",
+                len(spared),
+            )
+        if evicted and self._ask_tracker is not None:
             doomed_stashes: list[Any] = []
-            for pid in stale:
-                snap = await self._ask_tracker.snapshot_pending_replies_for_peer(pid)
+            for peer in evicted:
+                snap = await self._ask_tracker.snapshot_pending_replies_for_peer(
+                    peer.peer_id,
+                )
                 doomed_stashes.extend(snap)
             # snapshot → emit → forget so observers see the loss event
             # before the ask disappears.
             for ask in doomed_stashes:
                 self._emit_pending_reply_lost(ask, "stale_evict")
-            for pid in stale:
-                await self._ask_tracker.forget_peer(pid)
-        return len(stale)
+            for peer in evicted:
+                await self._ask_tracker.forget_peer(peer.peer_id)
+        return len(evicted)
+
+    @staticmethod
+    def _runtime_marker(peer: Peer) -> tuple[int | None, str | None]:
+        return (peer.agent_pid, peer.pane_id)
+
+    async def _runtime_evidence_ids(self, peers: list[Peer]) -> set[str]:
+        targets = [
+            peer for peer in peers
+            if (peer.agent_pid is not None and peer.agent_pid > 0) or peer.pane_id
+        ]
+        if not targets:
+            return set()
+
+        checks = await asyncio.gather(
+            *(asyncio.to_thread(has_runtime_evidence, peer) for peer in targets),
+            return_exceptions=True,
+        )
+        evidence: set[str] = set()
+        for peer, has_evidence in zip(targets, checks, strict=True):
+            if has_evidence is True:
+                evidence.add(peer.peer_id)
+            elif isinstance(has_evidence, Exception):
+                logger.warning(
+                    "runtime evidence check failed for %s during stale eviction",
+                    peer.peer_id,
+                    exc_info=has_evidence,
+                )
+        return evidence
+
+    def _emit_offline_peer_still_has_runtime_evidence(
+        self,
+        peer: Peer,
+        *,
+        reason: str,
+        cutoff: datetime,
+        ttl_seconds: float,
+    ) -> None:
+        self.add_event(
+            "offline_peer_still_has_runtime_evidence",
+            {
+                "peer_id": peer.peer_id,
+                "display_name": peer.display_name,
+                "backend": peer.backend.value,
+                "path": peer.path,
+                "pane_id": peer.pane_id,
+                "agent_pid": peer.agent_pid,
+                "last_seen": peer.last_seen.isoformat() if peer.last_seen else None,
+                "cutoff": cutoff.isoformat(),
+                "ttl_seconds": ttl_seconds,
+                "reason": reason,
+            },
+        )
 
     async def _emit_and_evict_expired_stashes(self) -> None:
         """Single owner for TTL-loss emission on stashed asks.

--- a/tests/test_lazy_repair.py
+++ b/tests/test_lazy_repair.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from repowire.config.models import AgentType, Config
+from repowire.daemon.ask_tracker import AskTracker
 from repowire.daemon.peer_registry import PeerRegistry, SessionMapping
 from repowire.daemon.websocket_transport import WebSocketTransport
 from repowire.protocol.peers import Peer, PeerStatus
@@ -42,14 +43,17 @@ def _make_peer(
 def _make_manager(
     transport: WebSocketTransport | None = None,
     query_tracker: MagicMock | None = None,
-    ask_tracker: MagicMock | None = None,
+    ask_tracker: AskTracker | MagicMock | None = None,
     *,
     peer_reap_ttl_seconds: float | None = None,
+    prune_max_age_hours: float | None = None,
     stale_busy_timeout_seconds: float | None = None,
 ) -> PeerRegistry:
     config = Config()
     if peer_reap_ttl_seconds is not None:
         config.daemon.peer_reap_ttl_seconds = peer_reap_ttl_seconds
+    if prune_max_age_hours is not None:
+        config.daemon.prune_max_age_hours = prune_max_age_hours
     if stale_busy_timeout_seconds is not None:
         config.daemon.stale_busy_timeout_seconds = stale_busy_timeout_seconds
     router = MagicMock()
@@ -469,7 +473,121 @@ class TestLazyRepairReaper:
         transport.disconnect.assert_awaited_once_with(peer.peer_id)
         ask_tracker.forget_peer.assert_awaited_once_with(peer.peer_id)
 
-    async def test_reaps_offline_peer_after_ttl(self):
+    async def test_spares_offline_peer_after_ttl_with_runtime_evidence(
+        self, monkeypatch,
+    ):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.disconnect = AsyncMock(return_value=True)
+        ask_tracker = MagicMock()
+        ask_tracker.forget_peer = AsyncMock(return_value=1)
+        ask_tracker.snapshot_pending_replies_for_peer = AsyncMock(return_value=[])
+        ask_tracker.snapshot_expired_pending_replies = AsyncMock(return_value=[])
+        ask_tracker.evict_expired = AsyncMock(return_value=0)
+        manager = _make_manager(
+            transport=transport,
+            ask_tracker=ask_tracker,
+            peer_reap_ttl_seconds=600,
+        )
+        stale_seen = datetime.now(timezone.utc) - timedelta(seconds=601)
+        peer = _make_peer(
+            status=PeerStatus.OFFLINE,
+            pane_id="%5",
+            last_seen=stale_seen,
+        )
+        peer.agent_pid = 12345
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = stale_seen
+            live.agent_pid = 12345
+            manager._mappings[peer.peer_id] = SessionMapping(
+                session_id=peer.peer_id,
+                display_name=peer.display_name,
+                circle=peer.circle,
+                backend=peer.backend,
+                path=peer.path,
+            )
+
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.has_runtime_evidence",
+            lambda _peer: True,
+        )
+
+        await manager.lazy_repair()
+
+        result = await manager.get_peer(peer.peer_id)
+        assert result is not None
+        assert result.status == PeerStatus.OFFLINE
+        assert manager._mappings[peer.peer_id].display_name == peer.display_name
+        transport.disconnect.assert_not_awaited()
+        ask_tracker.forget_peer.assert_not_awaited()
+        events = manager.get_events()
+        assert len(events) == 1
+        assert events[0]["type"] == "offline_peer_still_has_runtime_evidence"
+        assert events[0]["peer_id"] == peer.peer_id
+        assert events[0]["pane_id"] == "%5"
+        assert events[0]["agent_pid"] == 12345
+        assert events[0]["reason"] == "offline_ttl_with_runtime_evidence"
+
+    async def test_spared_offline_peer_keeps_mapping_and_stashed_ask(
+        self, monkeypatch,
+    ):
+        transport = MagicMock(spec=WebSocketTransport)
+        transport.disconnect = AsyncMock(return_value=True)
+        ask_tracker = AskTracker()
+        manager = _make_manager(
+            transport=transport,
+            ask_tracker=ask_tracker,
+            peer_reap_ttl_seconds=600,
+        )
+        stale_seen = datetime.now(timezone.utc) - timedelta(seconds=601)
+        peer = _make_peer(
+            status=PeerStatus.OFFLINE,
+            pane_id="%5",
+            last_seen=stale_seen,
+        )
+        peer.agent_pid = 12345
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = stale_seen
+            live.agent_pid = 12345
+            manager._mappings[peer.peer_id] = SessionMapping(
+                session_id=peer.peer_id,
+                display_name=peer.display_name,
+                circle=peer.circle,
+                backend=peer.backend,
+                path=peer.path,
+            )
+        cid = await ask_tracker.register(
+            from_peer_id=peer.peer_id,
+            from_peer_name=peer.display_name,
+            to_peer_id="repow-dev-answerer",
+            to_peer_name="answerer",
+            text="question",
+        )
+        assert await ask_tracker.set_pending_reply(cid, "stashed reply")
+
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.has_runtime_evidence",
+            lambda _peer: True,
+        )
+
+        await manager.lazy_repair()
+
+        assert await manager.get_peer(peer.peer_id) is not None
+        assert peer.peer_id in manager._mappings
+        ask = await ask_tracker.get(cid)
+        assert ask is not None
+        assert ask.pending_reply == "stashed reply"
+        assert "pending_reply_lost" not in {
+            event["type"] for event in manager.get_events()
+        }
+        transport.disconnect.assert_not_awaited()
+
+    async def test_reaps_offline_peer_after_ttl(self, monkeypatch):
         transport = MagicMock(spec=WebSocketTransport)
         transport.disconnect = AsyncMock(return_value=True)
         ask_tracker = MagicMock()
@@ -501,6 +619,11 @@ class TestLazyRepairReaper:
                 path=peer.path,
             )
 
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.has_runtime_evidence",
+            lambda _peer: False,
+        )
+
         await manager.lazy_repair()
 
         assert await manager.get_peer(peer.peer_id) is None
@@ -515,6 +638,56 @@ class TestLazyRepairReaper:
         assert events[0]["backend"] == peer.backend.value
         assert events[0]["pane_id"] == "%5"
         assert events[0]["reason"] == "offline_ttl"
+
+    async def test_stale_evict_spares_offline_peer_with_runtime_evidence(
+        self, monkeypatch,
+    ):
+        ask_tracker = MagicMock()
+        ask_tracker.forget_peer = AsyncMock(return_value=1)
+        ask_tracker.snapshot_pending_replies_for_peer = AsyncMock(return_value=[])
+        ask_tracker.snapshot_expired_pending_replies = AsyncMock(return_value=[])
+        ask_tracker.evict_expired = AsyncMock(return_value=0)
+        manager = _make_manager(
+            ask_tracker=ask_tracker,
+            peer_reap_ttl_seconds=0,
+            prune_max_age_hours=1 / 3600,
+        )
+        stale_seen = datetime.now(timezone.utc) - timedelta(seconds=2)
+        peer = _make_peer(
+            status=PeerStatus.OFFLINE,
+            pane_id="%5",
+            last_seen=stale_seen,
+        )
+        peer.agent_pid = 12345
+        await manager.register_peer(peer)
+        async with manager._lock:
+            live = manager._peers[peer.peer_id]
+            live.status = PeerStatus.OFFLINE
+            live.last_seen = stale_seen
+            live.agent_pid = 12345
+            manager._mappings[peer.peer_id] = SessionMapping(
+                session_id=peer.peer_id,
+                display_name=peer.display_name,
+                circle=peer.circle,
+                backend=peer.backend,
+                path=peer.path,
+            )
+
+        monkeypatch.setattr(
+            "repowire.daemon.peer_registry.has_runtime_evidence",
+            lambda _peer: True,
+        )
+
+        await manager.lazy_repair()
+
+        assert await manager.get_peer(peer.peer_id) is not None
+        assert peer.peer_id in manager._mappings
+        ask_tracker.forget_peer.assert_not_awaited()
+        events = manager.get_events()
+        assert len(events) == 1
+        assert events[0]["type"] == "offline_peer_still_has_runtime_evidence"
+        assert events[0]["peer_id"] == peer.peer_id
+        assert events[0]["reason"] == "stale_evict_with_runtime_evidence"
 
     async def test_does_not_reap_offline_peer_younger_than_ttl(self):
         manager = _make_manager(peer_reap_ttl_seconds=600)


### PR DESCRIPTION
## Summary

Fixes #367.

- Guard `_reap_dangling_peers()` with off-thread `has_runtime_evidence()` checks before deleting stale OFFLINE peers.
- Revalidate under the registry lock after probing: the peer must still exist, still be OFFLINE, still be past the relevant age cutoff, and still have the same runtime markers before any destructive cleanup.
- Emit `offline_peer_still_has_runtime_evidence` and preserve the peer, session mapping, descriptions/contradictions, transport, and asks when runtime evidence is still present.

## `_evict_stale_peers()` parity

While checking scope, `_evict_stale_peers()` turned out to be reachable for the same live-pane OFFLINE peer class: it runs after `_reap_dangling_peers()` in `lazy_repair()` and previously filtered only by OFFLINE status plus `prune_max_age_hours`. This PR applies the same evidence guard and lock revalidation there too, so the longer-age eviction path cannot delete a provably-live runtime either.

## Runtime evidence policy

A dead recorded `agent_pid` with a live tmux pane still reaps by design. `has_runtime_evidence()` treats the recorded agent PID as the strongest identity proof; if that PID is dead, a leftover pane/shell is not allowed to keep the old peer identity alive.

## Tests

- `uv run pytest tests/test_lazy_repair.py tests/test_registry_repair.py`
- `uv run ruff check repowire/ tests/test_lazy_repair.py`
- `uv run ruff check repowire/`
- `uv run ty check repowire/`
- `uv run pytest`

Full suite result: 1928 passed, 2 warnings.

## Docs

No docs update: this is a daemon correctness patch that preserves the intended lifecycle policy rather than adding a user-facing surface. Pre-PR hygiene flagged architecture docs for review because `peer_registry.py` changed; no doc behavior change is needed.