### PR TITLE
fix(lifecycle): evidence-gate session-closed (spurious close mass-offlined a live circle)

### DIFF
--- a/docs/troubleshooting/ghost-peers.md
+++ b/docs/troubleshooting/ghost-peers.md
@@ -12,6 +12,8 @@ Remaining ghosts are evicted by **lazy repair**: the next MCP tool call from any
 
 Orphaned ws-hook *processes* (a hook outliving its agent, e.g. one installed before the agent-pid watcher existed) are swept once at daemon startup: the sweep kills hooks whose pane is gone, whose recorded agent pid is dead, or whose pane subtree contains only shells — and only on conclusive evidence. `repowire doctor` reports the current orphan count read-only; `repowire service restart` runs the sweep.
 
+The `session-closed` tmux signal is **evidence-gated**: it offlines peers only after confirming the named session is genuinely gone from `tmux list-panes`, and even then spares any peer whose own pane is still live. A spurious `session-closed` (tmux resolves `#{session_name}` to the surviving session when a transient session exits) is ignored, so a short-lived spawned job finishing cannot mass-offline a populated circle.
+
 If `repowire peer doctor <peer>` reports `HOOK_PEERID_MISMATCH`, the pane's
 persisted ws-hook metadata still names an old peer identity. Run
 `repowire peer rehook <peer> --apply`: for a verified local pane, rehook rewrites

--- a/repowire/daemon/lifecycle_handler.py
+++ b/repowire/daemon/lifecycle_handler.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from repowire.hooks._tmux import list_all_panes
 from repowire.hooks.utils import clear_pane_runtime_state
 
 if TYPE_CHECKING:
@@ -66,13 +67,64 @@ class LifecycleHandler:
         return cancelled
 
     async def handle_session_closed(self, session_name: str) -> int:
-        """Batch-offline all peers in the given circle (session).
+        """Offline peers whose pane is genuinely gone after a session close.
 
-        Returns total cancelled queries.
+        Evidence-gated, not event-trusting. tmux's global ``session-closed``
+        hook fires with ``#{session_name}`` resolved against the *surviving*
+        attached session, not the one that closed — so when a transient session
+        (e.g. a short-lived spawned job) exits, this can arrive naming a circle
+        whose agents are all still alive. Blindly offlining + clearing pane
+        state on that signal nukes a live circle (and wipes hook metadata,
+        breaking inbound reconnect).
+
+        So: probe live tmux panes once. If the named session still has any live
+        pane, the event is spurious — do nothing. Otherwise offline only the
+        peers whose own pane is no longer present; a peer whose pane is still
+        live is kept (pane death has its own ``pane-died`` signal). A tmux probe
+        that returns nothing is inconclusive, not "everything died", so we
+        refuse to mass-offline on it.
         """
         peers = await self._registry.get_peers_by_circle(session_name)
         if not peers:
             logger.debug("session_closed: no peers in circle %s", session_name)
+            return 0
+
+        live_panes = await asyncio.to_thread(list_all_panes)
+        if not live_panes:
+            # Inconclusive (tmux unreachable / empty listing). Refuse to treat
+            # "no evidence" as "all gone" — that's how a probe blip would wipe
+            # a live circle. pane-died / lazy repair will catch real deaths.
+            logger.warning(
+                "session_closed: tmux pane probe returned nothing for %s; "
+                "skipping mass-offline (no runtime evidence of closure)",
+                session_name,
+            )
+            return 0
+
+        live_pane_ids = {p["pane_id"] for p in live_panes}
+        session_still_live = any(p["session"] == session_name for p in live_panes)
+        if session_still_live:
+            logger.info(
+                "session_closed ignored: session %s still has live panes "
+                "(spurious close — likely a transient session exit resolving "
+                "#{session_name} to the surviving session)",
+                session_name,
+            )
+            return 0
+
+        # Session is genuinely gone from tmux. Offline only peers whose pane is
+        # actually absent; spare any whose pane is somehow still live.
+        doomed = [
+            p for p in peers if not p.pane_id or p.pane_id not in live_pane_ids
+        ]
+        spared = len(peers) - len(doomed)
+        if not doomed:
+            logger.info(
+                "session_closed: session %s gone but all %d peers still hold "
+                "live panes; nothing offlined",
+                session_name,
+                len(peers),
+            )
             return 0
 
         async def _offline(peer_id: str) -> int:
@@ -81,7 +133,7 @@ class LifecycleHandler:
                 peer_id,
                 reason="session_closed",
                 source="tmux_lifecycle",
-                detail="tmux reported that the session closed.",
+                detail="tmux session closed and the peer's pane is gone.",
                 context={"tmux_session": session_name},
             )
             await self._transport.disconnect(peer_id)
@@ -90,14 +142,16 @@ class LifecycleHandler:
             return cancelled
 
         results = await asyncio.gather(
-            *(_offline(p.peer_id) for p in peers),
+            *(_offline(p.peer_id) for p in doomed),
         )
 
         total = sum(results)
         logger.info(
-            "session_closed: marked %d peers offline in circle %s",
-            len(peers),
+            "session_closed: marked %d peers offline in circle %s (%d spared "
+            "with live panes)",
+            len(doomed),
             session_name,
+            spared,
         )
         return total
 

--- a/tests/test_lifecycle_routes.py
+++ b/tests/test_lifecycle_routes.py
@@ -189,26 +189,139 @@ class TestPaneDied:
 # -- session-closed --
 
 
+def _pane(pane_id: str, session: str) -> dict:
+    return {
+        "pane_id": pane_id,
+        "pid": 123,
+        "command": "claude",
+        "cwd": "/tmp/test",
+        "session": session,
+        "window": "0",
+    }
+
+
 class TestSessionClosed:
     async def test_batch_offline(self, client_and_registry):
         client, registry = client_and_registry
-        p1 = _make_peer(peer_id="repow-dev-aaa11111", display_name="proj-a", circle="alpha")
-        p2 = _make_peer(peer_id="repow-dev-bbb22222", display_name="proj-b", circle="alpha")
-        p3 = _make_peer(peer_id="repow-dev-ccc33333", display_name="proj-c", circle="beta")
+        p1 = _make_peer(
+            peer_id="repow-dev-aaa11111", display_name="proj-a", circle="alpha",
+            pane_id="%5",
+        )
+        p2 = _make_peer(
+            peer_id="repow-dev-bbb22222", display_name="proj-b", circle="alpha",
+            pane_id="%6",
+        )
+        p3 = _make_peer(
+            peer_id="repow-dev-ccc33333", display_name="proj-c", circle="beta",
+            pane_id="%7",
+        )
         await registry.register_peer(p1)
         await registry.register_peer(p2)
         await registry.register_peer(p3)
 
-        r = await client.post(
-            "/hooks/lifecycle/session-closed",
-            json={"session_name": "alpha"},
-        )
+        # tmux confirms the 'alpha' session is gone (its panes %5/%6 absent);
+        # only the surviving 'beta' pane remains.
+        with patch(
+            "repowire.daemon.lifecycle_handler.list_all_panes",
+            return_value=[_pane("%7", "beta")],
+        ):
+            r = await client.post(
+                "/hooks/lifecycle/session-closed",
+                json={"session_name": "alpha"},
+            )
         assert r.status_code == 200
 
         assert (await registry.get_peer(p1.peer_id)).status == PeerStatus.OFFLINE
         assert (await registry.get_peer(p2.peer_id)).status == PeerStatus.OFFLINE
         # beta peer unaffected
         assert (await registry.get_peer(p3.peer_id)).status == PeerStatus.ONLINE
+
+    async def test_spurious_close_ignored_when_session_still_live(
+        self, client_and_registry
+    ):
+        """The repowire-egt-followup bug: a transient session exit fires
+        session-closed with #{session_name} resolved to the SURVIVING session.
+        If that session still has live panes, the close is spurious and must
+        NOT offline its (alive) peers."""
+        client, registry = client_and_registry
+        p1 = _make_peer(
+            peer_id="repow-dev-aaa11111", display_name="proj-a", circle="default",
+            pane_id="%50",
+        )
+        p2 = _make_peer(
+            peer_id="repow-dev-bbb22222", display_name="proj-b", circle="default",
+            pane_id="%228",
+        )
+        await registry.register_peer(p1)
+        await registry.register_peer(p2)
+
+        # tmux still reports live panes for 'default' -> spurious close.
+        with patch(
+            "repowire.daemon.lifecycle_handler.list_all_panes",
+            return_value=[_pane("%50", "default"), _pane("%228", "default")],
+        ):
+            r = await client.post(
+                "/hooks/lifecycle/session-closed",
+                json={"session_name": "default"},
+            )
+        assert r.status_code == 200
+
+        # Both stay ONLINE — no false offline, no pane-state wipe.
+        assert (await registry.get_peer(p1.peer_id)).status == PeerStatus.ONLINE
+        assert (await registry.get_peer(p2.peer_id)).status == PeerStatus.ONLINE
+
+    async def test_inconclusive_probe_does_not_mass_offline(
+        self, client_and_registry
+    ):
+        """tmux unreachable / empty listing is 'can't tell', not 'all dead'.
+        Refuse to offline on no evidence."""
+        client, registry = client_and_registry
+        p1 = _make_peer(
+            peer_id="repow-dev-aaa11111", display_name="proj-a", circle="default",
+            pane_id="%50",
+        )
+        await registry.register_peer(p1)
+
+        with patch(
+            "repowire.daemon.lifecycle_handler.list_all_panes",
+            return_value=[],
+        ):
+            r = await client.post(
+                "/hooks/lifecycle/session-closed",
+                json={"session_name": "default"},
+            )
+        assert r.status_code == 200
+        assert (await registry.get_peer(p1.peer_id)).status == PeerStatus.ONLINE
+
+    async def test_session_gone_spares_peer_with_live_pane(
+        self, client_and_registry
+    ):
+        """Even when the session is genuinely gone, a peer whose own pane is
+        still live is spared (pane death has its own signal)."""
+        client, registry = client_and_registry
+        dead = _make_peer(
+            peer_id="repow-dev-aaa11111", display_name="proj-a", circle="alpha",
+            pane_id="%5",
+        )
+        alive = _make_peer(
+            peer_id="repow-dev-bbb22222", display_name="proj-b", circle="alpha",
+            pane_id="%6",
+        )
+        await registry.register_peer(dead)
+        await registry.register_peer(alive)
+
+        # 'alpha' session not in the listing, but %6 survived (moved/reused).
+        with patch(
+            "repowire.daemon.lifecycle_handler.list_all_panes",
+            return_value=[_pane("%6", "other")],
+        ):
+            r = await client.post(
+                "/hooks/lifecycle/session-closed",
+                json={"session_name": "alpha"},
+            )
+        assert r.status_code == 200
+        assert (await registry.get_peer(dead.peer_id)).status == PeerStatus.OFFLINE
+        assert (await registry.get_peer(alive.peer_id)).status == PeerStatus.ONLINE
 
     async def test_unknown_session_is_ok(self, client_and_registry):
         client, _ = client_and_registry


### PR DESCRIPTION
## Summary

Fixes a real incident where a routine scheduled job finishing **mass-offlined the entire `default` mesh circle** (every agent marked offline + pane hook metadata wiped, despite all agents being alive in their panes).

## Root cause

tmux's global `session-closed` hook fires with `#{session_name}` resolved against the **surviving attached session**, not the one that closed. When a transient `default`-circle session exits (here: the `daily-email-brief-codex` scheduled job finishing), the hook POSTs `session_name=default`. The old `handle_session_closed` blindly trusted that event: it offlined **all** peers in the circle and called `clear_pane_runtime_state()` (wiping their pane hook metadata, which breaks inbound reconnect) — with **zero check that the panes/agents were actually gone**.

Evidence (`daemon.log`): `session_closed: marked 6 peers offline in circle default` immediately after `daily-email-brief-codex` unregistered; `tmux list-sessions` showed `default` still alive with 6 windows; `doctor` showed `status=offline` but `tmux_pane_exists=true`, `hook_meta_available=false`.

## Fix

`handle_session_closed` is now **evidence-gated** (same philosophy as the reaper/hydration fixes — prove the destructive premise before acting):
- Probe `list_all_panes()` once.
- If the named session **still has any live pane** → spurious close → do nothing.
- If the probe is **empty/inconclusive** (tmux unreachable) → refuse to mass-offline (no evidence ≠ all dead).
- Otherwise offline only peers whose **own pane is genuinely absent**; spare any whose pane is still live (pane death has its own `pane-died` signal).

## Tests (fail without the fix)

- `test_spurious_close_ignored_when_session_still_live` — the incident: live-session peers stay ONLINE.
- `test_inconclusive_probe_does_not_mass_offline`.
- `test_session_gone_spares_peer_with_live_pane`.
- `test_batch_offline` updated to mock the probe (session genuinely gone).

## Validation

- `uv run pytest` — 1957 passed.
- `uv run ruff check repowire/` / `uv run ty check repowire/` — clean.
- Behavioral check: new handler spares a live-session peer on spurious close; old handler offlined it.
