### PR TITLE
Restore pane-backed peers on daemon startup

### DIFF
--- a/docs/concepts/peer-identity-lifecycle.md
+++ b/docs/concepts/peer-identity-lifecycle.md
@@ -88,6 +88,32 @@ mapping-only holders, but they cannot demote a fresh online/busy orchestrator
 holder. To intentionally replace a live orchestrator, stop that holder first so
 the daemon no longer treats it as fresh.
 
+## Startup hydration
+
+On daemon startup, Repowire runs a one-shot hydration pass for pane-backed peers
+that were alive while the daemon was down. This is not a poller: it runs during
+startup only, then steady-state repair stays lazy.
+
+Hydration is anchored on persisted `peer_id` mappings and live tmux evidence.
+A pane is eligible only when daemon-written pane metadata names the same
+`peer_id`, or its embedded daemon-minted birth certificate validates through
+SQLite state. The backend, normalized project path, live pane cwd, and live
+`agent_pid` must all agree. Display name, cwd, command name, pane existence, and
+path/backend tuples are not identity proof; if any required proof is missing,
+ambiguous, stale, or contradictory, the daemon skips hydration and emits a
+`startup_hydration_skipped` event.
+
+Successful hydration recreates the peer with `status=offline`,
+`pane_id`, `agent_pid`, and `metadata.hydration_source=startup_hydration`.
+Offline is intentional: runtime evidence proves the session exists, but inbound
+delivery is not available until a WebSocket hook connects. Startup may respawn a
+ws-hook only for candidates that passed the full strict proof, and if no
+WebSocket connects within the bounded wait the peer remains offline and the
+daemon emits `startup_hydration_no_transport`.
+
+Unproven panes are left unadopted and continue to surface through
+`/panes/orphans` for explicit `repowire link`.
+
 MCP lazy registration treats tmux pane lookup as a locator, not as identity proof. A by-pane daemon result is accepted only when local pane runtime metadata proves the same daemon peer id, backend, and owning agent process. If that proof is missing or belongs to another process, MCP registers or resolves its own peer instead of adopting the incumbent. This keeps path and display name as useful context while avoiding path-based identity takeover.
 
 MCP lazy registration checks a daemon-minted birth certificate before the

--- a/docs/troubleshooting/ghost-peers.md
+++ b/docs/troubleshooting/ghost-peers.md
@@ -12,6 +12,14 @@ Remaining ghosts are evicted by **lazy repair**: the next MCP tool call from any
 
 Orphaned ws-hook *processes* (a hook outliving its agent, e.g. one installed before the agent-pid watcher existed) are swept once at daemon startup: the sweep kills hooks whose pane is gone, whose recorded agent pid is dead, or whose pane subtree contains only shells — and only on conclusive evidence. `repowire doctor` reports the current orphan count read-only; `repowire service restart` runs the sweep.
 
+Startup also rehydrates live pane-backed peers whose daemon registry was lost
+during the restart, but only when persisted peer identity and live pane metadata
+prove the same `peer_id` or a valid daemon-minted birth certificate. Rehydrated
+peers stay `offline` until their WebSocket hook reconnects; if no hook connects,
+the daemon emits `startup_hydration_no_transport` instead of advertising the
+peer as deliverable. Panes without that proof remain visible through
+`/panes/orphans` and require explicit `repowire link`.
+
 If you need an immediate eviction:
 
 ```bash

--- a/repowire/daemon/app.py
+++ b/repowire/daemon/app.py
@@ -458,6 +458,27 @@ def create_app(
             except Exception:
                 logger.warning("Orphan ws-hook sweep failed", exc_info=True)
 
+            try:
+                from repowire.daemon.startup_hydration import hydrate_startup_peers
+
+                result = await hydrate_startup_peers(
+                    registry=peer_registry,
+                    transport=transport,
+                    binding_store=session_binding_store,
+                )
+                if result.hydrated or result.skipped:
+                    logger.info(
+                        "Startup hydration complete: hydrated=%d respawned=%d "
+                        "connected=%d no_transport=%d skipped=%d",
+                        result.hydrated,
+                        result.respawned,
+                        result.connected,
+                        result.no_transport,
+                        result.skipped,
+                    )
+            except Exception:
+                logger.warning("Startup peer hydration failed", exc_info=True)
+
         # Start relay client if enabled
         relay_client: RelayClient | None = None
         if cfg.relay.enabled and cfg.relay.api_key:

--- a/repowire/daemon/startup_hydration.py
+++ b/repowire/daemon/startup_hydration.py
@@ -1,0 +1,389 @@
+"""One-shot startup rehydration for pane-backed peers.
+
+The daemon's live peer registry is intentionally in-memory. On daemon restart,
+idle sessions can still be alive in tmux while their ws-hook is gone, leaving
+them invisible until a hook/MCP path re-announces them. This module repairs
+only the cases where durable identity and live runtime evidence agree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from repowire.agent_types import AgentType
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.registry_identity import SessionMapping
+from repowire.daemon.registry_repair import pid_alive
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.hooks._tmux import PaneInfo, list_all_panes
+from repowire.hooks.utils import read_pane_runtime_metadata
+from repowire.protocol.peers import PeerStatus
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONNECT_WAIT_SECONDS = 2.0
+DEFAULT_RESPAWN_LIMIT = 20
+
+
+@dataclass(frozen=True)
+class StartupHydrationCandidate:
+    peer_id: str
+    display_name: str
+    circle: str
+    backend: AgentType
+    path: str
+    role: Any
+    model: str | None
+    pane_id: str
+    tmux_session: str | None
+    agent_pid: int
+    parent_pid: int | None
+    metadata: dict[str, Any]
+    cert_nonce: str | None = None
+
+
+@dataclass(frozen=True)
+class StartupHydrationResult:
+    hydrated: int = 0
+    respawned: int = 0
+    connected: int = 0
+    no_transport: int = 0
+    skipped: int = 0
+
+
+def _normalize_path(path: str | None) -> str:
+    if not path:
+        return ""
+    return os.path.normpath(os.path.abspath(path))
+
+
+def _int_value(value: Any) -> int | None:
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _contradicts(values: list[int | None]) -> bool:
+    concrete = {value for value in values if value is not None}
+    return len(concrete) > 1
+
+
+def _mapping_for_metadata(
+    *,
+    mappings: dict[str, SessionMapping],
+    metadata: dict[str, Any],
+    binding_store: SQLiteSessionBindingStore | None,
+    pane: PaneInfo,
+) -> tuple[SessionMapping | None, str | None, str | None]:
+    """Return (mapping, cert_nonce, skip_reason) for strict peer_id/cert proof."""
+    cert_nonce: str | None = None
+    raw_peer_id = metadata.get("peer_id")
+    peer_id = raw_peer_id if isinstance(raw_peer_id, str) and raw_peer_id else None
+    cert_envelope = metadata.get("birth_certificate")
+    cert_peer_id: str | None = None
+
+    if cert_envelope is not None:
+        if not isinstance(cert_envelope, dict):
+            return None, None, "invalid_certificate"
+        if binding_store is None:
+            return None, None, "certificate_store_unavailable"
+        cert_backend = cert_envelope.get("backend")
+        cert_path = cert_envelope.get("project_path")
+        cert_agent_pid = _int_value(cert_envelope.get("agent_pid"))
+        if not isinstance(cert_backend, str) or not isinstance(cert_path, str):
+            return None, None, "invalid_certificate"
+        cert = binding_store.validate_birth_certificate(
+            cert_envelope,
+            backend=cert_backend,
+            project_path=cert_path,
+            pane_id=pane["pane_id"],
+            agent_pid=cert_agent_pid,
+        )
+        if cert is None:
+            return None, None, "invalid_certificate"
+        cert_peer_id = cert.peer_id
+        cert_nonce = cert.nonce
+
+    if peer_id and cert_peer_id and peer_id != cert_peer_id:
+        return None, None, "peer_id_certificate_mismatch"
+
+    identity_peer_id = peer_id or cert_peer_id
+    if not identity_peer_id:
+        return None, None, "missing_peer_id"
+
+    mapping = mappings.get(identity_peer_id)
+    if mapping is None:
+        return None, None, "mapping_missing"
+    return mapping, cert_nonce, None
+
+
+def _candidate_from_pane(
+    *,
+    pane: PaneInfo,
+    metadata: dict[str, Any],
+    mapping: SessionMapping,
+    cert_nonce: str | None,
+) -> tuple[StartupHydrationCandidate | None, str | None]:
+    metadata_backend = metadata.get("backend")
+    if metadata_backend != mapping.backend.value:
+        return None, "backend_mismatch"
+
+    raw_metadata_path = metadata.get("cwd")
+    metadata_path = _normalize_path(
+        raw_metadata_path if isinstance(raw_metadata_path, str) else None
+    )
+    mapping_path = _normalize_path(mapping.path)
+    pane_path = _normalize_path(pane["cwd"])
+    if not metadata_path or not mapping_path:
+        return None, "path_missing"
+    if metadata_path != mapping_path or pane_path != mapping_path:
+        return None, "path_mismatch"
+
+    cert = metadata.get("birth_certificate")
+    cert_agent_pid = (
+        _int_value(cert.get("agent_pid")) if isinstance(cert, dict) else None
+    )
+    agent_pid = _int_value(metadata.get("agent_pid"))
+    mapping_agent_pid = _int_value(mapping.agent_pid)
+    if _contradicts([agent_pid, cert_agent_pid, mapping_agent_pid]):
+        return None, "agent_pid_mismatch"
+    effective_agent_pid = agent_pid or cert_agent_pid or mapping_agent_pid
+    if effective_agent_pid is None:
+        return None, "agent_pid_missing"
+    if not pid_alive(effective_agent_pid):
+        return None, "agent_pid_dead"
+
+    display_name = metadata.get("display_name")
+    if display_name is not None and display_name != mapping.display_name:
+        return None, "display_name_mismatch"
+
+    parent_pid = _int_value(metadata.get("parent_pid"))
+    tmux_session = f"{pane['session']}:{pane['window']}" if pane.get("session") else None
+    hydrated_metadata: dict[str, Any] = {
+        "startup_hydration": True,
+        "hydration_source": "startup_hydration",
+    }
+    hook_session_id = metadata.get("hook_session_id")
+    if isinstance(hook_session_id, str) and hook_session_id:
+        hydrated_metadata["hook_session_id"] = hook_session_id
+    if cert_nonce:
+        hydrated_metadata["birth_certificate_nonce"] = cert_nonce
+
+    return (
+        StartupHydrationCandidate(
+            peer_id=mapping.session_id,
+            display_name=mapping.display_name,
+            circle=mapping.circle,
+            backend=mapping.backend,
+            path=mapping_path,
+            role=mapping.role,
+            model=mapping.model,
+            pane_id=pane["pane_id"],
+            tmux_session=tmux_session,
+            agent_pid=effective_agent_pid,
+            parent_pid=parent_pid,
+            metadata=hydrated_metadata,
+            cert_nonce=cert_nonce,
+        ),
+        None,
+    )
+
+
+def _build_candidates(
+    *,
+    registry: PeerRegistry,
+    binding_store: SQLiteSessionBindingStore | None,
+    panes: list[PaneInfo],
+) -> tuple[list[StartupHydrationCandidate], list[tuple[str | None, str]]]:
+    candidates: list[StartupHydrationCandidate] = []
+    skipped: list[tuple[str | None, str]] = []
+    by_peer_id: dict[str, list[StartupHydrationCandidate]] = {}
+
+    mappings = dict(registry._mappings)
+    for pane in panes:
+        pane_id = pane["pane_id"]
+        metadata = read_pane_runtime_metadata(pane_id)
+        if not metadata:
+            skipped.append((pane_id, "metadata_missing"))
+            continue
+        mapping, cert_nonce, reason = _mapping_for_metadata(
+            mappings=mappings,
+            metadata=metadata,
+            binding_store=binding_store,
+            pane=pane,
+        )
+        if reason:
+            skipped.append((pane_id, reason))
+            continue
+        assert mapping is not None
+        candidate, reason = _candidate_from_pane(
+            pane=pane,
+            metadata=metadata,
+            mapping=mapping,
+            cert_nonce=cert_nonce,
+        )
+        if reason:
+            skipped.append((pane_id, reason))
+            continue
+        assert candidate is not None
+        by_peer_id.setdefault(candidate.peer_id, []).append(candidate)
+
+    for peer_id, peer_candidates in by_peer_id.items():
+        if len(peer_candidates) > 1:
+            for candidate in peer_candidates:
+                skipped.append((candidate.pane_id, "duplicate_peer_claim"))
+            logger.warning(
+                "startup hydration skipped %s: %d panes claimed the same peer_id",
+                peer_id,
+                len(peer_candidates),
+            )
+            continue
+        candidates.append(peer_candidates[0])
+    return candidates, skipped
+
+
+async def _wait_connected(
+    transport: WebSocketTransport,
+    peer_id: str,
+    *,
+    timeout_seconds: float,
+) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while True:
+        if transport.is_connected(peer_id):
+            return True
+        if asyncio.get_running_loop().time() >= deadline:
+            return False
+        await asyncio.sleep(0.05)
+
+
+async def hydrate_startup_peers(
+    *,
+    registry: PeerRegistry,
+    transport: WebSocketTransport,
+    binding_store: SQLiteSessionBindingStore | None,
+    connect_wait_seconds: float = DEFAULT_CONNECT_WAIT_SECONDS,
+    respawn_limit: int = DEFAULT_RESPAWN_LIMIT,
+) -> StartupHydrationResult:
+    """Recreate strictly proven pane-backed peers after daemon startup.
+
+    Candidates are anchored by persisted peer mappings and require daemon-minted
+    pane metadata naming the same peer_id or a validated runtime certificate.
+    Unproven panes are deliberately left for /panes/orphans and manual link.
+    """
+    panes = list_all_panes()
+    candidates, skipped = _build_candidates(
+        registry=registry,
+        binding_store=binding_store,
+        panes=panes,
+    )
+    for pane_id, reason in skipped:
+        registry.add_event(
+            "startup_hydration_skipped",
+            {"pane_id": pane_id, "reason": reason},
+        )
+
+    if not candidates:
+        return StartupHydrationResult(skipped=len(skipped))
+
+    from repowire.hooks.ws_hook_supervisor import startup_respawn_ws_hook
+
+    hydrated = 0
+    respawned = 0
+    connected = 0
+    no_transport = 0
+    pending_transport: list[StartupHydrationCandidate] = []
+
+    for candidate in candidates:
+        existing = await registry.get_peer(candidate.peer_id)
+        if (
+            existing is not None
+            and existing.status in (PeerStatus.ONLINE, PeerStatus.BUSY)
+        ):
+            if transport.is_connected(candidate.peer_id):
+                connected += 1
+            continue
+
+        await registry.allocate_and_register(
+            circle=candidate.circle,
+            backend=candidate.backend,
+            model=candidate.model,
+            path=candidate.path,
+            pane_id=candidate.pane_id,
+            tmux_session=candidate.tmux_session,
+            metadata=candidate.metadata,
+            role=candidate.role,
+            peer_id=candidate.peer_id,
+            initial_status=PeerStatus.OFFLINE,
+            agent_pid=candidate.agent_pid,
+            parent_pid=candidate.parent_pid,
+            circle_source="fallback",
+            display_name_override=candidate.display_name,
+        )
+        hydrated += 1
+
+        if transport.is_connected(candidate.peer_id):
+            connected += 1
+            continue
+
+        if respawned < respawn_limit:
+            did_respawn = await asyncio.to_thread(
+                startup_respawn_ws_hook,
+                candidate.pane_id,
+                peer_id=candidate.peer_id,
+                display_name=candidate.display_name,
+                backend=candidate.backend.value,
+                cwd=candidate.path,
+                agent_pid=candidate.agent_pid,
+            )
+            if did_respawn:
+                respawned += 1
+
+        pending_transport.append(candidate)
+
+    if pending_transport:
+        wait_results = await asyncio.gather(
+            *(
+                _wait_connected(
+                    transport,
+                    candidate.peer_id,
+                    timeout_seconds=connect_wait_seconds,
+                )
+                for candidate in pending_transport
+            )
+        )
+        for candidate, did_connect in zip(
+            pending_transport,
+            wait_results,
+            strict=True,
+        ):
+            if did_connect:
+                connected += 1
+                continue
+
+            no_transport += 1
+            registry.add_event(
+                "startup_hydration_no_transport",
+                {
+                    "peer_id": candidate.peer_id,
+                    "display_name": candidate.display_name,
+                    "pane_id": candidate.pane_id,
+                    "agent_pid": candidate.agent_pid,
+                },
+            )
+
+    return StartupHydrationResult(
+        hydrated=hydrated,
+        respawned=respawned,
+        connected=connected,
+        no_transport=no_transport,
+        skipped=len(skipped),
+    )

--- a/repowire/hooks/ws_hook_supervisor.py
+++ b/repowire/hooks/ws_hook_supervisor.py
@@ -278,6 +278,78 @@ def maybe_respawn(
         return False
 
 
+def startup_respawn_ws_hook(
+    pane_id: str,
+    *,
+    peer_id: str,
+    display_name: str,
+    backend: str,
+    cwd: str,
+    agent_pid: int,
+) -> bool:
+    """Start a ws-hook at daemon boot for a strictly proven peer.
+
+    This helper is intentionally narrower than ``link_spawn_ws_hook`` (manual
+    adoption) and ``maybe_respawn`` (Stop-hook lazy repair). The caller must
+    already have joined durable peer identity to live pane/runtime evidence.
+    """
+    lock_path = ws_hook_lock_path(pane_id)
+    try:
+        lock_fd = open(lock_path, "w")  # noqa: SIM115
+    except OSError as e:
+        logger.warning("startup_respawn_ws_hook: pane %s lock open failed: %s", pane_id, e)
+        return False
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return False
+
+        metadata = read_pane_runtime_metadata(pane_id)
+        metadata_peer_id = metadata.get("peer_id")
+        cert = metadata.get("birth_certificate")
+        cert_peer_id = cert.get("peer_id") if isinstance(cert, dict) else None
+        metadata_backend = metadata.get("backend")
+        metadata_cwd = metadata.get("cwd")
+        normalized_metadata_cwd = (
+            os.path.normpath(os.path.abspath(metadata_cwd))
+            if isinstance(metadata_cwd, str)
+            else None
+        )
+        normalized_cwd = os.path.normpath(os.path.abspath(cwd))
+        peer_matches = metadata_peer_id == peer_id or cert_peer_id == peer_id
+        if (
+            not peer_matches
+            or metadata_backend != backend
+            or normalized_metadata_cwd != normalized_cwd
+        ):
+            logger.warning(
+                "startup_respawn_ws_hook rejected: metadata peer/backend/cwd "
+                "mismatch for pane %s (peer=%s backend=%s cwd=%s)",
+                pane_id,
+                peer_id,
+                backend,
+                cwd,
+            )
+            return False
+
+        new_pid = spawn_ws_hook(
+            pane_id=pane_id,
+            peer_id=peer_id,
+            display_name=display_name,
+            backend=backend,
+            cwd=cwd,
+            lock_fd=lock_fd,
+            agent_pid=agent_pid,
+        )
+        return new_pid is not None
+    except Exception as e:
+        logger.warning("startup_respawn_ws_hook failed for pane %s: %s", pane_id, e)
+        return False
+    finally:
+        lock_fd.close()
+
+
 # ---------------------------------------------------------------------------
 # Orphan sweep
 # ---------------------------------------------------------------------------

--- a/tests/test_startup_hydration.py
+++ b/tests/test_startup_hydration.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repowire.agent_types import AgentType
+from repowire.config.models import Config
+from repowire.daemon.message_router import MessageRouter
+from repowire.daemon.peer_registry import PeerRegistry
+from repowire.daemon.query_tracker import QueryTracker
+from repowire.daemon.registry_identity import SessionMapping
+from repowire.daemon.startup_hydration import hydrate_startup_peers
+from repowire.daemon.state.database import StateDatabase
+from repowire.daemon.state.session_bindings import SQLiteSessionBindingStore
+from repowire.daemon.websocket_transport import WebSocketTransport
+from repowire.protocol.peers import PeerRole, PeerStatus
+
+PEER_ID = "repow-default-abc12345"
+PANE_ID = "%42"
+PATH = "/tmp/repowire-project"
+AGENT_PID = 12345
+
+
+def _pane(
+    *,
+    pane_id: str = PANE_ID,
+    cwd: str = PATH,
+    pid: int = 999,
+) -> dict:
+    return {
+        "pane_id": pane_id,
+        "pid": pid,
+        "command": "codex",
+        "cwd": cwd,
+        "session": "default",
+        "window": "1",
+    }
+
+
+def _metadata(**overrides):
+    data = {
+        "peer_id": PEER_ID,
+        "display_name": "repowire-project-codex",
+        "backend": "codex",
+        "cwd": PATH,
+        "agent_pid": AGENT_PID,
+        "parent_pid": 222,
+        "hook_session_id": "runtime-1",
+    }
+    data.update(overrides)
+    return data
+
+
+def _registry(tmp_path):
+    transport = WebSocketTransport()
+    tracker = QueryTracker()
+    router = MessageRouter(transport=transport, query_tracker=tracker)
+    db = StateDatabase(tmp_path / "state.db")
+    registry = PeerRegistry(
+        config=Config(),
+        message_router=router,
+        query_tracker=tracker,
+        transport=transport,
+        persistence_path=tmp_path / "sessions.json",
+        state_db=db,
+    )
+    registry._events_path = tmp_path / "events.json"
+    registry._events.clear()
+    return registry, transport, SQLiteSessionBindingStore(db)
+
+
+def _add_mapping(registry: PeerRegistry, *, peer_id: str = PEER_ID) -> None:
+    registry._mappings[peer_id] = SessionMapping(
+        session_id=peer_id,
+        display_name="repowire-project-codex",
+        circle="default",
+        backend=AgentType.CODEX,
+        path=PATH,
+        role=PeerRole.AGENT,
+        model="gpt-5.5",
+        agent_pid=AGENT_PID,
+    )
+
+
+def _mapping(
+    *,
+    peer_id: str,
+    display_name: str,
+    path: str,
+    agent_pid: int,
+) -> SessionMapping:
+    return SessionMapping(
+        session_id=peer_id,
+        display_name=display_name,
+        circle="default",
+        backend=AgentType.CODEX,
+        path=path,
+        role=PeerRole.AGENT,
+        model="gpt-5.5",
+        agent_pid=agent_pid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mapping_alone_does_not_hydrate(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+
+    with patch("repowire.daemon.startup_hydration.list_all_panes", return_value=[]):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert await registry.get_peer(PEER_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_matching_live_pane_hydrates_offline_and_reports_no_transport(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch("repowire.daemon.peer_registry.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=False,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 1
+    assert result.no_transport == 1
+    respawn.assert_called_once()
+    peer = await registry.get_peer(PEER_ID)
+    assert peer is not None
+    assert peer.status == PeerStatus.OFFLINE
+    assert peer.pane_id == PANE_ID
+    assert peer.agent_pid == AGENT_PID
+    assert peer.metadata["hydration_source"] == "startup_hydration"
+    assert any(
+        event["type"] == "startup_hydration_no_transport"
+        and event["peer_id"] == PEER_ID
+        for event in registry.get_events()
+    )
+
+
+@pytest.mark.asyncio
+async def test_dead_agent_pid_does_not_hydrate_or_respawn(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=False),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert await registry.get_peer(PEER_ID) is None
+    respawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retired_peer_without_live_pid_does_not_hydrate(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+    registry._retire(PEER_ID)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(agent_pid=None),
+        ),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert await registry.get_peer(PEER_ID) is None
+    respawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retired_peer_with_live_pid_hydrates_and_unretires(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+    registry._retire(PEER_ID)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch("repowire.daemon.peer_registry.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=False,
+        ),
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 1
+    assert PEER_ID not in registry._retired
+    peer = await registry.get_peer(PEER_ID)
+    assert peer is not None
+    assert peer.status == PeerStatus.OFFLINE
+    assert peer.agent_pid == AGENT_PID
+
+
+@pytest.mark.asyncio
+async def test_unproven_pane_does_not_respawn(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(peer_id=None, birth_certificate=None),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert result.skipped == 1
+    respawn.assert_not_called()
+    assert any(
+        event["type"] == "startup_hydration_skipped"
+        and event["reason"] == "missing_peer_id"
+        for event in registry.get_events()
+    )
+
+
+@pytest.mark.asyncio
+async def test_connected_peer_wins_hydration_noop(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+    await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path=PATH,
+        pane_id=PANE_ID,
+        role=PeerRole.AGENT,
+        peer_id=PEER_ID,
+        initial_status=PeerStatus.ONLINE,
+        agent_pid=AGENT_PID,
+        display_name_override="repowire-project-codex",
+    )
+    websocket = AsyncMock()
+    await transport.connect(PEER_ID, websocket, pane_id=PANE_ID)
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert result.connected == 1
+    respawn.assert_not_called()
+    peer = await registry.get_peer(PEER_ID)
+    assert peer is not None
+    assert peer.status == PeerStatus.ONLINE
+
+
+@pytest.mark.asyncio
+async def test_existing_online_peer_without_transport_is_not_downgraded(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+    await registry.allocate_and_register(
+        circle="default",
+        backend=AgentType.CODEX,
+        path=PATH,
+        pane_id=PANE_ID,
+        role=PeerRole.AGENT,
+        peer_id=PEER_ID,
+        initial_status=PeerStatus.ONLINE,
+        agent_pid=AGENT_PID,
+        display_name_override="repowire-project-codex",
+    )
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert result.no_transport == 0
+    respawn.assert_not_called()
+    peer = await registry.get_peer(PEER_ID)
+    assert peer is not None
+    assert peer.status == PeerStatus.ONLINE
+
+
+@pytest.mark.asyncio
+async def test_valid_certificate_can_hydrate_without_metadata_peer_id(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+    cert = store.mint_birth_certificate(
+        peer_id=PEER_ID,
+        display_name="repowire-project-codex",
+        backend=AgentType.CODEX,
+        project_path=PATH,
+        runtime_session_id="runtime-1",
+        pane_id=PANE_ID,
+        agent_pid=AGENT_PID,
+        parent_pid=222,
+        metadata={"circle": "default", "role": "agent"},
+    )
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[_pane()],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            return_value=_metadata(peer_id=None, birth_certificate=cert.as_envelope()),
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=False,
+        ),
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 1
+    peer = await registry.get_peer(PEER_ID)
+    assert peer is not None
+    assert peer.metadata["birth_certificate_nonce"] == cert.nonce
+
+
+@pytest.mark.asyncio
+async def test_respawn_limit_bounds_startup_hook_spawns(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    second_peer_id = "repow-default-def67890"
+    second_path = "/tmp/repowire-project-2"
+    second_pid = 23456
+    registry._mappings[PEER_ID] = _mapping(
+        peer_id=PEER_ID,
+        display_name="repowire-project-codex",
+        path=PATH,
+        agent_pid=AGENT_PID,
+    )
+    registry._mappings[second_peer_id] = _mapping(
+        peer_id=second_peer_id,
+        display_name="repowire-project-2-codex",
+        path=second_path,
+        agent_pid=second_pid,
+    )
+
+    def metadata_for(pane_id: str):
+        if pane_id == PANE_ID:
+            return _metadata()
+        return _metadata(
+            peer_id=second_peer_id,
+            display_name="repowire-project-2-codex",
+            cwd=second_path,
+            agent_pid=second_pid,
+        )
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[
+                _pane(),
+                _pane(pane_id="%43", cwd=second_path, pid=1000),
+            ],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            side_effect=metadata_for,
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+            respawn_limit=1,
+        )
+
+    assert result.hydrated == 2
+    assert result.respawned == 1
+    assert respawn.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_peer_claim_skips_all_claimants_and_does_not_respawn(tmp_path):
+    registry, transport, store = _registry(tmp_path)
+    _add_mapping(registry)
+
+    def metadata_for(_pane_id: str):
+        return _metadata()
+
+    with (
+        patch(
+            "repowire.daemon.startup_hydration.list_all_panes",
+            return_value=[
+                _pane(),
+                _pane(pane_id="%43", cwd=PATH, pid=1000),
+            ],
+        ),
+        patch(
+            "repowire.daemon.startup_hydration.read_pane_runtime_metadata",
+            side_effect=metadata_for,
+        ),
+        patch("repowire.daemon.startup_hydration.pid_alive", return_value=True),
+        patch(
+            "repowire.hooks.ws_hook_supervisor.startup_respawn_ws_hook",
+            return_value=True,
+        ) as respawn,
+    ):
+        result = await hydrate_startup_peers(
+            registry=registry,
+            transport=transport,
+            binding_store=store,
+            connect_wait_seconds=0,
+        )
+
+    assert result.hydrated == 0
+    assert result.skipped == 2
+    assert await registry.get_peer(PEER_ID) is None
+    respawn.assert_not_called()
+    duplicate_events = [
+        event
+        for event in registry.get_events()
+        if event["type"] == "startup_hydration_skipped"
+        and event["reason"] == "duplicate_peer_claim"
+    ]
+    assert {event["pane_id"] for event in duplicate_events} == {PANE_ID, "%43"}


### PR DESCRIPTION
## Summary

Fixes #368 by adding a one-shot startup hydration pass for pane-backed peers that were alive while the daemon was down.

The hydrator is intentionally fail-closed:
- persisted `peer_session_mappings` anchor candidate identity;
- live tmux panes and pane runtime metadata provide runtime evidence;
- identity proof is only `metadata.peer_id` or a validated daemon-minted birth certificate;
- no display-name/path/backend tuple fallback is used;
- backend, normalized mapping path, metadata cwd, live pane cwd, and live `agent_pid` must agree;
- duplicate live panes claiming the same `peer_id` are skipped;
- hydrated peers start `offline` and remain non-deliverable unless a WebSocket hook connects.

A narrow startup-only ws-hook respawn helper can run only after the strict proof stack passes, revalidates peer/backend/cwd under the pane lock, and is capped by `respawn_limit`.

## Validation

- `uv run pytest` (1939 passed, 2 warnings)
- `uv run ruff check repowire/`
- `uv run ty check repowire/`
- `python3 scripts/pre_pr_hygiene.py` (advisory; relevant docs updated, graphify refresh intentionally deferred)

## Notes

Docs updated in `docs/concepts/peer-identity-lifecycle.md` and `docs/troubleshooting/ghost-peers.md`.

Review focus requested: strict duplicate-claim guard, retired + live-pid hydration/unretire behavior, and no-transport stays `offline`.