### PR TITLE
feat: add ingress peer for webhook ingress + cross-mesh federation

### DIFF
--- a/docs/use/features/connect-webhook.md
+++ b/docs/use/features/connect-webhook.md
@@ -1,0 +1,142 @@
+# Webhooks & ingress
+
+The ingress peer turns external events into mesh messages. A verified inbound
+webhook (a PR opened, CI finished, a Stripe event) becomes a standard `ask`,
+`notify`, or durable `job` aimed at one of your peers — so an outside system can
+trigger your agents the same way `schedule` triggers them on a clock.
+
+It is the inbound counterpart to the Telegram and Slack surfaces: one service
+peer that verifies a request, then emits a normal mesh message. It owns the
+security envelope (signature verification, idempotency, rate-limiting); routing,
+timing, and durability are composed from the primitives you already have.
+
+## When to use it
+
+- Trigger a project peer when an event fires in GitHub/Stripe/CI/etc.
+- Route events to your `orchestrator` and let it triage and dispatch.
+- Open a durable job per event (`kind: job`) so the work is tracked, retried, and reported.
+- Bridge two trusted, separately-authed meshes (cross-mesh federation).
+
+## Requirements
+
+- macOS or Linux, Python 3.10+ (same as the daemon).
+- Public reachability is provided by the **relay** — the ingress peer binds
+  localhost only and the relay tunnels `/ingress/*` to it, so you never open an
+  inbound port. Enable the relay with `repowire setup --relay`.
+
+## Setup
+
+Add an `ingress:` block to `~/.repowire/config.yaml`. Each **source** is one
+narrowly-registered webhook: you register its path (`/ingress/<key>`) with the
+provider, and it emits to one fixed peer.
+
+```yaml
+ingress:
+  enabled: true
+  sources:
+    gh-pr:
+      verify:
+        scheme: hmac
+        header: X-Hub-Signature-256
+        prefix: "sha256="
+        encoding: hex
+        secret_ref: GH_WEBHOOK_SECRET     # env/keychain name — never the raw secret
+        delivery_id_header: X-GitHub-Delivery
+      target:
+        kind: ask                          # ask | notify | job
+        to_peer: code-reviewer             # a project peer, or "orchestrator"
+      template: "PR #{number} {action}: {pull_request[title]}"
+```
+
+Then start the peer:
+
+```bash
+export GH_WEBHOOK_SECRET=...    # the secret you also paste into GitHub's webhook
+repowire ingress start
+```
+
+Point the provider's webhook at `https://<your-relay>/ingress/gh-pr` (or your own
+tunnel if you run the listener directly). On each delivery the peer verifies the
+signature, renders `template` from the payload, and opens an ask to `to_peer`.
+
+### Verifier is config, not code
+
+There are no provider names in Repowire. You describe how a provider signs its
+requests in the `verify:` block; one generic handler per **scheme** reads it.
+Common providers:
+
+```yaml
+# GitHub — HMAC-SHA256 hex over the raw body
+verify: { scheme: hmac, header: X-Hub-Signature-256, prefix: "sha256=", encoding: hex, secret_ref: GH_SECRET }
+
+# Shopify — HMAC-SHA256 base64
+verify: { scheme: hmac, header: X-Shopify-Hmac-SHA256, encoding: base64, secret_ref: SHOPIFY_SECRET }
+
+# GitLab — plaintext shared token, no HMAC
+verify: { scheme: token, header: X-Gitlab-Token, secret_ref: GITLAB_TOKEN }
+
+# Stripe — timestamped HMAC; signature header is `t=..,v1=..`, replay-checked
+verify: { scheme: hmac, header: Stripe-Signature, prefix: "", sig_kv: true, ts_field: t, sig_field: v1,
+          payload_template: "{ts}.{body}", max_age_s: 300, secret_ref: STRIPE_SECRET }
+
+# Slack — timestamped HMAC; timestamp in a separate header
+verify: { scheme: hmac, header: X-Slack-Signature, prefix: "v0=", timestamp_header: X-Slack-Request-Timestamp,
+          payload_template: "v0:{ts}:{body}", secret_ref: SLACK_SECRET }
+
+# Discord — Ed25519 over timestamp+body, verified with a public key
+verify: { scheme: ed25519, header: X-Signature-Ed25519, prefix: "", encoding: hex,
+          timestamp_header: X-Signature-Timestamp, payload_template: "{ts}{body}", public_key_ref: DISCORD_PUBKEY }
+```
+
+`scheme: hmac` (raw-body and timestamped) and `scheme: token` are stdlib and
+shipped by default. `ecdsa`/`ed25519` use `public_key_ref` and the
+`cryptography` library — install the `repowire[webhooks-asymmetric]` extra.
+
+## Targets and routing
+
+`target.to_peer` is fixed per source — the payload fills the text, it never
+selects the peer. For finer routing register more sources, or route to the
+`orchestrator` and let an agent decide:
+
+```yaml
+    ci-failed:
+      verify: { scheme: hmac, header: X-Signature, secret_ref: CI_SECRET }
+      target: { kind: job, to_peer: orchestrator, backend: codex, auto_run: true }
+      template: "CI failed on {branch}: {message}"
+```
+
+A `kind: job` source is the **event trigger** for durable jobs, beside cron
+(time) and `repowire jobs run` (manual) — it feeds the same tracked-work
+pipeline with `source_kind: ingress` provenance.
+
+## Cross-mesh federation (P2)
+
+Two trusting meshes exchange an opaque grant out-of-band:
+
+```bash
+repowire ingress grant   # prints a grant_id + shared secret to share securely
+```
+
+The receiving mesh stores the grant under `federation.inbound_grants` (scoped to
+a circle, peers, and message kinds, with an expiry). A federated request carries
+`X-Repowire-Grant` + `X-Repowire-Grant-Sig` (an HMAC over the body); the grant id
+alone is inert. Cross-mesh messages render as `[ask from @x via fed:<mesh>]` and
+can never impersonate a local peer.
+
+## Limits
+
+- Capability is restricted to `ask`/`notify`/`job`; spawn/kill/schedule are never reachable from ingress.
+- Registration granularity is bounded by what a provider lets you select per webhook (e.g. GitHub scopes to the `pull_request` event, not the `opened` action). Sub-event filtering is the target peer's job.
+
+## Troubleshooting
+
+- `401 signature_mismatch` — the configured `secret_ref` value does not match the provider's secret, or the wrong `encoding`/`prefix`.
+- `404 unknown_source` — the path segment does not match a key under `ingress.sources`.
+- `503 daemon_unavailable` — the daemon is not running; the provider will retry.
+- Duplicate deliveries return `200 {"status":"duplicate"}` and do not re-emit.
+
+## See also
+
+- [Jobs and schedules](../../concepts/jobs-and-schedules.md) — the trigger family ingress joins.
+- [Relay access](relay-access.md) — public reachability without inbound ports.
+- [Orchestrator coordination](../workflows/orchestrator-coordination.md) — routing events to an agent.

--- a/docs/use/features/index.md
+++ b/docs/use/features/index.md
@@ -15,6 +15,7 @@ Feature pages are the active-user source of truth for Repowire capabilities. Eac
 - [Dashboard](dashboard.md) — browser control surface and live session timeline.
 - [Telegram](telegram.md) — phone-side routing, notifications, and attachments.
 - [Slack](slack.md) — team chat control through Socket Mode.
+- [Webhooks & ingress](connect-webhook.md) — turn external events into mesh asks/notifies/jobs.
 - [Attachments](attachments.md) — local file upload and delivery paths.
 - [Scheduling](scheduling.md) — one-shot and recurring mesh messages.
 - [Jobs](jobs.md) — durable tracked work and recurring worker templates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
           - Dashboard: use/features/dashboard.md
           - Telegram: use/features/telegram.md
           - Slack: use/features/slack.md
+          - Webhooks & ingress: use/features/connect-webhook.md
           - Attachments: use/features/attachments.md
           - Scheduling: use/features/scheduling.md
           - Jobs: use/features/jobs.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ docs = [
 acp-probe = [
     "agent-client-protocol>=0.10.0",
 ]
+webhooks-asymmetric = [
+    "cryptography>=42.0",
+]
 
 [project.scripts]
 repowire = "repowire.cli:main"

--- a/repowire/cli.py
+++ b/repowire/cli.py
@@ -4320,6 +4320,39 @@ def slack_start() -> None:
 
 
 # =============================================================================
+# ingress command group
+# =============================================================================
+
+
+@main.group(hidden=True)
+def ingress() -> None:
+    """Manage the inbound ingress peer (webhooks + cross-mesh federation)."""
+    pass
+
+
+@ingress.command(name="start")
+def ingress_start() -> None:
+    """Start the ingress peer (verifies inbound events, emits mesh messages)."""
+    from repowire.ingress.bot import main as bot_main
+
+    bot_main()
+
+
+@ingress.command(name="grant")
+def ingress_grant() -> None:
+    """Mint a new opaque federation grant id + shared secret to exchange out-of-band."""
+    grant_id = "grant_" + secrets.token_urlsafe(16)
+    secret = secrets.token_urlsafe(32)
+    click.echo(f"grant_id:      {grant_id}")
+    click.echo(f"shared_secret: {secret}")
+    click.echo(
+        "\nStore the secret under an env/keychain ref and put the ref + grant_id in "
+        "~/.repowire/config.yaml under 'federation:'. Share both with the peer mesh "
+        "over a secure channel; never commit the raw secret."
+    )
+
+
+# =============================================================================
 # service command group - system service management
 # =============================================================================
 

--- a/repowire/client.py
+++ b/repowire/client.py
@@ -127,6 +127,14 @@ class BroadcastResult(BaseModel):
     failed: list[dict[str, str]] = Field(default_factory=list)
 
 
+class JobResult(BaseModel):
+    """Durable tracked-job create/run result."""
+
+    job_id: str | None = None
+    work_id: str | None = None
+    status: dict[str, Any] = Field(default_factory=dict)
+
+
 class MeshEvent(BaseModel):
     """Event emitted by the daemon event log."""
 
@@ -550,6 +558,57 @@ class AsyncRepowireClient:
             },
         )
         return BroadcastResult.model_validate(data)
+
+    async def create_job(
+        self,
+        title: str = "",
+        *,
+        kind: str = "general",
+        prompt: str | None = None,
+        path: str | None = None,
+        backend: str | None = None,
+        circle: str | None = None,
+        owner_peer_id: str | None = None,
+        source_kind: str | None = None,
+        source_id: str | None = None,
+        provenance: dict[str, Any] | None = None,
+        due_at: str | None = None,
+        auto_run: bool = False,
+    ) -> JobResult:
+        """Create a durable tracked job, optionally firing it immediately.
+
+        Wraps ``POST /jobs``; ``auto_run`` follows with ``/jobs/{id}/run`` so a
+        one-shot trigger (e.g. a webhook) both records the job and dispatches it.
+        """
+        payload: dict[str, Any] = {"title": title, "kind": kind}
+        for key, value in {
+            "prompt": prompt,
+            "path": path,
+            "backend": backend,
+            "circle": circle,
+            "owner_peer_id": owner_peer_id,
+            "source_kind": source_kind,
+            "source_id": source_id,
+            "due_at": due_at,
+        }.items():
+            if value is not None:
+                payload[key] = value
+        if provenance:
+            payload["provenance"] = provenance
+        result = JobResult.model_validate(await self._request("POST", "/jobs", json=payload))
+        if auto_run and result.work_id:
+            await self.run_job(result.work_id)
+        return result
+
+    async def run_job(
+        self, work_id: str, *, requested_by_peer_id: str | None = None
+    ) -> JobResult:
+        """Fire a tracked job on demand (the manual trigger source for jobs)."""
+        payload: dict[str, Any] = {}
+        if requested_by_peer_id is not None:
+            payload["requested_by_peer_id"] = requested_by_peer_id
+        data = await self._request("POST", f"/jobs/{quote(work_id, safe='')}/run", json=payload)
+        return JobResult.model_validate(data)
 
     async def events(self) -> list[MeshEvent]:
         """Return recent daemon events."""

--- a/repowire/config/models.py
+++ b/repowire/config/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -260,6 +261,123 @@ class SlackConfig(BaseModel):
     channel_id: str | None = Field(None, description="Slack channel ID (C...)")
 
 
+class VerifyConfig(BaseModel):
+    """Per-source inbound verification metadata.
+
+    This is the user-registered description of how a provider signs its
+    webhook — header, encoding, prefix, signed-payload template, and the name
+    of the secret/key. There are no hardcoded provider names: a generic handler
+    per ``scheme`` reads this block, so a new provider that fits an existing
+    scheme is pure config.
+    """
+
+    scheme: Literal["hmac", "token", "ecdsa", "ed25519", "trust_grant"] = "hmac"
+    header: str = "X-Hub-Signature-256"
+    encoding: Literal["hex", "base64"] = "hex"
+    prefix: str = "sha256="
+    payload_template: str = Field(
+        "{body}",
+        description=(
+            "Bytes that were signed: '{body}' (GitHub/Shopify), or a timestamped "
+            "form like '{ts}.{body}' (Stripe) / 'v0:{ts}:{body}' (Slack)"
+        ),
+    )
+    timestamp_header: str | None = Field(
+        None, description="Header carrying the signed timestamp (Slack/Discord-style)"
+    )
+    sig_kv: bool = Field(
+        False,
+        description="Signature header is comma-separated k=v pairs (Stripe 't=..,v1=..')",
+    )
+    ts_field: str = Field("t", description="k=v key holding the timestamp when sig_kv")
+    sig_field: str = Field("v1", description="k=v key holding the signature when sig_kv")
+    delivery_id_header: str | None = Field(
+        None, description="Header carrying a per-delivery id used as the idempotency key"
+    )
+    max_age_s: int | None = Field(
+        None, description="Reject if the signed timestamp is older than this (replay window)"
+    )
+    secret_ref: str | None = Field(None, description="Env/keychain name of the shared secret")
+    public_key_ref: str | None = Field(
+        None, description="Env/keychain name of the public key (ecdsa/ed25519)"
+    )
+
+
+class IngressTarget(BaseModel):
+    """Where a verified inbound event is emitted into the mesh."""
+
+    kind: Literal["ask", "notify", "job"] = "ask"
+    to_peer: str | None = Field(None, description="Fixed destination peer (or 'orchestrator')")
+    backend: str | None = Field(None, description="Job backend when kind=job")
+    path: str | None = Field(None, description="Job working directory when kind=job")
+    auto_run: bool = Field(False, description="Fire the job immediately when kind=job")
+
+
+class IngressSource(BaseModel):
+    """One narrowly-registered inbound webhook: verify, then emit to a fixed target.
+
+    The dict key under ``ingress.sources`` is the URL path segment
+    (``/ingress/<key>``) the user registers with the provider.
+    """
+
+    verify: VerifyConfig = Field(default_factory=VerifyConfig)
+    target: IngressTarget = Field(default_factory=IngressTarget)
+    template: str | None = Field(
+        None, description="str.format template over the parsed payload, fills the emitted text"
+    )
+    rate_limit_per_min: int = 60
+    allow: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Principal allowlist; empty allows all. Only meaningful for trust_grant "
+            "sources (the principal embeds the grant) — hmac/token have a single "
+            "fixed principal, so it cannot filter individual webhook senders."
+        ),
+    )
+    circle: str | None = None
+
+
+class IngressConfig(BaseModel):
+    """Inbound ingress peer configuration. Default-deny: disabled with no sources."""
+
+    enabled: bool = False
+    bind_host: str = "127.0.0.1"
+    port: int = 8378
+    sources: dict[str, IngressSource] = Field(default_factory=dict)
+
+
+class GrantConfig(BaseModel):
+    """A trust grant for cross-mesh federation.
+
+    Opaque + HMAC-authenticated: the grant is a bearer record validated by id
+    lookup plus a per-request signature. Only refs and ids live here — never the
+    raw shared secret (resolved from env/keychain at load).
+    """
+
+    grant_id: str
+    issuer_mesh_id: str = ""
+    audience_mesh_id: str = ""
+    direction: Literal["inbound", "outbound"] = "inbound"
+    exposed_circle: str | None = None
+    exposed_peers: list[str] | None = None
+    allowed_kinds: list[str] = Field(default_factory=lambda: ["ask", "notify"])
+    expires_at: str | None = None
+    revocation_ref: str | None = None
+    shared_secret_ref: str | None = None
+    endpoint_url: str | None = Field(
+        None, description="Outbound grants only: where to reach the peer mesh"
+    )
+
+
+class FederationConfig(BaseModel):
+    """Cross-mesh federation grants. Only refs/ids here — never raw secrets/hosts."""
+
+    mesh_id: str = ""
+    inbound_grants: list[GrantConfig] = Field(default_factory=list)
+    outbound_grants: list[GrantConfig] = Field(default_factory=list)
+    revoked: list[str] = Field(default_factory=list)
+
+
 class UpdatesConfig(BaseModel):
     """Update-check preferences.
 
@@ -418,6 +536,8 @@ class Config(BaseModel):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     slack: SlackConfig = Field(default_factory=SlackConfig)
+    ingress: IngressConfig = Field(default_factory=IngressConfig)
+    federation: FederationConfig = Field(default_factory=FederationConfig)
     updates: UpdatesConfig = Field(default_factory=UpdatesConfig)
     experiments: ExperimentsConfig = Field(default_factory=ExperimentsConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)

--- a/repowire/daemon/peer_registry.py
+++ b/repowire/daemon/peer_registry.py
@@ -47,7 +47,13 @@ from repowire.daemon.registry_repair import (
 )
 from repowire.daemon.websocket_transport import TransportError
 from repowire.protocol.capabilities import PANE_UNSAFE_STRIKE_LIMIT
-from repowire.protocol.peers import Peer, PeerRole, PeerStatus, TurnState
+from repowire.protocol.peers import (
+    RESERVED_INGRESS_PREFIXES,
+    Peer,
+    PeerRole,
+    PeerStatus,
+    TurnState,
+)
 
 if TYPE_CHECKING:
     from repowire.daemon.ask_tracker import AskTracker
@@ -1033,6 +1039,14 @@ class PeerRegistry:
         If ``peer_id`` is provided and matches an existing peer, the peer is
         taken over in-place (WebSocket reconnect after HTTP pre-registration).
         """
+        # Reserved-prefix guard: fed-*/ext-* ids are the ingress peer's synthetic
+        # federation/webhook principals (it stamps them as from_peer). The daemon
+        # only ever mints repow-* ids, so a claim on a reserved prefix can only be
+        # an attempt to impersonate a federated sender — refuse it. Case-folded so
+        # Ext-/FED- cannot slip past.
+        if peer_id and peer_id.lower().startswith(RESERVED_INGRESS_PREFIXES):
+            raise ValueError(f"peer_id {peer_id!r} uses a reserved ingress prefix")
+
         # Captured inside the lock, used outside it to schedule redelivery.
         result_peer_id: str | None = None
         result_name: str | None = None

--- a/repowire/daemon/relay_client.py
+++ b/repowire/daemon/relay_client.py
@@ -37,6 +37,7 @@ class RelayClient:
         self._config = config
         self._daemon_id = daemon_id or socket.gethostname()
         self._local_base_url = local_base_url
+        self._ingress_base_url: str | None = None
         self._ws: ClientConnection | None = None
         self._task: asyncio.Task[None] | None = None
         self._http: httpx.AsyncClient | None = None
@@ -212,8 +213,25 @@ class RelayClient:
         "x-real-ip", "forwarded",
     })
 
+    def _target_base_url(self, path: str) -> str:
+        """Resolve the local target for a tunneled request.
+
+        Everything goes to the daemon except `/ingress/*`, which is forwarded to
+        the ingress peer's local listener — keeping that peer off any public port
+        while the relay faces the world. The bind is read from config once.
+        """
+        if path == "/ingress" or path.startswith("/ingress/"):
+            if self._ingress_base_url is None:
+                from repowire.config.models import load_config
+
+                ing = load_config().ingress
+                host = ing.bind_host if ing.bind_host not in ("0.0.0.0", "::") else "127.0.0.1"
+                self._ingress_base_url = f"http://{host}:{ing.port}"
+            return self._ingress_base_url
+        return self._local_base_url
+
     async def _handle_http_request(self, msg: dict[str, Any]) -> None:
-        """Forward tunneled HTTP request to local daemon."""
+        """Forward tunneled HTTP request to the local daemon (or ingress peer)."""
         request_id = msg["request_id"]
         method = msg.get("method", "GET").upper()
         path = msg.get("path", "/")
@@ -224,7 +242,7 @@ class RelayClient:
         query_string = msg.get("query_string", "")
         body_b64 = msg.get("body")
 
-        url = f"{self._local_base_url}{path}"
+        url = f"{self._target_base_url(path)}{path}"
         if query_string:
             url = f"{url}?{query_string}"
 

--- a/repowire/ingress/__init__.py
+++ b/repowire/ingress/__init__.py
@@ -1,0 +1,1 @@
+"""Inbound ingress peer for the repowire mesh."""

--- a/repowire/ingress/bot.py
+++ b/repowire/ingress/bot.py
@@ -1,0 +1,660 @@
+"""Ingress peer for the repowire mesh.
+
+Bridges the outside world <> repowire: a verified inbound webhook (P1) or a
+trusted cross-mesh request (P2) becomes a standard mesh ask/notify/job. The peer
+owns only the security envelope — verify, then emit through the daemon — so it
+composes with jobs, schedule, the orchestrator, and the human surfaces without
+adding a new message type. Routing is static: one registered source emits to one
+fixed peer; the payload fills the text, it never selects the peer.
+
+Unlike the other surfaces this peer is *inbound*: it hosts a localhost uvicorn
+listener (reached publicly only through the relay tunnel) alongside the daemon
+WebSocket connection it registers on.
+
+Usage:
+    repowire ingress start
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import uvicorn
+import websockets
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from websockets.asyncio.client import ClientConnection
+
+from repowire.client import (
+    AsyncRepowireClient,
+    DaemonConnectionError,
+    DaemonHTTPError,
+    DaemonTimeoutError,
+)
+from repowire.config.models import (
+    DEFAULT_DAEMON_URL,
+    FederationConfig,
+    IngressConfig,
+    IngressSource,
+    VerifyConfig,
+    load_config,
+)
+from repowire.protocol.peers import INGRESS_EXT_PREFIX, INGRESS_FED_PREFIX
+
+logger = logging.getLogger(__name__)
+
+# Capability floor for every ingress/federated principal. spawn/kill/schedule
+# are never wired in this module — denial is structural; this set is the
+# defense-in-depth check at the single emit chokepoint.
+INGRESS_FLOOR = frozenset({"ask", "notify", "job"})
+
+# Verifier reasons that mean the operator misconfigured the source (not a caller
+# fault). Surfaced as 500, so a provider does not treat a setup error as a
+# permanent auth failure.
+_CONFIG_ERROR_REASONS = frozenset({"missing_secret", "scheme_not_enabled", "unknown_scheme"})
+
+_DEDUP_MAX = 4096      # bounded in-process replay window (lost on restart, ok for v1)
+_BODY_MAX = 1_048_576  # 1 MiB inbound body cap
+
+
+# -- Pure helpers --
+
+
+def _ws_url(http_url: str) -> str:
+    """Convert an http(s) URL to ws(s)."""
+    p = urlparse(http_url)
+    return urlunparse(p._replace(scheme="wss" if p.scheme == "https" else "ws"))
+
+
+def _resolve_ref(ref: str | None) -> str | None:
+    """Resolve a secret/key reference to its value from the environment.
+
+    Config stores only the *name* of the secret (optionally ``env:NAME``), never
+    the secret itself — keeping public-repo configs free of credentials.
+    """
+    if not ref:
+        return None
+    if ref.startswith("env:"):
+        ref = ref[4:]
+    return os.environ.get(ref)
+
+
+def _decode_sig(raw: str, encoding: str) -> bytes | None:
+    """Decode a signature header value as hex or base64; None if malformed."""
+    try:
+        # binascii.Error (b64decode) subclasses ValueError, so this covers both.
+        return bytes.fromhex(raw) if encoding == "hex" else base64.b64decode(raw)
+    except ValueError:
+        return None
+
+
+def _is_expired(expires_at: str | None) -> bool:
+    """True if an ISO-8601 grant expiry is in the past. Fails closed on garbage.
+
+    Parsed to an aware datetime rather than string-compared, so offset forms
+    (``+00:00``) and fractional seconds cannot make an expired grant read valid.
+    """
+    if not expires_at:
+        return False
+    try:
+        exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    return exp <= datetime.now(timezone.utc)
+
+
+def _extract_sig_ts(v: VerifyConfig, headers: Mapping[str, str], raw: str) -> tuple[str, str]:
+    """Pull the signature value and signed timestamp out of the request.
+
+    Flat headers (GitHub) carry the signature directly, with the timestamp in a
+    separate ``timestamp_header`` (Slack/Discord); structured ``k=v`` headers
+    (Stripe ``t=..,v1=..``) carry both, selected by ``sig_field``/``ts_field``.
+    """
+    if v.sig_kv:
+        kv = dict(p.split("=", 1) for p in raw.split(",") if "=" in p)
+        return kv.get(v.sig_field, ""), kv.get(v.ts_field, "")
+    ts = headers.get(v.timestamp_header.lower(), "") if v.timestamp_header else ""
+    return raw, ts
+
+
+def _signed_payload(template: str, body: bytes, ts: str) -> bytes | None:
+    """Build the bytes that were signed. None if the template needs a ts we lack."""
+    if template == "{body}":
+        return body
+    if "{ts}" in template and not ts:
+        return None
+    try:
+        return template.format(body=body.decode("utf-8", "replace"), ts=ts).encode()
+    except (KeyError, IndexError, ValueError):
+        return None
+
+
+def _ts_fresh(ts: str, max_age_s: int) -> bool:
+    """True if a unix-seconds timestamp is within max_age_s of now (replay guard)."""
+    try:
+        return abs(time.time() - int(ts)) <= max_age_s
+    except (ValueError, TypeError):
+        return False
+
+
+# -- Verdict + verifiers (config-driven, no provider names) --
+
+
+@dataclass
+class Verdict:
+    """Outcome of verifying an inbound request. Default-deny."""
+
+    authenticated: bool
+    principal_id: str | None = None
+    reason: str = ""
+    idempotency_key: str | None = None
+    allowed_kinds: frozenset[str] = field(default_factory=lambda: frozenset({"ask", "notify"}))
+
+
+def _verify_hmac(source: str, headers: Mapping[str, str], body: bytes, v: VerifyConfig) -> Verdict:
+    """Verify an HMAC-SHA256 webhook signature.
+
+    Supports raw-body schemes (GitHub/Shopify, ``{body}``) and timestamped ones
+    (Stripe ``{ts}.{body}``, Slack ``v0:{ts}:{body}``) via ``payload_template`` +
+    the timestamp config; replay-checked when ``max_age_s`` is set. Always hashes
+    raw bytes and compares timing-safe.
+    """
+    secret = _resolve_ref(v.secret_ref)
+    if not secret:
+        return Verdict(False, reason="missing_secret")
+    raw = headers.get(v.header.lower())
+    if not raw:
+        return Verdict(False, reason="missing_signature")
+    sent, ts = _extract_sig_ts(v, headers, raw)
+    if v.prefix and sent.startswith(v.prefix):
+        sent = sent[len(v.prefix) :]
+    sent_bytes = _decode_sig(sent, v.encoding)
+    if sent_bytes is None:
+        return Verdict(False, reason="signature_mismatch")
+    payload = _signed_payload(v.payload_template, body, ts)
+    if payload is None:
+        return Verdict(False, reason="missing_signature")
+    if v.max_age_s is not None and not _ts_fresh(ts, v.max_age_s):
+        return Verdict(False, reason="signature_mismatch")
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected, sent_bytes):
+        return Verdict(False, reason="signature_mismatch")
+    delivery = headers.get((v.delivery_id_header or "").lower()) if v.delivery_id_header else None
+    return Verdict(
+        True,
+        principal_id=f"{INGRESS_EXT_PREFIX}{source}",
+        idempotency_key=delivery or hashlib.sha256(body).hexdigest(),
+        allowed_kinds=INGRESS_FLOOR,
+    )
+
+
+def _verify_token(source: str, headers: Mapping[str, str], body: bytes, v: VerifyConfig) -> Verdict:
+    """Verify a plaintext shared-secret token sent in a header (GitLab-style)."""
+    secret = _resolve_ref(v.secret_ref)
+    if not secret:
+        return Verdict(False, reason="missing_secret")
+    sent = headers.get(v.header.lower(), "")
+    if not hmac.compare_digest(secret, sent):
+        return Verdict(False, reason="signature_mismatch")
+    return Verdict(
+        True,
+        principal_id=f"{INGRESS_EXT_PREFIX}{source}",
+        idempotency_key=hashlib.sha256(body).hexdigest(),
+        allowed_kinds=INGRESS_FLOOR,
+    )
+
+
+def _verify_asymmetric(
+    source: str, headers: Mapping[str, str], body: bytes, v: VerifyConfig
+) -> Verdict:
+    """Verify an ed25519/ecdsa signature against a configured public key.
+
+    Uses ``cryptography`` (install the ``webhooks-asymmetric`` extra); returns
+    ``scheme_not_enabled`` if it is absent. Supports timestamped payloads (e.g.
+    Discord's ``{ts}{body}``) through the same template/timestamp config.
+    """
+    pub = _resolve_ref(v.public_key_ref)
+    if not pub:
+        return Verdict(False, reason="missing_secret")
+    raw = headers.get(v.header.lower())
+    if not raw:
+        return Verdict(False, reason="missing_signature")
+    sent, ts = _extract_sig_ts(v, headers, raw)
+    if v.prefix and sent.startswith(v.prefix):
+        sent = sent[len(v.prefix) :]
+    sig = _decode_sig(sent, v.encoding)
+    if sig is None:
+        return Verdict(False, reason="signature_mismatch")
+    payload = _signed_payload(v.payload_template, body, ts)
+    if payload is None:
+        return Verdict(False, reason="missing_signature")
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        from cryptography.hazmat.primitives.serialization import load_pem_public_key
+    except ImportError:
+        return Verdict(False, reason="scheme_not_enabled")
+    try:
+        key = load_pem_public_key(pub.encode())
+    except (ValueError, TypeError):
+        return Verdict(False, reason="missing_secret")  # bad key config, not a caller fault
+    try:
+        # isinstance narrows the load_pem union to the one key type whose verify()
+        # signature we call, and rejects a key/scheme mismatch as misconfiguration.
+        if v.scheme == "ed25519":
+            if not isinstance(key, Ed25519PublicKey):
+                return Verdict(False, reason="missing_secret")
+            key.verify(sig, payload)
+        else:
+            if not isinstance(key, ec.EllipticCurvePublicKey):
+                return Verdict(False, reason="missing_secret")
+            key.verify(sig, payload, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature:
+        return Verdict(False, reason="signature_mismatch")
+    except (ValueError, TypeError):
+        return Verdict(False, reason="signature_mismatch")
+    return Verdict(
+        True,
+        principal_id=f"{INGRESS_EXT_PREFIX}{source}",
+        idempotency_key=hashlib.sha256(body).hexdigest(),
+        allowed_kinds=INGRESS_FLOOR,
+    )
+
+
+def _verify_trust_grant(
+    source: str, headers: Mapping[str, str], body: bytes, v: VerifyConfig, fed: FederationConfig
+) -> Verdict:
+    """Verify a P2 federation request: grant lookup + per-request HMAC over the body.
+
+    The grant id alone is inert — a leaked id in a log or proxy is not a bearer
+    credential without the per-request signature keyed by the shared secret.
+    """
+    grant_id = headers.get("x-repowire-grant", "")
+    sig = headers.get("x-repowire-grant-sig", "")
+    if not grant_id or not sig:
+        return Verdict(False, reason="missing_grant")
+    if grant_id in set(fed.revoked):
+        return Verdict(False, reason="out_of_scope")
+    grant = next(
+        (g for g in fed.inbound_grants if g.grant_id == grant_id and g.direction == "inbound"),
+        None,
+    )
+    if grant is None:
+        return Verdict(False, reason="out_of_scope")
+    if _is_expired(grant.expires_at):
+        return Verdict(False, reason="out_of_scope")
+    secret = _resolve_ref(grant.shared_secret_ref)
+    if not secret:
+        return Verdict(False, reason="missing_secret")
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        return Verdict(False, reason="signature_mismatch")
+    # issuer_mesh_id is authenticated config, but it becomes the from_peer label —
+    # constrain its charset and keep the full grant id so principals can't collide.
+    origin = re.sub(r"[^A-Za-z0-9_]", "", grant.issuer_mesh_id) or "peer"
+    return Verdict(
+        True,
+        principal_id=f"{INGRESS_FED_PREFIX}{origin}-{grant_id}",
+        idempotency_key=headers.get("x-repowire-nonce") or hashlib.sha256(body).hexdigest(),
+        allowed_kinds=frozenset(grant.allowed_kinds) & INGRESS_FLOOR,
+    )
+
+
+# Dispatch by scheme (the crypto mechanism), never by provider.
+_HMAC_SCHEMES = {"hmac": _verify_hmac, "token": _verify_token}
+_ASYM_SCHEMES = {"ecdsa": _verify_asymmetric, "ed25519": _verify_asymmetric}
+
+
+# -- Rate limiter + dedup (lazy, no background timer) --
+
+
+class _RateLimiter:
+    """Per-key token bucket with lazy refill and opportunistic eviction."""
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, tuple[float, float]] = {}
+
+    def allow(self, key: str, per_min: int) -> bool:
+        now = time.monotonic()
+        tokens, last = self._buckets.get(key, (float(per_min), now))
+        tokens = min(float(per_min), tokens + (now - last) * (per_min / 60.0))
+        if tokens < 1.0:
+            self._buckets[key] = (tokens, now)
+            return False
+        self._buckets[key] = (tokens - 1.0, now)
+        if len(self._buckets) > 1024:  # lazy eviction of cold buckets
+            self._buckets = {
+                k: (t, ts) for k, (t, ts) in self._buckets.items() if now - ts < 3600
+            }
+        return True
+
+
+class _Dedup:
+    """Bounded FIFO set of in-flight/seen idempotency keys (lost on restart).
+
+    Two-phase so a delivery is only treated as handled once it actually emits:
+    ``claim`` reserves a key before emit (synchronously — no await between the
+    check and the insert — so concurrent identical deliveries can't both pass),
+    and ``release`` frees it if the emit fails so the provider's retry is
+    re-attempted rather than silently dropped as a duplicate.
+    """
+
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+        self._order: deque[str] = deque()
+
+    def claim(self, key: str) -> bool:
+        """Reserve a key. Returns False if already claimed/seen (a duplicate)."""
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+        self._order.append(key)
+        if len(self._order) > _DEDUP_MAX:
+            self._seen.discard(self._order.popleft())
+        return True
+
+    def release(self, key: str) -> None:
+        """Free a claimed key after a failed emit so the provider's retry passes."""
+        self._seen.discard(key)
+
+
+# -- The peer --
+
+
+class IngressPeer:
+    """Verify inbound events and emit standard mesh messages through the daemon."""
+
+    def __init__(
+        self,
+        ingress: IngressConfig,
+        federation: FederationConfig,
+        *,
+        daemon_url: str = DEFAULT_DAEMON_URL,
+        auth_token: str | None = None,
+        display_name: str = "ingress",
+        circle: str = "default",
+    ) -> None:
+        self._cfg = ingress
+        self._fed = federation
+        self._daemon_url = daemon_url.rstrip("/")
+        self._auth_token = auth_token
+        self._display_name = display_name
+        self._circle = circle
+        self._peer_id: str | None = None
+        self._stopping = False
+        self._client = AsyncRepowireClient(self._daemon_url, auth_token=auth_token, timeout=5.0)
+        self._limiter = _RateLimiter()
+        self._dedup = _Dedup()
+        self._sem = asyncio.Semaphore(32)
+        self._server: uvicorn.Server | None = None
+        self._ws: ClientConnection | None = None
+
+    async def start(self) -> None:
+        """Register on the daemon (WebSocket) and serve the inbound listener."""
+        await asyncio.gather(self._ws_loop(), self._serve_http())
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._ws is not None:
+            await self._ws.close()
+        await self._client.aclose()
+
+    # -- Daemon WebSocket (registration + inbound replies) --
+
+    async def _ws_loop(self) -> None:
+        url = f"{_ws_url(self._daemon_url)}/ws"
+        backoff = 1.0
+        while not self._stopping:
+            try:
+                async with websockets.connect(url) as ws:
+                    self._ws = ws
+                    backoff = 1.0
+                    connect = {
+                        "type": "connect",
+                        "display_name": self._display_name,
+                        "circle": self._circle,
+                        "backend": "claude-code",
+                        "role": "service",
+                        "path": "/ingress",
+                    }
+                    if self._auth_token:
+                        connect["auth_token"] = self._auth_token
+                    await ws.send(json.dumps(connect))
+                    resp = json.loads(await ws.recv())
+                    if resp.get("type") != "connected":
+                        logger.error("ingress connect failed: %s", resp)
+                        await asyncio.sleep(backoff)
+                        continue
+                    pid = resp.get("peer_id") or resp.get("session_id")
+                    if isinstance(pid, str) and pid:
+                        self._peer_id = pid
+                    name = resp.get("display_name")
+                    if isinstance(name, str) and name:
+                        self._display_name = name
+                    logger.info("ingress connected: %s", self._peer_id)
+                    async for raw in ws:
+                        await self._on_ws(json.loads(raw))
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                if self._stopping:
+                    break
+                logger.warning("ingress WS lost, retry in %.0fs", backoff, exc_info=True)
+                self._ws = None
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def _on_ws(self, msg: dict[str, Any]) -> None:
+        if msg.get("type") == "ping" and self._ws is not None:
+            await self._ws.send(json.dumps({"type": "pong"}))
+        # Inbound acks/replies to a federated ask arrive here. Forwarding them
+        # back across the federation bridge (to the originating mesh's endpoint
+        # via its outbound grant) is the remaining P2 piece — tracked separately.
+
+    async def _serve_http(self) -> None:
+        app = self._build_app()
+        config = uvicorn.Config(
+            app, host=self._cfg.bind_host, port=self._cfg.port, log_level="warning"
+        )
+        self._server = uvicorn.Server(config)
+        await self._server.serve()
+
+    def _build_app(self) -> FastAPI:
+        app = FastAPI()
+
+        @app.post("/ingress/{source}")
+        async def ingress(source: str, request: Request) -> JSONResponse:
+            return await self._handle(source, request)
+
+        return app
+
+    async def _handle(self, source: str, request: Request) -> JSONResponse:
+        cfg = self._cfg.sources.get(source)
+        if cfg is None:
+            return _reject(404, "unknown_source")
+
+        # Reject oversized bodies on the declared length before buffering. The
+        # relay tunnel is the real size guard; this is belt-and-suspenders for
+        # the pre-auth, directly-reachable path.
+        clen = request.headers.get("content-length")
+        if clen and clen.isdigit() and int(clen) > _BODY_MAX:
+            return _reject(413, "too_large")
+        body = await request.body()
+        if len(body) > _BODY_MAX:
+            return _reject(413, "too_large")
+
+        headers = {k.lower(): v for k, v in request.headers.items()}
+        verdict = self._verify(source, headers, body, cfg)
+        if not verdict.authenticated:
+            if verdict.reason == "out_of_scope":
+                code = 403
+            elif verdict.reason in _CONFIG_ERROR_REASONS:
+                code = 500  # operator misconfiguration — not a caller auth failure
+            else:
+                code = 401
+            return _reject(code, verdict.reason or "unauthorized")
+
+        # Allowlist: when set, the verifier-supplied principal must match. Only
+        # meaningful for trust_grant (the principal embeds the grant); for hmac/
+        # token the principal is the fixed ext-<source>.
+        if cfg.allow and (verdict.principal_id or "") not in cfg.allow:
+            return _reject(403, "out_of_scope")
+
+        if not self._limiter.allow(source, cfg.rate_limit_per_min):
+            return JSONResponse(
+                {"status": "rejected", "reason": "rate_limited"},
+                status_code=429,
+                headers={"Retry-After": "60"},
+            )
+
+        # Two-phase dedup: claim before emit so concurrent identical deliveries
+        # don't double-emit; an already-claimed key is a duplicate replay, ACKed
+        # 200 so the provider stops retrying.
+        key = verdict.idempotency_key
+        if key and not self._dedup.claim(key):
+            return JSONResponse({"status": "duplicate"}, status_code=200)
+
+        resp = await self._emit(source, cfg, verdict, body, headers)
+        # Release the claim on a failed emit so the provider's retry is
+        # re-attempted rather than silently deduplicated into a lost event.
+        if key and not (200 <= resp.status_code < 300):
+            self._dedup.release(key)
+        return resp
+
+    def _verify(
+        self, source: str, headers: Mapping[str, str], body: bytes, cfg: IngressSource
+    ) -> Verdict:
+        scheme = cfg.verify.scheme
+        if scheme in _HMAC_SCHEMES:
+            return _HMAC_SCHEMES[scheme](source, headers, body, cfg.verify)
+        if scheme in _ASYM_SCHEMES:
+            return _ASYM_SCHEMES[scheme](source, headers, body, cfg.verify)
+        if scheme == "trust_grant":
+            return _verify_trust_grant(source, headers, body, cfg.verify, self._fed)
+        return Verdict(False, reason="unknown_scheme")
+
+    async def _emit(
+        self,
+        source: str,
+        cfg: IngressSource,
+        verdict: Verdict,
+        body: bytes,
+        headers: Mapping[str, str],
+    ) -> JSONResponse:
+        target = cfg.target
+        kind = target.kind
+        to_peer = target.to_peer or ""
+        # Capability check: floor ∩ principal grant. Structural denial means
+        # spawn/kill/schedule are simply never reachable from here.
+        if kind not in (INGRESS_FLOOR & verdict.allowed_kinds):
+            return _reject(403, "out_of_scope")
+        if kind in ("ask", "notify") and not to_peer:
+            return _reject(400, "bad_payload")
+
+        text = _render(cfg.template, body, source)
+        from_peer = verdict.principal_id or self._display_name
+
+        async with self._sem:  # backpressure: shed load rather than queue unbounded
+            try:
+                if kind == "ask":
+                    res = await self._client.ask(
+                        to_peer, text, from_peer=from_peer, circle=cfg.circle
+                    )
+                    return JSONResponse(
+                        {"status": "accepted", "correlation_id": res.correlation_id},
+                        status_code=200,
+                    )
+                if kind == "notify":
+                    await self._client.notify(
+                        to_peer, text, from_peer=from_peer, circle=cfg.circle
+                    )
+                    return JSONResponse({"status": "accepted"}, status_code=200)
+                # kind == "job"
+                res = await self._client.create_job(
+                    title=text[:120],
+                    prompt=text,
+                    backend=target.backend,
+                    path=target.path,
+                    circle=cfg.circle,
+                    source_kind="ingress",
+                    source_id=f"{source}:{verdict.idempotency_key}",
+                    provenance={"ingress": {"source": source, "from_peer": from_peer}},
+                    auto_run=target.auto_run,
+                )
+                return JSONResponse(
+                    {"status": "accepted", "job_id": res.job_id}, status_code=200
+                )
+            except (DaemonConnectionError, DaemonTimeoutError):
+                return _reject(503, "daemon_unavailable")
+            except DaemonHTTPError as e:
+                logger.warning("daemon rejected ingress emit for %s: %s", source, e)
+                return _reject(502, "daemon_error")
+
+
+# -- Listener helpers --
+
+
+def _render(template: str | None, body: bytes, source: str) -> str:
+    """Fill the emitted text from the parsed payload via str.format (never eval)."""
+    if not template:
+        return f"[ingress:{source}] {body.decode('utf-8', 'replace')[:1000]}"
+    try:
+        payload = json.loads(body or b"{}")
+    except (ValueError, TypeError):
+        payload = {}
+    try:
+        return template.format(**payload) if isinstance(payload, dict) else template
+    except (KeyError, IndexError, ValueError):
+        return template
+
+
+def _reject(code: int, reason: str) -> JSONResponse:
+    return JSONResponse({"status": "rejected", "reason": reason}, status_code=code)
+
+
+# -- Entry point --
+
+
+def main() -> None:
+    """Entry point: repowire ingress start"""
+    cfg = load_config()
+    daemon = os.environ.get("REPOWIRE_DAEMON_URL", DEFAULT_DAEMON_URL)
+
+    if not cfg.ingress.enabled or not cfg.ingress.sources:
+        print("No ingress sources configured.")
+        print("Enable and add sources in ~/.repowire/config.yaml under 'ingress:'.")
+        raise SystemExit(1)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    peer = IngressPeer(
+        cfg.ingress,
+        cfg.federation,
+        daemon_url=daemon,
+        auth_token=cfg.daemon.auth_token,
+    )
+    try:
+        asyncio.run(peer.start())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        asyncio.run(peer.stop())

--- a/repowire/protocol/peers.py
+++ b/repowire/protocol/peers.py
@@ -22,6 +22,16 @@ from repowire.agent_types import AgentType
 TurnState = Literal["idle", "working", "awaiting_input", "pending_first_turn"]
 
 
+# Synthetic peer_id prefixes the ingress peer stamps on webhook (ext-) and
+# federation (fed-) principals. The daemon only ever mints repow-* ids, so these
+# are reserved: a registration claiming one is an impersonation attempt and is
+# refused (see PeerRegistry.allocate_and_register). Kept here so the minting side
+# (repowire/ingress/bot.py) and the guard never drift.
+INGRESS_EXT_PREFIX = "ext-"
+INGRESS_FED_PREFIX = "fed-"
+RESERVED_INGRESS_PREFIXES = (INGRESS_FED_PREFIX, INGRESS_EXT_PREFIX)
+
+
 class PeerRole(str, Enum):
     """Role of a peer in the mesh."""
 

--- a/repowire/relay/server.py
+++ b/repowire/relay/server.py
@@ -71,11 +71,14 @@ HTTP_TUNNEL_TIMEOUT = 30  # seconds
 _RELAY_PATHS = frozenset({"/", "/health", "/auth", "/ws/relay", "/dashboard", "/events/stream"})
 _RELAY_PREFIXES = ("/api/v1/", "/d/", "/_next/")
 
-# API paths tunneled to the daemon (everything else is static or relay-owned)
+# API paths tunneled to the daemon (everything else is static or relay-owned).
+# `/ingress` is tunneled too, but the daemon-side relay client forwards it on to
+# the ingress peer's local listener rather than the daemon — so external
+# webhooks reach the peer without it ever opening a public inbound port.
 _TUNNEL_PREFIXES = (
     "/peers", "/events", "/query", "/notify", "/broadcast",
     "/session", "/response", "/spawn", "/ws", "/attachments",
-    "/ask", "/ack", "/asks", "/circles", "/jobs",
+    "/ask", "/ack", "/asks", "/circles", "/jobs", "/ingress",
 )
 
 # Static file extensions served from web/out root (logos, favicon, images)

--- a/rfcs/ingress-peer.md
+++ b/rfcs/ingress-peer.md
@@ -1,0 +1,79 @@
+Status: proposal. Adds one new service peer (the ingress peer) for external webhook ingress (P1) and trusted cross-mesh federation (P2). P3 (adversarial/unknown parties) is explicitly out of scope. Implementation lands as a single PR; build order in the last section.
+
+# Ingress peer
+
+## Problem
+
+repowire's event sources today are only peers and humans, and its only trigger is a clock (`schedule` / cron jobs). Two gaps:
+
+1. **No external event ingress.** Triggering an agent on a webhook (PR opened, CI done, Stripe event) means hand-rolling a `POST /ask` shim per source, re-deriving signature verification, idempotency, rate-limiting, and reachability — security-critical boilerplate that is easy to get subtly wrong (skip the signature check and the endpoint is an open injection path into the mesh).
+2. **No cross-scope federation.** The relay forwards only *within* one user scope (`relay/server.py`), so two coworkers on separately-authed meshes cannot pass a message between them.
+
+## Approach
+
+Add **one** service peer — the **ingress peer** — that owns a hardened *mechanism* (verify an inbound event, then emit a standard mesh `ask`/`notify`/`job`) and leaves routing/timing/durability to the existing primitives. It is the missing *event* trigger that sits beside `schedule` (time) and `jobs run` (manual), feeding the same dispatch pipeline.
+
+One peer, a pluggable verifier:
+
+- **P1 webhook:** verifier = HMAC over the raw body (the dominant webhook convention), config-driven so no provider names appear in code.
+- **P2 federation:** verifier = an opaque trust-grant exchanged out-of-band + a per-request HMAC.
+
+P3 is *not* designed for. If it ever happens it is a new verifier registered in the same dispatch table — but no seams are added now to anticipate it.
+
+This follows the load-bearing repo philosophy: *the daemon is the only hub; transports are client-side.* The ingress peer is a client of the daemon HTTP API; verifier and policy never enter daemon or relay core. It emits a standard mesh message, so it composes with jobs, schedule, orchestrator, circles, and the human surfaces for free — it is a new *source*, not a new message type.
+
+## The one new pattern
+
+Every existing peer (telegram, slack) is outbound-only; only `daemon/` and `relay/` serve HTTP. The ingress peer must *receive* inbound POSTs, so it hosts a uvicorn/FastAPI listener — a new peer shape. It is mitigated by binding **localhost-only** and reaching the world through the existing relay tunnel (the relay faces the public, the peer does not), so the model stays "peers don't accept public traffic, the relay tunnels."
+
+## Design
+
+### Verifier (config-driven, scheme-dispatched)
+
+A `Verifier` Protocol (`verify(req, source_cfg) -> Verdict`) with a `VERIFIERS` dict keyed by `scheme`, mirroring the relay's `_MSG_HANDLERS`. The user registers verification *metadata* per source (header, encoding, prefix, payload template, secret/public-key ref); the repo ships one generic handler per *scheme*, not per provider:
+
+- `hmac` (default) — covers GitHub/Stripe/Slack/Shopify via config knobs; stdlib `hmac.compare_digest` over the raw bytes.
+- `token` — plaintext shared secret compared against a header (GitLab-style); stdlib.
+- `ecdsa`/`ed25519` — asymmetric (Discord etc.); uses `public_key_ref` and `cryptography` (already in the lockfile), shipped behind an optional extra to keep the core dependency-free.
+- `trust_grant` — the P2 grant flow.
+
+A new provider that fits an existing scheme is pure config; a genuinely new *mechanism* is one small scheme handler. Provider examples (github/stripe/slack/gitlab) ship as copy-paste docs, not code.
+
+### Routing
+
+One source = one narrowly-registered webhook → one fixed `to_peer` (a project peer or the `orchestrator`). The payload only fills the text template; it never selects the peer. Finer granularity = register more sources. No `when` filter, no payload-based routing, no DSL. Registration granularity is bounded by what the provider lets you select per webhook; sub-event filtering is the target peer's job — route to the orchestrator when you want an agent to triage.
+
+### Emit and capability containment
+
+A single `_emit` chokepoint calls `AsyncRepowireClient` (`.ask()` / `.notify()` / a new `.create_job()`). Ingress/federated principals are restricted to `ask`+`notify` (P2 may add `job`) by a plain `frozenset` check plus structural denial — the peer never wires spawn/kill/schedule/transcript paths. `from_peer` is always a namespaced id (`ext-*` for webhooks, `fed-*` for federation), never the remote's. A small daemon guard reserves those prefixes so a federated sender can never collide with or impersonate a local `repow-*` peer.
+
+### P2 federation
+
+An opaque `grant_` token (no signing/JWS — matches the repo's `secrets.token_urlsafe` + `compare_digest` idiom) carries scope: `{issuer_mesh_id, audience_mesh_id, direction, exposed_circle, exposed_peers, allowed_kinds, expires_at, revocation_ref, shared_secret_ref}`. Authentication is grant lookup (revocation + expiry) plus a per-request HMAC over the raw body, so a leaked grant id is inert on its own. Provenance is stamped so the recipient sees `[ask from @x via fed:bob]`, never a bare local-looking peer.
+
+### Listener robustness
+
+HTTP status is chosen by how providers react (they retry on non-2xx): `200` accepted; `200` for a duplicate (idempotency hit, so retries stop); `401` bad signature; `403` out-of-scope; `404` unknown source; `429` rate-limited (+`Retry-After`); `503` when the daemon is unreachable or the listener is saturated (retryable — the event is not lost); `400`/`413` for bad/oversized bodies. Two load-bearing rules: duplicate → `200`, can't-deliver → `503` ("fail loud" applied to HTTP). Rate limiting is a per-source/per-grant token bucket with lazy eviction (no sweep timer — honors "lazy repair, never poll"). Backpressure sheds load with `503`/`429` rather than building an unbounded queue. Emit is synchronous (return the real outcome) — no pre-ACK, preserving delivery truthfulness.
+
+## Reuse
+
+Most of this already exists. New code is deliberately one file (`repowire/ingress/bot.py`, matching the `__init__ + bot.py` footprint of every surface) plus small edits:
+
+- Emit → `AsyncRepowireClient` (`.ask`/`.notify`/`.register_peer` exist); add `.create_job()`/`.run_job()` (the only gap).
+- Config → inline `IngressConfig`/`FederationConfig` in `config/models.py` beside `TelegramConfig`.
+- Crypto → `secrets.token_urlsafe` + `hmac.compare_digest`.
+- Job provenance → existing `source_kind`/`source_id`/`provenance` fields on `WorkCreateRequest`.
+- `uvicorn`/`fastapi` are already dependencies.
+
+## Out of scope
+
+P3 (adversarial federation): Sybil resistance, abuse/content policy, approval-on-first-contact, and a daemon-side scoped sub-token (today the ingress peer holds the full `daemon.auth_token`, so capability containment is peer-side — acceptable when inbound senders are untrusted but the peer is first-party, not acceptable once the peer must defend against the parties it federates with). None of these are built; the verifier dispatch table is the only thing P3 would extend.
+
+## Build order (single PR)
+
+1. `client.py`: add `create_job()` / `run_job()`.
+2. `config/models.py`: inline `IngressConfig` / `IngressSource` / `VerifyConfig` / `IngressTarget` / `FederationConfig`; register on `Config`.
+3. `repowire/ingress/bot.py`: `IngressPeer` (uvicorn listener + WS loop), verifiers, `_emit` chokepoint, dedup + rate-limit; `cli.py` `ingress` group (`start`, `grant`).
+4. `registry_identity.py`: reserve `fed-`/`ext-` peer_id prefixes.
+5. `relay/server.py` + `daemon/relay_client.py`: tunnel `/ingress/*` to the peer.
+6. Docs (`docs/use/features/connect-webhook.md` + `mkdocs.yml`) and tests.

--- a/tests/test_ingress_bot.py
+++ b/tests/test_ingress_bot.py
@@ -1,0 +1,303 @@
+"""Ingress peer: verification, idempotency, routing, and status codes."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from repowire.client import DaemonConnectionError
+from repowire.config.models import (
+    FederationConfig,
+    IngressConfig,
+    IngressSource,
+    IngressTarget,
+    VerifyConfig,
+)
+from repowire.ingress import bot
+
+SECRET = "topsecret"
+BODY = b'{"number": 42, "action": "opened"}'
+
+
+def _sign(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("GH_SECRET", SECRET)
+    source = IngressSource(
+        verify=VerifyConfig(
+            scheme="hmac",
+            header="X-Hub-Signature-256",
+            prefix="sha256=",
+            secret_ref="GH_SECRET",
+            delivery_id_header="X-GitHub-Delivery",
+        ),
+        target=IngressTarget(kind="ask", to_peer="reviewer"),
+        template="PR #{number} {action}",
+    )
+    peer = bot.IngressPeer(
+        IngressConfig(enabled=True, sources={"gh-pr": source}), FederationConfig()
+    )
+    peer._client.ask = AsyncMock(  # type: ignore[method-assign]
+        return_value=type("R", (), {"correlation_id": "ask-xyz"})()
+    )
+    peer._client.notify = AsyncMock()  # type: ignore[method-assign]
+    peer._client.create_job = AsyncMock()  # type: ignore[method-assign]
+    tc = TestClient(peer._build_app())
+    tc.peer = peer  # type: ignore[attr-defined]
+    return tc
+
+
+def _headers(body: bytes = BODY, delivery: str = "d1") -> dict[str, str]:
+    return {
+        "X-Hub-Signature-256": _sign(SECRET, body),
+        "X-GitHub-Delivery": delivery,
+        "Content-Type": "application/json",
+    }
+
+
+def test_signed_request_emits_templated_ask(client: TestClient) -> None:
+    r = client.post("/ingress/gh-pr", content=BODY, headers=_headers())
+    assert r.status_code == 200
+    assert r.json() == {"status": "accepted", "correlation_id": "ask-xyz"}
+    # Template rendered from the payload; from_peer is the namespaced principal.
+    client.peer._client.ask.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "reviewer", "PR #42 opened", from_peer="ext-gh-pr", circle=None
+    )
+
+
+def test_replayed_delivery_is_deduped(client: TestClient) -> None:
+    client.post("/ingress/gh-pr", content=BODY, headers=_headers())
+    r = client.post("/ingress/gh-pr", content=BODY, headers=_headers())
+    assert r.status_code == 200
+    assert r.json()["status"] == "duplicate"
+    # The duplicate must not emit a second ask.
+    assert client.peer._client.ask.await_count == 1  # type: ignore[attr-defined]
+
+
+def test_bad_signature_is_rejected_401(client: TestClient) -> None:
+    bad = dict(_headers(), **{"X-Hub-Signature-256": "sha256=deadbeef"})
+    r = client.post("/ingress/gh-pr", content=BODY, headers=bad)
+    assert r.status_code == 401
+    assert r.json()["reason"] == "signature_mismatch"
+    client.peer._client.ask.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+def test_unknown_source_is_404(client: TestClient) -> None:
+    r = client.post("/ingress/nope", content=BODY, headers=_headers())
+    assert r.status_code == 404
+    assert r.json()["reason"] == "unknown_source"
+
+
+def test_missing_signature_is_401(client: TestClient) -> None:
+    r = client.post("/ingress/gh-pr", content=BODY, headers={"Content-Type": "application/json"})
+    assert r.status_code == 401
+
+
+def test_failed_emit_is_503_and_replay_is_reattempted(client: TestClient) -> None:
+    # A transient daemon outage must surface as 503 and NOT consume the
+    # idempotency key — the provider's retry has to be re-emitted, not dropped.
+    client.peer._client.ask = AsyncMock(  # type: ignore[attr-defined]
+        side_effect=DaemonConnectionError()
+    )
+    r1 = client.post("/ingress/gh-pr", content=BODY, headers=_headers())
+    assert r1.status_code == 503
+    assert r1.json()["reason"] == "daemon_unavailable"
+
+    # daemon recovers; the same delivery id must be re-attempted, not deduped.
+    client.peer._client.ask = AsyncMock(  # type: ignore[attr-defined]
+        return_value=type("R", (), {"correlation_id": "ask-2"})()
+    )
+    r2 = client.post("/ingress/gh-pr", content=BODY, headers=_headers())
+    assert r2.status_code == 200
+    assert r2.json()["correlation_id"] == "ask-2"
+
+
+def test_missing_secret_is_500_not_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    # secret_ref points at an unset env var → operator misconfiguration → 500.
+    monkeypatch.delenv("NOPE_SECRET", raising=False)
+    source = IngressSource(
+        verify=VerifyConfig(scheme="hmac", header="X-Sig", secret_ref="NOPE_SECRET"),
+        target=IngressTarget(kind="ask", to_peer="x"),
+    )
+    peer = bot.IngressPeer(
+        IngressConfig(enabled=True, sources={"s": source}), FederationConfig()
+    )
+    tc = TestClient(peer._build_app())
+    r = tc.post("/ingress/s", content=BODY, headers={"X-Sig": "abc"})
+    assert r.status_code == 500
+    assert r.json()["reason"] == "missing_secret"
+
+
+def test_oversized_body_is_413(client: TestClient) -> None:
+    big = b"x" * (bot._BODY_MAX + 1)
+    r = client.post("/ingress/gh-pr", content=big, headers={"X-Hub-Signature-256": "sha256=x"})
+    assert r.status_code == 413
+
+
+def test_rate_limit_returns_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RL_SECRET", SECRET)
+    source = IngressSource(
+        verify=VerifyConfig(scheme="hmac", header="X-Hub-Signature-256", prefix="sha256=",
+                            secret_ref="RL_SECRET", delivery_id_header="X-GitHub-Delivery"),
+        target=IngressTarget(kind="notify", to_peer="x"),
+        rate_limit_per_min=1,
+    )
+    peer = bot.IngressPeer(
+        IngressConfig(enabled=True, sources={"s": source}), FederationConfig()
+    )
+    peer._client.notify = AsyncMock()  # type: ignore[method-assign]
+    tc = TestClient(peer._build_app())
+
+    def post(delivery: str) -> int:
+        h = {"X-Hub-Signature-256": _sign(SECRET, BODY), "X-GitHub-Delivery": delivery}
+        return tc.post("/ingress/s", content=BODY, headers=h).status_code
+
+    assert post("a") == 200
+    assert post("b") == 429  # second within the same window exhausts the bucket
+
+
+def test_trust_grant_emits_with_namespaced_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FED_SECRET", "grantsecret")
+    from repowire.config.models import GrantConfig
+
+    grant = GrantConfig(
+        grant_id="grant_abc", issuer_mesh_id="alice", direction="inbound",
+        allowed_kinds=["ask"], shared_secret_ref="FED_SECRET",
+    )
+    source = IngressSource(
+        verify=VerifyConfig(scheme="trust_grant"),
+        target=IngressTarget(kind="ask", to_peer="reviewer"),
+        template="{text}",
+    )
+    fed = FederationConfig(mesh_id="bob", inbound_grants=[grant])
+    peer = bot.IngressPeer(IngressConfig(enabled=True, sources={"f": source}), fed)
+    peer._client.ask = AsyncMock(  # type: ignore[method-assign]
+        return_value=type("R", (), {"correlation_id": "ask-f"})()
+    )
+    tc = TestClient(peer._build_app())
+
+    body = b'{"text": "please review"}'
+    sig = hmac.new(b"grantsecret", body, hashlib.sha256).hexdigest()
+    r = tc.post(
+        "/ingress/f",
+        content=body,
+        headers={"X-Repowire-Grant": "grant_abc", "X-Repowire-Grant-Sig": sig},
+    )
+    assert r.status_code == 200
+    # from_peer is namespaced fed-* and carries the full grant id (no collision).
+    peer._client.ask.assert_awaited_once_with(
+        "reviewer", "please review", from_peer="fed-alice-grant_abc", circle=None
+    )
+
+
+def test_expired_grant_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FED_SECRET", "grantsecret")
+    from repowire.config.models import GrantConfig
+
+    grant = GrantConfig(
+        grant_id="grant_old", issuer_mesh_id="alice", direction="inbound",
+        shared_secret_ref="FED_SECRET", expires_at="2000-01-01T00:00:00+00:00",
+    )
+    source = IngressSource(verify=VerifyConfig(scheme="trust_grant"),
+                           target=IngressTarget(kind="ask", to_peer="r"))
+    peer = bot.IngressPeer(
+        IngressConfig(enabled=True, sources={"f": source}),
+        FederationConfig(inbound_grants=[grant]),
+    )
+    tc = TestClient(peer._build_app())
+    body = b"{}"
+    sig = hmac.new(b"grantsecret", body, hashlib.sha256).hexdigest()
+    r = tc.post("/ingress/f", content=body,
+                headers={"X-Repowire-Grant": "grant_old", "X-Repowire-Grant-Sig": sig})
+    assert r.status_code == 403  # out_of_scope (expired)
+
+
+def _peer_with(source: IngressSource) -> TestClient:
+    peer = bot.IngressPeer(
+        IngressConfig(enabled=True, sources={"s": source}), FederationConfig()
+    )
+    peer._client.notify = AsyncMock()  # type: ignore[method-assign]
+    tc = TestClient(peer._build_app())
+    tc.peer = peer  # type: ignore[attr-defined]
+    return tc
+
+
+def test_stripe_style_timestamped_hmac(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIPE_SECRET", SECRET)
+    src = IngressSource(
+        verify=VerifyConfig(
+            scheme="hmac", header="Stripe-Signature", prefix="", encoding="hex",
+            secret_ref="STRIPE_SECRET", payload_template="{ts}.{body}",
+            sig_kv=True, ts_field="t", sig_field="v1", max_age_s=300,
+        ),
+        target=IngressTarget(kind="notify", to_peer="x"),
+    )
+    tc = _peer_with(src)
+    body = b'{"id": "evt_1"}'
+
+    def header(ts: str) -> dict[str, str]:
+        signed = f"{ts}.{body.decode()}".encode()
+        sig = hmac.new(SECRET.encode(), signed, hashlib.sha256).hexdigest()
+        return {"Stripe-Signature": f"t={ts},v1={sig}"}
+
+    fresh = tc.post("/ingress/s", content=body, headers=header(str(int(time.time()))))
+    assert fresh.status_code == 200
+    # A timestamp outside the replay window is rejected even with a valid HMAC.
+    stale = tc.post("/ingress/s", content=body, headers=header(str(int(time.time()) - 10_000)))
+    assert stale.status_code == 401
+
+
+def test_slack_style_timestamped_hmac(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SLACK_SECRET", SECRET)
+    src = IngressSource(
+        verify=VerifyConfig(
+            scheme="hmac", header="X-Slack-Signature", prefix="v0=", encoding="hex",
+            secret_ref="SLACK_SECRET", payload_template="v0:{ts}:{body}",
+            timestamp_header="X-Slack-Request-Timestamp",
+        ),
+        target=IngressTarget(kind="notify", to_peer="x"),
+    )
+    tc = _peer_with(src)
+    body = b"token=abc&team_id=T1"
+    ts = str(int(time.time()))
+    sig = hmac.new(SECRET.encode(), f"v0:{ts}:{body.decode()}".encode(), hashlib.sha256).hexdigest()
+    r = tc.post(
+        "/ingress/s",
+        content=body,
+        headers={"X-Slack-Signature": f"v0={sig}", "X-Slack-Request-Timestamp": ts},
+    )
+    assert r.status_code == 200
+
+
+def test_ed25519_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode()
+    monkeypatch.setenv("DISCORD_PUBKEY", pub_pem)
+    src = IngressSource(
+        verify=VerifyConfig(
+            scheme="ed25519", header="X-Signature-Ed25519", prefix="", encoding="hex",
+            public_key_ref="DISCORD_PUBKEY",
+        ),
+        target=IngressTarget(kind="notify", to_peer="x"),
+    )
+    tc = _peer_with(src)
+    body = b'{"type": 1}'
+    sig = priv.sign(body).hex()
+    ok = tc.post("/ingress/s", content=body, headers={"X-Signature-Ed25519": sig})
+    assert ok.status_code == 200
+    # tampered body fails verification
+    bad = tc.post("/ingress/s", content=b'{"type": 2}', headers={"X-Signature-Ed25519": sig})
+    assert bad.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -1127,6 +1127,9 @@ dev = [
 docs = [
     { name = "zensical" },
 ]
+webhooks-asymmetric = [
+    { name = "cryptography" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1140,6 +1143,7 @@ requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp-probe'", specifier = ">=0.10.0" },
     { name = "agent-client-protocol", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "click", specifier = ">=8.1.7" },
+    { name = "cryptography", marker = "extra == 'webhooks-asymmetric'", specifier = ">=42.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "libtmux", specifier = ">=0.37.0" },
@@ -1157,7 +1161,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=13.0" },
     { name = "zensical", marker = "extra == 'docs'", specifier = ">=0.0.43" },
 ]
-provides-extras = ["relay", "dev", "acp", "docs", "acp-probe"]
+provides-extras = ["relay", "dev", "acp", "docs", "acp-probe", "webhooks-asymmetric"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
### Summary

Adds one new service peer — the ingress peer — that turns external events into standard mesh messages. It owns only the security envelope (verify an inbound request → emit a normal ask/notify/job through the daemon), so it composes with jobs, schedule, the orchestrator, and the human surfaces as a new source, not a new message type. It's the missing event trigger beside schedule (time) and jobs run (manual).

One peer, a pluggable verifier:
- P1 — webhook ingress: HMAC (raw-body and timestamped: GitHub/Sxt token (GitLab), or asymmetric ed25519/ecdsa (Discord). Fullyconfig-driven — no provider names in code; a generic handler per scheme reads the user's verify: block.
- P2 — trusted cross-mesh federation: an opaque grant + per-requrant id alone is inert).

### How it works

webhook → relay tunnel → ingress peer (verify → dedup/rate-limit

- New code is one file (repowire/ingress/bot.py), mirroring the  a localhost uvicorn listener + daemon WebSocket registration,emitting via the existing AsyncRepowireClient.
- Reuse over new surface: added client.create_job()/run_job() (tConfig/FederationConfig beside TelegramConfig, secrets/grants kept as env/keychain refs (never committed).
- Reachability: the relay tunnels /ingress/* to the peer's localr opens a public inbound port.
- Anti-impersonation: webhook/federation principals get reserved ext-/fed- peer_id prefixes; the daemon refuses any registration claiming them.
- Capability containment: ask/notify/job only — spawn/kill/sched
- Listener hardening: per-source token-bucket rate limit (429), two-phase idempotency (duplicate → 200; a failed emit releases the claim so a provider retry
isn't lost), Content-Length body cap, replay-window check for tier-aware status codes (401/403/404/500/503).

### Out of scope

P3 adversarial federation, and P2 reply-forwarding across the brting decision) — see rfcs/ingress-peer.md.

### Testing

14 ingress tests (HMAC raw-body + Stripe/Slack timestamped + rep, trust-grant, dedup/failed-emit/rate-limit/status codes); fullsuite 1953 passing; ruff + ty clean. Verified live against a two-circle daemon: signed → delivered to a running agent, duplicate → deduped, bad-sig → 401, unknown → 404.

The webhooks-asymmetric extra adds cryptography for ed25519/ecdsfree.