### PR TITLE
fix: reconnect services after unregister

### DIFF
--- a/daemon-go/hub/routes_peer_lifecycle_test.go
+++ b/daemon-go/hub/routes_peer_lifecycle_test.go
@@ -8,7 +8,10 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 	"github.com/repowire/repowire/daemon-go/proto"
 	"github.com/repowire/repowire/daemon-go/service"
 	"github.com/repowire/repowire/daemon-go/state"
@@ -103,6 +106,74 @@ func TestRegisterPeerEndpoint(t *testing.T) {
 	gone := postLifecycleJSON(t, mux, "/peer/unregister", UnregisterPeerRequest{Name: resp.DisplayName})
 	if gone.Code != http.StatusNotFound {
 		t.Fatalf("unregister of an unknown peer: want 404, got %d (%s)", gone.Code, gone.Body.String())
+	}
+}
+
+// TestUnregisterPeerClosesLiveSocket proves the self-healing contract for
+// long-lived service clients: removing their registry identity must close the
+// underlying socket so their read loop exits and reconnect backoff can run.
+func TestUnregisterPeerClosesLiveSocket(t *testing.T) {
+	h := newTestHub(t)
+	mux := http.NewServeMux()
+	h.Routes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):] + "/ws"
+	connectService := func(claimed *proto.PeerID) (*websocket.Conn, proto.PeerID) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial service: %v", err)
+		}
+		path := "/telegram"
+		if err := wsjson.Write(ctx, conn, proto.ConnectFrame{
+			Type: proto.FrameConnect, DisplayName: "telegram", Circle: "default",
+			Backend: proto.AgentClaudeCode, Role: proto.RoleService, Path: &path, PeerID: claimed,
+		}); err != nil {
+			conn.CloseNow()
+			t.Fatalf("connect service: %v", err)
+		}
+		var connected proto.ConnectedFrame
+		if err := wsjson.Read(ctx, conn, &connected); err != nil {
+			conn.CloseNow()
+			t.Fatalf("read service identity: %v", err)
+		}
+		return conn, connected.SessionID
+	}
+
+	conn, peerID := connectService(nil)
+	defer conn.CloseNow()
+	waitConnected(t, h, peerID)
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := conn.Read(readCtx)
+		readErr <- err
+	}()
+
+	rec := postLifecycleJSON(t, mux, "/peer/unregister", UnregisterPeerRequest{Name: string(peerID)})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unregister: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case err := <-readErr:
+		if status := websocket.CloseStatus(err); status != websocket.StatusGoingAway {
+			t.Fatalf("client read close status = %d (%v), want %d", status, err, websocket.StatusGoingAway)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("unregister left the service socket open; client cannot reconnect")
+	}
+
+	reconnected, newPeerID := connectService(&peerID)
+	defer reconnected.CloseNow()
+	waitConnected(t, h, newPeerID)
+	if newPeerID == "" {
+		t.Fatal("service reconnect did not receive a new mesh identity")
 	}
 }
 

--- a/daemon-go/peer/registry_lifecycle_byname.go
+++ b/daemon-go/peer/registry_lifecycle_byname.go
@@ -31,6 +31,9 @@ func (r *Registry) UnregisterPeer(ctx context.Context, identifier string, circle
 		delete(r.mappings, ps.peer.PeerID)
 		id := ps.peer.PeerID
 		r.mu.Unlock()
+		if r.transport != nil {
+			_ = r.transport.Close(id)
+		}
 		_ = r.store.DeleteMapping(ctx, id)
 		return true, nil
 	}
@@ -47,6 +50,9 @@ func (r *Registry) UnregisterPeer(ctx context.Context, identifier string, circle
 	delete(r.peers, id)
 	delete(r.mappings, id)
 	r.mu.Unlock()
+	if r.transport != nil {
+		_ = r.transport.Close(id)
+	}
 	_ = r.store.DeleteMapping(ctx, id)
 	return true, nil
 }

--- a/daemon-go/service/transport.go
+++ b/daemon-go/service/transport.go
@@ -318,8 +318,9 @@ func (t *WebSocketTransport) GetAllSessions() []proto.PeerID {
 	return out
 }
 
-// Close severs a retired peer's socket (peer.Transport). It removes the record
-// under lock and closes the underlying connection. Idempotent.
+// Close severs a peer's socket (peer.Transport). It removes the record under
+// lock and closes the underlying connection. Idempotent. Registry removal and
+// terminal retirement both use this seam, so the close reason stays generic.
 func (t *WebSocketTransport) Close(id proto.PeerID) error {
 	t.mu.Lock()
 	info, ok := t.conns[id]
@@ -329,7 +330,7 @@ func (t *WebSocketTransport) Close(id proto.PeerID) error {
 	}
 	t.mu.Unlock()
 	if ok && info.WS != nil {
-		err := info.WS.Close(websocket.StatusGoingAway, "peer retired")
+		err := info.WS.Close(websocket.StatusGoingAway, "peer removed by daemon")
 		if manager != nil {
 			manager.Drop(id)
 		}

--- a/docs/concepts/control-surfaces.md
+++ b/docs/concepts/control-surfaces.md
@@ -12,6 +12,11 @@ Human surfaces have the `human` role. That role bypasses circle filtering so the
 
 Control surfaces are clients of the routing API, not sources of truth. The daemon owns peer state, message routing, ask lifecycle, session bindings, and durable state. If a surface crashes or reconnects, it recovers by reading daemon state rather than reconstructing the mesh itself.
 
+When the daemon unregisters a connected control-surface peer, it also closes
+that peer's WebSocket. Long-lived service clients treat the close as a
+reconnect signal, so registry removal cannot leave them blocked forever on a
+socket the daemon no longer routes.
+
 ## Session-targeted controls
 
 Peer-targeted routes address live peer identity. Session-targeted controls address durable `repowire_session_id` bindings. That distinction matters because display names and runtime session ids are not stable routing identities.


### PR DESCRIPTION
## What changed

- close a peer's live transport whenever the registry unregisters it
- use a truthful generic close reason for both unregister and terminal retirement
- add a real HTTP/WebSocket regression test that unregisters a Telegram-shaped service peer, observes the socket close, and reconnects
- document the control-surface reconnection contract

## Why

The Go registry removed peer state without severing the corresponding WebSocket. Long-lived service peers could remain blocked on a socket the daemon no longer routed, so their reconnect loop never ran.

## Validation

- `gofmt` clean
- `go vet ./...`
- `go test -race ./...`
- native Go build
- 119 web tests
- production web build
- pre-PR hygiene