### PR TITLE
Fix Claude registration after tmux pane reuse

### DIFF
--- a/daemon-go/hooks/handlers.go
+++ b/daemon-go/hooks/handlers.go
@@ -16,7 +16,10 @@ import (
 	"github.com/repowire/repowire/daemon-go/proto"
 )
 
-var startSessionWSHook = startWSHook
+var (
+	startSessionWSHook  = startWSHook
+	repairPromptSession = handleSession
+)
 
 func Run(args []string) int {
 	if len(args) == 0 {
@@ -245,7 +248,20 @@ func handleSession(raw map[string]any, backend string, emitContext bool) int {
 func reusablePaneRegistration(prior map[string]any, sessionID, cwd, backend, priorPeerID, livePeerID string) bool {
 	return sessionID != "" && priorPeerID != "" && livePeerID == priorPeerID &&
 		stringValue(prior, "hook_session_id") == sessionID &&
-		stringValue(prior, "cwd") == cwd && stringValue(prior, "backend") == backend
+		stringValue(prior, "cwd") == cwd && stringValue(prior, "backend") == backend &&
+		!claudeInboxMetadataStale(prior, backend)
+}
+
+func claudeInboxMetadataStale(meta map[string]any, backend string) bool {
+	if backend != "claude-code" {
+		return false
+	}
+	current := strings.TrimPrefix(os.Getenv(claudeMessagingSocketEnv), "uds:")
+	if current == "" {
+		return false
+	}
+	registered := strings.TrimPrefix(stringValue(meta, "claude_messaging_socket"), "uds:")
+	return registered != current
 }
 
 func runStop(backend string, remindersOnly bool) int {
@@ -333,13 +349,14 @@ func handlePrompt(raw map[string]any, backend string) int {
 	}
 	pane := getPaneID()
 	updated := pane != "" && updateStatus(pane, "busy", "working", payload.Model, true)
-	if backend == "claude-code" && pane != "" && !updated {
+	staleInbox := backend == "claude-code" && pane != "" && claudeInboxMetadataStale(ReadPaneRuntimeMetadata(pane), backend)
+	if backend == "claude-code" && pane != "" && (!updated || staleInbox) {
 		repair := make(map[string]any, len(raw))
 		for key, value := range raw {
 			repair[key] = value
 		}
 		repair["hook_event_name"] = "SessionStart"
-		handleSession(repair, backend, false)
+		repairPromptSession(repair, backend, false)
 		updated = updateStatus(pane, "busy", "working", payload.Model, true)
 	}
 	if pane != "" && !updated {

--- a/daemon-go/hooks/hooks_test.go
+++ b/daemon-go/hooks/hooks_test.go
@@ -110,6 +110,50 @@ func TestPromptRepairsMissingClaudePaneRegistration(t *testing.T) {
 	}
 }
 
+func TestPromptRefreshesStaleClaudeInboxForRegisteredPane(t *testing.T) {
+	homeDir, binDir := hookTestEnvironment(t)
+	updates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/peers/by-pane/%2526":
+			_ = json.NewEncoder(w).Encode(map[string]any{"peer_id": "repow-26"})
+		case r.URL.Path == "/session/update":
+			updates++
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	configureHookTestDaemon(t, server.URL)
+	t.Setenv("PATH", binDir+":/usr/bin:/bin")
+	t.Setenv(claudeMessagingSocketEnv, "uds:/tmp/current-claude.sock")
+	t.Setenv(claudeMessagingTokenEnv, "current-token")
+	if err := writeMetadata("%26", map[string]any{
+		"peer_id": "repow-26", "display_name": "project-claude-code", "backend": "claude-code",
+		"cwd": homeDir, "hook_session_id": "session-2", "claude_messaging_socket": "/tmp/old-claude.sock",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	repairs := 0
+	previous := repairPromptSession
+	repairPromptSession = func(raw map[string]any, backend string, emitContext bool) int {
+		repairs++
+		if stringValue(raw, "hook_event_name") != "SessionStart" || backend != "claude-code" || emitContext {
+			t.Fatalf("unexpected repair call: raw=%v backend=%q emitContext=%v", raw, backend, emitContext)
+		}
+		return 0
+	}
+	t.Cleanup(func() { repairPromptSession = previous })
+
+	handlePrompt(map[string]any{
+		"hook_event_name": "UserPromptSubmit", "session_id": "session-2", "cwd": homeDir, "prompt": "hello",
+	}, "claude-code")
+	if repairs != 1 || updates != 2 {
+		t.Fatalf("stale inbox repairs=%d status updates=%d, want 1 and 2", repairs, updates)
+	}
+}
+
 func hookTestEnvironment(t *testing.T) (string, string) {
 	t.Helper()
 	homeDir := t.TempDir()

--- a/daemon-go/hub/routes_spawn_test.go
+++ b/daemon-go/hub/routes_spawn_test.go
@@ -143,6 +143,7 @@ func postSpawnJSON(t *testing.T, srv *httptest.Server, path string, body any) *h
 }
 
 func TestWindowBoundarySpawnUsesSourcePaneEvidence(t *testing.T) {
+	t.Setenv("REPOWIRE_CONFIG_DIR", t.TempDir())
 	root, pane := t.TempDir(), "%12"
 	tmux := &fakeTmux{
 		spawnResult: service.SpawnResult{DisplayName: "worker", TmuxSession: "mesh:work", PaneID: "%13"},

--- a/daemon-go/service/pane_ownership.go
+++ b/daemon-go/service/pane_ownership.go
@@ -219,6 +219,17 @@ func (o *fileOwnership) ValidateBootstrap(paneID string) OwnershipValidation {
 	if !ok {
 		return OwnershipValidation{OK: true, Evidence: ev}
 	}
+	// tmux pane ids are only unique for the lifetime of one tmux server. A pane
+	// such as %26 can therefore inherit an ownership record written for an old,
+	// now-unrelated session after tmux restarts. That record must not block a
+	// normal hook bootstrap: without it, this exact live pane would already be
+	// allowed to register from tmux evidence alone. Forget only when the tmux
+	// session itself differs. A window rename within the same session remains a
+	// fail-loud mismatch until UpdatePlacement has reconciled the durable proof.
+	if tmuxSessionName(rec.TmuxSession) != "" && ev.SessionName != "" && tmuxSessionName(rec.TmuxSession) != ev.SessionName {
+		o.Forget(paneID)
+		return OwnershipValidation{OK: true, Evidence: ev}
+	}
 	if rec.Machine != "" && rec.Machine != o.selfMachine {
 		return OwnershipValidation{Record: &rec, Evidence: ev, Error: "ownership_machine_mismatch", Hint: "Ownership proof was written on a different host."}
 	}
@@ -226,6 +237,11 @@ func (o *fileOwnership) ValidateBootstrap(paneID string) OwnershipValidation {
 		return OwnershipValidation{Record: &rec, Evidence: ev, Error: "pane_identity_mismatch", Hint: "Live tmux pane evidence does not match the ownership proof."}
 	}
 	return OwnershipValidation{OK: true, Record: &rec, Evidence: ev}
+}
+
+func tmuxSessionName(target string) string {
+	session, _, _ := strings.Cut(target, ":")
+	return session
 }
 
 // ValidateForPeer ports _effective_ownership_validation: a direct valid pane

--- a/daemon-go/service/pane_ownership_test.go
+++ b/daemon-go/service/pane_ownership_test.go
@@ -1,0 +1,46 @@
+package service
+
+import "testing"
+
+func TestValidateBootstrapForgetsRecordFromReusedPaneID(t *testing.T) {
+	t.Setenv("REPOWIRE_CONFIG_DIR", t.TempDir())
+	path := t.TempDir()
+	ownership := NewFileOwnership("host", func(string) *TmuxPaneEvidence {
+		return &TmuxPaneEvidence{
+			PaneID: "%26", SessionName: "current", TmuxSession: "current:agent-dj", CurrentPath: path,
+		}
+	})
+	ownership.Record(OwnershipRecord{
+		PaneID: "%26", Path: "/old/project", Backend: "codex", Circle: "old", Role: "agent",
+		TmuxSession: "old:repowire", Machine: "host",
+	})
+
+	got := ownership.ValidateBootstrap("%26")
+	if !got.OK || got.Record != nil || got.Evidence == nil {
+		t.Fatalf("reused-pane bootstrap = %#v, want live evidence without stale ownership", got)
+	}
+	if _, exists := ownership.loadLocked()["%26"]; exists {
+		t.Fatal("stale ownership record was not forgotten")
+	}
+}
+
+func TestValidateBootstrapRejectsMismatchWithinSameSession(t *testing.T) {
+	t.Setenv("REPOWIRE_CONFIG_DIR", t.TempDir())
+	ownership := NewFileOwnership("host", func(string) *TmuxPaneEvidence {
+		return &TmuxPaneEvidence{
+			PaneID: "%26", SessionName: "mesh", TmuxSession: "mesh:renamed", CurrentPath: "/other/project",
+		}
+	})
+	ownership.Record(OwnershipRecord{
+		PaneID: "%26", Path: "/expected/project", Backend: "claude-code", Circle: "mesh", Role: "agent",
+		TmuxSession: "mesh:original", Machine: "host",
+	})
+
+	got := ownership.ValidateBootstrap("%26")
+	if got.OK || got.Error != "pane_identity_mismatch" {
+		t.Fatalf("same-session mismatch = %#v, want pane_identity_mismatch", got)
+	}
+	if _, exists := ownership.loadLocked()["%26"]; !exists {
+		t.Fatal("same-session ownership record must remain for fail-loud reconciliation")
+	}
+}

--- a/docs/troubleshooting/hooks.md
+++ b/docs/troubleshooting/hooks.md
@@ -24,6 +24,12 @@ server-global tmux lifecycle hooks used for pane exits and renames.
 3. Start Claude Code in a tmux pane. After your first prompt, run `repowire peer list` in another shell. Peer should appear within a few seconds.
 4. On Claude Code 2.1.224+, `/status` should show a `Peer address` and `repowire peer describe NAME` should report `transport: claude-inbox`. If native delivery fails, Repowire logs the socket error under `~/.cache/repowire/logs/ws-hook-*.log` and returns a failed delivery receipt. There is no keystroke fallback.
 
+If the hook reports `pane_identity_mismatch` after tmux has restarted, the pane
+id may have been reused while an ownership record from an older tmux session
+remained on disk. Repowire discards that stale bootstrap record automatically.
+It still rejects path or placement mismatches within the same live tmux session,
+because those records may authorize destructive pane operations.
+
 ### Codex
 
 Current Codex releases use App Server for registration, lifecycle, chat, and
@@ -46,8 +52,10 @@ OpenCode does not use shell hooks. It uses a TypeScript plugin at `~/.config/ope
 All hooks shell out to the daemon over HTTP. If the daemon is down, hooks
 succeed (they do not block agent startup) but no peer state changes. A later
 Claude Code `UserPromptSubmit` repairs a missing pane registration with the
-current session's authenticated inbox; a failed SessionStart is never retained
-as an empty ws-hook identity. See [Daemon unreachable](daemon.md).
+current session's authenticated inbox. It also replaces a connected ws-hook
+whose Claude inbox socket belongs to an older process, rather than accepting a
+status-only recovery that cannot deliver messages. A failed SessionStart is
+never retained as an empty ws-hook identity. See [Daemon unreachable](daemon.md).
 
 ## After upgrading `repowire`
 


### PR DESCRIPTION
## Summary
- treat spawn ownership from a different tmux session as stale when a pane id is reused
- refresh Claude ws-hooks when a connected peer still points at an older native inbox socket
- isolate the window-boundary spawn test from real local ownership state

## Verification
- `go vet ./...`
- `go test -race ./...`
- `npm test -- --run`
- `npm run build`
- live Agent DJ recovery: stale ws-hook PID replaced; current Claude inbox socket captured
- live `/notify`: `transport_delivered`, Claude inbox `accepted`

Tracks repowire-ks7.