### PR TITLE
fix(mcp): authenticate stdio daemon requests

### DIFF
--- a/repowire/mcp/server.py
+++ b/repowire/mcp/server.py
@@ -15,7 +15,7 @@ from mcp.server.fastmcp import FastMCP
 
 from repowire.agent_backends import detect_mcp_backend, detect_mcp_backend_confident
 from repowire.agent_types import AgentType
-from repowire.config.models import DEFAULT_DAEMON_URL
+from repowire.config.models import DEFAULT_DAEMON_URL, load_config
 from repowire.hooks._tmux import get_pane_id, get_tmux_info
 from repowire.hooks.utils import (
     get_display_name,
@@ -226,9 +226,10 @@ async def daemon_request(
     try:
         client = _get_http_client()
         url = f"{DAEMON_URL}{path}"
-        headers = None
-        if _http_mcp_auth_token:
-            headers = {"Authorization": f"Bearer {_http_mcp_auth_token}"}
+        auth_token = _http_mcp_auth_token or os.environ.get("REPOWIRE_AUTH_TOKEN")
+        if not auth_token:
+            auth_token = load_config().daemon.auth_token
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
         if method == "GET":
             resp = await client.get(url, params=params, headers=headers)
         elif method == "DELETE":

--- a/tests/test_mcp_daemon_auth.py
+++ b/tests/test_mcp_daemon_auth.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import repowire.mcp.server as server
+
+
+def mock_http_client():
+    client = MagicMock()
+    client.get = AsyncMock()
+    response = MagicMock()
+    response.json.return_value = {"ok": True}
+    client.get.return_value = response
+    return client
+
+
+@pytest.fixture(autouse=True)
+def reset_mcp_context():
+    server.reset_mcp_context()
+    yield
+    server.reset_mcp_context()
+
+
+async def test_stdio_daemon_request_uses_environment_bearer_token(monkeypatch):
+    client = mock_http_client()
+    monkeypatch.setattr(server, "_http_client", client)
+    monkeypatch.setenv("REPOWIRE_AUTH_TOKEN", "stdio-secret")
+
+    await server.daemon_request("GET", "/peers")
+
+    client.get.assert_awaited_once_with(
+        f"{server.DAEMON_URL}/peers",
+        params=None,
+        headers={"Authorization": "Bearer stdio-secret"},
+    )
+
+
+async def test_stdio_daemon_request_falls_back_to_config_bearer_token(monkeypatch):
+    client = mock_http_client()
+    monkeypatch.setattr(server, "_http_client", client)
+    monkeypatch.delenv("REPOWIRE_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        server,
+        "load_config",
+        lambda: SimpleNamespace(daemon=SimpleNamespace(auth_token="config-secret")),
+    )
+
+    await server.daemon_request("GET", "/peers")
+
+    assert client.get.await_args.kwargs["headers"] == {
+        "Authorization": "Bearer config-secret"
+    }
+
+
+async def test_stdio_daemon_request_reloads_config_token(monkeypatch):
+    client = mock_http_client()
+    monkeypatch.setattr(server, "_http_client", client)
+    monkeypatch.delenv("REPOWIRE_AUTH_TOKEN", raising=False)
+    config = SimpleNamespace(daemon=SimpleNamespace(auth_token="first-secret"))
+    monkeypatch.setattr(server, "load_config", lambda: config)
+
+    await server.daemon_request("GET", "/peers")
+    config.daemon.auth_token = "rotated-secret"
+    await server.daemon_request("GET", "/peers")
+
+    first_call, second_call = client.get.await_args_list
+    assert first_call.kwargs["headers"] == {
+        "Authorization": "Bearer first-secret"
+    }
+    assert second_call.kwargs["headers"] == {
+        "Authorization": "Bearer rotated-secret"
+    }
+
+
+async def test_http_mcp_daemon_request_keeps_configured_http_token(monkeypatch):
+    client = mock_http_client()
+    monkeypatch.setattr(server, "_http_client", client)
+    monkeypatch.setenv("REPOWIRE_AUTH_TOKEN", "stdio-secret")
+    server.configure_http_mcp_context(auth_token="http-secret")
+
+    await server.daemon_request("GET", "/peers")
+
+    assert client.get.await_args.kwargs["headers"] == {
+        "Authorization": "Bearer http-secret"
+    }


### PR DESCRIPTION
## What changed

- authenticate stdio MCP-to-daemon requests with `REPOWIRE_AUTH_TOKEN`
- fall back to `daemon.auth_token` from the current config
- preserve the explicitly configured HTTP MCP token as the highest-priority credential
- add regression coverage for environment, config, token rotation, and HTTP MCP precedence

## Why

In stdio mode, `reset_mcp_context()` clears the HTTP MCP token. `daemon_request()` previously sent no authorization header after that reset, even when the daemon required bearer authentication and the token was available through the environment or config. The daemon consequently returned `401 Missing authorization header` for tools such as `list_peers`.

The token is resolved for each request so a rotated config token is picked up without restarting the MCP subprocess.

## Validation

- `uv run pytest -q tests/test_mcp_daemon_auth.py -W error` — 4 passed
- `uv run pytest -q` — 1,961 passed
- `uv run ruff check repowire/ tests/test_mcp_daemon_auth.py` — passed
- `uv run ty check repowire/` — passed
