### PR TITLE
chore: remove Python cutover remnants

### DIFF
--- a/.claude/memory/feedback_live_testing.md
+++ b/.claude/memory/feedback_live_testing.md
@@ -8,4 +8,4 @@ Always live test installer changes (hooks, config files, CLI detection) on an ac
 
 **Why:** Gemini installer support was merged without live testing and regressed. Codex was live-tested before merge and that caught a version parsing bug. Same rigor should apply to all installers.
 
-**How to apply:** For any PR that writes config files (`hooks.json`, `settings.json`, `config.toml`, `.claude.json`, `plugin/repowire.ts`), run the installer functions in a Python shell and inspect the output files before merging.
+**How to apply:** For any PR that writes config files (`hooks.json`, `settings.json`, `config.toml`, `.claude.json`, `plugin/repowire.ts`), build the native binary, run `repowire setup`, and inspect the output files before merging.

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -42,9 +42,15 @@ Each agent gets the full context for its mode and runs independently.
 
 ## Phase 1: Environment Discovery
 
-Run these commands to understand current state.
+Run these commands to understand current state. Keep all phases in the same
+shell so `REPOWIRE_BIN` continues to identify the exact binary under test.
 
 ```bash
+# Pin every command in this workflow to one binary. Phase 4 replaces this with
+# the freshly built checkout binary when a fresh install is requested.
+REPOWIRE_BIN="$(command -v repowire || true)"
+export REPOWIRE_BIN
+
 # System checks
 tmux list-sessions 2>/dev/null || echo "No tmux sessions"
 which opencode 2>/dev/null || echo "opencode not in PATH"
@@ -55,7 +61,7 @@ curl -s http://127.0.0.1:8377/health 2>/dev/null | jq . || echo "Daemon not runn
 curl -s http://127.0.0.1:8377/peers 2>/dev/null | jq '.peers[] | {name, status, circle}' || echo "No peers"
 
 # Installation status
-command -v repowire >/dev/null && repowire --version || echo "Repowire not installed"
+test -n "$REPOWIRE_BIN" && "$REPOWIRE_BIN" --version || echo "Repowire not installed"
 jq -r '"Hooks: " + ((.hooks // {}) | keys | join(", "))' "$HOME/.claude/settings.json" 2>/dev/null || echo "No Claude hooks"
 ls ~/.opencode/plugin/repowire.ts 2>/dev/null && echo "OpenCode plugin installed" || echo "No OpenCode plugin"
 ```
@@ -75,7 +81,7 @@ tmux kill-session -t circle-b 2>/dev/null || true
 tmux kill-session -t opencode-test 2>/dev/null || true
 tmux kill-session -t mixed-test 2>/dev/null || true
 curl -s http://127.0.0.1:8377/health >/dev/null 2>&1 && {
-  repowire peer prune --force 2>/dev/null || true
+  "$REPOWIRE_BIN" peer prune --force 2>/dev/null || true
 }
 
 rm -f ~/.repowire/pending/*.json 2>/dev/null || true
@@ -93,12 +99,14 @@ rm -f ~/.repowire/sessions.json 2>/dev/null || true
 cd /path/to/repowire
 mkdir -p bin
 (cd daemon-go && go build -o ../bin/repowire .)
+REPOWIRE_BIN="$(pwd)/bin/repowire"
+export REPOWIRE_BIN
 
 # Setup hooks and MCP server
-./bin/repowire setup --no-service
+"$REPOWIRE_BIN" setup --no-service
 
 # Verify
-./bin/repowire --version
+"$REPOWIRE_BIN" --version
 jq -r '"Hooks: " + ((.hooks // {}) | keys | join(", "))' "$HOME/.claude/settings.json"
 ls ~/.opencode/plugin/repowire.ts 2>/dev/null && echo "OpenCode plugin: OK"
 ```
@@ -106,8 +114,9 @@ ls ~/.opencode/plugin/repowire.ts 2>/dev/null && echo "OpenCode plugin: OK"
 ## Phase 5: Ensure Daemon Running
 
 ```bash
+test -x "$REPOWIRE_BIN" || { echo "REPOWIRE_BIN is not executable: $REPOWIRE_BIN" >&2; exit 1; }
 curl -s http://127.0.0.1:8377/health || {
-  nohup repowire serve > /tmp/repowire-daemon.log 2>&1 &
+  nohup "$REPOWIRE_BIN" serve > /tmp/repowire-daemon.log 2>&1 &
   sleep 3
 }
 curl -s http://127.0.0.1:8377/health | jq .
@@ -140,9 +149,20 @@ sleep 30  # Wait for sessions to initialize and hooks to register
 
 ```bash
 # All 3 peers should be online with correct circles and peer_id format
-curl -s http://127.0.0.1:8377/peers | jq --arg a1 "$PEER_A1" --arg a2 "$PEER_A2" --arg b1 "$PEER_B1" '
-  [.peers[] | select(.name == $a1 or .name == $a2 or .name == $b1) |
-   {name, status, circle, peer_id}]
+curl -fsS http://127.0.0.1:8377/peers | jq -e --arg a1 "$PEER_A1" --arg a2 "$PEER_A2" --arg b1 "$PEER_B1" '
+  def valid($name; $circle):
+    [.peers[] | select(
+      .name == $name and
+      .status == "online" and
+      .circle == $circle and
+      (.peer_id | test("^repow-" + $circle + "-[a-f0-9]{8}$"))
+    )] | length == 1;
+  if valid($a1; "circle-a") and valid($a2; "circle-a") and valid($b1; "circle-b") then
+    [.peers[] | select(.name == $a1 or .name == $a2 or .name == $b1) |
+     {name, status, circle, peer_id}]
+  else
+    error("registration assertion failed: expected exactly one online peer for each name with the correct circle and peer_id")
+  end
 '
 ```
 
@@ -152,13 +172,13 @@ If a peer doesn't register, check `.claude/settings.local.json` for `disableAllH
 
 1. **Direct query to peer-a1**
    ```bash
-   repowire peer ask $PEER_A1 "What is this project about in one sentence?" -t 120
+   "$REPOWIRE_BIN" peer ask $PEER_A1 "What is this project about in one sentence?" -t 120
    ```
    Expected: Direct response describing the project.
 
 2. **Peer-to-peer proxy** (peer-a1 → peer-a2 via MCP ask_peer)
    ```bash
-   repowire peer ask $PEER_A1 \
+   "$REPOWIRE_BIN" peer ask $PEER_A1 \
      "Use the ask_peer tool to ask $PEER_A2: What is this project about in one sentence? Return their exact response." \
      -t 180
    ```
@@ -179,7 +199,7 @@ If a peer doesn't register, check `.claude/settings.local.json` for `disableAllH
 ```bash
 tmux kill-session -t circle-a 2>/dev/null || true
 tmux kill-session -t circle-b 2>/dev/null || true
-repowire peer prune --force 2>/dev/null || true
+"$REPOWIRE_BIN" peer prune --force 2>/dev/null || true
 ```
 
 ### Success Criteria
@@ -243,20 +263,20 @@ curl -s http://127.0.0.1:8377/peers | jq '
 
 2. **Direct query to peer-1**
    ```bash
-   repowire peer ask $PEER_1 "What is this project about in one sentence?" -t 120
+   "$REPOWIRE_BIN" peer ask $PEER_1 "What is this project about in one sentence?" -t 120
    ```
    Expected: Response from the model (not "empty response" or "Not Found").
 
 3. **Peer-to-peer proxy** (peer-1 → peer-2)
    ```bash
-   repowire peer ask $PEER_1 \
+   "$REPOWIRE_BIN" peer ask $PEER_1 \
      "Use the ask_peer tool to ask $PEER_2: What is this project about in one sentence? Return their exact response." \
      -t 180
    ```
 
 4. **Reverse proxy** (peer-2 → peer-1)
    ```bash
-   repowire peer ask $PEER_2 \
+   "$REPOWIRE_BIN" peer ask $PEER_2 \
      "Use the ask_peer tool to ask $PEER_1: What is this project about in one sentence? Return their exact response." \
      -t 180
    ```
@@ -268,13 +288,13 @@ curl -s http://127.0.0.1:8377/peers | jq '
 | "No active session" | Warmup prompt didn't create session | Press Enter manually in opencode pane, or wait longer |
 | "(empty response)" | Model returned 0 parts | Check model config — switch to `anthropic/claude-sonnet-4-5-20250929` |
 | "Not Found" in TUI | LiteLLM model ID not recognized | Use `--model anthropic/<model-id>` directly |
-| Plugin not connecting | Wrong WS URL or old plugin | Reinstall with `repowire setup --no-service` |
+| Plugin not connecting | Wrong WS URL or old plugin | Reinstall with `"$REPOWIRE_BIN" setup --no-service` |
 
 ### Cleanup
 
 ```bash
 tmux kill-session -t opencode-test 2>/dev/null || true
-repowire peer prune --force 2>/dev/null || true
+"$REPOWIRE_BIN" peer prune --force 2>/dev/null || true
 ```
 
 ### Success Criteria
@@ -318,14 +338,14 @@ sleep 30
 
 2. **Claude → OpenCode proxy**
    ```bash
-   repowire peer ask $CLAUDE_PEER \
+   "$REPOWIRE_BIN" peer ask $CLAUDE_PEER \
      "Use ask_peer to ask $OPENCODE_PEER: What is this project about in one sentence? Return their response." \
      -t 180
    ```
 
 3. **OpenCode → Claude proxy**
    ```bash
-   repowire peer ask $OPENCODE_PEER \
+   "$REPOWIRE_BIN" peer ask $OPENCODE_PEER \
      "Use ask_peer to ask $CLAUDE_PEER: What is this project about in one sentence? Return their response." \
      -t 180
    ```
@@ -339,7 +359,7 @@ sleep 30
 
 ```bash
 tmux kill-session -t mixed-test 2>/dev/null || true
-repowire peer prune --force 2>/dev/null || true
+"$REPOWIRE_BIN" peer prune --force 2>/dev/null || true
 ```
 
 ### Success Criteria
@@ -388,16 +408,15 @@ tmux kill-session -t circle-a 2>/dev/null || true
 tmux kill-session -t circle-b 2>/dev/null || true
 tmux kill-session -t opencode-test 2>/dev/null || true
 tmux kill-session -t mixed-test 2>/dev/null || true
-pkill -f websocket_hook 2>/dev/null || true
-repowire peer prune --force 2>/dev/null || true
+"$REPOWIRE_BIN" peer prune --force 2>/dev/null || true
 ```
 
 ## Quick Reference
 
 ```bash
-repowire serve                    # Start daemon
-repowire peer ask NAME "q" -t 120 # Query a peer
+"$REPOWIRE_BIN" serve                    # Start daemon
+"$REPOWIRE_BIN" peer ask NAME "q" -t 120 # Query a peer
 curl -s localhost:8377/peers | jq  # List peers
 curl -s localhost:8377/events | jq '.[-5:]'  # Recent events
-repowire peer prune --force       # Remove offline peers
+"$REPOWIRE_BIN" peer prune --force       # Remove offline peers
 ```

--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -55,8 +55,8 @@ curl -s http://127.0.0.1:8377/health 2>/dev/null | jq . || echo "Daemon not runn
 curl -s http://127.0.0.1:8377/peers 2>/dev/null | jq '.peers[] | {name, status, circle}' || echo "No peers"
 
 # Installation status
-uv tool list 2>/dev/null | grep repowire || echo "No uv tool installation"
-python3 -c "import json; d=json.load(open('$HOME/.claude/settings.json')); print('Hooks:', list(d.get('hooks',{}).keys()))" 2>/dev/null || echo "No Claude hooks"
+command -v repowire >/dev/null && repowire --version || echo "Repowire not installed"
+jq -r '"Hooks: " + ((.hooks // {}) | keys | join(", "))' "$HOME/.claude/settings.json" 2>/dev/null || echo "No Claude hooks"
 ls ~/.opencode/plugin/repowire.ts 2>/dev/null && echo "OpenCode plugin installed" || echo "No OpenCode plugin"
 ```
 
@@ -74,8 +74,6 @@ tmux kill-session -t circle-a 2>/dev/null || true
 tmux kill-session -t circle-b 2>/dev/null || true
 tmux kill-session -t opencode-test 2>/dev/null || true
 tmux kill-session -t mixed-test 2>/dev/null || true
-pkill -f websocket_hook 2>/dev/null || true
-
 curl -s http://127.0.0.1:8377/health >/dev/null 2>&1 && {
   repowire peer prune --force 2>/dev/null || true
 }
@@ -91,19 +89,17 @@ rm -f ~/.repowire/sessions.json 2>/dev/null || true
 ```bash
 # Run in a tmux pane (e.g. tmux send-keys to a spare window):
 
-# Uninstall
-repowire uninstall 2>/dev/null || true
-uv tool uninstall repowire 2>/dev/null || true
-
-# Install as tool from local source
-uv tool install --force /path/to/repowire
+# Build from local source
+cd /path/to/repowire
+mkdir -p bin
+(cd daemon-go && go build -o ../bin/repowire .)
 
 # Setup hooks and MCP server
-repowire setup --no-service
+./bin/repowire setup --no-service
 
 # Verify
-repowire --version
-python3 -c "import json; d=json.load(open('$HOME/.claude/settings.json')); print('Hooks:', list(d.get('hooks',{}).keys()))"
+./bin/repowire --version
+jq -r '"Hooks: " + ((.hooks // {}) | keys | join(", "))' "$HOME/.claude/settings.json"
 ls ~/.opencode/plugin/repowire.ts 2>/dev/null && echo "OpenCode plugin: OK"
 ```
 
@@ -144,15 +140,10 @@ sleep 30  # Wait for sessions to initialize and hooks to register
 
 ```bash
 # All 3 peers should be online with correct circles and peer_id format
-curl -s http://127.0.0.1:8377/peers | python3 -c "
-import sys, json, re
-peers = json.load(sys.stdin)['peers']
-expected = {'$PEER_A1': 'circle-a', '$PEER_A2': 'circle-a', '$PEER_B1': 'circle-b'}
-for name, circle in expected.items():
-    match = [p for p in peers if p['name'] == name and p['status'] == 'online']
-    ok = match and match[0].get('circle') == circle and re.match(r'^repow-[\w-]+-[a-f0-9]{8}$', match[0].get('peer_id',''))
-    print(f'  {name}: {\"PASS\" if ok else \"FAIL\"} ({match[0] if match else \"not found\"})')
-"
+curl -s http://127.0.0.1:8377/peers | jq --arg a1 "$PEER_A1" --arg a2 "$PEER_A2" --arg b1 "$PEER_B1" '
+  [.peers[] | select(.name == $a1 or .name == $a2 or .name == $b1) |
+   {name, status, circle, peer_id}]
+'
 ```
 
 If a peer doesn't register, check `.claude/settings.local.json` for `disableAllHooks: true`.
@@ -188,7 +179,6 @@ If a peer doesn't register, check `.claude/settings.local.json` for `disableAllH
 ```bash
 tmux kill-session -t circle-a 2>/dev/null || true
 tmux kill-session -t circle-b 2>/dev/null || true
-pkill -f websocket_hook 2>/dev/null || true
 repowire peer prune --force 2>/dev/null || true
 ```
 
@@ -237,14 +227,10 @@ sleep 30  # Wait for warmup to complete
 ### Verify Registration
 
 ```bash
-curl -s http://127.0.0.1:8377/peers | python3 -c "
-import sys, json
-peers = json.load(sys.stdin)['peers']
-oc = [p for p in peers if p.get('backend') == 'opencode' and p['status'] == 'online']
-for p in oc:
-    print(f'  {p[\"name\"]}: peer_id={p.get(\"peer_id\")}, backend={p.get(\"backend\")}')
-print(f'  opencode peers: {len(oc)}')
-"
+curl -s http://127.0.0.1:8377/peers | jq '
+  [.peers[] | select(.backend == "opencode" and .status == "online") |
+   {name, peer_id, backend}]
+'
 ```
 
 ### Tests
@@ -282,7 +268,7 @@ print(f'  opencode peers: {len(oc)}')
 | "No active session" | Warmup prompt didn't create session | Press Enter manually in opencode pane, or wait longer |
 | "(empty response)" | Model returned 0 parts | Check model config — switch to `anthropic/claude-sonnet-4-5-20250929` |
 | "Not Found" in TUI | LiteLLM model ID not recognized | Use `--model anthropic/<model-id>` directly |
-| Plugin not connecting | Wrong WS URL or old plugin | Reinstall: `uv run python3 -c "from repowire.installers.opencode import install_plugin; install_plugin()"` |
+| Plugin not connecting | Wrong WS URL or old plugin | Reinstall with `repowire setup --no-service` |
 
 ### Cleanup
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,7 @@
-__pycache__/
 .DS_Store
-*.pyc
-*.pyo
-.venv/
 .env
-*.egg-info/
 dist/
 build/
-.ruff_cache/
-.mypy_cache/
-.pytest_cache/
 .repowire/
 ui/
 repowire-design-system/
@@ -25,7 +17,6 @@ session-logs.md
 # Dashboard and local native build output
 web/out/
 bin/
-.coverage
 
 # docs build output
 site/

--- a/daemon-go/README.md
+++ b/daemon-go/README.md
@@ -49,6 +49,5 @@ use `repowire setup`, which configures the local HTTP MCP endpoint, installs the
 identity shim and hooks/plugins for detected runtimes, and installs the user
 service.
 
-The wheel entry point is a small compatibility launcher for the bundled native
-binary. OpenCode, pi, and channel TypeScript assets are embedded into the binary
-so their installers also work from a standalone build.
+OpenCode, Pi, and channel TypeScript assets are embedded into the binary so
+their installers work from a standalone build.

--- a/daemon-go/main.go
+++ b/daemon-go/main.go
@@ -601,11 +601,6 @@ func findWebOutputDir() string {
 			filepath.Join(dir, "..", "..", "web", "out"),
 		)
 	}
-	for _, path := range filepath.SplitList(os.Getenv("PYTHONPATH")) {
-		if path != "" {
-			candidates = append(candidates, filepath.Join(path, "web", "out"))
-		}
-	}
 	for _, dir := range candidates {
 		if stat, err := os.Stat(filepath.Join(dir, "dashboard.html")); err == nil && !stat.IsDir() {
 			return filepath.Clean(dir)

--- a/daemon-go/service/acp_test.go
+++ b/daemon-go/service/acp_test.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"bufio"
+	"encoding/json"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,33 +11,12 @@ import (
 )
 
 func TestACPManagerPromptRoundTripAndSessionReuse(t *testing.T) {
-	python, err := exec.LookPath("python3")
-	if err != nil {
-		t.Skip("python3 unavailable")
-	}
-	script := filepath.Join(t.TempDir(), "echo_acp.py")
-	source := `import json, sys
-session = "echo-session"
-for line in sys.stdin:
-    msg = json.loads(line)
-    method = msg.get("method")
-    if method == "initialize": result = {"protocolVersion": 1, "agentCapabilities": {}}
-    elif method == "session/new": result = {"sessionId": session}
-    elif method == "session/prompt":
-        text = msg["params"]["prompt"][0]["text"]
-        print(json.dumps({"jsonrpc":"2.0","method":"session/update","params":{"sessionId":session,"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"[echo] "+text}}}}), flush=True)
-        result = {"stopReason":"end_turn"}
-    elif method == "session/close": result = {}
-    elif method == "session/cancel": continue
-    else: result = {}
-    print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":result}), flush=True)
-`
-	if err := os.WriteFile(script, []byte(source), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	manager := NewACPManager()
 	defer manager.Close()
-	spec := ACPPeerSpec{PeerID: "repow-test-acp", Command: python, Args: []string{script}, CWD: t.TempDir()}
+	spec := ACPPeerSpec{
+		PeerID: "repow-test-acp", Command: os.Args[0], Args: []string{"-test.run=^TestACPHelperProcess$"},
+		CWD: t.TempDir(), Env: map[string]string{"REPOWIRE_ACP_TEST_HELPER": "1"},
+	}
 	for _, prompt := range []string{"one", "two"} {
 		done := make(chan struct {
 			result ACPPromptResult
@@ -62,6 +41,50 @@ for line in sys.stdin:
 		case <-time.After(5 * time.Second):
 			t.Fatal("ACP prompt timed out")
 		}
+	}
+}
+
+func TestACPHelperProcess(t *testing.T) {
+	if os.Getenv("REPOWIRE_ACP_TEST_HELPER") != "1" {
+		return
+	}
+	type request struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params struct {
+			Prompt []struct {
+				Text string `json:"text"`
+			} `json:"prompt"`
+		} `json:"params"`
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var message request
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			t.Fatal(err)
+		}
+		var result any = map[string]any{}
+		switch message.Method {
+		case "initialize":
+			result = map[string]any{"protocolVersion": 1, "agentCapabilities": map[string]any{}}
+		case "session/new":
+			result = map[string]any{"sessionId": "echo-session"}
+		case "session/prompt":
+			text := message.Params.Prompt[0].Text
+			if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "method": "session/update", "params": map[string]any{"sessionId": "echo-session", "update": map[string]any{"sessionUpdate": "agent_message_chunk", "content": map[string]any{"type": "text", "text": "[echo] " + text}}}}); err != nil {
+				t.Fatal(err)
+			}
+			result = map[string]any{"stopReason": "end_turn"}
+		case "session/cancel":
+			continue
+		}
+		if err := encoder.Encode(map[string]any{"jsonrpc": "2.0", "id": message.ID, "result": result}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/docs/contributing/design-notes/session-binding-contract.md
+++ b/docs/contributing/design-notes/session-binding-contract.md
@@ -129,42 +129,41 @@ Rules:
 
 ## Existing touchpoints
 
-- `repowire/protocol/peers.py` defines live peer identity, backend, path,
+- `daemon-go/proto/proto.go` defines live peer identity, backend, path,
   machine, metadata, status, and turn state.
-- `repowire/daemon/peer_registry.py` persists `SessionMapping` in
-  `StateDatabase` and imports legacy `sessions.json` once. It owns peer ID reuse, display-name
+- `daemon-go/peer/` persists `SessionMapping` through `daemon-go/state/` and
+  imports legacy `sessions.json` once. It owns peer ID reuse, display-name
   collision handling, role claims, descriptions, pane hijack evidence, and
   ghost eviction.
-- `daemon-go/hooks/session.go` registers peers on `SessionStart` with
+- `daemon-go/hooks/handlers.go` registers peers on `SessionStart` with
   backend, path, pane, role, turn state, agent PID, and metadata such as
   `hook_session_id`.
-- `daemon-go/hooks/stop.go` posts chat turns with runtime `session_id`,
+- `daemon-go/hooks/handlers.go` posts chat turns with runtime `session_id`,
   turn IDs, pane IDs, and transcript-derived tool summaries.
-- `repowire/session/history.py` discovers and replays backend-owned history for
+- `daemon-go/hub/routes_history.go` discovers and replays backend-owned history for
   Claude Code and Codex by project path and runtime metadata.
-- `repowire/daemon/routes/peers.py` exposes `/peers/{name}/timeline` and
+- `daemon-go/hub/routes_history.go` exposes `/peers/{name}/timeline` and
   `/peers/{name}/transcript`, resolving through an unambiguous session binding
   when available and otherwise preserving peer/path/backend compatibility plus
   optional runtime `session_id` filtering.
-- `repowire/daemon/routes/messages.py` ingests live `chat_turn` and
+- `daemon-go/hub/routes_events.go` ingests live `chat_turn` and
   `chat_turn_delta` events using runtime `session_id` and `turn_id` for
   dashboard reconciliation.
-- `repowire/daemon/ask_tracker.py` keeps open asks and pending replies
+- `daemon-go/service/ask_tracker.go` keeps open asks and pending replies
   in-memory, with peer IDs as routing endpoints and strict identity snapshots
   for ACP reply rebind.
-- `repowire/daemon/peer_delivery.py` coordinates ask/notify delivery and
+- `daemon-go/service/delivery.go` coordinates ask/notify delivery and
   already exposes explicit delivered/queued outcomes for some paths.
-- `repowire/daemon/state/database.py` is the experimental daemon SQLite wrapper
-  currently used by schedules and session bindings. The existing
+- `daemon-go/state/` owns SQLite persistence for schedules and session bindings. The existing
   `rfcs/sqlite-state-expansion-plan.md` recommends expanding SQLite
   carefully and keeping raw transcripts outside SQLite.
-- `repowire/daemon/state/session_bindings.py` persists binding metadata,
+- `daemon-go/state/session_bindings.go` persists binding metadata,
   source locators, cursors, provenance, resume capability, and lifecycle
   status without storing raw runtime transcript bodies.
-- `repowire/daemon/session_control.py` is the first session-acquisition service
+- `daemon-go/service/session_control.go` is the first session-acquisition service
   used by durable jobs. It records a `session.acquire_executor` operation,
   then resolves a live peer, backend-native resume, or fresh spawn.
-- `repowire/daemon/state/operations.py` stores internal operation lifecycle
+- `daemon-go/state/operations.go` stores internal operation lifecycle
   records for acquisition attempts, strategies, results, and structured
   failures. Operations are audit/control records; they do not replace peer,
   session, or job identity.

--- a/rfcs/go-surface-and-http-mcp.md
+++ b/rfcs/go-surface-and-http-mcp.md
@@ -1,6 +1,6 @@
 # Go the full surface + HTTP MCP
 
-Status: implemented on `feat/daemon-go` (2026-07-10). Tracked in
+Status: implemented on `main` (2026-08-10). Tracked in
 repowire-53c (daemon), repowire-76o (hooks), repowire-sfh (HTTP MCP), and
 repowire-jx8 (CLI/distribution).
 
@@ -15,11 +15,9 @@ push the rest of the surface the same way:
   Stop / UserPromptSubmit). Each invocation pays the Python interpreter +
   import tax (~100–300 ms) versus ~5 ms for a static Go binary. This is the
   one place users feel the runtime on every single turn.
-- **Distribution.** A single static binary removes uv/venv variance and the
-  "hooks run from the installed package" reinstall foot-gun. During the
-  transition, wheels keep wrapping the binary so `uv tool install repowire`
-  continues to work (platform wheels already ship the Go hub via the hatch
-  hook).
+- **Distribution.** A single static binary removes package-manager and virtual
+  environment variance and the "hooks run from the installed package" reinstall
+  foot-gun.
 
 What stays as-is: the channel server and web dashboard are TypeScript and
 remain so (transports are client-side; the daemon philosophy is unchanged).
@@ -29,19 +27,17 @@ remain so (transports are client-side; the daemon philosophy is unchanged).
 The native binary now owns config loading, SQLite bootstrap/migrations, resume
 safety, the full daemon route surface, ACP subprocess routing and permission
 relay, hooks/ws-hook/chat streaming, runtime installers, service management,
-and the CLI. The wheel entry point execs the binary; it no longer selects a
-Python daemon fallback.
+and the CLI.
 
 The dashboard and channel server remain TypeScript. The hosted relay server and
-Telegram/Slack peers remain separate Python deployments/clients; they are not
-part of the local substrate and connect to the Go daemon unchanged.
+Telegram/Slack peers are native Go surfaces.
 
 ## Completed phases
 
 1. **Daemon independence:** Go loads config and owns state migrations/resume safety.
 2. **Hooks:** session/stop/prompt/notification/pre-tool hooks, ws-hook, chat streaming, and lifecycle hooks run in Go.
 3. **HTTP MCP:** all 31 tools live daemon-side at `/mcp`.
-4. **CLI/distribution:** the Go CLI and embedded runtime assets ship in platform wheels; the Python entry point is only a native-binary launcher.
+4. **CLI/distribution:** the Go CLI and embedded runtime assets ship in native release archives.
 
 ## HTTP MCP: /mcp on the daemon + stdio identity shim
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -15,7 +15,7 @@
 
 # next.js
 /.next/
-# /out/ - included in PyPI package for dashboard
+# /out/ - bundled into native releases
 
 # production
 /build


### PR DESCRIPTION
Removes the remaining active Python dependencies after the native Go cutover:

- replace the ACP test subprocess with a Go test helper
- remove the PYTHONPATH dashboard compatibility path
- update stale installer/integration docs and native distribution notes
- drop obsolete Python ignore entries

Historical migration references and the build-only Zensical docs image remain intentionally.

Verified with full Go vet/race/build, 119 web tests, and the production web build.