### PR TITLE
Detach Codex App Server from Repowire bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ repowire setup --update-checks         # let status/doctor report available upda
 repowire update                        # explicit package upgrade + hook reinstall + daemon restart
 repowire status                        # show installed components and daemon status
 repowire doctor                        # run diagnostics
-repowire service restart               # restart daemon; preserve live Codex bridge
-repowire service restart bridge        # explicitly restart bridge (interrupts Codex sessions)
+repowire service restart               # restart daemon; preserve Codex sessions
+repowire service restart bridge        # macOS: restart adapter; preserve Codex App Server
 repowire peer list                     # list mesh peers
 repowire peer new PATH [--profile P]   # spawn a peer in tmux
 repowire schedule self 10m "check CI"  # wake this peer later
@@ -306,6 +306,8 @@ changes, then restart the daemon service:
 ```
 
 If service management fails, use `repowire service status` first. Raw `launchctl` on macOS or `systemctl --user` on Linux are fallback troubleshooting tools.
+
+On macOS, setup runs the signed native Codex App Server as its own user LaunchAgent and has the Repowire bridge attach over its Unix socket. This keeps Codex and its tools out of Repowire's process tree, so macOS attributes privacy prompts to the process that actually requested access. Daemon and bridge updates leave that App Server—and its live threads—running. Upgrading an older installation performs one initial App Server handoff, which interrupts existing Codex processes once.
 
 ## References
 

--- a/daemon-go/cli/cli_test.go
+++ b/daemon-go/cli/cli_test.go
@@ -469,6 +469,7 @@ func TestInstallServicePreservesPath(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("PATH", pathValue)
 	t.Setenv("LC_ALL", "C.UTF-8")
+	stubNativeCodexResolver(t, filepath.Join(binDir, "codex"))
 	if err := installService(); err != nil {
 		t.Fatal(err)
 	}
@@ -485,6 +486,88 @@ func TestInstallServicePreservesPath(t *testing.T) {
 	bridgeRaw, err := os.ReadFile(filepath.Join(homeDir, "Library", "LaunchAgents", codexBridgeLabel()+".plist"))
 	if err != nil || !strings.Contains(string(bridgeRaw), "<string>codex-bridge</string>") {
 		t.Fatalf("Codex bridge plist missing: %v %s", err, bridgeRaw)
+	}
+	appServerRaw, err := os.ReadFile(filepath.Join(homeDir, "Library", "LaunchAgents", codexAppServerLabel()+".plist"))
+	if err != nil || !strings.Contains(string(appServerRaw), "<string>app-server</string><string>--listen</string><string>unix://</string>") {
+		t.Fatalf("Codex App Server plist missing: %v %s", err, appServerRaw)
+	}
+	if strings.Contains(string(appServerRaw), executable()) {
+		t.Fatalf("Codex App Server must execute native Codex directly: %s", appServerRaw)
+	}
+	if !strings.Contains(string(bridgeRaw), "<key>REPOWIRE_CODEX_APP_SERVER_MANAGED</key><string>1</string>") {
+		t.Fatalf("Codex bridge is not attach-only: %s", bridgeRaw)
+	}
+}
+
+func TestServiceEnvironmentPathDropsProtectedAndEphemeralDirectories(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	safe := filepath.Join(homeDir, ".local", "bin")
+	raw := strings.Join([]string{
+		safe,
+		filepath.Join(homeDir, "Downloads", "google-cloud-sdk", "bin"),
+		filepath.Join(homeDir, "Music", "tools"),
+		filepath.Join(homeDir, ".codex", "tmp", "arg0", "shim"),
+		safe,
+		"/usr/bin",
+	}, string(os.PathListSeparator))
+	got := serviceEnvironmentPath(raw)
+	want := strings.Join([]string{safe, "/usr/bin"}, string(os.PathListSeparator))
+	if got != want {
+		t.Fatalf("service PATH = %q, want %q", got, want)
+	}
+}
+
+func stubNativeCodexResolver(t *testing.T, path string) {
+	t.Helper()
+	previous := nativeCodexResolver
+	nativeCodexResolver = func() (string, error) { return path, nil }
+	t.Cleanup(func() { nativeCodexResolver = previous })
+}
+
+func TestResolveNativeCodexFromNPMEntrypoint(t *testing.T) {
+	root := t.TempDir()
+	packageRoot := filepath.Join(root, "lib", "node_modules", "@openai", "codex")
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(filepath.Join(packageRoot, "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	entrypoint := filepath.Join(packageRoot, "bin", "codex.js")
+	if err := os.WriteFile(entrypoint, []byte("#!/bin/sh\necho wrapper\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(entrypoint, filepath.Join(binDir, "codex")); err != nil {
+		t.Fatal(err)
+	}
+	platformPackage, vendorTriple := "codex-darwin-arm64", "aarch64-apple-darwin"
+	if runtime.GOARCH == "amd64" {
+		platformPackage, vendorTriple = "codex-darwin-x64", "x86_64-apple-darwin"
+	}
+	native := filepath.Join(packageRoot, "node_modules", "@openai", platformPackage, "vendor", vendorTriple, "bin", "codex")
+	if err := os.MkdirAll(filepath.Dir(native), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("#!/bin/sh\necho --listen\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	codesign := filepath.Join(binDir, "codesign")
+	if err := os.WriteFile(codesign, []byte("#!/bin/sh\nprintf 'Identifier=codex\\nTeamIdentifier="+codexTeamIdentifier+"\\n' >&2\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	got, err := resolveNativeCodex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(native)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("native Codex = %q, want %q", got, want)
 	}
 }
 
@@ -517,6 +600,7 @@ func TestInstallCodexBridgePreservesLoadedBridge(t *testing.T) {
 	}
 	t.Setenv("HOME", homeDir)
 	t.Setenv("PATH", binDir)
+	stubNativeCodexResolver(t, filepath.Join(binDir, "codex"))
 	if err := installCodexBridgeService(binDir, "C.UTF-8"); err != nil {
 		t.Fatal(err)
 	}
@@ -554,12 +638,65 @@ func TestInstallCodexBridgeBootstrapsWhenAbsent(t *testing.T) {
 	}
 	t.Setenv("HOME", homeDir)
 	t.Setenv("PATH", binDir)
+	stubNativeCodexResolver(t, filepath.Join(binDir, "codex"))
 	if err := installCodexBridgeService(binDir, "C.UTF-8"); err != nil {
 		t.Fatal(err)
 	}
 	calls, _ := os.ReadFile(filepath.Join(homeDir, "launchctl.calls"))
 	if !strings.Contains(string(calls), "bootstrap gui/") || !strings.Contains(string(calls), codexBridgeLabel()+".plist") {
 		t.Fatalf("absent bridge was not bootstrapped: %s", calls)
+	}
+}
+
+func TestInstallCodexServiceHandsOffLoadedLegacyBridge(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd only")
+	}
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(filepath.Join(homeDir, "Library", "LaunchAgents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	codex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codex, []byte("#!/bin/sh\necho --listen\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	domain := "gui/" + strconv.Itoa(os.Getuid()) + "/"
+	launchctl := `#!/bin/sh
+printf '%s\n' "$*" >> "$HOME/launchctl.calls"
+if [ "$1" = print ] && [ "$2" = "` + domain + codexAppServerLabel() + `" ]; then
+  [ -f "$HOME/app.loaded" ]; exit $?
+fi
+if [ "$1" = print ] && [ "$2" = "` + domain + codexBridgeLabel() + `" ]; then
+  [ ! -f "$HOME/bridge.stopped" ]; exit $?
+fi
+if [ "$1" = bootout ]; then
+  /usr/bin/touch "$HOME/bridge.stopped"
+fi
+if [ "$1" = bootstrap ]; then
+  case "$3" in *` + codexAppServerLabel() + `.plist) /usr/bin/touch "$HOME/app.loaded" ;; esac
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "launchctl"), []byte(launchctl), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", binDir)
+	stubNativeCodexResolver(t, codex)
+	if err := installCodexBridgeService(binDir, "C.UTF-8"); err != nil {
+		t.Fatal(err)
+	}
+	calls, _ := os.ReadFile(filepath.Join(homeDir, "launchctl.calls"))
+	text := string(calls)
+	stopAt := strings.Index(text, "bootout gui/")
+	appAt := strings.Index(text, "bootstrap gui/")
+	bridgeAt := strings.LastIndex(text, "bootstrap gui/")
+	if stopAt < 0 || appAt <= stopAt || bridgeAt <= appAt {
+		t.Fatalf("legacy bridge handoff order is wrong: %s", text)
 	}
 }
 
@@ -645,7 +782,7 @@ func TestDaemonRestartDoesNotKickCodexBridge(t *testing.T) {
 	}
 }
 
-func TestExplicitCodexBridgeRestartIsDestructive(t *testing.T) {
+func TestExplicitCodexBridgeRestartReplacesBridge(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("launchd only")
 	}
@@ -672,6 +809,38 @@ func TestExplicitCodexBridgeRestartIsDestructive(t *testing.T) {
 	calls, _ := os.ReadFile(filepath.Join(homeDir, "launchctl.calls"))
 	if !strings.Contains(string(calls), "kickstart -k") || !strings.Contains(string(calls), codexBridgeLabel()) {
 		t.Fatalf("explicit bridge restart did not replace bridge: %s", calls)
+	}
+}
+
+func TestExplicitCodexBridgeRestartPreservesAppServer(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd only")
+	}
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(filepath.Join(homeDir, "Library", "LaunchAgents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, label := range []string{codexBridgeLabel(), codexAppServerLabel()} {
+		if err := os.WriteFile(filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist"), []byte("plist"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	launchctl := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$HOME/launchctl.calls\"\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "launchctl"), []byte(launchctl), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", binDir)
+	if err := restartCodexBridgeService(); err != nil {
+		t.Fatal(err)
+	}
+	calls, _ := os.ReadFile(filepath.Join(homeDir, "launchctl.calls"))
+	if strings.Contains(string(calls), codexAppServerLabel()) {
+		t.Fatalf("bridge restart touched Codex App Server: %s", calls)
 	}
 }
 

--- a/daemon-go/cli/install.go
+++ b/daemon-go/cli/install.go
@@ -28,6 +28,7 @@ import (
 )
 
 var execLookPath = exec.LookPath
+var nativeCodexResolver = resolveNativeCodex
 
 const (
 	claudeDefaultSpawnCommand = "claude --dangerously-skip-permissions"
@@ -884,6 +885,7 @@ func runService(argv []string) int {
 }
 
 func serviceLabel() string                  { return "io.repowire.daemon" }
+func codexAppServerLabel() string           { return "io.repowire.codex-app-server" }
 func codexBridgeLabel() string              { return "io.repowire.codex-bridge" }
 func mobileServiceLabel(name string) string { return "io.repowire." + name }
 
@@ -906,6 +908,7 @@ func mobileServiceRunning(name string) bool {
 const obsoleteServiceLabel = "com.repowire.daemon"
 
 func installService() error {
+	pathValue := serviceEnvironmentPath(os.Getenv("PATH"))
 	if runtime.GOOS == "darwin" {
 		dir := home("Library", "LaunchAgents")
 		_ = os.MkdirAll(dir, 0o755)
@@ -921,7 +924,7 @@ func installService() error {
 		if locale == "" {
 			locale = "en_US.UTF-8"
 		}
-		plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>%s</string><key>ProgramArguments</key><array><string>%s</string><string>serve</string></array><key>EnvironmentVariables</key><dict><key>PATH</key><string>%s</string><key>LC_ALL</key><string>%s</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s</string><key>StandardErrorPath</key><string>%s</string></dict></plist>`, serviceLabel(), executable(), html.EscapeString(os.Getenv("PATH")), html.EscapeString(locale), logPath, logPath)
+		plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>%s</string><key>ProgramArguments</key><array><string>%s</string><string>serve</string></array><key>EnvironmentVariables</key><dict><key>PATH</key><string>%s</string><key>LC_ALL</key><string>%s</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s</string><key>StandardErrorPath</key><string>%s</string></dict></plist>`, serviceLabel(), executable(), html.EscapeString(pathValue), html.EscapeString(locale), logPath, logPath)
 		_ = exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid()), path).Run()
 		if err := os.WriteFile(path, []byte(plist), 0o600); err != nil {
 			return err
@@ -929,10 +932,10 @@ func installService() error {
 		if err := exec.Command("launchctl", "bootstrap", "gui/"+strconv.Itoa(os.Getuid()), path).Run(); err != nil {
 			return err
 		}
-		if err := installCodexBridgeService(os.Getenv("PATH"), locale); err != nil {
+		if err := installCodexBridgeService(pathValue, locale); err != nil {
 			return err
 		}
-		return installConfiguredMobileServices(os.Getenv("PATH"), locale)
+		return installConfiguredMobileServices(pathValue, locale)
 	}
 	dir := home(".config", "systemd", "user")
 	_ = os.MkdirAll(dir, 0o755)
@@ -940,14 +943,47 @@ func installService() error {
 	if err := os.WriteFile(filepath.Join(dir, "repowire.service"), []byte(unit), 0o600); err != nil {
 		return err
 	}
-	if err := installCodexBridgeService(os.Getenv("PATH"), ""); err != nil {
+	if err := installCodexBridgeService(pathValue, ""); err != nil {
 		return err
 	}
-	if err := installConfiguredMobileServices(os.Getenv("PATH"), ""); err != nil {
+	if err := installConfiguredMobileServices(pathValue, ""); err != nil {
 		return err
 	}
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return exec.Command("systemctl", "--user", "enable", "--now", "repowire.service").Run()
+}
+
+func serviceEnvironmentPath(raw string) string {
+	if raw == "" {
+		return "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+	}
+	userHome, _ := os.UserHomeDir()
+	protected := make([]string, 0, 7)
+	for _, name := range []string{"Desktop", "Documents", "Downloads", "Movies", "Music", "Pictures"} {
+		protected = append(protected, filepath.Join(userHome, name))
+	}
+	protected = append(protected, filepath.Join(userHome, ".codex", "tmp"))
+	seen := map[string]bool{}
+	cleaned := make([]string, 0, len(filepath.SplitList(raw)))
+	for _, entry := range filepath.SplitList(raw) {
+		entry = filepath.Clean(entry)
+		if entry == "." || seen[entry] {
+			continue
+		}
+		skip := false
+		for _, root := range protected {
+			if entry == root || strings.HasPrefix(entry, root+string(filepath.Separator)) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		seen[entry] = true
+		cleaned = append(cleaned, entry)
+	}
+	return strings.Join(cleaned, string(os.PathListSeparator))
 }
 
 func installConfiguredMobileServices(pathValue, locale string) error {
@@ -1019,14 +1055,20 @@ func removeMobileService(name string) error {
 
 func installCodexBridgeService(pathValue, locale string) error {
 	if !codexAppServerSupported() {
-		return removeCodexBridgeService()
+		if err := removeCodexBridgeService(); err != nil {
+			return err
+		}
+		return removeCodexAppServerService()
 	}
 	if runtime.GOOS == "darwin" {
+		if err := installCodexAppServerService(pathValue, locale); err != nil {
+			return err
+		}
 		dir := home("Library", "LaunchAgents")
 		path := filepath.Join(dir, codexBridgeLabel()+".plist")
 		loaded := launchAgentLoaded(codexBridgeLabel())
 		logPath := home(".repowire", "codex-bridge.log")
-		plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>%s</string><key>ProgramArguments</key><array><string>%s</string><string>codex-bridge</string></array><key>EnvironmentVariables</key><dict><key>PATH</key><string>%s</string><key>LC_ALL</key><string>%s</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s</string><key>StandardErrorPath</key><string>%s</string></dict></plist>`, codexBridgeLabel(), executable(), html.EscapeString(pathValue), html.EscapeString(locale), logPath, logPath)
+		plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>%s</string><key>ProgramArguments</key><array><string>%s</string><string>codex-bridge</string></array><key>EnvironmentVariables</key><dict><key>PATH</key><string>%s</string><key>LC_ALL</key><string>%s</string><key>REPOWIRE_CODEX_APP_SERVER_MANAGED</key><string>1</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s</string><key>StandardErrorPath</key><string>%s</string></dict></plist>`, codexBridgeLabel(), executable(), html.EscapeString(pathValue), html.EscapeString(locale), logPath, logPath)
 		if err := os.WriteFile(path, []byte(plist), 0o600); err != nil {
 			return err
 		}
@@ -1046,6 +1088,77 @@ func installCodexBridgeService(pathValue, locale string) error {
 		return nil
 	}
 	return exec.Command("systemctl", "--user", "enable", "--now", "repowire-codex.service").Run()
+}
+
+const codexTeamIdentifier = "2DC432GLL2"
+
+func installCodexAppServerService(pathValue, locale string) error {
+	nativeCodex, err := nativeCodexResolver()
+	if err != nil {
+		return fmt.Errorf("install independent Codex App Server: %w", err)
+	}
+	dir := home("Library", "LaunchAgents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, codexAppServerLabel()+".plist")
+	loaded := launchAgentLoaded(codexAppServerLabel())
+	logPath := home(".repowire", "codex-app-server.log")
+	environment := fmt.Sprintf(`<key>PATH</key><string>%s</string><key>LC_ALL</key><string>%s</string>`, html.EscapeString(pathValue), html.EscapeString(locale))
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		environment += fmt.Sprintf(`<key>CODEX_HOME</key><string>%s</string>`, html.EscapeString(codexHome))
+	}
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>Label</key><string>%s</string><key>ProgramArguments</key><array><string>%s</string><string>app-server</string><string>--listen</string><string>unix://</string></array><key>EnvironmentVariables</key><dict>%s</dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s</string><key>StandardErrorPath</key><string>%s</string></dict></plist>`, codexAppServerLabel(), html.EscapeString(nativeCodex), environment, logPath, logPath)
+	if err := os.WriteFile(path, []byte(plist), 0o600); err != nil {
+		return err
+	}
+	if loaded {
+		return nil
+	}
+	// A bridge installed before the App Server service owns the App Server as a
+	// child. Stop it once so launchd can become the stable responsibility root.
+	if launchAgentLoaded(codexBridgeLabel()) {
+		if err := exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexBridgeLabel()).Run(); err != nil {
+			return fmt.Errorf("stop bridge for App Server handoff: %w", err)
+		}
+	}
+	return exec.Command("launchctl", "bootstrap", "gui/"+strconv.Itoa(os.Getuid()), path).Run()
+}
+
+func resolveNativeCodex() (string, error) {
+	entrypoint, err := execLookPath("codex")
+	if err != nil {
+		return "", errors.New("codex executable not found")
+	}
+	resolved, err := filepath.EvalSymlinks(entrypoint)
+	if err != nil {
+		resolved = entrypoint
+	}
+	candidates := []string{entrypoint}
+	if resolved != entrypoint {
+		candidates = append(candidates, resolved)
+	}
+	packageRoot := filepath.Dir(filepath.Dir(resolved))
+	switch runtime.GOARCH {
+	case "arm64":
+		candidates = append(candidates, filepath.Join(packageRoot, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex"))
+	case "amd64":
+		candidates = append(candidates, filepath.Join(packageRoot, "node_modules", "@openai", "codex-darwin-x64", "vendor", "x86_64-apple-darwin", "bin", "codex"))
+	}
+	for _, candidate := range candidates {
+		if info, statErr := os.Stat(candidate); statErr != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		signature, signErr := exec.Command("codesign", "-dv", "--verbose=4", candidate).CombinedOutput()
+		if signErr != nil || !strings.Contains(string(signature), "Identifier=codex") || !strings.Contains(string(signature), "TeamIdentifier="+codexTeamIdentifier) {
+			continue
+		}
+		help, helpErr := exec.Command(candidate, "app-server", "--help").CombinedOutput()
+		if helpErr == nil && strings.Contains(string(help), "--listen") {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no signed native Codex executable from OpenAI team %s was found", codexTeamIdentifier)
 }
 
 func launchAgentLoaded(label string) bool {
@@ -1086,10 +1199,27 @@ func removeCodexBridgeService() error {
 	return err
 }
 
+func removeCodexAppServerService() error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	path := home("Library", "LaunchAgents", codexAppServerLabel()+".plist")
+	_ = exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexAppServerLabel()).Run()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func startService() error {
 	if runtime.GOOS == "darwin" {
 		if err := startLaunchAgent(serviceLabel()); err != nil {
 			return err
+		}
+		if _, err := os.Stat(home("Library", "LaunchAgents", codexAppServerLabel()+".plist")); err == nil {
+			if err := startLaunchAgent(codexAppServerLabel()); err != nil {
+				return err
+			}
 		}
 		if _, err := os.Stat(home("Library", "LaunchAgents", codexBridgeLabel()+".plist")); err == nil {
 			if err := startLaunchAgent(codexBridgeLabel()); err != nil {
@@ -1164,6 +1294,7 @@ func stopService() error {
 			_ = exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+mobileServiceLabel(name)).Run()
 		}
 		_ = exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexBridgeLabel()).Run()
+		_ = exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexAppServerLabel()).Run()
 		return exec.Command("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/"+serviceLabel()).Run()
 	}
 	for _, name := range []string{"telegram", "slack"} {
@@ -1178,6 +1309,9 @@ func serviceStatus() int {
 		commands = append(commands, exec.Command("launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())+"/"+serviceLabel()))
 		if _, err := os.Stat(home("Library", "LaunchAgents", codexBridgeLabel()+".plist")); err == nil {
 			commands = append(commands, exec.Command("launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexBridgeLabel()))
+		}
+		if _, err := os.Stat(home("Library", "LaunchAgents", codexAppServerLabel()+".plist")); err == nil {
+			commands = append(commands, exec.Command("launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())+"/"+codexAppServerLabel()))
 		}
 		for _, name := range []string{"telegram", "slack"} {
 			label := mobileServiceLabel(name)
@@ -1212,6 +1346,9 @@ func uninstallService() error {
 		}
 	}
 	if err := removeCodexBridgeService(); err != nil {
+		return err
+	}
+	if err := removeCodexAppServerService(); err != nil {
 		return err
 	}
 	if runtime.GOOS == "darwin" {

--- a/daemon-go/codexbridge/bridge.go
+++ b/daemon-go/codexbridge/bridge.go
@@ -198,6 +198,9 @@ func ensureAppServer(ctx context.Context) (*websocket.Conn, *exec.Cmd, error) {
 	if conn, err := dialAppServer(ctx); err == nil {
 		return conn, nil, nil
 	}
+	if os.Getenv("REPOWIRE_CODEX_APP_SERVER_MANAGED") == "1" {
+		return nil, nil, errors.New("managed Codex App Server is not accepting connections")
+	}
 	codex, err := exec.LookPath("codex")
 	if err != nil {
 		return nil, nil, errors.New("codex executable not found")

--- a/daemon-go/codexbridge/bridge_test.go
+++ b/daemon-go/codexbridge/bridge_test.go
@@ -237,6 +237,18 @@ func TestConfiguredProviderEnvKeys(t *testing.T) {
 	}
 }
 
+func TestManagedAppServerNeverFallsBackToChildProcess(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("REPOWIRE_CODEX_APP_SERVER_MANAGED", "1")
+	conn, child, err := ensureAppServer(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "managed Codex App Server") {
+		t.Fatalf("ensureAppServer error = %v", err)
+	}
+	if conn != nil || child != nil {
+		t.Fatalf("managed connection unexpectedly returned conn=%v child=%v", conn, child)
+	}
+}
+
 func containsEnv(env []string, value string) bool {
 	for _, item := range env {
 		if item == value {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,13 +56,20 @@ repowire service uninstall
 ```
 
 Manage the installed user services. `install` writes and starts the daemon and,
-when supported, the independent Codex App Server bridge. `start` starts installed
-services. `restart` defaults to the routing daemon only, so live Codex threads
-are not bounced. `restart bridge` explicitly replaces the Codex bridge and its
-owned App Server and therefore interrupts active Codex sessions; `restart all`
-does both. `status` reports both; `stop`
-through `repowire daemon stop` and `uninstall` stop both. Prefer these commands
+when supported, the Codex App Server and its independent Repowire bridge.
+`start` starts installed services. `restart` defaults to the routing daemon;
+`restart bridge` replaces the adapter; and `restart all` replaces both daemon
+and adapter. On macOS all three preserve the separately owned Codex App Server
+and live Codex threads. `status` reports installed services. `stop` through
+`repowire daemon stop` and `uninstall` stop every service. Prefer these commands
 over raw `launchctl` or `systemctl` unless troubleshooting the service manager.
+
+On macOS, `service install` also installs `io.repowire.codex-app-server` when an official signed native Codex App Server is available. The LaunchAgent executes Codex directly; the separate `io.repowire.codex-bridge` process only attaches to its Unix socket. `restart daemon`, `restart bridge`, and `restart all` preserve the App Server and live Codex threads. The first migration from a bridge-owned App Server requires a one-time Codex process restart.
+
+Generated service environments keep normal executable search paths but omit
+protected user folders (`Desktop`, `Documents`, `Downloads`, `Movies`, `Music`,
+and `Pictures`) and ephemeral Codex shim directories. This prevents an unrelated
+PATH lookup from causing macOS Files & Folders prompts under a service's name.
 
 ## `repowire doctor`
 

--- a/docs/use/features/connect-codex.md
+++ b/docs/use/features/connect-codex.md
@@ -78,16 +78,16 @@ branch and git status, plus tmux diagnostics only when exactly one matching
 Codex pane can be identified; ambiguous cwd matches are deliberately omitted.
 
 The App Server companion is separate from the Repowire daemon. `repowire service
-restart` restarts routing without killing Codex threads; `repowire service stop`
+restart` restarts routing without killing Codex threads. On macOS, restarting
+the bridge also preserves the independent App Server. `repowire service stop`
 or `uninstall` stops both services.
 
-For custom Codex model providers, the bridge reads the provider `env_key` names
-from `~/.codex/config.toml`. When it must start App Server and those variables
-are absent from the user-service environment, it takes a bounded snapshot from
-the user's login shell and forwards only the configured variables to App
-Server. Values are not copied into Repowire config or service definitions. If a
-key is still unavailable, the bridge log names the missing variable and Codex
-fails normally instead of silently switching providers.
+On macOS the independent App Server uses Codex's stored login. Custom model
+providers that rely on an `env_key` must expose that variable to the launchd
+user domain (for example with `launchctl setenv KEY VALUE` before service
+installation); Repowire does not copy secrets into its plist. The legacy
+bridge-owned fallback on other platforms still takes a bounded login-shell
+snapshot and forwards only provider variables named in Codex config.
 
 ## Verifying
 
@@ -101,10 +101,14 @@ repowire peer list
 The Codex peer should already be listed. Its metadata reports
 `transport=codex-app-server`, and its TUI remains interactive.
 
+### macOS process ownership
+
+Repowire setup installs the official signed native Codex App Server as the user LaunchAgent `io.repowire.codex-app-server`. The Repowire bridge is a separate client of its Unix socket, not its parent. This matters for macOS privacy controls: tools launched by Codex are attributed to Codex instead of to the Repowire executable. Routine Repowire daemon and bridge restarts preserve the App Server and its live threads. Existing installations have one unavoidable process restart when they first migrate to this layout.
+
 ## Troubleshooting
 
 - Codex peer never registers → run `repowire service status`, then inspect
-  `~/.repowire/codex-bridge.log`.
+  `~/.repowire/codex-bridge.log` and `~/.repowire/codex-app-server.log`.
 - Codex joins `default` instead of a tmux circle → more than one Codex tmux
   circle matched the same working directory, or none did. Spawn it through
   Repowire for an explicit circle.


### PR DESCRIPTION
## Summary

- run the official signed native Codex App Server as its own macOS user LaunchAgent
- make the Repowire bridge attach-only and preserve App Server threads across daemon/bridge restarts
- perform a safe one-time handoff from legacy bridge-owned App Server processes
- sanitize service PATH values to omit protected user folders and ephemeral Codex shim paths
- document process ownership, migration behavior, and custom-provider environment constraints

## Verification

- gofmt -w .
- go vet ./...
- go test -race ./...
- go build -o ../bin/repowire .
- npm test -- --run (128 tests)
- npm run build
- isolated real signed-Codex install; both generated LaunchAgent plists pass plutil lint

## Migration note

The first service install on a legacy macOS setup intentionally restarts the bridge-owned Codex App Server once so launchd becomes its parent. Subsequent daemon and bridge updates preserve the App Server.