### PR TITLE
fix(acp): restore Python 3.10 compatibility (datetime.UTC is 3.11+)

### DIFF
--- a/repowire/acp/manager.py
+++ b/repowire/acp/manager.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from repowire.acp.client import AcpClient, AcpClientError, AcpPromptResult
@@ -190,4 +190,4 @@ class AcpClientManager:
 
 
 def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()
+    return datetime.now(timezone.utc).isoformat()

--- a/repowire/acp/permissions.py
+++ b/repowire/acp/permissions.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
@@ -345,4 +345,4 @@ def _normalize_payload(value: Any) -> dict[str, Any]:
 
 
 def _utc_now() -> str:
-    return datetime.now(UTC).isoformat()
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## Problem

`repowire/acp/manager.py` and `repowire/acp/permissions.py` import `from datetime import UTC`, but the `UTC` alias was only added in **Python 3.11** ([3.11 what's new](https://docs.python.org/3/whatsnew/3.11.html#datetime)).

The project advertises **Python 3.10+** in three places:
- `pyproject.toml`: `Requires-Python = ">=3.10"` + `Programming Language :: Python :: 3.10` classifier
- `install.sh`: gates on `minor >= 10` with the message `Python 3.10+ is required.`
- `CONTRIBUTING.md`: "You'll need Python 3.10+"

On Python 3.10 the daemon import chain therefore dies:

```
$ repowire doctor          # (or `status`, or the daemon started by `setup`)
  File ".../repowire/acp/manager.py", line 16, in <module>
    from datetime import UTC, datetime
ImportError: cannot import name 'UTC' from 'datetime' (/usr/lib/python3.10/datetime.py)
```

The practical symptom: `repowire setup` installs the service but reports `daemon health did not respond yet`, and `doctor`/`status` traceback instead of running.

## Fix

Use `datetime.now(timezone.utc)` instead of `datetime.now(UTC)`. This is already the dominant convention in the codebase — ~34 modules use `datetime.now(timezone.utc)`; these two files were the only outliers using the 3.11-only alias. Minimal 4-line change, no behavior change on 3.11+.

## Verification

Installed the patched package into a Python **3.10.12** venv and ran the exact command that failed before:

```
$ repowire doctor
✓ repowire version  0.17.0
✓ Python version  3.10 (>= 3.10)
...
```

`ruff check` passes on both files.

## Note on why CI didn't catch this

`.github/workflows/ci.yml` uses `astral-sh/setup-uv` without pinning a Python version, so `uv sync` resolves to the newest available interpreter (3.11/3.12) and 3.10 is never exercised. If you want to keep the 3.10 floor, adding `3.10` to a CI test matrix would prevent regressions. Happy to add that to this PR if you'd like — or, alternatively, if 3.10 support isn't intended, the floor should be bumped to `>=3.11` in `pyproject.toml`/`install.sh`/`CONTRIBUTING.md` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)