### PR TITLE
feat: publish releases through Homebrew tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
             echo "ok $target"
           done
 
+      - name: Test Homebrew formula renderer
+        run: scripts/test-render-homebrew-formula.sh
+
   web:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,27 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes \
             || gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v5
+        with:
+          repository: prassanna-ravishankar/homebrew-repowire
+          path: homebrew-tap
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+
+      - name: Update Homebrew formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/render-homebrew-formula.sh "$GITHUB_REF_NAME" dist/checksums.txt \
+            > homebrew-tap/Formula/repowire.rb
+          cd homebrew-tap
+          if [ -z "$(git status --porcelain -- Formula/repowire.rb)" ]; then
+            echo "Homebrew formula is already current."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/repowire.rb
+          git commit -m "repowire ${GITHUB_REF_NAME}"
+          git push

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Repowire runs locally by default through a daemon on your machine. The hosted re
 **1. Install Repowire and wire your agents.**
 
 ```bash
-curl -fsSL https://github.com/prassanna-ravishankar/repowire/releases/latest/download/install.sh | sh
+brew install prassanna-ravishankar/repowire/repowire
+repowire setup
 ```
 
-The installer downloads a checksum-verified native binary from GitHub Releases.
+Homebrew downloads a checksum-pinned native release. Alternatively, use the
+[native installer](https://docs.repowire.io/start/install/).
 
 **2. Open your normal agent CLIs.**
 

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -7,14 +7,25 @@ required.
 ## Recommended
 
 ```bash
+brew install prassanna-ravishankar/repowire/repowire
+repowire setup
+```
+
+The formula downloads the checksum-pinned native release for your OS and
+architecture. `repowire setup` wires the installed agent runtimes and starts the
+local services.
+
+Without Homebrew, use the native installer:
+
+```bash
 curl -fsSL https://github.com/prassanna-ravishankar/repowire/releases/latest/download/install.sh | sh
 ```
 
-The installer detects the current OS and architecture, downloads the matching
-GitHub Release archive, verifies its SHA-256 checksum, and then runs [setup](setup.md).
+The installer detects the current OS and architecture, verifies the release
+checksum, installs the archive, and runs [setup](setup.md).
 
 Set `REPOWIRE_VERSION=v0.X.Y`, `REPOWIRE_INSTALL_DIR`, or `REPOWIRE_BIN_DIR`
-before running the installer to pin a version or choose alternate locations.
+before running the native installer to pin a version or choose alternate locations.
 
 ## What gets installed
 

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Render Formula/repowire.rb from checksums produced by publish.yml.
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 VERSION CHECKSUMS_FILE" >&2
+  exit 2
+fi
+
+version=${1#v}
+checksums=$2
+
+checksum() {
+  asset=$1
+  value=$(awk -v asset="$asset" '$2 == asset { print $1; exit }' "$checksums")
+  if [ -z "$value" ]; then
+    echo "missing checksum for $asset" >&2
+    exit 1
+  fi
+  printf '%s' "$value"
+}
+
+darwin_arm64="repowire_${version}_darwin_arm64.tar.gz"
+darwin_amd64="repowire_${version}_darwin_amd64.tar.gz"
+linux_arm64="repowire_${version}_linux_arm64.tar.gz"
+linux_amd64="repowire_${version}_linux_amd64.tar.gz"
+base="https://github.com/prassanna-ravishankar/repowire/releases/download/v${version}"
+darwin_arm64_sha=$(checksum "$darwin_arm64")
+darwin_amd64_sha=$(checksum "$darwin_amd64")
+linux_arm64_sha=$(checksum "$linux_arm64")
+linux_amd64_sha=$(checksum "$linux_amd64")
+
+cat <<EOF
+class Repowire < Formula
+  desc "Mesh network for AI coding agents"
+  homepage "https://repowire.io"
+  version "${version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${base}/${darwin_arm64}"
+      sha256 "${darwin_arm64_sha}"
+    else
+      url "${base}/${darwin_amd64}"
+      sha256 "${darwin_amd64_sha}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${base}/${linux_arm64}"
+      sha256 "${linux_arm64_sha}"
+    else
+      url "${base}/${linux_amd64}"
+      sha256 "${linux_amd64_sha}"
+    end
+  end
+
+  def install
+    prefix.install "repowire", "web"
+    bin.install_symlink prefix/"repowire"
+  end
+
+  def caveats
+    <<~EOS
+      Finish installation and start the local service with:
+        repowire setup
+
+      Before removing the formula, detach hooks and stop services with:
+        repowire uninstall
+    EOS
+  end
+
+  test do
+    assert_equal version.to_s, shell_output("#{bin}/repowire version").strip
+    assert_path_exists prefix/"web/out/dashboard.html"
+  end
+end
+EOF

--- a/scripts/test-render-homebrew-formula.sh
+++ b/scripts/test-render-homebrew-formula.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/repowire-homebrew-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+cat >"$tmp/checksums.txt" <<'EOF'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  repowire_0.18.0_darwin_arm64.tar.gz
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  repowire_0.18.0_darwin_amd64.tar.gz
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  repowire_0.18.0_linux_arm64.tar.gz
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  repowire_0.18.0_linux_amd64.tar.gz
+EOF
+
+"$root/scripts/render-homebrew-formula.sh" v0.18.0 "$tmp/checksums.txt" >"$tmp/repowire.rb"
+
+grep -Fq 'version "0.18.0"' "$tmp/repowire.rb"
+grep -Fq 'releases/download/v0.18.0/repowire_0.18.0_darwin_arm64.tar.gz' "$tmp/repowire.rb"
+grep -Fq 'sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' "$tmp/repowire.rb"
+grep -Fq 'prefix.install "repowire", "web"' "$tmp/repowire.rb"
+grep -Fq 'assert_path_exists prefix/"web/out/dashboard.html"' "$tmp/repowire.rb"
+
+if "$root/scripts/render-homebrew-formula.sh" v0.18.0 /dev/null >/dev/null 2>&1; then
+  echo "renderer accepted incomplete checksums" >&2
+  exit 1
+fi
+
+echo "Homebrew formula renderer: ok"


### PR DESCRIPTION
## What changed

- add a deterministic Homebrew formula renderer for the four native release archives
- update the public `homebrew-repowire` tap from the tagged-release workflow using a tap-scoped deploy key
- test the renderer in CI and document Homebrew as the recommended installation path

## Why

Repowire now ships self-contained native archives, but installation still requires a curl installer. A maintained tap gives macOS and Linuxbrew users checksum-pinned installs and normal `brew upgrade` behavior without duplicating the release build.

The formula keeps `repowire` and `web/out` as siblings under the Cellar prefix so the daemon's executable-relative dashboard discovery continues to work. It deliberately does not run `repowire setup` during package installation because setup mutates user runtime configuration and services.

## Validation

- `scripts/test-render-homebrew-formula.sh`
- `brew audit --strict --formula prassanna-ravishankar/repowire/repowire`
- live local Cellar install from a release-shaped archive: `repowire version` returned `0.18.0`; `web/out/dashboard.html` was present
- `cd daemon-go && gofmt -w . && go vet ./... && go test -race ./...`
- `cd web && npm ci && npm test -- --run && npm run build` (121 tests)
- `scripts/pre-pr-hygiene.sh`

## Release note

The tap repository exists and its workflow is green, but the formula intentionally remains unpublished until `v0.18.0` creates the first native release assets. Beads follow-up `repowire-rkb` tracks that activation.
