### PR TITLE
fix(relay): keepalive ping + real connection state in /health (relay client could silently die)

### DIFF
--- a/docs/operate/relay.md
+++ b/docs/operate/relay.md
@@ -20,6 +20,23 @@ The relay landing page accepts the relay key from setup and redirects to the das
 
 Self-hosting runs the same relay server under your own deployment and points the daemon at your relay URL.
 
+## Diagnosing a disconnected relay
+
+If the dashboard login bounces back to the landing page with `no_daemon`, or peers do not appear in the remote dashboard, the daemon's relay client is not connected — the relay has no daemon to bind the session to. Check live relay state on the local daemon:
+
+```bash
+curl -s http://127.0.0.1:8377/health | jq .relay
+```
+
+The `relay` block reports the real connection, not just the config flag:
+
+- `status: connected` — the relay client holds a live WebSocket.
+- `status: connecting` — the reconnect loop is running but not yet connected.
+- `status: down` — relay is enabled but not connected; `last_error`/`last_error_at` carry the cause. Hitting `/health` also lazily relaunches the loop if it had stopped.
+- `status: disabled` — relay is not enabled in config.
+
+`relay_mode` remains the config intent (`relay.enabled`); `relay.status` is the truth. The relay client keeps an application-level keepalive ping so half-open connections are detected and reconnected rather than silently wedging.
+
 ## Related
 
 - [Relay access](../use/features/relay-access.md)

--- a/repowire/daemon/relay_client.py
+++ b/repowire/daemon/relay_client.py
@@ -11,6 +11,7 @@ import base64
 import json
 import logging
 import socket
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -23,6 +24,15 @@ logger = logging.getLogger(__name__)
 
 _MAX_BACKOFF = 30.0
 _INITIAL_BACKOFF = 1.0
+
+# Application-level keepalive. The relay (or an intermediary proxy) silently
+# drops idle connections; without an explicit ping the daemon can sit in
+# ``async for raw in ws`` on a half-open socket that never yields. websockets
+# raises ConnectionClosed from the keepalive task when a pong is missed, which
+# breaks the listen loop and triggers a reconnect. Tuned tighter than the
+# library defaults so a dead connection is caught within ~30s, not minutes.
+_PING_INTERVAL = 20.0
+_PING_TIMEOUT = 20.0
 
 
 class RelayClient:
@@ -41,21 +51,69 @@ class RelayClient:
         self._task: asyncio.Task[None] | None = None
         self._http: httpx.AsyncClient | None = None
         self._stopping = False
+        # Liveness telemetry surfaced via /health so a dead relay client is
+        # visible instead of masked behind the static relay-enabled config flag.
+        self._last_connected_at: datetime | None = None
+        self._last_error: str | None = None
+        self._last_error_at: datetime | None = None
 
     @property
     def connected(self) -> bool:
         """Whether currently connected to relay."""
         return self._ws is not None and self._ws.close_code is None
 
+    def status(self) -> dict[str, Any]:
+        """Live connection telemetry for health reporting (not the config flag)."""
+        task = self._task
+        return {
+            "connected": self.connected,
+            "running": task is not None and not task.done(),
+            "url": self._config.url,
+            "daemon_id": self._daemon_id,
+            "last_connected_at": (
+                self._last_connected_at.isoformat()
+                if self._last_connected_at
+                else None
+            ),
+            "last_error": self._last_error,
+            "last_error_at": (
+                self._last_error_at.isoformat() if self._last_error_at else None
+            ),
+        }
+
     async def start(self) -> None:
-        """Start the relay client as a background task."""
+        """Start the relay client as a background task.
+
+        Idempotent: if a prior loop task is still alive this is a no-op, so it
+        doubles as a lazy self-heal — a caller that observes a dead task (via
+        :meth:`ensure_running`) can restart without spawning duplicates.
+        """
         if not self._config.enabled or not self._config.api_key:
             logger.info("Relay disabled or no API key — skipping relay client")
             return
+        if self._task is not None and not self._task.done():
+            return
         self._stopping = False
-        self._http = httpx.AsyncClient()
+        if self._http is None:
+            self._http = httpx.AsyncClient()
         self._task = asyncio.create_task(self._run_loop())
         logger.info("Relay client started (daemon_id=%s)", self._daemon_id)
+
+    async def ensure_running(self) -> bool:
+        """Lazy self-heal: restart the loop if it died. Returns True if it relaunched.
+
+        Lazy-repair, not polling: call this from request paths (e.g. /health),
+        never on a timer. The hardened :meth:`_run_loop` should never exit on
+        its own, so this is a belt-and-braces backstop, not the primary
+        mechanism.
+        """
+        if self._stopping or not self._config.enabled or not self._config.api_key:
+            return False
+        if self._task is not None and not self._task.done():
+            return False
+        logger.warning("Relay loop was not running; relaunching (lazy self-heal)")
+        await self.start()
+        return True
 
     async def stop(self) -> None:
         """Gracefully disconnect."""
@@ -127,10 +185,13 @@ class RelayClient:
                     self._build_url(),
                     open_timeout=10,
                     close_timeout=5,
+                    ping_interval=_PING_INTERVAL,
+                    ping_timeout=_PING_TIMEOUT,
                     max_size=16 * 1024 * 1024,  # 16MB for attachment tunneling
                 ) as ws:
                     self._ws = ws
                     backoff = _INITIAL_BACKOFF
+                    self._last_connected_at = datetime.now(timezone.utc)
                     logger.info("Connected to relay at %s", self._config.url)
                     # Recreate httpx client on each reconnect (clear stale state)
                     if self._http:
@@ -139,15 +200,29 @@ class RelayClient:
                     await self._listen(ws)
             except asyncio.CancelledError:
                 break
-            except Exception:
+            except Exception as exc:
+                # Record the error before the stopping-check: a failure is a
+                # failure even if a shutdown is concurrently in flight, and
+                # surfacing it in /health is the whole point.
+                self._ws = None
+                self._last_error = f"{type(exc).__name__}: {exc}"
+                self._last_error_at = datetime.now(timezone.utc)
                 if self._stopping:
                     break
                 logger.warning(
                     "Relay connection lost, reconnecting in %.0fs", backoff, exc_info=True
                 )
-                self._ws = None
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, _MAX_BACKOFF)
+            else:
+                # _listen returned without an exception (server closed the
+                # stream cleanly). Loop and reconnect rather than exiting —
+                # falling out of the while body silently here is how the
+                # client could go permanently dark.
+                self._ws = None
+        # Loop exits only via stop()/cancel. A done task while not stopping is
+        # treated as dead by ensure_running() (lazy self-heal on next /health).
+        logger.info("Relay reconnect loop exited (stopping=%s)", self._stopping)
 
     async def _listen(self, ws: ClientConnection) -> None:
         """Listen for messages from relay and dispatch."""

--- a/repowire/daemon/relay_client.py
+++ b/repowire/daemon/relay_client.py
@@ -216,10 +216,20 @@ class RelayClient:
                 backoff = min(backoff * 2, _MAX_BACKOFF)
             else:
                 # _listen returned without an exception (server closed the
-                # stream cleanly). Loop and reconnect rather than exiting —
-                # falling out of the while body silently here is how the
-                # client could go permanently dark.
+                # stream cleanly, e.g. 1000/1001). Reconnect rather than
+                # exiting — falling out of the while body silently here is how
+                # the client could go permanently dark — but back off and log
+                # like the error path so a relay that repeatedly accepts and
+                # immediately closes cannot spin a tight reconnect loop.
                 self._ws = None
+                if self._stopping:
+                    break
+                logger.info(
+                    "Relay closed the connection cleanly, reconnecting in %.0fs",
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, _MAX_BACKOFF)
         # Loop exits only via stop()/cancel. A done task while not stopping is
         # treated as dead by ensure_running() (lazy self-heal on next /health).
         logger.info("Relay reconnect loop exited (stopping=%s)", self._stopping)

--- a/repowire/daemon/routes/health.py
+++ b/repowire/daemon/routes/health.py
@@ -54,12 +54,31 @@ class AcpBrokerHealth(BaseModel):
     permissions: AcpPermissionHealth = Field(default_factory=AcpPermissionHealth)
 
 
+class RelayHealth(BaseModel):
+    """Live relay-client connection state (not the static config flag).
+
+    ``enabled`` is the config intent; ``connected``/``running`` are the truth.
+    A relay that is enabled-but-not-connected is the failure that used to hide
+    behind ``relay_mode: true`` while the client was silently dead.
+    """
+
+    status: Literal["disabled", "connected", "connecting", "down"]
+    enabled: bool = False
+    connected: bool = False
+    running: bool = False
+    url: str | None = None
+    last_connected_at: str | None = None
+    last_error: str | None = None
+    last_error_at: str | None = None
+
+
 class HealthResponse(BaseModel):
     """Health check response."""
 
     status: str
     version: str
     relay_mode: bool = False
+    relay: RelayHealth
     channel: ChannelHealth
     acp_broker: AcpBrokerHealth
 
@@ -74,8 +93,48 @@ async def health_check(request: Request) -> HealthResponse:
         status="ok",
         version=__version__,
         relay_mode=relay_mode,
+        relay=await _relay_health(request),
         channel=_channel_health(config),
         acp_broker=await _acp_broker_health(request, config),
+    )
+
+
+async def _relay_health(request: Request) -> RelayHealth:
+    """Report live relay-client state, lazily self-healing a dead loop.
+
+    Lazy repair, not polling: this runs only when /health is hit. If the
+    reconnect loop somehow died, ``ensure_running`` relaunches it here rather
+    than on a timer.
+    """
+    client = getattr(request.app.state, "relay_client", None)
+    enabled = bool(getattr(request.app.state, "relay_mode", False))
+    if client is None:
+        return RelayHealth(
+            status="disabled" if not enabled else "down",
+            enabled=enabled,
+        )
+
+    try:
+        await client.ensure_running()
+    except Exception:  # noqa: BLE001 — health must never raise
+        pass
+
+    st = client.status()
+    if st["connected"]:
+        status = "connected"
+    elif st["running"]:
+        status = "connecting"
+    else:
+        status = "down"
+    return RelayHealth(
+        status=status,
+        enabled=enabled,
+        connected=bool(st["connected"]),
+        running=bool(st["running"]),
+        url=st.get("url"),
+        last_connected_at=st.get("last_connected_at"),
+        last_error=st.get("last_error"),
+        last_error_at=st.get("last_error_at"),
     )
 
 

--- a/tests/test_relay_client.py
+++ b/tests/test_relay_client.py
@@ -1,0 +1,135 @@
+"""Tests for the daemon-side RelayClient liveness + health telemetry.
+
+Guards the failure mode where the reconnect loop silently died (no logs for
+hours) while /health still reported relay as up. See repowire-blr.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from repowire.config.relay import RelayConfig
+from repowire.daemon import relay_client as relay_client_mod
+from repowire.daemon.relay_client import (
+    _PING_INTERVAL,
+    _PING_TIMEOUT,
+    RelayClient,
+)
+
+
+def _client() -> RelayClient:
+    cfg = RelayConfig(enabled=True, api_key="rw_testtesttesttesttesttest", url="wss://relay.test")
+    return RelayClient(config=cfg, daemon_id="daemon-test")
+
+
+class TestRelayStatus:
+    def test_status_disconnected_by_default(self):
+        client = _client()
+        st = client.status()
+        assert st["connected"] is False
+        assert st["running"] is False
+        assert st["url"] == "wss://relay.test"
+        assert st["daemon_id"] == "daemon-test"
+        assert st["last_connected_at"] is None
+        assert st["last_error"] is None
+
+    def test_status_reflects_last_error(self):
+        client = _client()
+        client._last_error = "ConnectionClosedError: no close frame"
+        st = client.status()
+        assert st["last_error"].startswith("ConnectionClosedError")
+
+
+class TestEnsureRunning:
+    async def test_ensure_running_relaunches_dead_loop(self, monkeypatch):
+        client = _client()
+
+        started = asyncio.Event()
+
+        async def fake_loop():
+            started.set()
+            # Stay alive until cancelled so the task is "running".
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(client, "_run_loop", fake_loop)
+
+        # No task yet -> ensure_running starts one.
+        relaunched = await client.ensure_running()
+        assert relaunched is True
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert client.status()["running"] is True
+
+        # Already running -> no-op (no duplicate task).
+        first_task = client._task
+        assert await client.ensure_running() is False
+        assert client._task is first_task
+
+        await client.stop()
+
+    async def test_ensure_running_noop_when_disabled(self):
+        cfg = RelayConfig(enabled=False, api_key="rw_x", url="wss://relay.test")
+        client = RelayClient(config=cfg)
+        assert await client.ensure_running() is False
+        assert client._task is None
+
+    async def test_ensure_running_noop_when_stopping(self):
+        client = _client()
+        client._stopping = True
+        assert await client.ensure_running() is False
+
+
+class TestConnectArgs:
+    async def test_connect_uses_explicit_keepalive_ping(self, monkeypatch):
+        """The half-open-detection fix: ping_interval/timeout are passed explicitly."""
+        captured: dict = {}
+
+        class FakeWS:
+            close_code = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        def fake_connect(url, **kwargs):
+            captured.update(kwargs)
+            # Stop the loop after one connect attempt.
+            client._stopping = True
+            return FakeWS()
+
+        async def fake_listen(ws):
+            return None
+
+        monkeypatch.setattr(relay_client_mod.websockets, "connect", fake_connect)
+
+        client = _client()
+        monkeypatch.setattr(client, "_listen", fake_listen)
+        await client._run_loop()
+
+        assert captured["ping_interval"] == _PING_INTERVAL
+        assert captured["ping_timeout"] == _PING_TIMEOUT
+
+    async def test_loop_records_last_error_on_failure(self, monkeypatch):
+        attempts = {"n": 0}
+
+        def fake_connect(url, **kwargs):
+            attempts["n"] += 1
+            client._stopping = True  # one shot
+            raise RuntimeError("boom relay")
+
+        monkeypatch.setattr(relay_client_mod.websockets, "connect", fake_connect)
+        # Don't actually sleep on backoff.
+        monkeypatch.setattr(relay_client_mod.asyncio, "sleep", _noop_sleep)
+
+        client = _client()
+        await client._run_loop()
+
+        assert attempts["n"] == 1
+        st = client.status()
+        assert st["last_error"] == "RuntimeError: boom relay"
+        assert st["last_error_at"] is not None
+
+
+async def _noop_sleep(_seconds):
+    return None

--- a/tests/test_relay_client.py
+++ b/tests/test_relay_client.py
@@ -11,6 +11,7 @@ import asyncio
 from repowire.config.relay import RelayConfig
 from repowire.daemon import relay_client as relay_client_mod
 from repowire.daemon.relay_client import (
+    _INITIAL_BACKOFF,
     _PING_INTERVAL,
     _PING_TIMEOUT,
     RelayClient,
@@ -129,6 +130,46 @@ class TestConnectArgs:
         st = client.status()
         assert st["last_error"] == "RuntimeError: boom relay"
         assert st["last_error_at"] is not None
+
+    async def test_clean_close_backs_off_not_tight_loop(self, monkeypatch):
+        """Nit fix (review #373): a clean WS close reconnects WITH a backoff
+        sleep, so a relay that accepts-then-cleanly-closes can't spin a tight
+        loop. Guards the `else` branch of _run_loop."""
+        sleeps: list[float] = []
+
+        async def record_sleep(seconds):
+            sleeps.append(seconds)
+
+        class FakeWS:
+            close_code = None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        connects = {"n": 0}
+
+        def fake_connect(url, **kwargs):
+            connects["n"] += 1
+            if connects["n"] >= 2:
+                client._stopping = True  # stop after the second clean cycle
+            return FakeWS()
+
+        async def fake_listen(ws):
+            return None  # clean close → the else branch
+
+        monkeypatch.setattr(relay_client_mod.websockets, "connect", fake_connect)
+        monkeypatch.setattr(relay_client_mod.asyncio, "sleep", record_sleep)
+
+        client = _client()
+        monkeypatch.setattr(client, "_listen", fake_listen)
+        await client._run_loop()
+
+        # First clean close backed off before reconnecting (not a no-delay spin).
+        assert sleeps, "clean close must sleep before reconnecting"
+        assert sleeps[0] >= _INITIAL_BACKOFF
 
 
 async def _noop_sleep(_seconds):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -40,6 +40,80 @@ class TestHealth:
         assert "acp_broker" in body
         assert body["acp_broker"]["status"] == "inactive"
 
+    async def test_health_relay_disabled_when_no_client(self, client):
+        # No relay client on app.state and relay_mode false => disabled.
+        r = await client.get("/health")
+        body = r.json()
+        assert body["relay"]["status"] == "disabled"
+        assert body["relay"]["connected"] is False
+
+    async def test_health_relay_down_when_enabled_but_client_dead(self):
+        # The bug this guards: relay enabled but the client is not connected.
+        # Old /health reported relay_mode:true and hid it; now relay.status=down.
+        class DeadRelay:
+            def __init__(self):
+                self.ensured = False
+
+            async def ensure_running(self):
+                self.ensured = True
+                return False
+
+            def status(self):
+                return {
+                    "connected": False,
+                    "running": False,
+                    "url": "wss://relay.example",
+                    "last_connected_at": "2026-06-20T17:44:44+00:00",
+                    "last_error": "ConnectionClosedError: no close frame",
+                    "last_error_at": "2026-06-20T17:44:40+00:00",
+                }
+
+        dead = DeadRelay()
+        app = FastAPI()
+        app.state.config = Config()
+        app.state.relay_mode = True
+        app.state.relay_client = dead
+        app.include_router(health.router)
+
+        t = ASGITransport(app=app)
+        async with AsyncClient(transport=t, base_url="http://test") as c:
+            r = await c.get("/health")
+        body = r.json()
+        assert body["relay_mode"] is True  # config flag still true...
+        assert body["relay"]["status"] == "down"  # ...but truth is exposed
+        assert body["relay"]["enabled"] is True
+        assert body["relay"]["connected"] is False
+        assert body["relay"]["last_error"].startswith("ConnectionClosedError")
+        assert dead.ensured is True  # lazy self-heal was attempted
+
+    async def test_health_relay_connected(self):
+        class LiveRelay:
+            async def ensure_running(self):
+                return False
+
+            def status(self):
+                return {
+                    "connected": True,
+                    "running": True,
+                    "url": "wss://relay.example",
+                    "last_connected_at": "2026-06-21T03:00:00+00:00",
+                    "last_error": None,
+                    "last_error_at": None,
+                }
+
+        app = FastAPI()
+        app.state.config = Config()
+        app.state.relay_mode = True
+        app.state.relay_client = LiveRelay()
+        app.include_router(health.router)
+
+        t = ASGITransport(app=app)
+        async with AsyncClient(transport=t, base_url="http://test") as c:
+            r = await c.get("/health")
+        body = r.json()
+        assert body["relay"]["status"] == "connected"
+        assert body["relay"]["connected"] is True
+
     async def test_health_reports_acp_broker_snapshot(self, monkeypatch):
         monkeypatch.setattr("repowire.daemon.routes.health.shutil.which", lambda _tool: None)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes a relay reliability bug surfaced by a dashboard login failure (`no_daemon`) on 2026-06-21: the daemon's relay client had silently died ~9 hours earlier (last `Connected to relay` log at 17:44, then zero relay activity while the daemon otherwise ran normally), so the relay had no daemon bound to the key. That manifests as **both** "can't log in to the dashboard" **and** "no peers show up." A daemon restart fixed it — this PR removes the need for that band-aid.

Two coupled defects:

1. **Silent death.** `websockets.connect()` was called without explicit `ping_interval`/`ping_timeout`, so half-open connections could wedge `async for raw in ws` with no keepalive to break out, and the reconnect loop could fall dark. Earlier in the day it was flapping every ~13 min with `ConnectionClosedError: no close frame received or sent`.
2. **`/health` lied (fail-loud violation).** It reported `relay_mode` from `cfg.relay.enabled` (the **config flag**), so it returned `relay_mode: true` the entire time the client was dead. `RelayClient.connected` existed but was never surfaced.

## Changes

- **`relay_client.py`**: explicit keepalive ping (`ping_interval=ping_timeout=20s`) for fast half-open detection; `status()` telemetry (connected/running/url/last_connected_at/last_error); hardened `_run_loop` so it only exits via `stop()`/cancel (a clean server close reconnects instead of falling out of the loop); idempotent `start()` + `ensure_running()` lazy self-heal.
- **`routes/health.py`**: new `relay` block reporting real connection state (`connected`/`connecting`/`down`/`disabled`) with `last_error`. `relay_mode` kept for back-compat (config intent); `relay.status` is the truth. Hitting `/health` lazily relaunches a dead loop (lazy-repair, not polling).
- **Docs**: `docs/operate/relay.md` — "Diagnosing a disconnected relay" (the `no_daemon` symptom → `curl /health | jq .relay`).

## Philosophy fit

- **Fail loud**: a dead relay is now visible in `/health` instead of masked by the config flag.
- **Lazy repair, no poll**: self-heal runs on `/health` access, not a timer; keepalive ping is library-level, not an app poll loop.
- **Simplest honest description**: rather than add a supervisor task, make the loop that should never die actually un-exitable and its state observable.

## Validation

- `uv run pytest` — **1949 passed** (1939 on main + 10 new).
- `uv run ruff check repowire/` / `uv run ty check repowire/` — clean.
- Adversarially verified both new guard tests fail without their fix: removed the ping kwargs → ping test fails; reverted `/health` to the config-flag lie → `down` test fails.

Closes repowire-blr.

---

**Update (review nit addressed):** cross-model codex review returned MERGE-WITH-NITS, no blockers. Fixed the one nit: the clean-WS-close path (`_run_loop` `else` branch) now backs off + logs before reconnecting, so a relay that repeatedly accepts-then-cleanly-closes cannot spin a tight reconnect loop. Added `test_clean_close_backs_off_not_tight_loop` (adversarially verified it fails without the fix). Full suite now 1950 passed; ruff + ty clean.