### PR TITLE
fix(dashboard): guard native backend switching

### DIFF
--- a/daemon-go/hub/routes_peer_read.go
+++ b/daemon-go/hub/routes_peer_read.go
@@ -53,6 +53,7 @@ type PeerInfo struct {
 	Path        *string           `json:"path"`
 	Machine     *string           `json:"machine"`
 	TmuxSession *string           `json:"tmux_session"`
+	PaneID      *string           `json:"pane_id"`
 	Backend     proto.AgentType   `json:"backend"`
 	Model       *string           `json:"model"`
 	Circle      string            `json:"circle"`
@@ -386,6 +387,7 @@ func peerToInfo(p *proto.Peer) PeerInfo {
 		Path:          path,
 		Machine:       machine,
 		TmuxSession:   p.TmuxSession,
+		PaneID:        p.PaneID,
 		Backend:       p.Backend,
 		Model:         p.Model,
 		Circle:        p.Circle,

--- a/daemon-go/hub/routes_peer_read_test.go
+++ b/daemon-go/hub/routes_peer_read_test.go
@@ -39,6 +39,7 @@ func TestListPeersWireShape(t *testing.T) {
 	defer srv.Close()
 
 	path := "/work/alpha"
+	paneID := "%7"
 	// in_process metadata exempts the peer from lazy_repair's no-WS ghost demote,
 	// so it stays online without a live socket (mirrors @jobs service peers).
 	registerTestPeer(t, h, peer.AllocateParams{
@@ -46,6 +47,7 @@ func TestListPeersWireShape(t *testing.T) {
 		Backend:  proto.AgentClaudeCode,
 		Role:     proto.RoleAgent,
 		Path:     &path,
+		PaneID:   &paneID,
 		Machine:  "host-a",
 		Metadata: map[string]any{"in_process": true},
 	})
@@ -72,6 +74,9 @@ func TestListPeersWireShape(t *testing.T) {
 	}
 	if info.PeerID == "" {
 		t.Fatalf("peer_id empty")
+	}
+	if info.PaneID == nil || *info.PaneID != paneID {
+		t.Fatalf("pane_id = %v, want %q", info.PaneID, paneID)
 	}
 	if info.Status != string(proto.StatusOnline) {
 		t.Fatalf("status = %q, want online", info.Status)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -145,7 +145,7 @@ self-attestation.
 
 ## `daemon.spawn`
 
-Spawn is disabled until `allowed_paths` and at least one runtime command are configured. `commands` is keyed by backend (`claude-code`, `codex`, `opencode`, `pi`) and is the single launch profile used by MCP `spawn_peer`, dashboard spawn, backend switching, `repowire peer restart`, and `repowire orchestrator start`. Legacy Gemini or Antigravity keys are ignored.
+Spawn is disabled until `allowed_paths` and at least one runtime command are configured. `commands` is keyed by backend (`claude-code`, `codex`, `opencode`, `pi`) and is the single launch profile used by MCP `spawn_peer`, dashboard spawn, backend switching, `repowire peer restart`, and `repowire orchestrator start`. Backend switching is destructive and is offered only for Repowire-managed tmux peers whose pane ownership can be proven; native pane-less sessions remain attached to their runtime. Legacy Gemini or Antigravity keys are ignored.
 
 Backend commands are reloaded from config when a spawn request needs them, so
 `repowire setup` and manual command edits take effect without restarting the

--- a/docs/use/features/dashboard.md
+++ b/docs/use/features/dashboard.md
@@ -50,6 +50,8 @@ The dashboard uses daemon HTTP and SSE routes directly:
 
 Dashboard spawn and backend controls use the same allowed paths, backend commands, and profile configuration as CLI and MCP surfaces.
 
+Backend switching appears only for Repowire-managed tmux peers with a recorded pane id. Pane-less native sessions, including Codex App Server threads, show `native · no switch`: Repowire cannot prove and terminate their exact runtime process safely, so it does not offer a destructive control. A rejected switch on an eligible peer is shown inline in the peer header.
+
 ## Limits
 
 - The dashboard does not poll. It streams daemon events and receives chat turns from runtime hooks or plugin bridges.

--- a/web/app/dashboard/components/PeerView.test.tsx
+++ b/web/app/dashboard/components/PeerView.test.tsx
@@ -110,6 +110,66 @@ describe("PeerView lifecycle controls", () => {
   });
 });
 
+describe("PeerView backend switching", () => {
+  it("does not offer a destructive switch for a pane-less native peer", () => {
+    render(
+      <PeerView
+        peer={{ ...PEER, backend: "codex", pane_id: null }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("native · no switch")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Switch backend" })).not.toBeInTheDocument();
+  });
+
+  it("targets the immutable peer id and shows a rejected switch inline", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/spawn/config") {
+        return new Response(JSON.stringify({ commands: { codex: "codex", "claude-code": "claude" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url === "/peers/peer-1/switch-backend" && init?.method === "POST") {
+        return new Response(JSON.stringify({ detail: { hint: "Pane ownership changed; retry after rehooking." } }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("confirm", vi.fn(() => true));
+
+    render(
+      <PeerView
+        peer={{ ...PEER, backend: "codex", pane_id: "%7" }}
+        events={[]}
+        apiBase=""
+        onClose={() => {}}
+        onSent={() => {}}
+      />,
+    );
+
+    const select = await screen.findByRole("combobox", { name: "Switch backend" });
+    fireEvent.change(select, { target: { value: "claude-code" } });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Pane ownership changed; retry after rehooking.");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/peers/peer-1/switch-backend",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ new_backend: "claude-code" }),
+      }),
+    );
+  });
+});
+
 describe("PeerView session protection", () => {
   it("renders persisted transcript turns in the primary chat timeline", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/web/app/dashboard/components/PeerView.tsx
+++ b/web/app/dashboard/components/PeerView.tsx
@@ -2173,6 +2173,7 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!peer.pane_id) return;
     let cancelled = false;
     fetch(`${apiBase}/spawn/config`, { credentials: "include" })
       .then((r) => (r.ok ? r.json() : null))
@@ -2188,7 +2189,7 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
     return () => {
       cancelled = true;
     };
-  }, [apiBase]);
+  }, [apiBase, peer.pane_id]);
 
   // Map configured runtimes → unique backends, filter out current backend.
   const options = useMemo(() => {
@@ -2202,6 +2203,17 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
     }
     return out;
   }, [configuredBackends, peer.backend]);
+
+  if (!peer.pane_id) {
+    return (
+      <span
+        className="hidden h-8 items-center rounded border border-border px-2 font-mono text-[10px] uppercase tracking-[0.12em] text-outline sm:flex"
+        title="Backend switching requires a Repowire-managed tmux pane. Native sessions stay attached to their runtime."
+      >
+        native · no switch
+      </span>
+    );
+  }
 
   if (configuredBackends === null || options.length === 0) return null;
 
@@ -2218,7 +2230,7 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
     setBusy(true);
     try {
       const r = await fetch(
-        `${apiBase}/peers/${encodeURIComponent(peer.name)}/switch-backend`,
+        `${apiBase}/peers/${encodeURIComponent(peer.peer_id)}/switch-backend`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -2244,7 +2256,7 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
   }
 
   return (
-    <div className="hidden items-center gap-1.5 sm:flex" title={error || undefined}>
+    <div className="hidden max-w-[220px] flex-col items-end gap-1 sm:flex">
       <select
         aria-label="Switch backend"
         disabled={busy}
@@ -2265,6 +2277,11 @@ function SwitchBackendControl({ peer, apiBase }: { peer: Peer; apiBase: string }
           </option>
         ))}
       </select>
+      {error ? (
+        <span role="alert" className="font-mono text-[10px] leading-tight text-error">
+          {error}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/web/app/dashboard/types.ts
+++ b/web/app/dashboard/types.ts
@@ -7,6 +7,7 @@ export interface Peer {
   machine: string;
   path: string;
   tmux_session?: string;
+  pane_id?: string | null;
   backend?: string;
   model?: string | null;
   circle: string;


### PR DESCRIPTION
## Summary
- expose pane IDs in the authenticated peer roster so dashboard controls can reflect real pane ownership
- disable backend switching for pane-less native sessions and show switch failures inline
- address switch requests by immutable peer ID and document the tmux-only safety boundary

## Verification
- go vet ./...
- go test -race ./...
- npm test -- --run (127 tests)
- npm run lint
- npm run build
- live dashboard verification: native Codex shows no-switch state; tmux orchestrator retains switch control
- local daemon-only restart preserved Codex bridge PID 21840 and Telegram PID 68729