### PR TITLE
Repair missing Claude pane registrations

### DIFF
--- a/daemon-go/hooks/handlers.go
+++ b/daemon-go/hooks/handlers.go
@@ -16,6 +16,8 @@ import (
 	"github.com/repowire/repowire/daemon-go/proto"
 )
 
+var startSessionWSHook = startWSHook
+
 func Run(args []string) int {
 	if len(args) == 0 {
 		errf("usage: repowire hook <session|stop|prompt|notification|pretooluse>")
@@ -51,6 +53,10 @@ func runSession(backend string) int {
 		errf("session: invalid JSON input: %v", err)
 		return 0
 	}
+	return handleSession(raw, backend, true)
+}
+
+func handleSession(raw map[string]any, backend string, emitContext bool) int {
 	payload := Normalize(raw, backend)
 	cwd := firstNonempty(payload.CWD, mustGetwd())
 	info := getTmuxInfo()
@@ -75,11 +81,15 @@ func runSession(backend string) int {
 	locked := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) == nil
 	prior := ReadPaneRuntimeMetadata(info.PaneID)
 	needsTakeover := !locked
-	if needsTakeover && payload.SessionID != "" && stringValue(prior, "hook_session_id") == payload.SessionID && stringValue(prior, "cwd") == cwd && stringValue(prior, "backend") == backend {
+	livePeerID := ""
+	if needsTakeover {
+		livePeerID = peerForPane(info.PaneID)
+	}
+	priorPeerID := firstNonempty(stringValue(prior, "peer_id"), livePeerID)
+	if needsTakeover && reusablePaneRegistration(prior, payload.SessionID, cwd, backend, priorPeerID, livePeerID) {
 		lock.Close()
 		return 0
 	}
-	priorPeerID := firstNonempty(stringValue(prior, "peer_id"), peerForPane(info.PaneID))
 
 	hint := consumeSpawnHint(cwd, backend)
 	_, circle, circleSource, boundaryErr := tmuxPlacement(info)
@@ -165,12 +175,13 @@ func runSession(backend string) int {
 		return 0
 	}
 	peerID := stringValue(registered, "peer_id")
-	displayName := firstNonempty(stringValue(registered, "display_name"), filepath.Base(cwd))
-	if needsTakeover && peerID == "" {
-		errf("registration unconfirmed during pane takeover, leaving incumbent in place")
+	if status < http.StatusOK || status >= http.StatusMultipleChoices || peerID == "" {
+		detail := firstNonempty(stringValue(registered, "detail"), http.StatusText(status))
+		errf("SessionStart registration failed (status=%d): %s", status, detail)
 		lock.Close()
 		return 0
 	}
+	displayName := firstNonempty(stringValue(registered, "display_name"), filepath.Base(cwd))
 	if assigned, present := registered["pane_assigned"].(bool); present && !assigned {
 		errf("pane %s held by live orchestrator; registered as %s (%s) without pane ownership", info.PaneID, displayName, peerID)
 		lock.Close()
@@ -209,7 +220,7 @@ func runSession(backend string) int {
 		meta["birth_certificate"] = cert
 	}
 	_ = writeMetadata(info.PaneID, meta)
-	if err := startWSHook(info.PaneID, peerID, displayName, backend, cwd, agentPID, lock); err != nil {
+	if err := startSessionWSHook(info.PaneID, peerID, displayName, backend, cwd, agentPID, lock); err != nil {
 		errf("failed to start WebSocket hook: %v", err)
 	}
 	lock.Close()
@@ -223,10 +234,18 @@ func runSession(backend string) int {
 	if context := loadHandoff(cwd, backend, payload.SessionID); context != "" {
 		sections = append(sections, context)
 	}
-	printJSON(map[string]any{"hookSpecificOutput": map[string]any{
-		"hookEventName": "SessionStart", "additionalContext": strings.Join(sections, "\n\n"),
-	}})
+	if emitContext {
+		printJSON(map[string]any{"hookSpecificOutput": map[string]any{
+			"hookEventName": "SessionStart", "additionalContext": strings.Join(sections, "\n\n"),
+		}})
+	}
 	return 0
+}
+
+func reusablePaneRegistration(prior map[string]any, sessionID, cwd, backend, priorPeerID, livePeerID string) bool {
+	return sessionID != "" && priorPeerID != "" && livePeerID == priorPeerID &&
+		stringValue(prior, "hook_session_id") == sessionID &&
+		stringValue(prior, "cwd") == cwd && stringValue(prior, "backend") == backend
 }
 
 func runStop(backend string, remindersOnly bool) int {
@@ -304,12 +323,26 @@ func runPrompt(backend string) int {
 		errf("prompt: invalid JSON input: %v", err)
 		return 0
 	}
+	return handlePrompt(raw, backend)
+}
+
+func handlePrompt(raw map[string]any, backend string) int {
 	payload := Normalize(raw, backend)
 	if payload.Event != "UserPromptSubmit" {
 		return 0
 	}
 	pane := getPaneID()
-	if pane != "" && !updateStatus(pane, "busy", "working", payload.Model, true) {
+	updated := pane != "" && updateStatus(pane, "busy", "working", payload.Model, true)
+	if backend == "claude-code" && pane != "" && !updated {
+		repair := make(map[string]any, len(raw))
+		for key, value := range raw {
+			repair[key] = value
+		}
+		repair["hook_event_name"] = "SessionStart"
+		handleSession(repair, backend, false)
+		updated = updateStatus(pane, "busy", "working", payload.Model, true)
+	}
+	if pane != "" && !updated {
 		errf("prompt: failed to update status for pane %s", pane)
 	}
 	if backend == "claude-code" && pane != "" && payload.TranscriptPath != "" {

--- a/daemon-go/hooks/hooks_test.go
+++ b/daemon-go/hooks/hooks_test.go
@@ -14,6 +14,126 @@ import (
 	"time"
 )
 
+func TestReusablePaneRegistrationRequiresConfirmedLivePeer(t *testing.T) {
+	prior := map[string]any{
+		"hook_session_id": "session-1", "cwd": "/project", "backend": "claude-code", "peer_id": "repow-1",
+	}
+	if !reusablePaneRegistration(prior, "session-1", "/project", "claude-code", "repow-1", "repow-1") {
+		t.Fatal("confirmed matching pane registration was not reusable")
+	}
+	for name, peers := range map[string][2]string{
+		"empty metadata":      {"", ""},
+		"missing live peer":   {"repow-1", ""},
+		"different live peer": {"repow-1", "repow-2"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if reusablePaneRegistration(prior, "session-1", "/project", "claude-code", peers[0], peers[1]) {
+				t.Fatal("unconfirmed pane registration was reused")
+			}
+		})
+	}
+}
+
+func TestFailedSessionRegistrationDoesNotPersistEmptyPeer(t *testing.T) {
+	homeDir, binDir := hookTestEnvironment(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/peers/by-pane/%2526" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Path == "/peers" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]any{"detail": "daemon warming up"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	configureHookTestDaemon(t, server.URL)
+	t.Setenv("PATH", binDir+":/usr/bin:/bin")
+	handleSession(map[string]any{
+		"hook_event_name": "SessionStart", "session_id": "session-1", "cwd": homeDir,
+	}, "claude-code", false)
+	if meta := ReadPaneRuntimeMetadata("%26"); len(meta) != 0 {
+		t.Fatalf("failed registration persisted pane metadata: %v", meta)
+	}
+	if _, err := os.Stat(wsHookPath("%26", ".pid")); !os.IsNotExist(err) {
+		t.Fatalf("failed registration started ws-hook: %v", err)
+	}
+}
+
+func TestPromptRepairsMissingClaudePaneRegistration(t *testing.T) {
+	homeDir, binDir := hookTestEnvironment(t)
+	registered := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/peers/by-pane/%2526" && !registered:
+			http.NotFound(w, r)
+		case r.URL.Path == "/peers/by-pane/%2526":
+			_ = json.NewEncoder(w).Encode(map[string]any{"peer_id": "repow-26"})
+		case r.URL.Path == "/peers" && r.Method == http.MethodPost:
+			registered = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"peer_id": "repow-26", "display_name": "project-claude-code"})
+		case r.URL.Path == "/peers":
+			_ = json.NewEncoder(w).Encode(map[string]any{"peers": []any{}})
+		case r.URL.Path == "/session/update":
+			if !registered {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	configureHookTestDaemon(t, server.URL)
+	t.Setenv("PATH", binDir+":/usr/bin:/bin")
+	t.Setenv(claudeMessagingSocketEnv, "uds:/tmp/current-claude.sock")
+	t.Setenv(claudeMessagingTokenEnv, "current-token")
+	startedPeer := ""
+	previous := startSessionWSHook
+	startSessionWSHook = func(_ string, peerID, _, _, _ string, _ int, _ *os.File) error {
+		startedPeer = peerID
+		return nil
+	}
+	t.Cleanup(func() { startSessionWSHook = previous })
+	handlePrompt(map[string]any{
+		"hook_event_name": "UserPromptSubmit", "session_id": "session-2", "cwd": homeDir, "prompt": "hello",
+	}, "claude-code")
+	if !registered || startedPeer != "repow-26" {
+		t.Fatalf("prompt repair registered=%v startedPeer=%q", registered, startedPeer)
+	}
+	meta := ReadPaneRuntimeMetadata("%26")
+	if stringValue(meta, "claude_messaging_socket") != "uds:/tmp/current-claude.sock" || stringValue(meta, "claude_messaging_token") != "current-token" {
+		t.Fatalf("prompt repair did not capture current inbox environment: %v", meta)
+	}
+}
+
+func hookTestEnvironment(t *testing.T) (string, string) {
+	t.Helper()
+	homeDir := t.TempDir()
+	binDir := filepath.Join(homeDir, "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tmux := "#!/bin/sh\nprintf '0\\tzsh\\t@1\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(tmux), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", homeDir)
+	t.Setenv("TMUX_PANE", "%26")
+	return homeDir, binDir
+}
+
+func configureHookTestDaemon(t *testing.T, serverURL string) {
+	t.Helper()
+	port, _ := strconv.Atoi(strings.TrimPrefix(serverURL, "http://127.0.0.1:"))
+	t.Setenv("REPOWIRE_DAEMON__HOST", "127.0.0.1")
+	t.Setenv("REPOWIRE_DAEMON__PORT", strconv.Itoa(port))
+	t.Setenv("REPOWIRE_DAEMON__AUTH_TOKEN", "")
+}
+
 func TestNormalizeBackendPayloads(t *testing.T) {
 	p := Normalize(map[string]any{
 		"hook_event_name": "StopFailure",

--- a/docs/troubleshooting/hooks.md
+++ b/docs/troubleshooting/hooks.md
@@ -43,7 +43,11 @@ OpenCode does not use shell hooks. It uses a TypeScript plugin at `~/.config/ope
 
 ## Daemon must be running
 
-All hooks shell out to the daemon over HTTP. If the daemon is down, hooks succeed (they do not block agent startup) but no peer state changes. See [Daemon unreachable](daemon.md).
+All hooks shell out to the daemon over HTTP. If the daemon is down, hooks
+succeed (they do not block agent startup) but no peer state changes. A later
+Claude Code `UserPromptSubmit` repairs a missing pane registration with the
+current session's authenticated inbox; a failed SessionStart is never retained
+as an empty ws-hook identity. See [Daemon unreachable](daemon.md).
 
 ## After upgrading `repowire`
 

--- a/docs/use/features/connect-claude-code.md
+++ b/docs/use/features/connect-claude-code.md
@@ -13,7 +13,7 @@ Six lifecycle events are wired by default:
 | Event | What it does |
 | --- | --- |
 | `SessionStart` | Registers the peer with the daemon, spawns the WebSocket hook supervisor, injects the peer list as context |
-| `UserPromptSubmit` | Marks the peer `busy` |
+| `UserPromptSubmit` | Lazily repairs a missing pane registration, then marks the peer `busy` |
 | `Notification` | Resets the peer to `online` when Claude Code emits an idle prompt |
 | `Stop` | Extracts response + tool calls from the transcript, drains any old legacy `/query` FIFO response, fetches `/asks/pending` and emits a reminder block if open asks exist, then marks the peer `online` |
 | `StopFailure` | Uses the same stop handler to repair status after API-level stop failures |


### PR DESCRIPTION
## Summary

- reject SessionStart responses that do not contain a confirmed peer ID
- only reuse same-session ws-hook metadata when the daemon confirms the same live pane peer
- lazily repair a missing Claude registration on the next UserPromptSubmit using the current authenticated inbox environment
- cover failed registration, stale metadata, and prompt-driven recovery with tests and docs

## Root cause

A transient failed registration created pane metadata and a ws-hook with an empty peer_id. A replacement Claude process in the same pane/session matched the stale metadata and returned early forever.

## Verification

- gofmt -w .
- go vet ./...
- go test -race ./...
- go build -o ../bin/repowire .
- npm test -- --run (128 tests)
- npm run build
- fixed binary installed locally without restarting services